### PR TITLE
Use assertj fluent style in flowable-engine.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationTest.java
@@ -27,39 +27,50 @@ import org.flowable.task.api.history.HistoricTaskInstance;
 
 public class AbstractProcessInstanceMigrationTest extends PluggableFlowableTestCase {
 
-    protected void checkActivityInstances(ProcessDefinition processDefinition, ProcessInstance processInstance, String activityType, String... expectedActivityIds) {
+    protected void checkActivityInstances(ProcessDefinition processDefinition, ProcessInstance processInstance, String activityType,
+            String... expectedActivityIds) {
         List<HistoricActivityInstance> historicTaskExecutions = historyService.createHistoricActivityInstanceQuery()
-            .processInstanceId(processInstance.getId())
-            .activityType(activityType)
-            .list();
-        assertThat(historicTaskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder(expectedActivityIds);
-        assertThat(historicTaskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(processDefinition.getId());
+                .processInstanceId(processInstance.getId())
+                .activityType(activityType)
+                .list();
+        assertThat(historicTaskExecutions)
+                .extracting(HistoricActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(expectedActivityIds);
+        assertThat(historicTaskExecutions)
+                .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                .containsOnly(processDefinition.getId());
         List<ActivityInstance> activityInstances = runtimeService.createActivityInstanceQuery()
-            .processInstanceId(processInstance.getId())
-            .activityType(activityType)
-            .list();
+                .processInstanceId(processInstance.getId())
+                .activityType(activityType)
+                .list();
         if (runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 1) {
-            assertThat(activityInstances).extracting(ActivityInstance::getActivityId).containsExactlyInAnyOrder(expectedActivityIds);
+            assertThat(activityInstances)
+                    .extracting(ActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder(expectedActivityIds);
             assertThat(activityInstances).extracting(ActivityInstance::getProcessDefinitionId).containsOnly(processDefinition.getId());
             activityInstances.forEach(
-                activityInstance -> {
-                    HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
-                        .activityInstanceId(activityInstance.getId()).singleResult();
-                    assertThat(activityInstance).isEqualToComparingFieldByField(historicActivityInstance);
-                }
+                    activityInstance -> {
+                        HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
+                                .activityInstanceId(activityInstance.getId()).singleResult();
+                        assertThat(activityInstance).isEqualToComparingFieldByField(historicActivityInstance);
+                    }
             );
         } else {
             assertThat(activityInstances).isEmpty();
         }
     }
 
-    protected void checkTaskInstance(ProcessDefinition processDefinition, ProcessInstance processInstance, String... expectestTaskDefinitionKeys) {
+    protected void checkTaskInstance(ProcessDefinition processDefinition, ProcessInstance processInstance, String... expectedTaskDefinitionKeys) {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .list();
-            assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder(expectestTaskDefinitionKeys);
-            assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(processDefinition.getId());
+                    .processInstanceId(processInstance.getId())
+                    .list();
+            assertThat(historicTasks)
+                    .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                    .containsExactlyInAnyOrder(expectedTaskDefinitionKeys);
+            assertThat(historicTasks)
+                    .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                    .containsOnly(processDefinition.getId());
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
@@ -10,6 +10,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.flowable.engine.test.api.runtime.migration;
 
@@ -60,7 +72,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
     @Test
     public void testProcessMigrationBatchMissingMapping() {
         // Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         // Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("MP");
@@ -79,24 +92,25 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(task.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
         processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        assertEquals(processDefinitions.get(0).getId(), version1ProcessDef.getId());
-        assertEquals(processDefinitions.get(1).getId(), version2ProcessDef.getId());
+        assertThat(processDefinitions)
+                .extracting(ProcessDefinition::getId)
+                .containsExactly(version1ProcessDef.getId(), version2ProcessDef.getId());
 
         // Prepare the process Instance migration builder as usual
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId());
 
         // Try batch migrate the process instances
         Batch migrationBatch = processInstanceMigrationBuilder.batchMigrateProcessInstances(version1ProcessDef.getId());
-        assertTrue(JobTestHelper.areJobsAvailable(managementService));
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isTrue();
 
         // Confirm the batch is not finished
         ProcessInstanceBatchMigrationResult migrationResult = processMigrationService.getResultsOfBatchProcessInstanceMigration(migrationBatch.getId());
@@ -105,10 +119,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_IN_PROGRESS);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(0L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getWaitingMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getSuccessfulMigrationParts()).isEmpty();
+        assertThat(migrationResult.getFailedMigrationParts()).isEmpty();
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getAllMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_WAITING);
@@ -117,8 +131,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
 
         // Start async executor to process the batches
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 1000L, 500L, true);
-        assertFalse(JobTestHelper.areJobsAvailable(managementService));
-        
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isFalse();
+
         List<Job> timerJobs = managementService.createTimerJobQuery().handlerType(ProcessInstanceMigrationStatusJobHandler.TYPE).list();
         for (Job timerJob : timerJobs) {
             Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
@@ -132,10 +146,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(2L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getWaitingMigrationParts()).isEmpty();
+        assertThat(migrationResult.getSuccessfulMigrationParts()).isEmpty();
+        assertThat(migrationResult.getFailedMigrationParts()).hasSize(2);
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getAllMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
@@ -162,7 +176,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
     @Test
     public void testProcessMigrationBatchPartialMissingMapping() {
         // Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("MP");
@@ -179,25 +194,26 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(task.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
 
         // Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(2);
         processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        
-        assertEquals(processDefinitions.get(0).getId(), version1ProcessDef.getId());
-        assertEquals(processDefinitions.get(1).getId(), version2ProcessDef.getId());
+
+        assertThat(version1ProcessDef.getId()).isEqualTo(processDefinitions.get(0).getId());
+        assertThat(version2ProcessDef.getId()).isEqualTo(processDefinitions.get(1).getId());
 
         // Prepare the process Instance migration builder as usual
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-                        .migrateToProcessDefinition(version2ProcessDef.getId()); 
+                .migrateToProcessDefinition(version2ProcessDef.getId());
 
         // Try batch migrate the process instances
         Batch migrationBatch = processInstanceMigrationBuilder.batchMigrateProcessInstances(version1ProcessDef.getId());
-        assertTrue(JobTestHelper.areJobsAvailable(managementService));
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isTrue();
 
         //Confirm the batch is not finished
         ProcessInstanceBatchMigrationResult migrationResult = processMigrationService.getResultsOfBatchProcessInstanceMigration(migrationBatch.getId());
@@ -206,10 +222,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_IN_PROGRESS);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(0L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getWaitingMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getSuccessfulMigrationParts()).isEmpty();
+        assertThat(migrationResult.getFailedMigrationParts()).isEmpty();
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getAllMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_WAITING);
@@ -218,8 +234,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
 
         // Start async executor to process the batches
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000L, 500L, true);
-        assertFalse(JobTestHelper.areJobsAvailable(managementService));
-        
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isFalse();
+
         List<Job> timerJobs = managementService.createTimerJobQuery().handlerType(ProcessInstanceMigrationStatusJobHandler.TYPE).list();
         for (Job timerJob : timerJobs) {
             Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
@@ -232,10 +248,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(2L);
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(1L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(1L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
+        assertThat(migrationResult.getWaitingMigrationParts()).isEmpty();
+        assertThat(migrationResult.getSuccessfulMigrationParts()).hasSize(1);
+        assertThat(migrationResult.getFailedMigrationParts()).hasSize(1);
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getSuccessfulMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
@@ -255,7 +271,7 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(task.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("userTask1Id");
-        
+
         // This task migrated
         assertThat(task.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
 
@@ -270,7 +286,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
     @Test
     public void testProcessMigrationBatchTwentyMixedSuccessAndFails() {
         // Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         // Instances that will validate and migrate properly
         List<String> successInstances = new ArrayList<>();
@@ -281,14 +298,14 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         for (int i = 0; i < 12; i++) {
             successInstances.add(runtimeService.startProcessInstanceByKey("MP").getId());
         }
-        
+
         for (int i = 0; i < 8; i++) {
             failedInstances.add(runtimeService.startProcessInstanceByKey("MP").getId());
         }
-        
+
         List<String> allInstances = new ArrayList<>(successInstances);
         allInstances.addAll(failedInstances);
-        
+
         // Set the instances to fail in a state where they won't map properly during validation and migration
         for (String processInstanceId : failedInstances) {
             Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
@@ -296,26 +313,27 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         }
 
         // Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         // Prepare the process instance migration builder
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService
-                        .createProcessInstanceMigrationBuilder()
-                        .migrateToProcessDefinition(version2ProcessDef.getId());
-        
+                .createProcessInstanceMigrationBuilder()
+                .migrateToProcessDefinition(version2ProcessDef.getId());
+
         // Migrate the processes
         Batch migrationBatch = processInstanceMigrationBuilder.batchMigrateProcessInstances(version1ProcessDef.getId());
-        assertTrue(JobTestHelper.areJobsAvailable(managementService));
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isTrue();
 
         // Partial Results - migration inProgress
         ProcessInstanceBatchMigrationResult migrationResult = processMigrationService.getResultsOfBatchProcessInstanceMigration(migrationBatch.getId());
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_IN_PROGRESS);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(successInstances.size() + failedInstances.size());
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(successInstances.size() + failedInstances.size());
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(0L);
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(successInstances.size() + failedInstances.size());
+        assertThat(migrationResult.getWaitingMigrationParts()).hasSize(successInstances.size() + failedInstances.size());
+        assertThat(migrationResult.getSuccessfulMigrationParts()).isEmpty();
+        assertThat(migrationResult.getFailedMigrationParts()).isEmpty();
 
         // Each batch part is inProgress
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getAllMigrationParts()) {
@@ -325,8 +343,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
 
         // Start async executor to process the batches
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 10000L, 500L, true);
-        assertFalse(JobTestHelper.areJobsAvailable(managementService));
-        
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isFalse();
+
         List<Job> timerJobs = managementService.createTimerJobQuery().handlerType(ProcessInstanceMigrationStatusJobHandler.TYPE).list();
         for (Job timerJob : timerJobs) {
             Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
@@ -338,10 +356,10 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
-        assertThat(migrationResult.getAllMigrationParts().size()).isEqualTo(successInstances.size() + failedInstances.size());
-        assertThat(migrationResult.getWaitingMigrationParts().size()).isEqualTo(0L);
-        assertThat(migrationResult.getSuccessfulMigrationParts().size()).isEqualTo(successInstances.size());
-        assertThat(migrationResult.getFailedMigrationParts().size()).isEqualTo(failedInstances.size());
+        assertThat(migrationResult.getAllMigrationParts()).hasSize(successInstances.size() + failedInstances.size());
+        assertThat(migrationResult.getWaitingMigrationParts()).isEmpty();
+        assertThat(migrationResult.getSuccessfulMigrationParts()).hasSize(successInstances.size());
+        assertThat(migrationResult.getFailedMigrationParts()).hasSize(failedInstances.size());
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getSuccessfulMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
@@ -354,24 +372,24 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
             assertThat(part.getResult()).isEqualTo(ProcessInstanceBatchMigrationResult.RESULT_FAIL);
             assertThat(part.getMigrationMessage()).isEqualTo("Migration Activity mapping missing for activity definition Id:'userTask2Id' or its MI Parent");
         }
-        
+
         List<Batch> searchBatches = managementService.findBatchesBySearchKey(version1ProcessDef.getId());
-        assertThat(searchBatches.size()).isEqualTo(1);
+        assertThat(searchBatches).hasSize(1);
         assertThat(searchBatches.get(0).getId()).isEqualTo(migrationBatch.getId());
         assertThat(searchBatches.get(0).getBatchSearchKey()).isEqualTo(version1ProcessDef.getId());
         assertThat(searchBatches.get(0).getBatchSearchKey2()).isEqualTo(version2ProcessDef.getId());
         assertThat(searchBatches.get(0).getBatchType()).isEqualTo(Batch.PROCESS_MIGRATION_TYPE);
         assertThat(searchBatches.get(0).getCreateTime()).isNotNull();
-        
+
         assertThat(managementService.createBatchQuery().searchKey(version1ProcessDef.getId()).count()).isEqualTo(1);
         assertThat(managementService.createBatchQuery().searchKey(version2ProcessDef.getId()).count()).isEqualTo(0);
         assertThat(managementService.createBatchQuery().searchKey2(version1ProcessDef.getId()).count()).isEqualTo(0);
         assertThat(managementService.createBatchQuery().searchKey2(version2ProcessDef.getId()).count()).isEqualTo(1);
         assertThat(managementService.createBatchQuery().createTimeLowerThan(new Date()).count()).isEqualTo(1);
         assertThat(managementService.createBatchQuery().createTimeHigherThan(new Date()).count()).isEqualTo(0);
-        
+
         List<BatchPart> searchBatchParts = managementService.findBatchPartsByBatchId(migrationBatch.getId());
-        assertThat(searchBatchParts.size()).isEqualTo(20);
+        assertThat(searchBatchParts).hasSize(20);
         for (BatchPart batchPart : searchBatchParts) {
             assertThat(batchPart.getBatchId()).isEqualTo(migrationBatch.getId());
             assertThat(batchPart.getBatchSearchKey()).isEqualTo(version1ProcessDef.getId());
@@ -390,25 +408,25 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
             assertThat(task.getTaskDefinitionKey()).isEqualTo("userTask1Id");
             assertThat(task.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
         }
-        
+
         // Confirm the migration of failedParts
         for (String processInstanceId : failedInstances) {
             Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
             assertThat(task.getTaskDefinitionKey()).isEqualTo("userTask2Id");
             assertThat(task.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
         }
-        
+
         // Complete the processes
         for (String processInstanceId : successInstances) {
             completeProcessInstanceTasks(processInstanceId);
             assertProcessEnded(processInstanceId);
         }
-        
+
         for (String processInstanceId : failedInstances) {
             completeProcessInstanceTasks(processInstanceId);
             assertProcessEnded(processInstanceId);
         }
-        
+
         managementService.deleteBatch(migrationBatch.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationDocumentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationDocumentTest.java
@@ -42,15 +42,17 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String definitionTenantId = "admin";
 
         ActivityMigrationMapping oneToOneMapping = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
-            .withLocalVariable("varForNewActivity1", "varValue")
-            .withNewAssignee("kermit");
+                .withLocalVariable("varForNewActivity1", "varValue")
+                .withNewAssignee("kermit");
 
-        ActivityMigrationMapping manyToOneMapping = ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
-            .withLocalVariable("varForNewActivity3", 9876);
+        ActivityMigrationMapping manyToOneMapping = ActivityMigrationMapping
+                .createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
+                .withLocalVariable("varForNewActivity3", 9876);
 
-        ActivityMigrationMapping oneToManyMapping = ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
-            .withLocalVariableForAllActivities("var1ForNewActivity2.x", "varValue")
-            .withLocalVariableForAllActivities("var2ForNewActivity2.x", 1234.567);
+        ActivityMigrationMapping oneToManyMapping = ActivityMigrationMapping
+                .createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
+                .withLocalVariableForAllActivities("var1ForNewActivity2.x", "varValue")
+                .withLocalVariableForAllActivities("var2ForNewActivity2.x", 1234.567);
 
         HashMap<String, Map<String, Object>> activityLocalVariables = new HashMap<String, Map<String, Object>>() {
 
@@ -95,11 +97,12 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String jsonAsStr = IoUtil.readFileAsString("org/flowable/engine/test/api/runtime/migration/completeProcessInstanceMigrationDocument.json");
 
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(jsonAsStr);
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
-        assertEquals(definitionKey, migrationDocument.getMigrateToProcessDefinitionKey());
-        assertEquals(definitionVer, migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertEquals(definitionTenantId, migrationDocument.getMigrateToProcessDefinitionTenantId());
-        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOneMapping, oneToManyMapping, manyToOneMapping);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isEqualTo(definitionKey);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isEqualTo(definitionVer);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
+        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator()
+                .containsExactly(oneToOneMapping, oneToManyMapping, manyToOneMapping);
         assertThat(migrationDocument.getActivitiesLocalVariables()).isEqualTo(activityLocalVariables);
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVariables);
         assertThat(migrationDocument.getPreUpgradeScript()).isEqualToComparingFieldByField(new Script("groovy", "1+1"));
@@ -167,24 +170,26 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
             }
         };
         ActivityMigrationMapping.OneToOneMapping oneToOneMapping = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
-            .withLocalVariable("varForNewActivity1", "varValue")
-            .withNewAssignee("kermit");
-        ActivityMigrationMapping.ManyToOneMapping manyToOneMapping = ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
-            .withLocalVariable("varForNewActivity3", 9876);
-        ActivityMigrationMapping.OneToManyMapping oneToManyMapping = ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
-            .withLocalVariablesForActivity("newActivity2.1", varsForNewActivity2_1)
-            .withLocalVariablesForActivity("newActivity2.2", varsForNewActivity2_2);
+                .withLocalVariable("varForNewActivity1", "varValue")
+                .withNewAssignee("kermit");
+        ActivityMigrationMapping.ManyToOneMapping manyToOneMapping = ActivityMigrationMapping
+                .createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
+                .withLocalVariable("varForNewActivity3", 9876);
+        ActivityMigrationMapping.OneToManyMapping oneToManyMapping = ActivityMigrationMapping
+                .createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
+                .withLocalVariablesForActivity("newActivity2.1", varsForNewActivity2_1)
+                .withLocalVariablesForActivity("newActivity2.2", varsForNewActivity2_2);
 
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionId)
-            .preUpgradeScript(new Script("groovy", "1+1"))
-            .postUpgradeScript(new Script("groovy", "2+2"))
-            .addActivityMigrationMapping(oneToOneMapping)
-            .addActivityMigrationMapping(oneToManyMapping)
-            .addActivityMigrationMapping(manyToOneMapping)
-            .withProcessInstanceVariable("processVar1", "varValue1")
-            .withProcessInstanceVariable("processVar2", 456.789)
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionId)
+                .preUpgradeScript(new Script("groovy", "1+1"))
+                .postUpgradeScript(new Script("groovy", "2+2"))
+                .addActivityMigrationMapping(oneToOneMapping)
+                .addActivityMigrationMapping(oneToManyMapping)
+                .addActivityMigrationMapping(manyToOneMapping)
+                .withProcessInstanceVariable("processVar1", "varValue1")
+                .withProcessInstanceVariable("processVar2", 456.789)
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -192,11 +197,12 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
-        assertNull(migrationDocument.getMigrateToProcessDefinitionKey());
-        assertNull(migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertNull(migrationDocument.getMigrateToProcessDefinitionTenantId());
-        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsAnyOf(oneToOneMapping, oneToManyMapping, manyToOneMapping);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isNull();
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isNull();
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isNull();
+        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator()
+                .containsAnyOf(oneToOneMapping, oneToManyMapping, manyToOneMapping);
         assertThat(migrationDocument.getActivitiesLocalVariables()).isEqualTo(activityLocalVariables);
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVariables);
         assertThat(migrationDocument.getPreUpgradeScript().getLanguage()).isEqualTo("groovy");
@@ -210,10 +216,10 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String definitionId = "someProcessId";
 
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionId)
-            .preUpgradeJavaDelegate("new javadelegate")
-            .postUpgradeJavaDelegate("new post javadelegate")
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionId)
+                .preUpgradeJavaDelegate("new javadelegate")
+                .postUpgradeJavaDelegate("new post javadelegate")
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -221,7 +227,7 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
         assertThat(migrationDocument.getPreUpgradeJavaDelegate()).isEqualTo("new javadelegate");
         assertThat(migrationDocument.getPostUpgradeJavaDelegate()).isEqualTo("new post javadelegate");
     }
@@ -231,10 +237,10 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String definitionId = "someProcessId";
 
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionId)
-            .preUpgradeJavaDelegateExpression("new expression")
-            .postUpgradeJavaDelegateExpression("new post expression")
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionId)
+                .preUpgradeJavaDelegateExpression("new expression")
+                .postUpgradeJavaDelegateExpression("new post expression")
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -242,7 +248,7 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
         assertThat(migrationDocument.getPreUpgradeJavaDelegateExpression()).isEqualTo("new expression");
         assertThat(migrationDocument.getPostUpgradeJavaDelegateExpression()).isEqualTo("new post expression");
     }
@@ -250,49 +256,49 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
     @Test
     void preUpgradeAllowsOneTaskOnly_ScriptExpression() {
         assertThatThrownBy(() -> new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition("testProcessDefinition")
-            .preUpgradeScript(new Script("groovy", "1+1"))
-            .preUpgradeJavaDelegateExpression("new Expression()")
-            .getProcessInstanceMigrationDocument()
-        ).
-            isInstanceOf(IllegalArgumentException.class).
-            hasMessage("Pre upgrade expression can't be set when another pre-upgrade task was already specified.");
+                .migrateToProcessDefinition("testProcessDefinition")
+                .preUpgradeScript(new Script("groovy", "1+1"))
+                .preUpgradeJavaDelegateExpression("new Expression()")
+                .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(IllegalArgumentException.class).
+                hasMessage("Pre upgrade expression can't be set when another pre-upgrade task was already specified.");
     }
 
     @Test
     void postUpgradeAllowsOneTaskOnly_ScriptExpression() {
         assertThatThrownBy(() -> new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition("testProcessDefinition")
-            .postUpgradeScript(new Script("groovy", "1+1"))
-            .postUpgradeJavaDelegateExpression("new Expression()")
-            .getProcessInstanceMigrationDocument()
-        ).
-            isInstanceOf(IllegalArgumentException.class).
-            hasMessage("Post upgrade expression can't be set when another post-upgrade task was already specified.");
+                .migrateToProcessDefinition("testProcessDefinition")
+                .postUpgradeScript(new Script("groovy", "1+1"))
+                .postUpgradeJavaDelegateExpression("new Expression()")
+                .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(IllegalArgumentException.class).
+                hasMessage("Post upgrade expression can't be set when another post-upgrade task was already specified.");
     }
 
     @Test
     void preUpgradeAllowsOneTaskOnly_ExpressionJavaDelegate() {
         assertThatThrownBy(() -> new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition("testProcessDefinition")
-            .preUpgradeScript(new Script("groovy", "1+1"))
-            .preUpgradeJavaDelegate("JavaDelegate")
-            .getProcessInstanceMigrationDocument()
-        ).
-            isInstanceOf(IllegalArgumentException.class).
-            hasMessage("Pre upgrade java delegate can't be set when another pre-upgrade task was already specified.");
+                .migrateToProcessDefinition("testProcessDefinition")
+                .preUpgradeScript(new Script("groovy", "1+1"))
+                .preUpgradeJavaDelegate("JavaDelegate")
+                .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(IllegalArgumentException.class).
+                hasMessage("Pre upgrade java delegate can't be set when another pre-upgrade task was already specified.");
     }
 
     @Test
     void postUpgradeAllowsOneTaskOnly_ExpressionJavaDelegate() {
         assertThatThrownBy(() -> new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition("testProcessDefinition")
-            .postUpgradeScript(new Script("groovy", "1+1"))
-            .postUpgradeJavaDelegate("JavaDelegate")
-            .getProcessInstanceMigrationDocument()
-        ).
-            isInstanceOf(IllegalArgumentException.class).
-            hasMessage("Post upgrade java delegate can't be set when another post-upgrade task was already specified.");
+                .migrateToProcessDefinition("testProcessDefinition")
+                .postUpgradeScript(new Script("groovy", "1+1"))
+                .postUpgradeJavaDelegate("JavaDelegate")
+                .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(IllegalArgumentException.class).
+                hasMessage("Post upgrade java delegate can't be set when another post-upgrade task was already specified.");
     }
 
     @Test
@@ -300,32 +306,33 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
 
         String definitionId = "someProcessId";
 
-        try {
-            new ProcessInstanceMigrationBuilderImpl(null)
-                .migrateToProcessDefinition(definitionId)
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1").withLocalVariable("varForNewActivity1", "varValue"))
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity2"))
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity1", "newActivity2")))
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity2", "originalActivity3"), "newActivity3"))
-                .withProcessInstanceVariable("processVar1", "varValue1")
-                .getProcessInstanceMigrationDocument();
-            fail("Should not allow duplicated values in 'from' activity");
-        } catch (FlowableException e) {
-            assertTextPresent("From activity '[originalActivity1, originalActivity2]' is mapped more than once", e.getMessage());
-        }
+        assertThatThrownBy(() ->
+                new ProcessInstanceMigrationBuilderImpl(null)
+                        .migrateToProcessDefinition(definitionId)
+                        .addActivityMigrationMapping(
+                                ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
+                                        .withLocalVariable("varForNewActivity1", "varValue"))
+                        .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity2"))
+                        .addActivityMigrationMapping(
+                                ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity1", "newActivity2")))
+                        .addActivityMigrationMapping(
+                                ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity2", "originalActivity3"), "newActivity3"))
+                        .withProcessInstanceVariable("processVar1", "varValue1")
+                        .getProcessInstanceMigrationDocument()
+        )
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("From activity '[originalActivity1, originalActivity2]' is mapped more than once");
     }
 
     @Test
     public void testDeSerializeDuplicatedFromActivity() {
 
-        String jsonAsStr = IoUtil.readFileAsString("org/flowable/engine/test/api/runtime/migration/duplicatedFromActivitiesInFromMappingMigrationDocument.json");
+        String jsonAsStr = IoUtil
+                .readFileAsString("org/flowable/engine/test/api/runtime/migration/duplicatedFromActivitiesInFromMappingMigrationDocument.json");
 
-        try {
-            ProcessInstanceMigrationDocumentImpl.fromJson(jsonAsStr);
-            fail("Should not allow duplicated values in 'from' activity");
-        } catch (FlowableException e) {
-            assertTextPresent("From activity '[originalActivity1, originalActivity2]' is mapped more than once", e.getMessage());
-        }
+        assertThatThrownBy(() -> ProcessInstanceMigrationDocumentImpl.fromJson(jsonAsStr))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("From activity '[originalActivity1, originalActivity2]' is mapped more than once");
     }
 
     @Test
@@ -339,11 +346,11 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
 
         //Build a process migration document
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionKey, definitionVer)
-            .withMigrateToProcessDefinitionTenantId(definitionTenantId)
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2"))
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionKey, definitionVer)
+                .withMigrateToProcessDefinitionTenantId(definitionTenantId)
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2"))
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -351,10 +358,10 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertNull(migrationDocument.getMigrateToProcessDefinitionId());
-        assertEquals(definitionKey, migrationDocument.getMigrateToProcessDefinitionKey());
-        assertEquals(definitionVer, migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertEquals(definitionTenantId, migrationDocument.getMigrateToProcessDefinitionTenantId());
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isNull();
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isEqualTo(definitionKey);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isEqualTo(definitionVer);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
         assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOne1, oneToOne2);
     }
 
@@ -365,9 +372,9 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String definitionTenantId = "admin";
 
         ActivityMigrationMapping.OneToOneMapping oneToOne1 = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
-            .withLocalVariables(Collections.singletonMap("variableString", "variableValue"));
+                .withLocalVariables(Collections.singletonMap("variableString", "variableValue"));
         ActivityMigrationMapping.OneToOneMapping oneToOne2 = ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2")
-            .withLocalVariable("variableDouble", 12345.6789);
+                .withLocalVariable("variableDouble", 12345.6789);
 
         HashMap processInstanceVars = new HashMap<String, Object>() {
 
@@ -379,13 +386,15 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
 
         //Build a process migration document
         ProcessInstanceMigrationDocument document = new ProcessInstanceMigrationBuilderImpl(null)
-            .migrateToProcessDefinition(definitionKey, definitionVer)
-            .withMigrateToProcessDefinitionTenantId(definitionTenantId)
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1").withLocalVariables(Collections.singletonMap("variableString", "variableValue")))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2").withLocalVariable("variableDouble", 12345.6789))
-            .withProcessInstanceVariable("instanceVar1", "stringValue")
-            .withProcessInstanceVariable("instanceVar2", 12345.6789)
-            .getProcessInstanceMigrationDocument();
+                .migrateToProcessDefinition(definitionKey, definitionVer)
+                .withMigrateToProcessDefinitionTenantId(definitionTenantId)
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
+                        .withLocalVariables(Collections.singletonMap("variableString", "variableValue")))
+                .addActivityMigrationMapping(
+                        ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2").withLocalVariable("variableDouble", 12345.6789))
+                .withProcessInstanceVariable("instanceVar1", "stringValue")
+                .withProcessInstanceVariable("instanceVar2", 12345.6789)
+                .getProcessInstanceMigrationDocument();
 
         //Serialize the document as Json
         String serializedDocument = document.asJsonString();
@@ -393,13 +402,14 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         //DeSerialize the document
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(serializedDocument);
 
-        assertNull(migrationDocument.getMigrateToProcessDefinitionId());
-        assertEquals(definitionKey, migrationDocument.getMigrateToProcessDefinitionKey());
-        assertEquals(definitionVer, migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertEquals(definitionTenantId, migrationDocument.getMigrateToProcessDefinitionTenantId());
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isNull();
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isEqualTo(definitionKey);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isEqualTo(definitionVer);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
         assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOne1, oneToOne2);
         assertThat(migrationDocument.getActivitiesLocalVariables()).containsKeys("newActivity1", "newActivity2");
-        assertThat(migrationDocument.getActivitiesLocalVariables().get("newActivity1")).isEqualTo((Collections.singletonMap("variableString", "variableValue")));
+        assertThat(migrationDocument.getActivitiesLocalVariables().get("newActivity1"))
+                .isEqualTo((Collections.singletonMap("variableString", "variableValue")));
         assertThat(migrationDocument.getActivitiesLocalVariables().get("newActivity2")).isEqualTo((Collections.singletonMap("variableDouble", 12345.6789)));
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVars);
     }
@@ -414,23 +424,25 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
 
         //last occurrence of inSubProcessOfCallActivityId prevails
         ActivityMigrationMapping oneToOneMapping = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
-            .inSubProcessOfCallActivityId("wrongCallActivity", -4)
-            .inSubProcessOfCallActivityId("callActivityId")
-            .withLocalVariable("varForNewActivity1", "varValue")
-            .withNewAssignee("kermit");
+                .inSubProcessOfCallActivityId("wrongCallActivity", -4)
+                .inSubProcessOfCallActivityId("callActivityId")
+                .withLocalVariable("varForNewActivity1", "varValue")
+                .withNewAssignee("kermit");
 
         //inParentProcessOfCallActivityId and inSubProcess are mutually exclusive, last occurrence prevails
-        ActivityMigrationMapping oneToManyMapping = ActivityMigrationMapping.createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
-            .withLocalVariableForAllActivities("var1ForNewActivity2.x", "varValue")
-            .withLocalVariableForAllActivities("var2ForNewActivity2.x", 1234.567)
-            .inParentProcessOfCallActivityId("someCallActivityId")
-            .inSubProcessOfCallActivityId("someCallActivityId", 2);
+        ActivityMigrationMapping oneToManyMapping = ActivityMigrationMapping
+                .createMappingFor("originalActivity2", Arrays.asList("newActivity2.1", "newActivity2.2"))
+                .withLocalVariableForAllActivities("var1ForNewActivity2.x", "varValue")
+                .withLocalVariableForAllActivities("var2ForNewActivity2.x", 1234.567)
+                .inParentProcessOfCallActivityId("someCallActivityId")
+                .inSubProcessOfCallActivityId("someCallActivityId", 2);
 
         //inParentProcessOfCallActivityId and inSubProcess are mutually exclusive, last occurrence prevails
-        ActivityMigrationMapping manyToOneMapping = ActivityMigrationMapping.createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
-            .withLocalVariable("varForNewActivity3", 9876)
-            .inSubProcessOfCallActivityId("subProcKey", 2)
-            .inParentProcessOfCallActivityId("someCallActivityId");
+        ActivityMigrationMapping manyToOneMapping = ActivityMigrationMapping
+                .createMappingFor(Arrays.asList("originalActivity3", "originalActivity4"), "newActivity3")
+                .withLocalVariable("varForNewActivity3", 9876)
+                .inSubProcessOfCallActivityId("subProcKey", 2)
+                .inParentProcessOfCallActivityId("someCallActivityId");
 
         HashMap<String, Map<String, Object>> activityLocalVariables = new HashMap<String, Map<String, Object>>() {
 
@@ -475,11 +487,12 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         String jsonAsStr = IoUtil.readFileAsString("org/flowable/engine/test/api/runtime/migration/withCallActivityProcessInstanceMigrationDocument.json");
 
         ProcessInstanceMigrationDocument migrationDocument = ProcessInstanceMigrationDocumentImpl.fromJson(jsonAsStr);
-        assertEquals(definitionId, migrationDocument.getMigrateToProcessDefinitionId());
-        assertEquals(definitionKey, migrationDocument.getMigrateToProcessDefinitionKey());
-        assertEquals(definitionVer, migrationDocument.getMigrateToProcessDefinitionVersion());
-        assertEquals(definitionTenantId, migrationDocument.getMigrateToProcessDefinitionTenantId());
-        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOneMapping, oneToManyMapping, manyToOneMapping);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionId()).isEqualTo(definitionId);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionKey()).isEqualTo(definitionKey);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionVersion()).isEqualTo(definitionVer);
+        assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
+        assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator()
+                .containsExactly(oneToOneMapping, oneToManyMapping, manyToOneMapping);
         assertThat(migrationDocument.getActivitiesLocalVariables()).isEqualTo(activityLocalVariables);
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVariables);
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
@@ -59,19 +59,26 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideSignalEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -79,21 +86,27 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("eventSubProcessTask", procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -112,19 +125,26 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideMessageEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -132,21 +152,30 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey)
+                .isEqualTo("eventSubProcessTask");
+        assertThat(task)
+                .extracting(Task::getProcessDefinitionId)
+                .isEqualTo(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -154,19 +183,21 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
             //Check History
             checkActivityInstances(procWithSignal, processInstance, "userTask", "eventSubProcessTask");
             List<ActivityInstance> taskExecutions = runtimeService.createActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(ActivityInstance::getActivityId).containsExactlyInAnyOrder("eventSubProcessTask");
-            assertThat(taskExecutions).extracting(ActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(ActivityInstance::getActivityId, ActivityInstance::getProcessDefinitionId)
+                    .containsExactly(tuple("eventSubProcessTask", procWithSignal.getId()));
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "eventSubProcess");
             List<ActivityInstance> eventSubProcExecution = runtimeService.createActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("eventSubProcess")
-                .list();
-            assertThat(eventSubProcExecution).extracting(ActivityInstance::getActivityId).containsExactlyInAnyOrder("eventSubProcess");
-            assertThat(eventSubProcExecution).extracting(ActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("eventSubProcess")
+                    .list();
+            assertThat(eventSubProcExecution)
+                    .extracting(ActivityInstance::getActivityId, ActivityInstance::getProcessDefinitionId)
+                    .containsExactly(tuple("eventSubProcess", procWithSignal.getId()));
 
             checkTaskInstance(procWithSignal, processInstance, "eventSubProcessTask");
         }
@@ -177,19 +208,26 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideTimerEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -197,23 +235,29 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("eventSubProcessTask", procWithSignal.getId());
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -229,19 +273,26 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideNonInterruptingSignalEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -249,21 +300,27 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("eventSubProcessTask", procWithSignal.getId());
 
         //Since the only task in the parent scope was moved, it behaves as a interrupting eventSubProcess
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
@@ -283,16 +340,22 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideNonInterruptingMessageEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -303,18 +366,23 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
@@ -337,16 +405,22 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideNonInterruptingTimerEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -357,25 +431,30 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
 
         //Since the only task in the parent scope was moved, it behaves as a interrupting eventSubProcess
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -392,8 +471,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideSignalEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -405,11 +486,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -417,21 +506,30 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -440,25 +538,37 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             List<HistoricActivityInstance> eventSubProcExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("eventSubProcess")
-                .list();
-            assertThat(eventSubProcExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("eventSubProcess");
-            assertThat(eventSubProcExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("eventSubProcess")
+                    .list();
+            assertThat(eventSubProcExecution)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactly("eventSubProcess");
+            assertThat(eventSubProcExecution)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -467,8 +577,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideMessageEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -480,11 +592,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -492,21 +612,30 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -525,8 +654,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideTimerEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -538,11 +669,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -550,23 +689,32 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -583,8 +731,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNonInterruptingSignalEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -596,11 +746,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -608,37 +766,51 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("eventSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "signal", "eventSignal"));
 
         //Fire the signal
         runtimeService.signalEventReceived("eventSignal");
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask",
+                        "eventSubProcessTask");
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("eventSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "signal", "eventSignal"));
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -655,8 +827,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNonInterruptingMessageEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -668,131 +842,153 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
         changeStateEventListener.clear();
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "processStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask"),
-                tuple("boundaryEvent", "timerBound"),
-                tuple("sequenceFlow", "flow3"),
-                tuple("userTask", "parallelTask")
-            );
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "processStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask"),
+                        tuple("boundaryEvent", "timerBound"),
+                        tuple("sequenceFlow", "flow3"),
+                        tuple("userTask", "parallelTask")
+                );
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                // old activities
-                tuple("startEvent", "processStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask"),
-                tuple("boundaryEvent", "timerBound"),
-                tuple("sequenceFlow", "flow3"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        // old activities
+                        tuple("startEvent", "processStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask"),
+                        tuple("boundaryEvent", "timerBound"),
+                        tuple("sequenceFlow", "flow3"),
 
-                // new activities
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("userTask", "eventSubProcessTask")
-            );
+                        // new activities
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("userTask", "eventSubProcessTask")
+                );
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event
-        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).messageEventSubscriptionName("someMessage").singleResult();
+        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId())
+                .messageEventSubscriptionName("someMessage").singleResult();
         runtimeService.messageEventReceived("someMessage", messageSubscriptionExecution.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask",
+                        "eventSubProcessTask");
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                // old activities
-                tuple("startEvent", "processStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask"),
-                tuple("boundaryEvent", "timerBound"),
-                tuple("sequenceFlow", "flow3"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        // old activities
+                        tuple("startEvent", "processStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask"),
+                        tuple("boundaryEvent", "timerBound"),
+                        tuple("sequenceFlow", "flow3"),
 
-                // After migration
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("userTask", "eventSubProcessTask"),
+                        // After migration
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("userTask", "eventSubProcessTask"),
 
-                // After message received
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("startEvent", "eventSubProcessStart"),
-                tuple("sequenceFlow", "subProcessFlow1"),
-                tuple("userTask", "eventSubProcessTask")
-            );
+                        // After message received
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("startEvent", "eventSubProcessStart"),
+                        tuple("sequenceFlow", "subProcessFlow1"),
+                        tuple("userTask", "eventSubProcessTask")
+                );
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             assertThat(historyService.createHistoricActivityInstanceQuery().list())
-                .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
-                .containsExactlyInAnyOrder(
-                    // old activities
-                    tuple("startEvent", "processStart"),
-                    tuple("sequenceFlow", "flow1"),
-                    tuple("userTask", "processTask"),
-                    tuple("boundaryEvent", "timerBound"),
-                    tuple("sequenceFlow", "flow3"),
+                    .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder(
+                            // old activities
+                            tuple("startEvent", "processStart"),
+                            tuple("sequenceFlow", "flow1"),
+                            tuple("userTask", "processTask"),
+                            tuple("boundaryEvent", "timerBound"),
+                            tuple("sequenceFlow", "flow3"),
 
-                    // After migration
-                    tuple("eventSubProcess", "eventSubProcess"),
-                    tuple("userTask", "eventSubProcessTask"),
+                            // After migration
+                            tuple("eventSubProcess", "eventSubProcess"),
+                            tuple("userTask", "eventSubProcessTask"),
 
-                    // After message received
-                    tuple("eventSubProcess", "eventSubProcess"),
-                    tuple("startEvent", "eventSubProcessStart"),
-                    tuple("sequenceFlow", "subProcessFlow1"),
-                    tuple("userTask", "eventSubProcessTask"),
+                            // After message received
+                            tuple("eventSubProcess", "eventSubProcess"),
+                            tuple("startEvent", "eventSubProcessStart"),
+                            tuple("sequenceFlow", "subProcessFlow1"),
+                            tuple("userTask", "eventSubProcessTask"),
 
-                    // After tasks completion
-                    tuple("sequenceFlow", "subProcessFlow2"),
-                    tuple("endEvent", "eventSubProcessEnd"),
-                    tuple("sequenceFlow", "subProcessFlow2"),
-                    tuple("endEvent", "eventSubProcessEnd"),
-                    tuple("sequenceFlow", "flow2"),
-                    tuple("endEvent", "theEnd")
-                );
-
+                            // After tasks completion
+                            tuple("sequenceFlow", "subProcessFlow2"),
+                            tuple("endEvent", "eventSubProcessEnd"),
+                            tuple("sequenceFlow", "subProcessFlow2"),
+                            tuple("endEvent", "eventSubProcessEnd"),
+                            tuple("sequenceFlow", "flow2"),
+                            tuple("endEvent", "theEnd")
+                    );
 
             checkTaskInstance(procWithSignal, processInstance, "processTask", "eventSubProcessTask", "eventSubProcessTask");
         }
@@ -802,8 +998,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNonInterruptingTimerEventSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -815,59 +1013,76 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
         changeStateEventListener.clear();
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "processStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask"),
-                tuple("boundaryEvent", "timerBound"),
-                tuple("sequenceFlow", "flow3"),
-                tuple("userTask", "parallelTask")
-            );
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "processStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask"),
+                        tuple("boundaryEvent", "timerBound"),
+                        tuple("sequenceFlow", "flow3"),
+                        tuple("userTask", "parallelTask")
+                );
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "eventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                // old activities
-                tuple("startEvent", "processStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask"),
-                tuple("boundaryEvent", "timerBound"),
-                tuple("sequenceFlow", "flow3"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        // old activities
+                        tuple("startEvent", "processStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask"),
+                        tuple("boundaryEvent", "timerBound"),
+                        tuple("sequenceFlow", "flow3"),
 
-                // new activities
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("userTask", "eventSubProcessTask")
-            );
+                        // new activities
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("userTask", "eventSubProcessTask")
+                );
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).extracting(this::getJobActivityId).isEqualTo("eventSubProcessStart");
 
@@ -876,30 +1091,35 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         managementService.executeJob(job.getId());
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                // old activities
-                tuple("startEvent", "processStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask"),
-                tuple("boundaryEvent", "timerBound"),
-                tuple("sequenceFlow", "flow3"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        // old activities
+                        tuple("startEvent", "processStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask"),
+                        tuple("boundaryEvent", "timerBound"),
+                        tuple("sequenceFlow", "flow3"),
 
-                // After migration
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("userTask", "eventSubProcessTask"),
+                        // After migration
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("userTask", "eventSubProcessTask"),
 
-                // After timer executed
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("startEvent", "eventSubProcessStart"),
-                tuple("sequenceFlow", "eventSubProcessFlow1"),
-                tuple("userTask", "eventSubProcessTask")
-            );
+                        // After timer executed
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("startEvent", "eventSubProcessStart"),
+                        tuple("sequenceFlow", "eventSubProcessFlow1"),
+                        tuple("userTask", "eventSubProcessTask")
+                );
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessStart", "eventSubProcessTask",
+                        "eventSubProcessTask");
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("eventSubProcessTask", "eventSubProcessTask", "processTask");
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).extracting(this::getJobActivityId).isEqualTo("eventSubProcessStart");
 
@@ -908,34 +1128,33 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             assertThat(historyService.createHistoricActivityInstanceQuery().list())
-                .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
-                .containsExactlyInAnyOrder(
-                    // old activities
-                    tuple("startEvent", "processStart"),
-                    tuple("sequenceFlow", "flow1"),
-                    tuple("userTask", "processTask"),
-                    tuple("boundaryEvent", "timerBound"),
-                    tuple("sequenceFlow", "flow3"),
+                    .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder(
+                            // old activities
+                            tuple("startEvent", "processStart"),
+                            tuple("sequenceFlow", "flow1"),
+                            tuple("userTask", "processTask"),
+                            tuple("boundaryEvent", "timerBound"),
+                            tuple("sequenceFlow", "flow3"),
 
-                    // new activities
-                    tuple("eventSubProcess", "eventSubProcess"),
-                    tuple("userTask", "eventSubProcessTask"),
+                            // new activities
+                            tuple("eventSubProcess", "eventSubProcess"),
+                            tuple("userTask", "eventSubProcessTask"),
 
-                    // After timer executed
-                    tuple("eventSubProcess", "eventSubProcess"),
-                    tuple("startEvent", "eventSubProcessStart"),
-                    tuple("sequenceFlow", "eventSubProcessFlow1"),
-                    tuple("userTask", "eventSubProcessTask"),
+                            // After timer executed
+                            tuple("eventSubProcess", "eventSubProcess"),
+                            tuple("startEvent", "eventSubProcessStart"),
+                            tuple("sequenceFlow", "eventSubProcessFlow1"),
+                            tuple("userTask", "eventSubProcessTask"),
 
-                    // After complete all tasks
-                    tuple("sequenceFlow", "eventSubProcessFlow2"),
-                    tuple("endEvent", "eventSubProcessEnd"),
-                    tuple("sequenceFlow", "eventSubProcessFlow2"),
-                    tuple("endEvent", "eventSubProcessEnd"),
-                    tuple("sequenceFlow", "flow2"),
-                    tuple("endEvent", "theEnd")
-                );
-
+                            // After complete all tasks
+                            tuple("sequenceFlow", "eventSubProcessFlow2"),
+                            tuple("endEvent", "eventSubProcessEnd"),
+                            tuple("sequenceFlow", "eventSubProcessFlow2"),
+                            tuple("endEvent", "eventSubProcessEnd"),
+                            tuple("sequenceFlow", "flow2"),
+                            tuple("endEvent", "theEnd")
+                    );
 
             checkTaskInstance(procWithSignal, processInstance, "processTask", "eventSubProcessTask", "eventSubProcessTask");
         }
@@ -945,16 +1164,22 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideSubProcessInNewDefinitionWithNestedSignalEventSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -965,35 +1190,44 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedSignalEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedSignalEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedSignalEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedSignalEventSubProcessStart", "signal", "someSignal"));
 
         //Fire the signal
         runtimeService.signalEventReceived("someSignal");
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessStart");
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("nestedSignalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("nestedSignalEventSubProcessTask");
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().list();
-        eventSubscriptions.isEmpty();
+        assertThat(eventSubscriptions).isEmpty();
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -1010,16 +1244,22 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideSubProcessInNewDefinitionWithNestedMessageEventSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1030,36 +1270,47 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedMessageEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedMessageEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedMessageEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedMessageEventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event
-        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).messageEventSubscriptionName("someMessage").singleResult();
+        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId())
+                .messageEventSubscriptionName("someMessage").singleResult();
         runtimeService.messageEventReceived("someMessage", messageSubscriptionExecution.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask",
+                        "nestedMessageEventSubProcessStart");
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("nestedMessageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("nestedMessageEventSubProcessTask");
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().list();
-        eventSubscriptions.isEmpty();
+        assertThat(eventSubscriptions).isEmpty();
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -1076,24 +1327,30 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideSubProcessInNewDefinitionWithNestedTimerEventSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
-                tuple("userTask", "userTask1Id")
-            );
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
+                        tuple("userTask", "userTask1Id")
+                );
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1104,29 +1361,34 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
 
-                // After migration
-                tuple("subProcess", "subProcess"),
-                tuple("userTask", "subProcessTask")
-            );
+                        // After migration
+                        tuple("subProcess", "subProcess"),
+                        tuple("userTask", "subProcessTask")
+                );
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedTimerEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedTimerEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
@@ -1138,29 +1400,32 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessStart");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessStart");
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("nestedTimerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("nestedTimerEventSubProcessTask");
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
 
-                // After migration
-                tuple("subProcess", "subProcess"),
-                tuple("userTask", "subProcessTask"),
+                        // After migration
+                        tuple("subProcess", "subProcess"),
+                        tuple("userTask", "subProcessTask"),
 
-                // After timer fire
-                tuple("eventSubProcess", "nestedTimerEventSubProcess"),
-                tuple("startEvent", "nestedTimerEventSubProcessStart"),
-                tuple("sequenceFlow", "subSeqFlow1"),
-                tuple("userTask", "nestedTimerEventSubProcessTask")
-            );
-
+                        // After timer fire
+                        tuple("eventSubProcess", "nestedTimerEventSubProcess"),
+                        tuple("startEvent", "nestedTimerEventSubProcessStart"),
+                        tuple("sequenceFlow", "subSeqFlow1"),
+                        tuple("userTask", "nestedTimerEventSubProcessTask")
+                );
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -1171,29 +1436,29 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
             checkTaskInstance(procWithSignal, processInstance, "subProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
 
             assertThat(historyService.createHistoricActivityInstanceQuery().list())
-                .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
-                .containsExactlyInAnyOrder(
-                    tuple("startEvent", "startEvent1"),
-                    tuple("sequenceFlow", "seqFlow1Id"),
+                    .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder(
+                            tuple("startEvent", "startEvent1"),
+                            tuple("sequenceFlow", "seqFlow1Id"),
 
-                    // After migration
-                    tuple("subProcess", "subProcess"),
-                    tuple("userTask", "subProcessTask"),
+                            // After migration
+                            tuple("subProcess", "subProcess"),
+                            tuple("userTask", "subProcessTask"),
 
-                    // After timer fire
-                    tuple("eventSubProcess", "nestedTimerEventSubProcess"),
-                    tuple("startEvent", "nestedTimerEventSubProcessStart"),
-                    tuple("sequenceFlow", "subSeqFlow1"),
-                    tuple("userTask", "nestedTimerEventSubProcessTask"),
+                            // After timer fire
+                            tuple("eventSubProcess", "nestedTimerEventSubProcess"),
+                            tuple("startEvent", "nestedTimerEventSubProcessStart"),
+                            tuple("sequenceFlow", "subSeqFlow1"),
+                            tuple("userTask", "nestedTimerEventSubProcessTask"),
 
-                    // After tasks complete
-                    tuple("sequenceFlow", "subSeqFlow2"),
-                    tuple("endEvent", "nestedEventSubProcEnd"),
-                    tuple("sequenceFlow", "seqFlow3"),
-                    tuple("userTask", "afterSubProcessTask"),
-                    tuple("sequenceFlow", "seqFlow4"),
-                    tuple("endEvent", "procEnd")
-                );
+                            // After tasks complete
+                            tuple("sequenceFlow", "subSeqFlow2"),
+                            tuple("endEvent", "nestedEventSubProcEnd"),
+                            tuple("sequenceFlow", "seqFlow3"),
+                            tuple("userTask", "afterSubProcessTask"),
+                            tuple("sequenceFlow", "seqFlow4"),
+                            tuple("endEvent", "procEnd")
+                    );
         }
 
         assertProcessEnded(processInstance.getId());
@@ -1201,16 +1466,22 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideSubProcessInNewDefinitionWithNestedNonInterruptingSignalEventSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1221,38 +1492,54 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSignalEventSubProcessStart", "subProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSignalEventSubProcessStart", "subProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedSignalEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedSignalEventSubProcessStart", "signal", "someSignal"));
 
         //Check that the trigger works
         runtimeService.signalEventReceived("someSignal");
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSignalEventSubProcessStart", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask", "subProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSignalEventSubProcessStart", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask",
+                        "subProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedSignalEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedSignalEventSubProcessStart", "signal", "someSignal"));
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -1269,16 +1556,22 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideSubProcessInNewDefinitionWithNestedNonInterruptingMessageEventSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1286,79 +1579,95 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         assertThat(eventSubscriptions).isEmpty();
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
-                tuple("userTask", "userTask1Id")
-            );
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
+                        tuple("userTask", "userTask1Id")
+                );
 
         changeStateEventListener.clear();
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
 
-                // After migration
+                        // After migration
 
-                tuple("subProcess", "subProcess"),
-                tuple("userTask", "subProcessTask")
-            );
+                        tuple("subProcess", "subProcess"),
+                        tuple("userTask", "subProcessTask")
+                );
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedMessageEventSubProcessStart", "subProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedMessageEventSubProcessStart", "subProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedMessageEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedMessageEventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event
-        Execution messageCatchExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).messageEventSubscriptionName("someMessage").singleResult();
+        Execution messageCatchExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId())
+                .messageEventSubscriptionName("someMessage").singleResult();
         runtimeService.messageEventReceived("someMessage", messageCatchExecution.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessStart", "nestedMessageEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessStart",
+                        "nestedMessageEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedMessageEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedMessageEventSubProcessStart", "message", "someMessage"));
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
 
-                // After migration
-                tuple("subProcess", "subProcess"),
-                tuple("userTask", "subProcessTask"),
+                        // After migration
+                        tuple("subProcess", "subProcess"),
+                        tuple("userTask", "subProcessTask"),
 
-                //  After message received
-                tuple("eventSubProcess", "nestedMessageEventSubProcess"),
-                tuple("startEvent", "nestedMessageEventSubProcessStart"),
-                tuple("sequenceFlow", "subSeqFlow1"),
-                tuple("userTask", "nestedMessageEventSubProcessTask")
-            );
-
+                        //  After message received
+                        tuple("eventSubProcess", "nestedMessageEventSubProcess"),
+                        tuple("startEvent", "nestedMessageEventSubProcessStart"),
+                        tuple("sequenceFlow", "subSeqFlow1"),
+                        tuple("userTask", "nestedMessageEventSubProcessTask")
+                );
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -1369,31 +1678,31 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
             checkTaskInstance(procWithSignal, processInstance, "subProcessTask", "nestedMessageEventSubProcessTask", "afterSubProcessTask");
 
             assertThat(historyService.createHistoricActivityInstanceQuery().list())
-                .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
-                .containsExactlyInAnyOrder(
-                    tuple("startEvent", "startEvent1"),
-                    tuple("sequenceFlow", "seqFlow1Id"),
+                    .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder(
+                            tuple("startEvent", "startEvent1"),
+                            tuple("sequenceFlow", "seqFlow1Id"),
 
-                    // After migration
-                    tuple("subProcess", "subProcess"),
-                    tuple("userTask", "subProcessTask"),
+                            // After migration
+                            tuple("subProcess", "subProcess"),
+                            tuple("userTask", "subProcessTask"),
 
-                    //  After message received
-                    tuple("eventSubProcess", "nestedMessageEventSubProcess"),
-                    tuple("startEvent", "nestedMessageEventSubProcessStart"),
-                    tuple("sequenceFlow", "subSeqFlow1"),
-                    tuple("userTask", "nestedMessageEventSubProcessTask"),
+                            //  After message received
+                            tuple("eventSubProcess", "nestedMessageEventSubProcess"),
+                            tuple("startEvent", "nestedMessageEventSubProcessStart"),
+                            tuple("sequenceFlow", "subSeqFlow1"),
+                            tuple("userTask", "nestedMessageEventSubProcessTask"),
 
-                    // After tasks completion
-                    tuple("sequenceFlow", "outerSubSeqFlow2"),
-                    tuple("endEvent", "subProcEnd"),
-                    tuple("sequenceFlow", "subSeqFlow2"),
-                    tuple("endEvent", "nestedEventSubProcEnd"),
-                    tuple("sequenceFlow", "seqFlow3"),
-                    tuple("userTask", "afterSubProcessTask"),
-                    tuple("sequenceFlow", "seqFlow4"),
-                    tuple("endEvent", "procEnd")
-                );
+                            // After tasks completion
+                            tuple("sequenceFlow", "outerSubSeqFlow2"),
+                            tuple("endEvent", "subProcEnd"),
+                            tuple("sequenceFlow", "subSeqFlow2"),
+                            tuple("endEvent", "nestedEventSubProcEnd"),
+                            tuple("sequenceFlow", "seqFlow3"),
+                            tuple("userTask", "afterSubProcessTask"),
+                            tuple("sequenceFlow", "seqFlow4"),
+                            tuple("endEvent", "procEnd")
+                    );
         }
 
         assertProcessEnded(processInstance.getId());
@@ -1401,16 +1710,22 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateSimpleActivityToActivityInsideSubProcessInNewDefinitionWithNestedNonInterruptingTimerEventSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1418,40 +1733,45 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         assertThat(eventSubscriptions).isEmpty();
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
-                tuple("userTask", "userTask1Id")
-            );
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
+                        tuple("userTask", "userTask1Id")
+                );
 
         changeStateEventListener.clear();
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
 
-                // After migration
-                tuple("subProcess", "subProcess"),
-                tuple("userTask", "subProcessTask")
-            );
+                        // After migration
+                        tuple("subProcess", "subProcess"),
+                        tuple("userTask", "subProcessTask")
+                );
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedTimerEventSubProcessStart", "subProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedTimerEventSubProcessStart", "subProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
@@ -1464,28 +1784,37 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "startEvent1"),
-                tuple("sequenceFlow", "seqFlow1Id"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "startEvent1"),
+                        tuple("sequenceFlow", "seqFlow1Id"),
 
-                // After migration
-                tuple("subProcess", "subProcess"),
-                tuple("userTask", "subProcessTask"),
+                        // After migration
+                        tuple("subProcess", "subProcess"),
+                        tuple("userTask", "subProcessTask"),
 
-                // After timer fire
-                tuple("eventSubProcess", "nestedTimerEventSubProcess"),
-                tuple("startEvent", "nestedTimerEventSubProcessStart"),
-                tuple("sequenceFlow", "subSeqFlow1"),
-                tuple("userTask", "nestedTimerEventSubProcessTask")
-            );
+                        // After timer fire
+                        tuple("eventSubProcess", "nestedTimerEventSubProcess"),
+                        tuple("startEvent", "nestedTimerEventSubProcessStart"),
+                        tuple("sequenceFlow", "subSeqFlow1"),
+                        tuple("userTask", "nestedTimerEventSubProcessTask")
+                );
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedTimerEventSubProcessStart", "nestedTimerEventSubProcess", "subProcessTask", "nestedTimerEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedTimerEventSubProcessStart", "nestedTimerEventSubProcess", "subProcessTask",
+                        "nestedTimerEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).extracting(this::getJobActivityId).isEqualTo("nestedTimerEventSubProcessStart");
 
@@ -1498,31 +1827,31 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
             checkTaskInstance(procWithSignal, processInstance, "subProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
 
             assertThat(historyService.createHistoricActivityInstanceQuery().list())
-                .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
-                .containsExactlyInAnyOrder(
-                    tuple("startEvent", "startEvent1"),
-                    tuple("sequenceFlow", "seqFlow1Id"),
+                    .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder(
+                            tuple("startEvent", "startEvent1"),
+                            tuple("sequenceFlow", "seqFlow1Id"),
 
-                    // After migration
-                    tuple("subProcess", "subProcess"),
-                    tuple("userTask", "subProcessTask"),
+                            // After migration
+                            tuple("subProcess", "subProcess"),
+                            tuple("userTask", "subProcessTask"),
 
-                    //  After message received
-                    tuple("eventSubProcess", "nestedTimerEventSubProcess"),
-                    tuple("startEvent", "nestedTimerEventSubProcessStart"),
-                    tuple("sequenceFlow", "subSeqFlow1"),
-                    tuple("userTask", "nestedTimerEventSubProcessTask"),
+                            //  After message received
+                            tuple("eventSubProcess", "nestedTimerEventSubProcess"),
+                            tuple("startEvent", "nestedTimerEventSubProcessStart"),
+                            tuple("sequenceFlow", "subSeqFlow1"),
+                            tuple("userTask", "nestedTimerEventSubProcessTask"),
 
-                    // After tasks completion
-                    tuple("sequenceFlow", "outerSubSeqFlow2"),
-                    tuple("endEvent", "subProcEnd"),
-                    tuple("sequenceFlow", "subSeqFlow2"),
-                    tuple("endEvent", "nestedEventSubProcEnd"),
-                    tuple("sequenceFlow", "seqFlow3"),
-                    tuple("userTask", "afterSubProcessTask"),
-                    tuple("sequenceFlow", "seqFlow4"),
-                    tuple("endEvent", "procEnd")
-                );
+                            // After tasks completion
+                            tuple("sequenceFlow", "outerSubSeqFlow2"),
+                            tuple("endEvent", "subProcEnd"),
+                            tuple("sequenceFlow", "subSeqFlow2"),
+                            tuple("endEvent", "nestedEventSubProcEnd"),
+                            tuple("sequenceFlow", "seqFlow3"),
+                            tuple("userTask", "afterSubProcessTask"),
+                            tuple("sequenceFlow", "seqFlow4"),
+                            tuple("endEvent", "procEnd")
+                    );
 
         }
 
@@ -1531,8 +1860,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedSignalEventSubProcessInNewDefinitionAndActivityToRootScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -1544,11 +1875,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -1556,22 +1895,31 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedSignalEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedSignalEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
@@ -1581,16 +1929,21 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             checkActivityInstances(procWithSignal, processInstance, "userTask",
-                "beforeSubProcessTask", "nestedSignalEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask"
+                    "beforeSubProcessTask", "nestedSignalEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask"
             );
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedSignalEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                                "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -1599,8 +1952,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedSignalEventSubProcessInNewDefinitionAndActivityToParentScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -1612,11 +1967,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -1624,22 +1987,31 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedSignalEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedSignalEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("nestedSignalEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("nestedSignalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
@@ -1653,10 +2025,14 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask", "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -1665,8 +2041,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedMessageEventSubProcessInNewDefinitionAndActivityToRootScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -1678,11 +2056,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -1690,22 +2076,31 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedMessageEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedMessageEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
@@ -1715,20 +2110,30 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                            "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedMessageEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                                "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -1737,8 +2142,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedMessageEventSubProcessInNewDefinitionAndActivityToParentScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -1750,11 +2157,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -1762,22 +2177,31 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedMessageEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedMessageEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("nestedMessageEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("nestedMessageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
@@ -1787,20 +2211,28 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedMessageEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -1809,8 +2241,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedTimerEventSubProcessInNewDefinitionAndActivityToRootScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -1822,11 +2256,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -1834,45 +2276,64 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedTimerEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedTimerEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                            "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedTimerEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                                "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -1881,8 +2342,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedTimerEventSubProcessInNewDefinitionAndActivityToParentScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -1894,11 +2357,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -1906,45 +2377,62 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedTimerEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedTimerEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("nestedTimerEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("nestedTimerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedTimerEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -1953,8 +2441,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedNonInterruptingSignalEventSubProcessInNewDefinitionAndActivityToRootScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -1966,11 +2456,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -1978,22 +2476,31 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedSignalEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedSignalEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
@@ -2003,20 +2510,30 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                            "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedSignalEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedSignalEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                                "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -2025,8 +2542,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedNonInterruptingSignalEventSubProcessInNewDefinitionAndActivityToParentScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -2038,11 +2557,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -2050,63 +2577,90 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedSignalEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedSignalEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask",
+                        "nestedSignalEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedSignalEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedSignalEventSubProcessStart", "signal", "someSignal"));
 
         //Trigger the event
         runtimeService.signalEventReceived("someSignal");
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId)
-            .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask",
+                        "nestedSignalEventSubProcess", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedSignalEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedSignalEventSubProcessStart", "signal", "someSignal"));
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessTask", "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedSignalEventSubProcess", "nestedSignalEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("subProcessTask", "nestedSignalEventSubProcessTask", "nestedSignalEventSubProcessTask",
+                                "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -2115,8 +2669,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedNonInterruptingMessageEventSubProcessInNewDefinitionAndActivityToRootScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -2128,11 +2684,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -2140,22 +2704,31 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedMessageEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedMessageEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
@@ -2165,20 +2738,30 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                            "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedMessageEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedMessageEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                                "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -2187,8 +2770,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedNonInterruptingMessageEventSubProcessInNewDefinitionAndActivityToParentScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -2200,11 +2785,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -2212,65 +2805,93 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedMessageEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedMessageEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "nestedMessageEventSubProcess", "subProcessTask", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedMessageEventSubProcess", "subProcessTask", "nestedMessageEventSubProcessTask",
+                        "nestedMessageEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedMessageEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedMessageEventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event
-        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage").singleResult();
+        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage")
+                .singleResult();
         runtimeService.messageEventReceived("someMessage", eventExecution.getExecutionId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId)
-            .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask",
-                "nestedMessageEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask",
+                        "nestedMessageEventSubProcess", "nestedMessageEventSubProcessTask",
+                        "nestedMessageEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("nestedMessageEventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("nestedMessageEventSubProcessStart", "message", "someMessage"));
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcessTask", "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedMessageEventSubProcess", "nestedMessageEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("subProcessTask", "nestedMessageEventSubProcessTask", "nestedMessageEventSubProcessTask",
+                                "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -2279,8 +2900,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedNonInterruptingTimerEventSubProcessInNewDefinitionAndActivityToRootScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -2292,11 +2915,19 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -2304,46 +2935,65 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedTimerEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "beforeSubProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedTimerEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "subProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         //Behaves like interrupting since theres no execution in the parentScop
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(job);
+        assertThat(job).isNull();
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                            "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedTimerEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask", "subProcessTask", "afterSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("beforeSubProcessTask", "nestedTimerEventSubProcessTask", "subProcessTask", "afterSubProcessTask",
+                                "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -2352,8 +3002,10 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateParallelActivityToActivityInsideNestedNonInterruptingTimerEventSubProcessInNewDefinitionAndActivityToParentScope() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
@@ -2365,35 +3017,55 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(jobs).extracting(this::getJobActivityId).doesNotContain("nestedTimerEventSubProcessStart");
+        assertThat(jobs)
+                .extracting(this::getJobActivityId)
+                .doesNotContain("nestedTimerEventSubProcessStart");
 
         changeStateEventListener.clear();
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedTimerEventSubProcessTask"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "subProcessTask"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "nestedTimerEventSubProcessTask"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask",
+                        "nestedTimerEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).extracting(this::getJobActivityId).isEqualTo("nestedTimerEventSubProcessStart");
@@ -2403,12 +3075,20 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         managementService.executeJob(job.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId)
-            .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subProcessTask", "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask",
+                        "nestedTimerEventSubProcess", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithSignal.getId());
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).extracting(this::getJobActivityId).isEqualTo("nestedTimerEventSubProcessStart");
@@ -2418,20 +3098,28 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithSignal.getId());
 
             checkActivityInstances(procWithSignal, processInstance, "eventSubProcess", "nestedTimerEventSubProcess", "nestedTimerEventSubProcess");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithSignal.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("subProcessTask", "nestedTimerEventSubProcessTask", "nestedTimerEventSubProcessTask", "afterSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithSignal.getId());
             }
         }
 
@@ -2440,52 +3128,68 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateInterruptingEventSubProcessToInterruptingEventSubProcessOfDifferentEventType() {
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
-        ProcessDefinition procWithMessage = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procWithMessage = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignal.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("eventSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "signal", "eventSignal"));
 
         //Migrate only with autoMapping
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithMessage.getId());
+                .migrateToProcessDefinition(procWithMessage.getId());
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm migration
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithMessage.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event
-        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage").singleResult();
+        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage")
+                .singleResult();
         runtimeService.messageEventReceived("someMessage", eventExecution.getExecutionId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithMessage.getId());
@@ -2497,18 +3201,26 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithMessage.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithMessage.getId());
             }
         }
         assertProcessEnded(processInstance.getId());
@@ -2516,170 +3228,206 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateNonInterruptingEventSubProcessToNonInterruptingEventSubProcessOfDifferentEventType() {
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
-        ProcessDefinition procWithMessage = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procWithMessage = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignal.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("eventSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "signal", "eventSignal"));
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "theStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask")
-            );
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "theStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask")
+                );
 
         //Migrate only with autoMapping
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithMessage.getId());
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procWithMessage.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm migration
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "theStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask")
-            );
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "theStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask")
+                );
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithMessage.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event
-        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage").singleResult();
+        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage")
+                .singleResult();
         runtimeService.messageEventReceived("someMessage", eventExecution.getExecutionId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithMessage.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "theStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "theStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask"),
 
-                // After message trigger
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("startEvent", "eventSubProcessStart"),
-                tuple("sequenceFlow", "subProcessFlow1"),
-                tuple("userTask", "eventSubProcessTask")
-            );
-
+                        // After message trigger
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("startEvent", "eventSubProcessStart"),
+                        tuple("sequenceFlow", "subProcessFlow1"),
+                        tuple("userTask", "eventSubProcessTask")
+                );
 
         //Trigger the event again
         eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage").singleResult();
         runtimeService.messageEventReceived("someMessage", eventExecution.getExecutionId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart",
+                        "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithMessage.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
-            .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
-            .containsExactlyInAnyOrder(
-                tuple("startEvent", "theStart"),
-                tuple("sequenceFlow", "flow1"),
-                tuple("userTask", "processTask"),
+                .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
+                .containsExactlyInAnyOrder(
+                        tuple("startEvent", "theStart"),
+                        tuple("sequenceFlow", "flow1"),
+                        tuple("userTask", "processTask"),
 
-                // After message trigger
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("startEvent", "eventSubProcessStart"),
-                tuple("sequenceFlow", "subProcessFlow1"),
-                tuple("userTask", "eventSubProcessTask"),
+                        // After message trigger
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("startEvent", "eventSubProcessStart"),
+                        tuple("sequenceFlow", "subProcessFlow1"),
+                        tuple("userTask", "eventSubProcessTask"),
 
-                // After message second trigger
-                tuple("eventSubProcess", "eventSubProcess"),
-                tuple("startEvent", "eventSubProcessStart"),
-                tuple("sequenceFlow", "subProcessFlow1"),
-                tuple("userTask", "eventSubProcessTask")
-            );
+                        // After message second trigger
+                        tuple("eventSubProcess", "eventSubProcess"),
+                        tuple("startEvent", "eventSubProcessStart"),
+                        tuple("sequenceFlow", "subProcessFlow1"),
+                        tuple("userTask", "eventSubProcessTask")
+                );
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithMessage.getId());
 
             assertThat(historyService.createHistoricActivityInstanceQuery().list())
-                .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
-                .containsExactlyInAnyOrder(
-                    tuple("startEvent", "theStart"),
-                    tuple("sequenceFlow", "flow1"),
-                    tuple("userTask", "processTask"),
+                    .extracting(HistoricActivityInstance::getActivityType, HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder(
+                            tuple("startEvent", "theStart"),
+                            tuple("sequenceFlow", "flow1"),
+                            tuple("userTask", "processTask"),
 
-                    // After message trigger
-                    tuple("eventSubProcess", "eventSubProcess"),
-                    tuple("startEvent", "eventSubProcessStart"),
-                    tuple("sequenceFlow", "subProcessFlow1"),
-                    tuple("userTask", "eventSubProcessTask"),
+                            // After message trigger
+                            tuple("eventSubProcess", "eventSubProcess"),
+                            tuple("startEvent", "eventSubProcessStart"),
+                            tuple("sequenceFlow", "subProcessFlow1"),
+                            tuple("userTask", "eventSubProcessTask"),
 
-                    // After message second trigger
-                    tuple("eventSubProcess", "eventSubProcess"),
-                    tuple("startEvent", "eventSubProcessStart"),
-                    tuple("sequenceFlow", "subProcessFlow1"),
-                    tuple("userTask", "eventSubProcessTask"),
+                            // After message second trigger
+                            tuple("eventSubProcess", "eventSubProcess"),
+                            tuple("startEvent", "eventSubProcessStart"),
+                            tuple("sequenceFlow", "subProcessFlow1"),
+                            tuple("userTask", "eventSubProcessTask"),
 
-                    // After tasks completion
+                            // After tasks completion
 
-                    tuple("sequenceFlow", "flow2"),
-                    tuple("endEvent", "theEnd"),
-                    tuple("sequenceFlow", "subProcessFlow2"),
-                    tuple("endEvent", "eventSubProcessEnd"),
-                    tuple("sequenceFlow", "subProcessFlow2"),
-                    tuple("endEvent", "eventSubProcessEnd")
-                );
+                            tuple("sequenceFlow", "flow2"),
+                            tuple("endEvent", "theEnd"),
+                            tuple("sequenceFlow", "subProcessFlow2"),
+                            tuple("endEvent", "eventSubProcessEnd"),
+                            tuple("sequenceFlow", "subProcessFlow2"),
+                            tuple("endEvent", "eventSubProcessEnd")
+                    );
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithMessage.getId());
             }
         }
         assertProcessEnded(processInstance.getId());
@@ -2687,92 +3435,129 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateInterruptingEventSubProcessToNonInterruptingEventSubProcessOfDifferentEventType() {
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
-        ProcessDefinition procWithMessage = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procWithMessage = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignal.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("eventSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "signal", "eventSignal"));
 
         //Migrate only with autoMapping
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithMessage.getId());
+                .migrateToProcessDefinition(procWithMessage.getId());
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm migration
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithMessage.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event
-        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage").singleResult();
+        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage")
+                .singleResult();
         runtimeService.messageEventReceived("someMessage", eventExecution.getExecutionId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithMessage.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event again
         eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage").singleResult();
         runtimeService.messageEventReceived("someMessage", eventExecution.getExecutionId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart", "eventSubProcessTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcess", "eventSubProcess", "eventSubProcessTask", "eventSubProcessStart",
+                        "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procWithMessage.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithMessage.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("processTask", "eventSubProcessTask", "eventSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithMessage.getId());
             }
         }
         assertProcessEnded(processInstance.getId());
@@ -2780,53 +3565,69 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateNonInterruptingEventSubProcessToInterruptingEventSubProcessOfDifferentEventType() {
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
-        ProcessDefinition procWithMessage = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procWithMessage = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-message-event-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignal.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("eventSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "signal", "eventSignal"));
 
         //Migrate only with autoMapping
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithMessage.getId());
+                .migrateToProcessDefinition(procWithMessage.getId());
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm migration
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).size().isEqualTo(2);
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions).hasSize(2);
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithMessage.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("someMessage");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "message", "someMessage"));
 
         //Trigger the event
-        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage").singleResult();
+        EventSubscription eventExecution = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).eventName("someMessage")
+                .singleResult();
         runtimeService.messageEventReceived("someMessage", eventExecution.getExecutionId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithMessage.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("eventSubProcess", "eventSubProcessTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithMessage.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithMessage.getId());
@@ -2838,18 +3639,26 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procWithMessage.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procWithMessage.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("processTask", "eventSubProcessTask");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procWithMessage.getId());
             }
         }
         assertProcessEnded(processInstance.getId());
@@ -2857,41 +3666,52 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
 
     @Test
     public void testMigrateProcessActivityWithActiveEventSubProcessStart() {
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignal.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("eventSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "signal", "eventSignal"));
 
         changeStateEventListener.clear();
 
         //Migrate only the user task
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            //This is still a "valid" migration of the Event SubProcess Start execution, doing it along with the task activity execution that requires migration, but is not a "direct" migration of the task
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(Arrays.asList("processTask", "eventSubProcessStart"), "userTask1Id"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                //This is still a "valid" migration of the Event SubProcess Start execution, doing it along with the task activity execution that requires migration, but is not a "direct" migration of the task
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(Arrays.asList("processTask", "eventSubProcessStart"), "userTask1Id"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -2902,24 +3722,32 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("processTask", "userTask1Id");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("processTask", "userTask1Id");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procDefOneTask.getId());
 
             List<HistoricActivityInstance> eventSubProcExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("eventSubProcess")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("eventSubProcess")
+                    .list();
             assertThat(eventSubProcExecution).isEmpty();
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "userTask1Id");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("processTask", "userTask1Id");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procDefOneTask.getId());
             }
         }
         assertProcessEnded(processInstance.getId());
@@ -2928,37 +3756,47 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
     @Test
     @Disabled("Will work when manual and auto-cancelling of activities is implemented. To cancel SubProcessStartEvent when there's no counter-part in the new definition and allow direct migration og processTask")
     public void testMigrateProcessActivityWithActiveEventSubProcessStartUsingCancel() {
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/interrupting-signal-event-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignal.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("processTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("eventSubProcessStart");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventName).containsExactly("eventSignal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType, EventSubscription::getEventName)
+                .containsExactly(tuple("eventSubProcessStart", "signal", "eventSignal"));
 
         changeStateEventListener.clear();
 
         //Migrate only the user task
         processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "userTask1Id"))
-            //.deleteActivityExcution("eventSubProcessStart")
-            .migrate(processInstance.getId());
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "userTask1Id"))
+                //.deleteActivityExcution("eventSubProcessStart")
+                .migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationGatewaysTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationGatewaysTest.java
@@ -14,6 +14,8 @@
 package org.flowable.engine.test.api.runtime.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,32 +51,42 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
     //-- Exclusive Gateway
     @Test
     public void testMigrateActivityToExclusiveGatewayStartWithDefaultFlow() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithExcGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw"));
+                .migrateToProcessDefinition(procWithExcGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("defaultFlowTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("defaultFlowTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("defaultFlowTask");
 
@@ -98,35 +110,45 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToExclusiveGatewayStartWithConditionSpecifiedBeforeMigration() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         runtimeService.setVariable(executions.get(0).getId(), "input", 1);
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithExcGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw"));
+                .migrateToProcessDefinition(procWithExcGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("theTask1");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("theTask1");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("theTask1");
 
@@ -144,36 +166,46 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToExclusiveGatewayStartWithConditionSpecifiedDuringMigration() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithExcGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw").withLocalVariable("input", Integer.valueOf(1)));
+                .migrateToProcessDefinition(procWithExcGtw.getId())
+                .addActivityMigrationMapping(
+                        ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw").withLocalVariable("input", Integer.valueOf(1)));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("theTask1");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("theTask1");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("theTask1");
-
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -199,34 +231,44 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToExclusiveGatewayStartWithConditionSpecifiedAsProcessVariableDuringMigration() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithExcGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw"))
-            .withProcessInstanceVariable("input", 1);
+                .migrateToProcessDefinition(procWithExcGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw"))
+                .withProcessInstanceVariable("input", 1);
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("theTask1");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("theTask1");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("theTask1");
 
@@ -254,33 +296,43 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToActivityInsideExclusiveGateway() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithExcGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "theTask2"));
+                .migrateToProcessDefinition(procWithExcGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "theTask2"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("theTask2");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("theTask2");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("theTask2");
 
@@ -289,9 +341,9 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
             checkActivityInstances(procWithExcGtw, processInstance, "userTask", "theTask2");
 
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("exclusiveGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("exclusiveGateway")
+                    .list();
             assertThat(gtwExecution).isEmpty();
 
             checkTaskInstance(procWithExcGtw, processInstance, "theTask2");
@@ -305,9 +357,9 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
             checkActivityInstances(procWithExcGtw, processInstance, "userTask", "theTask2");
 
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("exclusiveGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("exclusiveGateway")
+                    .list();
             assertThat(gtwExecution).isEmpty();
 
             checkTaskInstance(procWithExcGtw, processInstance, "theTask2");
@@ -318,8 +370,10 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityInsideExclusiveGatewayToActivityOutside() {
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance without timer
         Map<String, Object> gtwCondition = Collections.singletonMap("input", Integer.valueOf(2));
@@ -327,25 +381,33 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("theTask2");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithExcGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("theTask2");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithExcGtw.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("theTask2");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithExcGtw.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("theTask2", procWithExcGtw.getId());
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("theTask2", "userTask1Id"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("theTask2", "userTask1Id"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
 
@@ -373,33 +435,43 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToExclusiveGatewayStartInsideEmbeddedSubProcessDefaultFlow() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence-inside-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence-inside-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithExcGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw"));
+                .migrateToProcessDefinition(procWithExcGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("theSubProcess", "defaultFlowTask");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("theSubProcess", "defaultFlowTask");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("defaultFlowTask");
 
@@ -429,33 +501,44 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToExclusiveGatewayStartInsideEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence-inside-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence-inside-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithExcGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw").withLocalVariables(Collections.singletonMap("input", Integer.valueOf(1))));
+                .migrateToProcessDefinition(procWithExcGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "exclusiveGw")
+                        .withLocalVariables(Collections.singletonMap("input", Integer.valueOf(1))));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("theSubProcess", "theTask1");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("theSubProcess", "theTask1");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("theTask1");
 
@@ -485,33 +568,43 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToActivityInsideExclusiveGatewayInsideEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence-inside-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithExcGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/exclusive-gateway-with-default-sequence-inside-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithExcGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "theTask2"));
+                .migrateToProcessDefinition(procWithExcGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "theTask2"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("theSubProcess", "theTask2");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("theSubProcess", "theTask2");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("theTask2");
 
@@ -520,9 +613,9 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
             checkActivityInstances(procWithExcGtw, processInstance, "userTask", "theTask2");
             checkActivityInstances(procWithExcGtw, processInstance, "subProcess", "theSubProcess");
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("exclusiveGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("exclusiveGateway")
+                    .list();
             assertThat(gtwExecution).isEmpty();
 
             checkTaskInstance(procWithExcGtw, processInstance, "theTask2");
@@ -536,9 +629,9 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
             checkActivityInstances(procWithExcGtw, processInstance, "userTask", "theTask2", "afterSubProcessTask");
             checkActivityInstances(procWithExcGtw, processInstance, "subProcess", "theSubProcess");
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("exclusiveGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("exclusiveGateway")
+                    .list();
             assertThat(gtwExecution).isEmpty();
 
             checkTaskInstance(procWithExcGtw, processInstance, "theTask2", "afterSubProcessTask");
@@ -550,37 +643,53 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
     //-- Parallel Gateway
     @Test
     public void testMigrateActivityToParallelGatewayFork() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-gateway-two-splits-four-tasks.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-gateway-two-splits-four-tasks.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate each of the parallel task to a task in the parallel gateway
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "parallelFork"));
+                .migrateToProcessDefinition(procParallelGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "parallelFork"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask2");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask2");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelGtw.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask2");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask2");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelGtw.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -595,7 +704,8 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
-            checkActivityInstances(procParallelGtw, processInstance, "userTask", "userTask1Id", "oddFlowTask1", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
+            checkActivityInstances(procParallelGtw, processInstance, "userTask", "userTask1Id", "oddFlowTask1", "oddFlowTask3", "evenFlowTask2",
+                    "evenFlowTask4", "taskAfter");
             checkActivityInstances(procParallelGtw, processInstance, "parallelGateway", "parallelFork", "parallelJoin", "parallelJoin");
 
             checkTaskInstance(procParallelGtw, processInstance, "userTask1Id", "oddFlowTask1", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
@@ -606,8 +716,10 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateParallelActivitiesToParallelGatewayActivities() {
-        ProcessDefinition procParallelTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-gateway-two-splits-four-tasks.bpmn20.xml");
+        ProcessDefinition procParallelTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-gateway-two-splits-four-tasks.bpmn20.xml");
 
         //Start the processInstance and spawn the parallel task
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procParallelTask.getId());
@@ -618,57 +730,86 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks).
+                extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelTask.getId());
 
         //Migrate each of the parallel task to a task in the parallel gateway
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "oddFlowTask1"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "evenFlowTask4"));
+                .migrateToProcessDefinition(procParallelGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "oddFlowTask1"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "evenFlowTask4"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask4");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask4");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelGtw.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask4");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask4");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelGtw.getId());
 
         //Complete the process
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> subProcesses = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
             //Direct Migration
-            assertThat(subProcesses).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("oddFlowTask1", "oddFlowTask3", "evenFlowTask4", "taskAfter");
-            assertThat(subProcesses).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+            assertThat(subProcesses)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("oddFlowTask1", "oddFlowTask3", "evenFlowTask4", "taskAfter");
+            assertThat(subProcesses)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelGtw.getId());
 
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("parallelGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("parallelGateway")
+                    .list();
             //Two flows to join in, fork was not executed
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("parallelJoin", "parallelJoin");
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("parallelJoin", "parallelJoin");
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelGtw.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("oddFlowTask1", "oddFlowTask3", "evenFlowTask4", "taskAfter");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("oddFlowTask1", "oddFlowTask3", "evenFlowTask4", "taskAfter");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procParallelGtw.getId());
             }
         }
 
@@ -677,63 +818,91 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToParallelGatewayActivities() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-gateway-two-splits-four-tasks.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-gateway-two-splits-four-tasks.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate each of the parallel task to a task in the parallel gateway
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("oddFlowTask3", "evenFlowTask2")));
+                .migrateToProcessDefinition(procParallelGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("oddFlowTask3", "evenFlowTask2")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("oddFlowTask3", "evenFlowTask2");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("oddFlowTask3", "evenFlowTask2");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelGtw.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("oddFlowTask3", "evenFlowTask2");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("oddFlowTask3", "evenFlowTask2");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelGtw.getId());
 
         //Complete the process
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> subProcesses = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(subProcesses).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("userTask1Id", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
-            assertThat(subProcesses).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(subProcesses)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("userTask1Id", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
+            assertThat(subProcesses)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelGtw.getId());
 
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("parallelGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("parallelGateway")
+                    .list();
             //Two flows to join in, fork was not executed
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("parallelJoin", "parallelJoin");
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("parallelJoin", "parallelJoin");
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelGtw.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("userTask1Id", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("userTask1Id", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procParallelGtw.getId());
             }
         }
 
@@ -742,79 +911,113 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToParallelGatewayActivitiesIncompleteActivityMapping() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-gateway-three-splits.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-gateway-three-splits.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate each of the parallel task to a task in the parallel gateway
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("task1", "task3")));
+                .migrateToProcessDefinition(procParallelGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("task1", "task3")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("task1", "task3");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("task1", "task3");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelGtw.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("task1", "task3");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("task1", "task3");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelGtw.getId());
 
         //Try to complete the process
         completeProcessInstanceTasks(processInstance.getId());
 
         //Parallel Gateway join is not satisfied since there is a missing sequence flow
         List<Execution> parallelJoinExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(parallelJoinExecutions).extracting(Execution::getActivityId).containsOnly("parallelJoin");
+        assertThat(parallelJoinExecutions)
+                .extracting(Execution::getActivityId)
+                .containsOnly("parallelJoin");
     }
 
     @Test
     public void testMigrateActivityToParallelGatewayForkInsideEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-gateway-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-gateway-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate each of the parallel task to a task in the parallel gateway
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "parallelFork"));
+                .migrateToProcessDefinition(procParallelGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "parallelFork"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "oddFlowTask1", "evenFlowTask2");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "oddFlowTask1", "evenFlowTask2");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelGtw.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask2");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask2");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelGtw.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -830,31 +1033,41 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
-            checkActivityInstances(procParallelGtw, processInstance, "userTask", "userTask1Id", "oddFlowTask1", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
+            checkActivityInstances(procParallelGtw, processInstance, "userTask", "userTask1Id", "oddFlowTask1", "oddFlowTask3", "evenFlowTask2",
+                    "evenFlowTask4", "taskAfter");
             checkActivityInstances(procParallelGtw, processInstance, "subProcess", "subProcess");
             checkActivityInstances(procParallelGtw, processInstance, "parallelGateway", "parallelFork", "parallelJoin", "parallelJoin");
 
             List<HistoricActivityInstance> subProcExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("subProcess")
-                .list();
-            assertThat(subProcExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("subProcess");
-            assertThat(subProcExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("subProcess")
+                    .list();
+            assertThat(subProcExecution)
+                    .extracting(HistoricActivityInstance::getActivityId, HistoricActivityInstance::getProcessDefinitionId)
+                    .containsExactly(tuple("subProcess", procParallelGtw.getId()));
 
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("parallelGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("parallelGateway")
+                    .list();
             //Two flows to join in
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("parallelFork", "parallelJoin", "parallelJoin");
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("parallelFork", "parallelJoin", "parallelJoin");
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelGtw.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("userTask1Id", "oddFlowTask1", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("userTask1Id", "oddFlowTask1", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procParallelGtw.getId());
             }
         }
 
@@ -863,8 +1076,10 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateParallelActivitiesToParallelGatewayActivitiesInsideEmbeddedSubProcess() {
-        ProcessDefinition procParallelTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-gateway-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procParallelTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-gateway-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance and spawn the parallel task
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procParallelTask.getId());
@@ -875,30 +1090,47 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelTask.getId());
 
         //Migrate each of the parallel task to a task in the parallel gateway
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "oddFlowTask1"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "evenFlowTask4"));
+                .migrateToProcessDefinition(procParallelGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "oddFlowTask1"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "evenFlowTask4"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "oddFlowTask1", "evenFlowTask4");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "oddFlowTask1", "evenFlowTask4");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelGtw.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask4");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("oddFlowTask1", "evenFlowTask4");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelGtw.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procParallelGtw, processInstance, "userTask", "oddFlowTask1", "evenFlowTask4");
@@ -918,26 +1150,35 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
             checkTaskInstance(procParallelGtw, processInstance, "oddFlowTask1", "oddFlowTask3", "evenFlowTask4", "taskAfter");
 
             List<HistoricActivityInstance> subProcExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("subProcess")
-                .list();
-            assertThat(subProcExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("subProcess");
-            assertThat(subProcExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("subProcess")
+                    .list();
+            assertThat(subProcExecution)
+                    .extracting(HistoricActivityInstance::getActivityId, HistoricActivityInstance::getProcessDefinitionId)
+                    .containsExactly(tuple("subProcess", procParallelGtw.getId()));
 
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("parallelGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("parallelGateway")
+                    .list();
             //Two flows to join in, fork was not executed
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("parallelJoin", "parallelJoin");
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("parallelJoin", "parallelJoin");
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelGtw.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("oddFlowTask1", "oddFlowTask3", "evenFlowTask4", "taskAfter");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("oddFlowTask1", "oddFlowTask3", "evenFlowTask4", "taskAfter");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procParallelGtw.getId());
             }
         }
 
@@ -946,37 +1187,53 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToParallelGatewayActivitiesInsideEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-gateway-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-gateway-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         //Migrate each of the parallel task to a task in the parallel gateway
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("oddFlowTask3", "evenFlowTask2")));
+                .migrateToProcessDefinition(procParallelGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("oddFlowTask3", "evenFlowTask2")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "oddFlowTask3", "evenFlowTask2");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "oddFlowTask3", "evenFlowTask2");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelGtw.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("oddFlowTask3", "evenFlowTask2");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("oddFlowTask3", "evenFlowTask2");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelGtw.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procParallelGtw, processInstance, "userTask", "userTask1Id", "evenFlowTask2", "oddFlowTask3");
@@ -994,26 +1251,38 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
             checkActivityInstances(procParallelGtw, processInstance, "parallelGateway", "parallelJoin", "parallelJoin");
 
             List<HistoricActivityInstance> subProcExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("subProcess")
-                .list();
-            assertThat(subProcExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("subProcess");
-            assertThat(subProcExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("subProcess")
+                    .list();
+            assertThat(subProcExecution)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactly("subProcess");
+            assertThat(subProcExecution)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelGtw.getId());
 
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("parallelGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("parallelGateway")
+                    .list();
             //Two flows to join in, fork was not executed
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("parallelJoin", "parallelJoin");
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("parallelJoin", "parallelJoin");
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelGtw.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("userTask1Id", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procParallelGtw.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("userTask1Id", "oddFlowTask3", "evenFlowTask2", "evenFlowTask4", "taskAfter");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procParallelGtw.getId());
             }
         }
 
@@ -1023,47 +1292,67 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
     //-- Inclusive Gateway
     @Test
     public void testMigrateActivityToInclusiveGatewaySplitWithDefault() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("taskEquals");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("taskEquals");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskEquals");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("taskEquals", procInclusiveGtw.getId()));
 
         //Complete gateway tasks
         tasks.forEach(this::completeTask);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
         assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1071,7 +1360,6 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
             checkTaskInstance(procInclusiveGtw, processInstance, "userTask1Id", "taskEquals", "taskAfter");
         }
-
 
         completeProcessInstanceTasks(processInstance.getId());
 
@@ -1088,81 +1376,108 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToInclusiveGatewaySplitNoOutgoingSequenceSelectionException() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
-        try {
+        assertThatThrownBy(() -> {
             ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-                .migrateToProcessDefinition(procInclusiveGtw.getId())
-                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")).withLocalVariableForAllActivities("myConditionVar", 10));
+                    .migrateToProcessDefinition(procInclusiveGtw.getId())
+                    .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork"))
+                            .withLocalVariableForAllActivities("myConditionVar", 10));
 
-            ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+            ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                    .validateMigration(processInstance.getId());
             assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
             processInstanceMigrationBuilder.migrate(processInstance.getId());
-
-            fail("No outgoing sequence for the inclusive gateway could've been selected");
-        } catch (FlowableException e) {
-            assertTextPresent("No outgoing sequence flow of element 'gwFork' could be selected for continuing the process", e.getMessage());
-        }
+        })
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessage("No outgoing sequence flow of element 'gwFork' could be selected for continuing the process");
     }
 
     @Test
     public void testMigrateActivityToInclusiveGatewaySplitWithConditionSpecifiedBeforeMigration() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procDefOneTask.getId());
 
         runtimeService.setVariable(executions.get(0).getId(), "myConditionVar", 11);
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("taskMore");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("taskMore");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskMore");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskMore", procInclusiveGtw.getId()));
 
         //Complete gateway tasks
         tasks.forEach(this::completeTask);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procInclusiveGtw, processInstance, "userTask", "userTask1Id", "taskMore", "taskAfter");
@@ -1188,47 +1503,68 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToInclusiveGatewaySplitWithConditionSpecifiedDuringMigration() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")).withLocalVariableForAllActivities("myConditionVar", 11));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork"))
+                        .withLocalVariableForAllActivities("myConditionVar", 11));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("taskMore");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("taskMore");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskMore");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskMore", procInclusiveGtw.getId()));
 
         //Complete gateway tasks
         tasks.forEach(this::completeTask);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1255,48 +1591,66 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToInclusiveGatewaySplitWithConditionSpecifiedAsProcessVariableDuringMigration() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")))
-            .withProcessInstanceVariable("myConditionVar", 11);
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")))
+                .withProcessInstanceVariable("myConditionVar", 11);
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("taskMore");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("taskMore");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskMore");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskMore", procInclusiveGtw.getId()));
 
         //Complete gateway tasks
         tasks.forEach(this::completeTask);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1322,47 +1676,71 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToOneActivityInsideInclusiveGateway() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("taskLess")));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("taskLess")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskLess", procInclusiveGtw.getId()));
 
         //Complete the task
         completeTask(tasks.get(0));
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskAfter");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1387,59 +1765,85 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToParallelActivitiesInsideInclusiveGateway() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("taskMore", "taskLess")));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("taskMore", "taskLess")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("taskMore", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("taskMore", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskMore", "taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("taskMore", "taskLess");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procInclusiveGtw.getId());
 
         //Complete one sequence
         task = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("taskMore")).findFirst().get();
         completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("gwJoin", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("gwJoin", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskLess", procInclusiveGtw.getId()));
 
         //Complete the rest
         tasks.forEach(this::completeTask);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1464,8 +1868,10 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateParallelActivitiesToParallelActivitiesInsideInclusiveGateway() {
-        ProcessDefinition procParallelTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-multiple-outgoing-sequences.bpmn20.xml");
+        ProcessDefinition procParallelTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/timer-parallel-task.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-multiple-outgoing-sequences.bpmn20.xml");
 
         //Start the processInstance
         //Start the processInstance and spawn the parallel task
@@ -1477,53 +1883,80 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("timerBound", "processTask", "parallelTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelTask.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("processTask", "parallelTask");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("processTask", "parallelTask");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelTask.getId());
 
         //Migrate each of the parallel task to a task in the parallel gateway
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "taskMore"))
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "taskLess"));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("processTask", "taskMore"))
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTask", "taskLess"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("taskMore", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("taskMore", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskMore", "taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("taskMore", "taskLess");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procInclusiveGtw.getId());
 
         //Complete one sequence
         Task task = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("taskMore")).findFirst().get();
         completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("gwJoin", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("gwJoin", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskLess", procInclusiveGtw.getId()));
 
         //Complete the rest
         tasks.forEach(this::completeTask);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1546,8 +1979,10 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateInclusiveGatewayParallelActivitiesToSingleActivity() {
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-multiple-outgoing-sequences.bpmn20.xml");
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-multiple-outgoing-sequences.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procInclusiveGtw.getId(), Collections.singletonMap("myConditionVar", 10));
@@ -1555,28 +1990,48 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("taskMore", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("taskMore", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskMore", "taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("taskMore", "taskLess");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procInclusiveGtw.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(Arrays.asList("taskMore", "taskLess"), "userTask1Id"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(Arrays.asList("taskMore", "taskLess"), "userTask1Id"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("userTask1Id");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("userTask1Id");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("userTask1Id", procDefOneTask.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1601,47 +2056,65 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToInclusiveGatewaySplitWithDefaultInsideEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("gwFork")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "taskEquals");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "taskEquals");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskEquals");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskEquals", procInclusiveGtw.getId()));
 
         //Complete gateway tasks
         tasks.forEach(this::completeTask);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1668,47 +2141,65 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToOneActivityInsideInclusiveGatewayInsideEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("taskLess")));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("taskLess")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskLess", procInclusiveGtw.getId()));
 
         //Complete the task
         completeTask(tasks.get(0));
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1719,14 +2210,18 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
             checkTaskInstance(procInclusiveGtw, processInstance, "taskAfter", "taskLess");
 
             List<HistoricActivityInstance> gtwExecution = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("inclusiveGateway")
-                .list();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("inclusiveGateway")
+                    .list();
             //Join gateway only
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("gwJoin");
-            assertThat(gtwExecution).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactly("gwJoin");
+            assertThat(gtwExecution)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procInclusiveGtw.getId());
         }
-      
+
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -1743,59 +2238,85 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
     @Test
     public void testMigrateActivityToParallelActivitiesInsideInclusiveGatewayInsideEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default-nested-in-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-and-join-with-default-nested-in-embedded-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procInclusiveGtw.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("taskMore", "taskLess")));
+                .migrateToProcessDefinition(procInclusiveGtw.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", Arrays.asList("taskMore", "taskLess")));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "taskMore", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "taskMore", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskMore", "taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("taskMore", "taskLess");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procInclusiveGtw.getId());
 
         //Complete one sequence
         task = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("taskMore")).findFirst().get();
         completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "gwJoin", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "gwJoin", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskLess", procInclusiveGtw.getId()));
 
         //Complete the rest
         tasks.forEach(this::completeTask);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("taskAfter");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("taskAfter");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("taskAfter");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("taskAfter", procInclusiveGtw.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
@@ -1823,9 +2344,9 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
     @Test
     public void testMigrateInclusiveGatewayParallelActivitiesInsideEmbeddedSubProcessToSingleActivity() {
         ProcessDefinition procInclusiveGtw = deployProcessDefinition("my deploy",
-            "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-multiple-outgoing-sequences-nested-in-embedded-subprocess.bpmn20.xml");
+                "org/flowable/engine/test/api/runtime/migration/inclusive-gateway-fork-multiple-outgoing-sequences-nested-in-embedded-subprocess.bpmn20.xml");
         ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
-            "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procInclusiveGtw.getId(), Collections.singletonMap("myConditionVar", 10));
@@ -1833,28 +2354,42 @@ public class ProcessInstanceMigrationGatewaysTest extends AbstractProcessInstanc
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "taskMore", "taskLess");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procInclusiveGtw.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "taskMore", "taskLess");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procInclusiveGtw.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("taskMore", "taskLess");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procInclusiveGtw.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("taskMore", "taskLess");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procInclusiveGtw.getId());
 
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(Arrays.asList("taskMore", "taskLess"), "userTask1Id"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(Arrays.asList("taskMore", "taskLess"), "userTask1Id"));
 
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("userTask1Id");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procDefOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("userTask1Id", procDefOneTask.getId()));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationMultiInstanceTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.api.runtime.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,41 +51,54 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateActivityToSequentialMultiInstanceActivity() {
-        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-task.bpmn20.xml");
+        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-task.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procSimpleOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSimpleOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSimpleOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSimpleOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procSimpleOneTask.getId());
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procSequentialMultiInst.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "seqTasks"))
-            .withProcessInstanceVariable("nrOfLoops", 3);
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procSequentialMultiInst.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "seqTasks"))
+                .withProcessInstanceVariable("nrOfLoops", 3);
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI root execution and 1 instance
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("seqTasks", "seqTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 3);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("seqTasks");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("seqTasks", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
 
         //Complete one instance...
@@ -92,16 +106,21 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Next instance in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("seqTasks", "seqTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 1, 3);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("seqTasks");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("seqTasks", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         //Complete this and the last
@@ -111,17 +130,22 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Out of the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("afterMultiInstance");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
-        assertFalse(executions.stream().anyMatch(e -> ((ExecutionEntity) e).isMultiInstanceRoot()));
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("afterMultiInstance");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions.stream().anyMatch(e -> ((ExecutionEntity) e).isMultiInstanceRoot())).isFalse();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("afterMultiInstance");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("afterMultiInstance", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "userTask1Id", "seqTasks", "seqTasks", "seqTasks",
-                "afterMultiInstance");
+                    "afterMultiInstance");
 
             checkTaskInstance(procSequentialMultiInst, processInstance, "userTask1Id", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
         }
@@ -129,7 +153,8 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "userTask1Id", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
+            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "userTask1Id", "seqTasks", "seqTasks", "seqTasks",
+                    "afterMultiInstance");
 
             checkTaskInstance(procSequentialMultiInst, processInstance, "userTask1Id", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
         }
@@ -139,41 +164,54 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateActivityToParallelMultiInstanceActivity() {
-        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-task.bpmn20.xml");
+        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-task.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procSimpleOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSimpleOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSimpleOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSimpleOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procSimpleOneTask.getId());
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelMultiInst.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "parallelTasks"))
-            .withProcessInstanceVariable("nrOfLoops", 3);
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procParallelMultiInst.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "parallelTasks"))
+                .withProcessInstanceVariable("nrOfLoops", 3);
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI root execution and 3 parallel instances
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(3);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(3, 0, 3);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("parallelTasks", "parallelTasks", "parallelTasks");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procSimpleOneTask.getId());
         assertThat(tasks).extracting(aTask -> taskService.getVariable(aTask.getId(), "loopCounter")).isNotNull();
 
         //Complete one instance...
@@ -182,19 +220,28 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Next instance in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI Root and its 3 parallel instances
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(2);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(2, 1, 3);
+
         //Two executions are inactive, the completed instance and the MI root
         assertThat(executions).haveExactly(2, new Condition<>((Execution execution) -> !((ExecutionEntity) execution).isActive(), "inactive"));
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         //Two tasks remain for completion
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("parallelTasks", "parallelTasks");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("parallelTasks", "parallelTasks");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelMultiInst.getId());
         assertThat(tasks).extracting(aTask -> taskService.getVariable(aTask.getId(), "loopCounter")).isNotNull();
 
         //Complete the remaining parallel tasks
@@ -202,16 +249,22 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Out of the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("afterMultiInstance");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
-        assertFalse(executions.stream().anyMatch(e -> ((ExecutionEntity) e).isMultiInstanceRoot()));
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("afterMultiInstance");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
+        assertThat(executions.stream().anyMatch(e -> ((ExecutionEntity) e).isMultiInstanceRoot())).isFalse();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("afterMultiInstance");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procParallelMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("afterMultiInstance", procParallelMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "userTask1Id", "parallelTasks", "parallelTasks", "parallelTasks", "afterMultiInstance");
+            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "userTask1Id", "parallelTasks", "parallelTasks", "parallelTasks",
+                    "afterMultiInstance");
 
             checkTaskInstance(procParallelMultiInst, processInstance, "userTask1Id", "parallelTasks", "parallelTasks", "parallelTasks", "afterMultiInstance");
         }
@@ -219,7 +272,8 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "userTask1Id", "parallelTasks", "parallelTasks", "parallelTasks", "afterMultiInstance");
+            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "userTask1Id", "parallelTasks", "parallelTasks", "parallelTasks",
+                    "afterMultiInstance");
 
             checkTaskInstance(procParallelMultiInst, processInstance, "userTask1Id", "parallelTasks", "parallelTasks", "parallelTasks", "afterMultiInstance");
         }
@@ -229,8 +283,10 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateSequentialMultiInstanceActivityToSimpleActivity() {
-        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-task.bpmn20.xml");
-        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-task.bpmn20.xml");
+        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procSequentialMultiInst.getId(), Collections.singletonMap("nrOfLoops", 3));
@@ -239,17 +295,22 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MultiInstance parent and one instance of the task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("seqTasks", "seqTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 3);
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("seqTasks");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("seqTasks", procSequentialMultiInst.getId());
         Map<String, Object> miTaskVars = taskService.getVariables(task.getId());
         assertThat(miTaskVars).extracting("loopCounter").isEqualTo(0);
 
@@ -258,35 +319,46 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MultiInstance parent and one instance of the task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("seqTasks", "seqTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
 
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 1, 3);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("seqTasks");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("seqTasks", procSequentialMultiInst.getId());
         miTaskVars = taskService.getVariables(task.getId());
         assertThat(miTaskVars).extracting("loopCounter").isEqualTo(1);
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procSimpleOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("seqTasks", "userTask1Id"));
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procSimpleOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("seqTasks", "userTask1Id"));
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSimpleOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSimpleOneTask.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSimpleOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procSimpleOneTask.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -308,8 +380,10 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateParallelMultiInstanceActivityToSimpleActivity() {
-        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-task.bpmn20.xml");
-        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-task.bpmn20.xml");
+        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         Condition<Execution> isInactiveExecution = new Condition<>(execution -> !((ExecutionEntity) execution).isActive(), "inactive execution");
         Consumer<Task> hasLoopCounter = task -> {
@@ -324,62 +398,79 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MultiInstance parent and its parallel instances
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
         //Parallel MI root execution is inactive
         assertThat(executions).haveExactly(1, isInactiveExecution);
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting("processDefinitionId").
+                containsOnly(procParallelMultiInst.getId());
 
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(3);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(3, 0, 3);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(3);
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("parallelTasks");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("parallelTasks", procParallelMultiInst.getId()));
         assertThat(tasks).allSatisfy(hasLoopCounter);
 
         //Complete one...
         completeTask(tasks.get(0));
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
         //MultiInstance parent and one completed/inactive execution
         assertThat(executions).haveExactly(2, isInactiveExecution);
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
 
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(2);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(2, 1, 3);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("parallelTasks");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("parallelTasks", procParallelMultiInst.getId()));
         assertThat(tasks).allSatisfy(hasLoopCounter);
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procSimpleOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTasks", "userTask1Id"));
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procSimpleOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTasks", "userTask1Id"));
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSimpleOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSimpleOneTask.getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("userTask1Id");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsExactlyInAnyOrder(procSimpleOneTask.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly(tuple("userTask1Id", procSimpleOneTask.getId()));
         assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSimpleOneTask, processInstance, "userTask", "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "userTask1Id");
+            checkActivityInstances(procSimpleOneTask, processInstance, "userTask", "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks",
+                    "userTask1Id");
 
             checkTaskInstance(procSimpleOneTask, processInstance, "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "userTask1Id");
         }
@@ -387,7 +478,8 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSimpleOneTask, processInstance, "userTask", "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "userTask1Id");
+            checkActivityInstances(procSimpleOneTask, processInstance, "userTask", "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks",
+                    "userTask1Id");
 
             checkTaskInstance(procSimpleOneTask, processInstance, "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "userTask1Id");
         }
@@ -397,8 +489,10 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateSequentialMultiInstanceActivityToParallelMultiInstanceActivity() {
-        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-task.bpmn20.xml");
-        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-task.bpmn20.xml");
+        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-task.bpmn20.xml");
+        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-task.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procSequentialMultiInst.getId(), Collections.singletonMap("nrOfLoops", 3));
@@ -407,17 +501,22 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MultiInstance parent and one instance of the task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("seqTasks", "seqTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 3);
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("seqTasks");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("seqTasks", procSequentialMultiInst.getId());
         Map<String, Object> miTaskVars = taskService.getVariables(task.getId());
         assertThat(miTaskVars).extracting("loopCounter").isEqualTo(0);
 
@@ -426,41 +525,55 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MultiInstance parent and one instance of the task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("seqTasks", "seqTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
 
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 1, 3);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("seqTasks");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("seqTasks", procSequentialMultiInst.getId());
         miTaskVars = taskService.getVariables(task.getId());
         assertThat(miTaskVars).extracting("loopCounter").isEqualTo(1);
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelMultiInst.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("seqTasks", "parallelTasks"));
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procParallelMultiInst.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("seqTasks", "parallelTasks"));
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI root execution and 3 parallel instances
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(3);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(3, 0, 3);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("parallelTasks", "parallelTasks", "parallelTasks");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelMultiInst.getId());
         assertThat(tasks).extracting(aTask -> taskService.getVariable(aTask.getId(), "loopCounter")).isNotNull();
 
         //Complete one instance...
@@ -469,19 +582,27 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Next instance in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI Root and its 3 parallel instances
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(2);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(2, 1, 3);
         //Two executions are inactive, the completed instance and the MI root
         assertThat(executions).haveExactly(2, new Condition<>((Execution execution) -> !((ExecutionEntity) execution).isActive(), "inactive"));
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         //Two tasks remain for completion
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactly("parallelTasks", "parallelTasks");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("parallelTasks", "parallelTasks");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelMultiInst.getId());
         assertThat(tasks).extracting(aTask -> taskService.getVariable(aTask.getId(), "loopCounter")).isNotNull();
 
         //Complete the remaining parallel tasks
@@ -489,26 +610,35 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Out of the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("afterMultiInstance");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
-        assertFalse(executions.stream().anyMatch(e -> ((ExecutionEntity) e).isMultiInstanceRoot()));
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("afterMultiInstance");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
+        assertThat(executions.stream().anyMatch(e -> ((ExecutionEntity) e).isMultiInstanceRoot())).isFalse();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("afterMultiInstance");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procParallelMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("afterMultiInstance", procParallelMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "beforeMultiInstance", "seqTasks", "seqTasks", "parallelTasks", "parallelTasks", "parallelTasks", "afterMultiInstance");
+            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "beforeMultiInstance", "seqTasks", "seqTasks", "parallelTasks",
+                    "parallelTasks", "parallelTasks", "afterMultiInstance");
 
-            checkTaskInstance(procParallelMultiInst, processInstance, "beforeMultiInstance", "seqTasks", "seqTasks", "parallelTasks", "parallelTasks", "parallelTasks", "afterMultiInstance");
+            checkTaskInstance(procParallelMultiInst, processInstance, "beforeMultiInstance", "seqTasks", "seqTasks", "parallelTasks", "parallelTasks",
+                    "parallelTasks", "afterMultiInstance");
         }
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "beforeMultiInstance", "seqTasks", "seqTasks", "parallelTasks", "parallelTasks", "parallelTasks", "afterMultiInstance");
+            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "beforeMultiInstance", "seqTasks", "seqTasks", "parallelTasks",
+                    "parallelTasks", "parallelTasks", "afterMultiInstance");
 
-            checkTaskInstance(procParallelMultiInst, processInstance, "beforeMultiInstance", "seqTasks", "seqTasks", "parallelTasks", "parallelTasks", "parallelTasks", "afterMultiInstance");
+            checkTaskInstance(procParallelMultiInst, processInstance, "beforeMultiInstance", "seqTasks", "seqTasks", "parallelTasks", "parallelTasks",
+                    "parallelTasks", "afterMultiInstance");
         }
 
         assertProcessEnded(processInstance.getId());
@@ -516,8 +646,10 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateParallelMultiInstanceActivityToSequentialMultiInstanceActivity() {
-        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-task.bpmn20.xml");
-        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-task.bpmn20.xml");
+        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-task.bpmn20.xml");
+        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-task.bpmn20.xml");
 
         Condition<Execution> isInactiveExecution = new Condition<>(execution -> !((ExecutionEntity) execution).isActive(), "inactive execution");
         Consumer<Task> hasLoopCounter = task -> {
@@ -532,64 +664,80 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MultiInstance parent and its parallel instances
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
         //Parallel MI root execution is inactive
         assertThat(executions).haveExactly(1, isInactiveExecution);
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
 
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(3);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(3, 0, 3);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(3);
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("parallelTasks");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("parallelTasks", procParallelMultiInst.getId()));
         assertThat(tasks).allSatisfy(hasLoopCounter);
 
         //Complete one...
         completeTask(tasks.get(0));
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
         //MultiInstance parent and one completed/inactive execution
         assertThat(executions).haveExactly(2, isInactiveExecution);
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
 
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(2);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(2, 1, 3);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("parallelTasks");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("parallelTasks", procParallelMultiInst.getId()));
         assertThat(tasks).allSatisfy(hasLoopCounter);
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procSequentialMultiInst.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTasks", "seqTasks"));
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procSequentialMultiInst.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelTasks", "seqTasks"));
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI root execution and 1 instance
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("seqTasks", "seqTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 3);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("seqTasks");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("seqTasks", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
 
         //Complete one instance...
@@ -597,16 +745,21 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Next instance in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("seqTasks", "seqTasks");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 1, 3);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("seqTasks");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("seqTasks", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         //Complete this and the last
@@ -616,26 +769,35 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Out of the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("afterMultiInstance");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
-        assertFalse(executions.stream().anyMatch(e -> ((ExecutionEntity) e).isMultiInstanceRoot()));
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("afterMultiInstance");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions.stream().anyMatch(e -> ((ExecutionEntity) e).isMultiInstanceRoot())).isFalse();
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("afterMultiInstance");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("afterMultiInstance", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
+            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "beforeMultiInstance", "parallelTasks", "parallelTasks",
+                    "parallelTasks", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
 
-            checkTaskInstance(procSequentialMultiInst, processInstance, "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
+            checkTaskInstance(procSequentialMultiInst, processInstance, "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "seqTasks",
+                    "seqTasks", "seqTasks", "afterMultiInstance");
         }
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
+            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "beforeMultiInstance", "parallelTasks", "parallelTasks",
+                    "parallelTasks", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
 
-            checkTaskInstance(procSequentialMultiInst, processInstance, "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "seqTasks", "seqTasks", "seqTasks", "afterMultiInstance");
+            checkTaskInstance(procSequentialMultiInst, processInstance, "beforeMultiInstance", "parallelTasks", "parallelTasks", "parallelTasks", "seqTasks",
+                    "seqTasks", "seqTasks", "afterMultiInstance");
         }
 
         assertProcessEnded(processInstance.getId());
@@ -643,41 +805,54 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateActivityToSequentialMultiInstanceSubProcess() {
-        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-subprocess.bpmn20.xml");
+        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procSimpleOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSimpleOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSimpleOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSimpleOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procSimpleOneTask.getId());
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procSequentialMultiInst.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "sequentialMISubProcess"))
-            .withProcessInstanceVariable("nrOfLoops", 3);
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procSequentialMultiInst.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "sequentialMISubProcess"))
+                .withProcessInstanceVariable("nrOfLoops", 3);
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI subProcess root execution, actual subProcess and 1 task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 3);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask1");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("subTask1", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
 
         //Complete tha task and the next in the subprocess
@@ -689,16 +864,21 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Should be in the next MI subProcess iteration
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI subprocess root execution, actual subprocess and 1 task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 1, 3);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask1");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("subTask1", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -711,9 +891,11 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "userTask1Id", "subTask1", "subTask2", "subTask1", "subTask2", "subTask1", "subTask2", "afterMultiInstance");
+            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "userTask1Id", "subTask1", "subTask2", "subTask1", "subTask2",
+                    "subTask1", "subTask2", "afterMultiInstance");
 
-            checkTaskInstance(procSequentialMultiInst, processInstance, "userTask1Id", "subTask1", "subTask2", "subTask1", "subTask2", "subTask1", "subTask2", "afterMultiInstance");
+            checkTaskInstance(procSequentialMultiInst, processInstance, "userTask1Id", "subTask1", "subTask2", "subTask1", "subTask2", "subTask1", "subTask2",
+                    "afterMultiInstance");
         }
 
         assertProcessEnded(processInstance.getId());
@@ -721,43 +903,59 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateActivityToParallelMultiInstanceSubProcess() {
-        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-subprocess.bpmn20.xml");
+        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procSimpleOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSimpleOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSimpleOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSimpleOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procSimpleOneTask.getId());
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelMultiInst.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "parallelMISubProcess"))
-            .withProcessInstanceVariable("nrOfLoops", 3);
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procParallelMultiInst.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "parallelMISubProcess"))
+                .withProcessInstanceVariable("nrOfLoops", 3);
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI subProcess root execution, 3 subProcesses and 3 tasks
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "subTask1", "subTask1", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
-        assertThat(executions).haveExactly(1, new Condition<>((Execution execution) -> ((ExecutionEntity) execution).isMultiInstanceRoot(), "is Multi Instance root"));
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "subTask1", "subTask1",
+                        "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .haveExactly(1, new Condition<>((Execution execution) -> ((ExecutionEntity) execution).isMultiInstanceRoot(), "is Multi Instance root"));
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(3);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(3, 0, 3);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("subTask1");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
-        List<Integer> loopCounters = tasks.stream().map(aTask -> taskService.getVariable(aTask.getId(), "loopCounter", Integer.class)).collect(Collectors.toList());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("subTask1", procParallelMultiInst.getId()));
+        List<Integer> loopCounters = tasks.stream().map(aTask -> taskService.getVariable(aTask.getId(), "loopCounter", Integer.class))
+                .collect(Collectors.toList());
         assertThat(loopCounters).containsExactlyInAnyOrder(0, 1, 2);
 
         //Complete the tasks with loopCounter 1
@@ -768,17 +966,23 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Two subProcess Instances remain
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "subTask1", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
-        assertThat(executions).haveExactly(1, new Condition<>((Execution execution) -> ((ExecutionEntity) execution).isMultiInstanceRoot(), "is Multi Instance root"));
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "subTask1", "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .haveExactly(1, new Condition<>((Execution execution) -> ((ExecutionEntity) execution).isMultiInstanceRoot(), "is Multi Instance root"));
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(2);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(2, 1, 3);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("subTask1");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("subTask1", procParallelMultiInst.getId()));
         loopCounters = tasks.stream().map(aTask -> taskService.getVariable(aTask.getId(), "loopCounter", Integer.class)).collect(Collectors.toList());
         assertThat(loopCounters).containsExactlyInAnyOrder(0, 2);
 
@@ -792,9 +996,11 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "userTask1Id", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2", "subTask2", "afterMultiInstance");
+            checkActivityInstances(procParallelMultiInst, processInstance, "userTask", "userTask1Id", "subTask1", "subTask1", "subTask1", "subTask2",
+                    "subTask2", "subTask2", "afterMultiInstance");
 
-            checkTaskInstance(procParallelMultiInst, processInstance, "userTask1Id", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2", "subTask2", "afterMultiInstance");
+            checkTaskInstance(procParallelMultiInst, processInstance, "userTask1Id", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2", "subTask2",
+                    "afterMultiInstance");
         }
 
         assertProcessEnded(processInstance.getId());
@@ -802,8 +1008,10 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateSequentialMultiInstanceSubProcessToSimpleActivity() {
-        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-subprocess.bpmn20.xml");
-        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-subprocess.bpmn20.xml");
+        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procSequentialMultiInst.getId(), Collections.singletonMap("nrOfLoops", 3));
@@ -816,16 +1024,21 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI subProcess root execution, actual subProcess and 1 task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 3);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask1");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("subTask1", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
 
         //Complete iteration...
@@ -836,25 +1049,32 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Confirm Second iteration
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask1");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("subTask1", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procSimpleOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("sequentialMISubProcess", "userTask1Id"));
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procSimpleOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("sequentialMISubProcess", "userTask1Id"));
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSimpleOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSimpleOneTask.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSimpleOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procSimpleOneTask.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -877,8 +1097,10 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateParallelMultiInstanceSubProcessToSimpleActivity() {
-        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-subprocess.bpmn20.xml");
-        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-subprocess.bpmn20.xml");
+        ProcessDefinition procSimpleOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procParallelMultiInst.getId(), Collections.singletonMap("nrOfLoops", 3));
@@ -891,17 +1113,27 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI subProcess root execution, actual subProcess and 1 task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "subTask1", "subTask1", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "subTask1", "subTask1",
+                        "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(3);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(3, 0, 3);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("subTask1");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
-        List<Integer> loopCounters = tasks.stream().map(aTask -> taskService.getVariable(aTask.getId(), "loopCounter", Integer.class)).collect(Collectors.toList());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsOnly("subTask1");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId)
+                .containsOnly(procParallelMultiInst.getId());
+        List<Integer> loopCounters = tasks.stream().map(aTask -> taskService.getVariable(aTask.getId(), "loopCounter", Integer.class))
+                .collect(Collectors.toList());
         assertThat(loopCounters).containsExactlyInAnyOrder(0, 1, 2);
 
         //Complete the iteration with loopCounter 1
@@ -912,55 +1144,73 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Two subProcess Instances remain
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "subTask1", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
-        assertThat(executions).haveExactly(1, new Condition<>((Execution execution) -> ((ExecutionEntity) execution).isMultiInstanceRoot(), "is Multi Instance root"));
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelMISubProcess", "parallelMISubProcess", "parallelMISubProcess", "subTask1", "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .haveExactly(1, new Condition<>((Execution execution) -> ((ExecutionEntity) execution).isMultiInstanceRoot(), "is Multi Instance root"));
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(2);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(3);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(2, 1, 3);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("subTask1");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("subTask1", procParallelMultiInst.getId()));
         loopCounters = tasks.stream().map(aTask -> taskService.getVariable(aTask.getId(), "loopCounter", Integer.class)).collect(Collectors.toList());
         assertThat(loopCounters).containsExactlyInAnyOrder(0, 2);
 
         //Complete one of the tasks
         completeTask(tasks.get(0));
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsExactlyInAnyOrder("subTask1", "subTask2");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactlyInAnyOrder("subTask1", "subTask2");
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procSimpleOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelMISubProcess", "userTask1Id"));
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procSimpleOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("parallelMISubProcess", "userTask1Id"));
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSimpleOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSimpleOneTask.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSimpleOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("userTask1Id", procSimpleOneTask.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSimpleOneTask, processInstance, "userTask", "beforeMultiInstance", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2", "userTask1Id");
+            checkActivityInstances(procSimpleOneTask, processInstance, "userTask", "beforeMultiInstance", "subTask1", "subTask1", "subTask1", "subTask2",
+                    "subTask2", "userTask1Id");
 
-            checkTaskInstance(procSimpleOneTask, processInstance, "beforeMultiInstance", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2", "userTask1Id");
+            checkTaskInstance(procSimpleOneTask, processInstance, "beforeMultiInstance", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2",
+                    "userTask1Id");
         }
 
         //Complete the process
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSimpleOneTask, processInstance, "userTask", "beforeMultiInstance", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2", "userTask1Id");
+            checkActivityInstances(procSimpleOneTask, processInstance, "userTask", "beforeMultiInstance", "subTask1", "subTask1", "subTask1", "subTask2",
+                    "subTask2", "userTask1Id");
 
-            checkTaskInstance(procSimpleOneTask, processInstance, "beforeMultiInstance", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2", "userTask1Id");
+            checkTaskInstance(procSimpleOneTask, processInstance, "beforeMultiInstance", "subTask1", "subTask1", "subTask1", "subTask2", "subTask2",
+                    "userTask1Id");
         }
 
         assertProcessEnded(processInstance.getId());
@@ -985,8 +1235,10 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateNestedSequentialMultiInstanceSubProcessActivityToOuterSequentialSubProcessActivity() {
-        ProcessDefinition procNestedSequentialMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/nested-sequential-multi-instance-subprocesses.bpmn20.xml");
-        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-subprocess.bpmn20.xml");
+        ProcessDefinition procNestedSequentialMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/nested-sequential-multi-instance-subprocesses.bpmn20.xml");
+        ProcessDefinition procSequentialMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/sequential-multi-instance-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procNestedSequentialMultiInst.getId());
@@ -1004,12 +1256,18 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI subProcess root execution, actual subProcess and 1 task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "nestedSequentialMISubProcess", "nestedSequentialMISubProcess", "nestedSubTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procNestedSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "nestedSequentialMISubProcess", "nestedSequentialMISubProcess",
+                        "nestedSubTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procNestedSequentialMultiInst.getId());
         assertThat(executions).haveExactly(2, new Condition<>(execution -> ((ExecutionEntity) execution).isMultiInstanceRoot(), "is MultiInstance root"));
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("nestedSubTask1");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procNestedSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("nestedSubTask1", procNestedSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
         completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -1017,31 +1275,38 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         completeTask(task);
         //Confirm one iteration of the nested MI subProcess is completed
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("nestedSubTask1");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procNestedSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("nestedSubTask1", procNestedSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procSequentialMultiInst.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("nestedSequentialMISubProcess", "sequentialMISubProcess"));
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procSequentialMultiInst.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("nestedSequentialMISubProcess", "sequentialMISubProcess"));
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI subProcess root execution, actual subProcess and 1 task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(0);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(2);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 2);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask1");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("subTask1", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
 
         //Complete one iteration
@@ -1053,48 +1318,67 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //Confirm
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //MI subProcess root execution, actual subProcess and 1 task
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procSequentialMultiInst.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("sequentialMISubProcess", "sequentialMISubProcess", "subTask1");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procSequentialMultiInst.getId());
         miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
         miRootVars = runtimeService.getVariables(miRoot.getId());
-        assertThat(miRootVars).extracting("nrOfActiveInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfCompletedInstances").isEqualTo(1);
-        assertThat(miRootVars).extracting("nrOfLoops").isEqualTo(2);
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 1, 2);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask1");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procSequentialMultiInst.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly("subTask1", procSequentialMultiInst.getId());
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1", "subTask1", "subTask2", "subTask1");
+            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2",
+                    "nestedSubTask1", "subTask1", "subTask2", "subTask1");
 
-            checkTaskInstance(procSequentialMultiInst, processInstance, "beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1", "subTask1", "subTask2", "subTask1");
+            checkTaskInstance(procSequentialMultiInst, processInstance, "beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1",
+                    "subTask1", "subTask2", "subTask1");
         }
 
         //Complete the process
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1", "subTask1", "subTask2", "subTask1", "subTask2", "afterMultiInstance");
+            checkActivityInstances(procSequentialMultiInst, processInstance, "userTask", "beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2",
+                    "nestedSubTask1", "subTask1", "subTask2", "subTask1", "subTask2", "afterMultiInstance");
 
-            checkTaskInstance(procSequentialMultiInst, processInstance, "beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1", "subTask1", "subTask2", "subTask1", "subTask2", "afterMultiInstance");
+            checkTaskInstance(procSequentialMultiInst, processInstance, "beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1",
+                    "subTask1", "subTask2", "subTask1", "subTask2", "afterMultiInstance");
         }
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1", "subTask1", "subTask2", "subTask1", "subTask2", "afterMultiInstance");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procSequentialMultiInst.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1", "subTask1", "subTask2",
+                            "subTask1", "subTask2", "afterMultiInstance");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procSequentialMultiInst.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).containsExactlyInAnyOrder("beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1", "subTask1", "subTask2", "subTask1", "subTask2", "afterMultiInstance");
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procSequentialMultiInst.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .containsExactlyInAnyOrder("beforeMultiInstance", "subTask1", "nestedSubTask1", "nestedSubTask2", "nestedSubTask1", "subTask1",
+                                "subTask2", "subTask1", "subTask2", "afterMultiInstance");
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procSequentialMultiInst.getId());
             }
         }
 
@@ -1103,8 +1387,10 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
     @Test
     public void testMigrateNestedParallelMultiInstanceSubProcessActivityToOuterParallelSubProcessActivity() {
-        ProcessDefinition procNestedParallelMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/nested-parallel-multi-instance-subprocesses.bpmn20.xml");
-        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-subprocess.bpmn20.xml");
+        ProcessDefinition procNestedParallelMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/nested-parallel-multi-instance-subprocesses.bpmn20.xml");
+        ProcessDefinition procParallelMultiInst = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-multi-instance-subprocess.bpmn20.xml");
 
         //Start the processInstance
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procNestedParallelMultiInst.getId());
@@ -1113,10 +1399,14 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
 
         //Progress to the MI subProcess
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("beforeMultiInstance");
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey)
+                .isEqualTo("beforeMultiInstance");
         completeTask(task);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("subTask1");
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsOnly("subTask1");
         tasks.forEach(this::completeTask);
 
         //Confirm the state to migrate
@@ -1124,37 +1414,54 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         //MI subProcess root execution, actual subProcess and 1 task
         assertThat(executions).hasSize(17);
         assertThat(executions).haveExactly(3, new Condition<>(execution -> execution.getActivityId().equals("parallelMISubProcess"), "Outer MI SubProcess"));
-        assertThat(executions).haveExactly(1, new Condition<>(execution -> execution.getActivityId().equals("parallelMISubProcess") && ((ExecutionEntity) execution).isMultiInstanceRoot(), "Outer MI SubProcess roots"));
-        assertThat(executions).haveExactly(8, new Condition<>(execution -> execution.getActivityId().equals("nestedParallelMISubProcess"), "Nested MI SubProcess"));
-        assertThat(executions).haveExactly(2, new Condition<>(execution -> execution.getActivityId().equals("nestedParallelMISubProcess") && ((ExecutionEntity) execution).isMultiInstanceRoot(), "Nested MI SubProcess roots"));
+        assertThat(executions).haveExactly(1,
+                new Condition<>(execution -> execution.getActivityId().equals("parallelMISubProcess") && ((ExecutionEntity) execution).isMultiInstanceRoot(),
+                        "Outer MI SubProcess roots"));
+        assertThat(executions)
+                .haveExactly(8, new Condition<>(execution -> execution.getActivityId().equals("nestedParallelMISubProcess"), "Nested MI SubProcess"));
+        assertThat(executions).haveExactly(2, new Condition<>(
+                execution -> execution.getActivityId().equals("nestedParallelMISubProcess") && ((ExecutionEntity) execution).isMultiInstanceRoot(),
+                "Nested MI SubProcess roots"));
         assertThat(executions).haveExactly(6, new Condition<>(execution -> execution.getActivityId().equals("nestedSubTask1"), "Task Executions"));
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procNestedParallelMultiInst.getId());
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procNestedParallelMultiInst.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(6);
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("nestedSubTask1");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procNestedParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("nestedSubTask1", procNestedParallelMultiInst.getId()));
 
         //Prepare and action the migration
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procParallelMultiInst.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("nestedParallelMISubProcess", "parallelMISubProcess"));
-        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(procParallelMultiInst.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("nestedParallelMISubProcess", "parallelMISubProcess"));
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //IMPORTANT: Might not be the expected result, but it is currently the correct one, as there are two MI roots (nestedParallelMISubProcess) migrating independently
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(10);
-        assertThat(executions).haveExactly(6, new Condition<>(execution -> execution.getActivityId().equals("parallelMISubProcess"), "Outer MI SubProcess"));
-        assertThat(executions).haveExactly(2, new Condition<>(execution -> execution.getActivityId().equals("parallelMISubProcess") && ((ExecutionEntity) execution).isMultiInstanceRoot(), "Outer MI SubProcess roots"));
-        assertThat(executions).haveExactly(4, new Condition<>(execution -> execution.getActivityId().equals("subTask1"), "Task Executions"));
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procParallelMultiInst.getId());
+        assertThat(executions)
+                .haveExactly(6, new Condition<>(execution -> execution.getActivityId().equals("parallelMISubProcess"), "Outer MI SubProcess"));
+        assertThat(executions)
+                .haveExactly(2, new Condition<>(
+                        execution -> execution.getActivityId().equals("parallelMISubProcess") && ((ExecutionEntity) execution).isMultiInstanceRoot(),
+                        "Outer MI SubProcess roots"));
+        assertThat(executions)
+                .haveExactly(4, new Condition<>(execution -> execution.getActivityId().equals("subTask1"), "Task Executions"));
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procParallelMultiInst.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(4);
-        assertThat(tasks).extracting(Task::getTaskDefinitionKey).containsOnly("subTask1");
-        assertThat(tasks).extracting(Task::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsOnly(tuple("subTask1", procParallelMultiInst.getId()));
 
         //Complete the process
         completeProcessInstanceTasks(processInstance.getId());
@@ -1162,26 +1469,50 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).haveAtMost(1, new Condition<>((String s) -> s.equals("beforeMultiInstance"), "beforeMultiInstance completed task"));
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).haveAtMost(6, new Condition<>((String s) -> s.equals("nestedSubTask1"), "nestedSubTask1 completed task"));
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).haveAtMost(6, new Condition<>((String s) -> s.equals("subTask1"), "subTask1 completed task"));
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).haveAtMost(4, new Condition<>((String s) -> s.equals("subTask2"), "subTask2 completed task"));
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).haveAtMost(2, new Condition<>((String s) -> s.equals("afterMultiInstance"), "afterMultiInstance completed task"));
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .haveAtMost(1, new Condition<>((String s) -> s.equals("beforeMultiInstance"), "beforeMultiInstance completed task"));
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .haveAtMost(6, new Condition<>((String s) -> s.equals("nestedSubTask1"), "nestedSubTask1 completed task"));
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .haveAtMost(6, new Condition<>((String s) -> s.equals("subTask1"), "subTask1 completed task"));
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .haveAtMost(4, new Condition<>((String s) -> s.equals("subTask2"), "subTask2 completed task"));
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .haveAtMost(2, new Condition<>((String s) -> s.equals("afterMultiInstance"), "afterMultiInstance completed task"));
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procParallelMultiInst.getId());
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                    .processInstanceId(processInstance.getId())
-                    .list();
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).haveAtMost(1, new Condition<>((String s) -> s.equals("beforeMultiInstance"), "beforeMultiInstance completed task"));
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).haveAtMost(6, new Condition<>((String s) -> s.equals("nestedSubTask1"), "nestedSubTask1 completed task"));
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).haveAtMost(6, new Condition<>((String s) -> s.equals("subTask1"), "subTask1 completed task"));
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).haveAtMost(4, new Condition<>((String s) -> s.equals("subTask2"), "subTask2 completed task"));
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getTaskDefinitionKey).haveAtMost(2, new Condition<>((String s) -> s.equals("afterMultiInstance"), "afterMultiInstance completed task"));
-                assertThat(historicTasks).extracting(HistoricTaskInstance::getProcessDefinitionId).containsOnly(procParallelMultiInst.getId());
+                        .processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .haveAtMost(1, new Condition<>((String s) -> s.equals("beforeMultiInstance"), "beforeMultiInstance completed task"));
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .haveAtMost(6, new Condition<>((String s) -> s.equals("nestedSubTask1"), "nestedSubTask1 completed task"));
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .haveAtMost(6, new Condition<>((String s) -> s.equals("subTask1"), "subTask1 completed task"));
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .haveAtMost(4, new Condition<>((String s) -> s.equals("subTask2"), "subTask2 completed task"));
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getTaskDefinitionKey)
+                        .haveAtMost(2, new Condition<>((String s) -> s.equals("afterMultiInstance"), "afterMultiInstance completed task"));
+                assertThat(historicTasks)
+                        .extracting(HistoricTaskInstance::getProcessDefinitionId)
+                        .containsOnly(procParallelMultiInst.getId());
             }
         }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
@@ -14,7 +14,7 @@
 package org.flowable.engine.test.api.runtime.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -80,64 +80,67 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     @Test
     public void testSimpleMigrationWithActivityAutoMapping() {
         //Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("MP");
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(2);
         processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        assertEquals(processDefinitions.get(0).getId(), version1ProcessDef.getId());
-        assertEquals(processDefinitions.get(1).getId(), version2ProcessDef.getId());
+        assertThat(version1ProcessDef.getId()).isEqualTo(processDefinitions.get(0).getId());
+        assertThat(version2ProcessDef.getId()).isEqualTo(processDefinitions.get(1).getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         executions.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version1ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId()));
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version1ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version1ProcessDef.getId(), "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult validationResult = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .validateMigration(processInstance.getId());
 
-        assertEquals(true, validationResult.isMigrationValid());
+        assertThat(validationResult.isMigrationValid()).isEqualTo(true);
 
         // Migrate process
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId());
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
 
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         executions.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version2ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId()));
 
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version2ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasks.get(0).getTaskDefinitionKey()); //AutoMapped by Id
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version2ProcessDef.getId(), "userTask1Id")); //AutoMapped by Id
 
         //The first process version only had one activity, there should be a second activity in the process now
         taskService.complete(tasks.get(0).getId());
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals("userTask2Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("userTask2Id");
         taskService.complete(tasks.get(0).getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -154,39 +157,43 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Task beforeMigrationTask = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/three-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/three-tasks-simple-process.bpmn20.xml");
 
         //Migrate process
         processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask2Id", "intermediateTask"))
-            .migrate(processInstanceToMigrate.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask2Id", "intermediateTask"))
+                .migrate(processInstanceToMigrate.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         for (Execution execution : executions) {
-            assertEquals(version2ProcessDef.getId(), ((ExecutionEntity) execution).getProcessDefinitionId());
+            assertThat(((ExecutionEntity) execution).getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
         }
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        assertEquals(version2ProcessDef.getId(), task.getProcessDefinitionId());
-        assertEquals("intermediateTask", task.getTaskDefinitionKey());
-        assertEquals(beforeMigrationTask.getId(), task.getId());
+        assertThat(task)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey, Task::getId)
+                .containsExactly(version2ProcessDef.getId(), "intermediateTask", beforeMigrationTask.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-            assertEquals(version2ProcessDef.getId(), historicProcessInstance.getProcessDefinitionId());
+            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).singleResult();
+            assertThat(historicProcessInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
 
-            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-            assertEquals(2, historicTaskInstances.size());
+            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).list();
+            assertThat(historicTaskInstances).hasSize(2);
             for (HistoricTaskInstance historicTaskInstance : historicTaskInstances) {
-                assertEquals(version2ProcessDef.getId(), historicTaskInstance.getProcessDefinitionId());
+                assertThat(historicTaskInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             }
 
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-            assertEquals(5, historicActivityInstances.size());
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).list();
+            assertThat(historicActivityInstances).hasSize(5);
             for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
-                assertEquals(version2ProcessDef.getId(), historicActivityInstance.getProcessDefinitionId());
+                assertThat(historicActivityInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             }
         }
 
@@ -212,7 +219,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Task beforeMigrationTask = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/three-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/three-tasks-simple-process.bpmn20.xml");
 
         ObjectMapper objectMapper = processEngineConfiguration.getObjectMapper();
         ObjectNode migrationNode = objectMapper.createObjectNode();
@@ -227,24 +235,27 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processMigrationService.migrateProcessInstance(processInstanceToMigrate.getId(), migrationDocument);
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        assertEquals(version2ProcessDef.getId(), task.getProcessDefinitionId());
-        assertEquals("intermediateTask", task.getTaskDefinitionKey());
-        assertEquals(beforeMigrationTask.getId(), task.getId());
+        assertThat(task)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey, Task::getId)
+                .containsExactly(version2ProcessDef.getId(), "intermediateTask", beforeMigrationTask.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-            assertEquals(version2ProcessDef.getId(), historicProcessInstance.getProcessDefinitionId());
+            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).singleResult();
+            assertThat(historicProcessInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
 
-            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-            assertEquals(2, historicTaskInstances.size());
+            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).list();
+            assertThat(historicTaskInstances).hasSize(2);
             for (HistoricTaskInstance historicTaskInstance : historicTaskInstances) {
-                assertEquals(version2ProcessDef.getId(), historicTaskInstance.getProcessDefinitionId());
+                assertThat(historicTaskInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             }
 
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-            assertEquals(5, historicActivityInstances.size());
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).list();
+            assertThat(historicActivityInstances).hasSize(5);
             for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
-                assertEquals(version2ProcessDef.getId(), historicActivityInstance.getProcessDefinitionId());
+                assertThat(historicActivityInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             }
         }
 
@@ -268,46 +279,51 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult().getId());
 
         List<Task> parallelTasks = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-        assertEquals(2, parallelTasks.size());
+        assertThat(parallelTasks).hasSize(2);
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/parallel-gateway-two-tasks-and-before.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/parallel-gateway-two-tasks-and-before.bpmn20.xml");
 
         List<String> fromActivityIds = new ArrayList<>();
         fromActivityIds.add("parallelTask1");
         fromActivityIds.add("parallelTask2");
         //Migrate process
         processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(fromActivityIds, "beforeTask"))
-            .migrate(processInstanceToMigrate.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor(fromActivityIds, "beforeTask"))
+                .migrate(processInstanceToMigrate.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         for (Execution execution : executions) {
-            assertEquals(version2ProcessDef.getId(), ((ExecutionEntity) execution).getProcessDefinitionId());
+            assertThat(((ExecutionEntity) execution).getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
         }
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        assertEquals(version2ProcessDef.getId(), task.getProcessDefinitionId());
-        assertEquals("beforeTask", task.getTaskDefinitionKey());
-        assertNotEquals(parallelTasks.get(0).getId(), task.getId());
-        assertNotEquals(parallelTasks.get(1).getId(), task.getId());
+        assertThat(task)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(version2ProcessDef.getId(), "beforeTask");
+        assertThat(parallelTasks.get(0).getId()).isNotEqualTo(task.getId());
+        assertThat(parallelTasks.get(1).getId()).isNotEqualTo(task.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-            assertEquals(version2ProcessDef.getId(), historicProcessInstance.getProcessDefinitionId());
+            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).singleResult();
+            assertThat(historicProcessInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
 
-            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-            assertEquals(4, historicTaskInstances.size());
+            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).list();
+            assertThat(historicTaskInstances).hasSize(4);
             for (HistoricTaskInstance historicTaskInstance : historicTaskInstances) {
-                assertEquals(version2ProcessDef.getId(), historicTaskInstance.getProcessDefinitionId());
+                assertThat(historicTaskInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             }
 
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-            assertEquals(10, historicActivityInstances.size());
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).list();
+            assertThat(historicActivityInstances).hasSize(10);
             for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
-                assertEquals(version2ProcessDef.getId(), historicActivityInstance.getProcessDefinitionId());
+                assertThat(historicActivityInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             }
         }
 
@@ -341,47 +357,53 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Task lastTask = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/three-tasks-with-sub-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/three-tasks-with-sub-process.bpmn20.xml");
 
         //Migrate process
         processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(
-                ActivityMigrationMapping.createMappingFor("userTask2Id", "subScriptTask")
-                    .withLocalVariable("subprocessVariable", "passedValue"))
-            .migrate(processInstanceToMigrate.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(
+                        ActivityMigrationMapping.createMappingFor("userTask2Id", "subScriptTask")
+                                .withLocalVariable("subprocessVariable", "passedValue"))
+                .migrate(processInstanceToMigrate.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-        assertEquals(3, executions.size()); //includes root execution
+        assertThat(executions).hasSize(3); //includes root execution
         for (Execution execution : executions) {
-            assertEquals(version2ProcessDef.getId(), ((ExecutionEntity) execution).getProcessDefinitionId());
+            assertThat(((ExecutionEntity) execution).getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
         }
 
         Execution execution = runtimeService.createExecutionQuery().activityId("subProcess").singleResult();
-        assertEquals("passedValue", runtimeService.getVariable(execution.getId(), "subprocessVariable"));
-        assertFalse(runtimeService.hasVariable(execution.getProcessInstanceId(), "subprocessVariable"));
-        assertEquals("hello", runtimeService.getVariable(execution.getId(), "anotherVar"));
-        assertFalse(runtimeService.hasVariable(execution.getProcessInstanceId(), "anotherVar"));
+        assertThat(runtimeService.getVariable(execution.getId(), "subprocessVariable")).isEqualTo("passedValue");
+        assertThat(runtimeService.hasVariable(execution.getProcessInstanceId(), "subprocessVariable")).isFalse();
+        assertThat(runtimeService.getVariable(execution.getId(), "anotherVar")).isEqualTo("hello");
+
+        assertThat(runtimeService.hasVariable(execution.getProcessInstanceId(), "anotherVar")).isFalse();
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        assertEquals(version2ProcessDef.getId(), task.getProcessDefinitionId());
-        assertEquals("subTask", task.getTaskDefinitionKey());
-        assertNotEquals(lastTask.getId(), task.getId());
+        assertThat(task)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(version2ProcessDef.getId(), "subTask");
+        assertThat(lastTask.getId()).isNotEqualTo(task.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-            assertEquals(version2ProcessDef.getId(), historicProcessInstance.getProcessDefinitionId());
+            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).singleResult();
+            assertThat(historicProcessInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
 
-            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-            assertEquals(3, historicTaskInstances.size());
+            List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).list();
+            assertThat(historicTaskInstances).hasSize(3);
             for (HistoricTaskInstance historicTaskInstance : historicTaskInstances) {
-                assertEquals(version2ProcessDef.getId(), historicTaskInstance.getProcessDefinitionId());
+                assertThat(historicTaskInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             }
 
-            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstanceToMigrate.getId()).list();
-            assertEquals(9, historicActivityInstances.size());
+            List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery()
+                    .processInstanceId(processInstanceToMigrate.getId()).list();
+            assertThat(historicActivityInstances).hasSize(9);
             for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
-                assertEquals(version2ProcessDef.getId(), historicActivityInstance.getProcessDefinitionId());
+                assertThat(historicActivityInstance.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             }
         }
 
@@ -399,52 +421,55 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     public void testSimpleMigrationWithExplicitActivityMapping1() {
         //Deploy first version of the process
         Deployment oneActivityProcessDeployment = repositoryService.createDeployment()
-            .name("My Process Deployment")
-            .addClasspathResource("org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml")
-            .deploy();
+                .name("My Process Deployment")
+                .addClasspathResource("org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml")
+                .deploy();
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("MP");
 
         //Deploy second version of the process
         Deployment twoActivitiesProcessDeployment = repositoryService.createDeployment()
-            .name("My Process Deployment")
-            .addClasspathResource("org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml")
-            .deploy();
+                .name("My Process Deployment")
+                .addClasspathResource("org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml")
+                .deploy();
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(2);
 
         ProcessDefinition version1ProcessDef = processDefinitions.stream().filter(d -> d.getVersion() == 1).findFirst().get();
-        assertEquals(oneActivityProcessDeployment.getId(), version1ProcessDef.getDeploymentId());
+        assertThat(version1ProcessDef.getDeploymentId()).isEqualTo(oneActivityProcessDeployment.getId());
         ProcessDefinition version2ProcessDef = processDefinitions.stream().filter(d -> d.getVersion() == 2).findFirst().get();
-        assertEquals(twoActivitiesProcessDeployment.getId(), version2ProcessDef.getDeploymentId());
+        assertThat(version2ProcessDef.getDeploymentId()).isEqualTo(twoActivitiesProcessDeployment.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         executions.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version1ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId()));
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version1ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId());
+        assertThat(tasks.get(0).getTaskDefinitionKey()).isEqualTo("userTask1Id");
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version1ProcessDef.getId(), "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult validationResult = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask1Id"))
-            .validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask1Id"))
+                .validateMigration(processInstance.getId());
 
-        assertTrue(validationResult.isMigrationValid());
+        assertThat(validationResult.isMigrationValid()).isTrue();
 
         //Migrate process - moving the current execution explicitly
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask1Id"));
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -452,22 +477,23 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         executions.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version2ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId()));
 
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version2ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version2ProcessDef.getId(), "userTask1Id"));
 
         //This new process definition has two activities
         taskService.complete(tasks.get(0).getId());
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version2ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask2Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version2ProcessDef.getId(), "userTask2Id"));
+
         taskService.complete(tasks.get(0).getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -476,61 +502,62 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     public void testSimpleMigrationWithExplicitActivityMapping2() {
         //Deploy first version of the process
         Deployment oneActivityProcessDeployment = repositoryService.createDeployment()
-            .name("My Process Deployment")
-            .addClasspathResource("org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml")
-            .deploy();
+                .name("My Process Deployment")
+                .addClasspathResource("org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml")
+                .deploy();
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("MP");
 
         //Deploy second version of the process
         Deployment twoActivitiesProcessDeployment = repositoryService.createDeployment()
-            .name("My Process Deployment")
-            .addClasspathResource("org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml")
-            .deploy();
+                .name("My Process Deployment")
+                .addClasspathResource("org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml")
+                .deploy();
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(2);
 
         ProcessDefinition version1ProcessDef = processDefinitions.stream().filter(d -> d.getVersion() == 1).findFirst().get();
-        assertEquals(oneActivityProcessDeployment.getId(), version1ProcessDef.getDeploymentId());
+        assertThat(version1ProcessDef.getDeploymentId()).isEqualTo(oneActivityProcessDeployment.getId());
         ProcessDefinition version2ProcessDef = processDefinitions.stream().filter(d -> d.getVersion() == 2).findFirst().get();
-        assertEquals(twoActivitiesProcessDeployment.getId(), version2ProcessDef.getDeploymentId());
+        assertThat(version2ProcessDef.getDeploymentId()).isEqualTo(twoActivitiesProcessDeployment.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         executions.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version1ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId()));
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version1ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version1ProcessDef.getId(), "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask3Id"))
-            .validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask3Id"))
+                .validateMigration(processInstance.getId());
 
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isFalse();
         assertThat(processInstanceMigrationValidationResult.getValidationMessages())
-            .isEqualTo(Collections.singletonList("Invalid mapping for 'userTask1Id' to 'userTask3Id', cannot be found in the process definition with id 'MP'"));
+                .isEqualTo(Collections
+                        .singletonList("Invalid mapping for 'userTask1Id' to 'userTask3Id', cannot be found in the process definition with id 'MP'"));
 
         processInstanceMigrationValidationResult = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask2Id"))
-            .validateMigration(processInstance.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask2Id"))
+                .validateMigration(processInstance.getId());
 
         assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
 
         //Migrate process - moving the current execution explicitly
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask2Id"));
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask2Id"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -538,15 +565,15 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         executions.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version2ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId()));
 
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version2ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask2Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version2ProcessDef.getId(), "userTask2Id"));
 
         //This new process definition has two activities, but we have mapped to the last activity explicitly
         taskService.complete(tasks.get(0).getId());
@@ -558,52 +585,52 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     public void testSimpleMigrationWithExplicitActivityMapping3() {
         //Deploy first version of the process
         Deployment twoActivitiesProcessDeployment = repositoryService.createDeployment()
-            .name("My Process Deployment")
-            .addClasspathResource("org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml")
-            .deploy();
+                .name("My Process Deployment")
+                .addClasspathResource("org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml")
+                .deploy();
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("MP");
 
         //Deploy second version of the process
         Deployment oneActivityProcessDeployment = repositoryService.createDeployment()
-            .name("My Process Deployment")
-            .addClasspathResource("org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml")
-            .deploy();
+                .name("My Process Deployment")
+                .addClasspathResource("org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml")
+                .deploy();
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(2);
 
         ProcessDefinition version1ProcessDef = processDefinitions.stream().filter(d -> d.getVersion() == 1).findFirst().get();
-        assertEquals(twoActivitiesProcessDeployment.getId(), version1ProcessDef.getDeploymentId());
+        assertThat(version1ProcessDef.getDeploymentId()).isEqualTo(twoActivitiesProcessDeployment.getId());
         ProcessDefinition version2ProcessDef = processDefinitions.stream().filter(d -> d.getVersion() == 2).findFirst().get();
-        assertEquals(oneActivityProcessDeployment.getId(), version2ProcessDef.getDeploymentId());
+        assertThat(version2ProcessDef.getDeploymentId()).isEqualTo(oneActivityProcessDeployment.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         executions.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version1ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId()));
 
         List<Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version1ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version1ProcessDef.getId(), "userTask1Id"));
 
         //We want to migrate from the next activity
         taskService.complete(tasks.get(0).getId());
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals(version1ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
-        assertEquals("userTask2Id", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version1ProcessDef.getId(), "userTask2Id"));
 
         //Migrate process - moving the current execution explicitly
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask2Id", "userTask1Id"));
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask2Id", "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -611,15 +638,15 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         executions = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executions.size()); //includes root execution
+        assertThat(executions).hasSize(2); //includes root execution
         executions.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version2ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId()));
 
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        assertEquals("userTask1Id", tasks.get(0).getTaskDefinitionKey());
-        assertEquals(version2ProcessDef.getId(), tasks.get(0).getProcessDefinitionId());
+        assertThat(tasks)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version2ProcessDef.getId(), "userTask1Id"));
 
         //This new process version only have one activity
         taskService.complete(tasks.get(0).getId());
@@ -631,33 +658,35 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Almost all tests use UserTask, thus are direct migrations, but this one checks explicitly for changes in History
         //Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("MP");
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(2);
         processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        assertEquals(processDefinitions.get(0).getId(), version1ProcessDef.getId());
-        assertEquals(processDefinitions.get(1).getId(), version2ProcessDef.getId());
+        assertThat(version1ProcessDef.getId()).isEqualTo(processDefinitions.get(0).getId());
+        assertThat(version2ProcessDef.getId()).isEqualTo(processDefinitions.get(1).getId());
 
         List<Execution> executionsBefore = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executionsBefore.size()); //includes root execution
+        assertThat(executionsBefore).hasSize(2); //includes root execution
         executionsBefore.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version1ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId()));
 
         List<Task> tasksBefore = taskService.createTaskQuery().list();
-        assertEquals(1, tasksBefore.size());
-        assertEquals(version1ProcessDef.getId(), tasksBefore.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasksBefore.get(0).getTaskDefinitionKey());
+        assertThat(tasksBefore)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version1ProcessDef.getId(), "userTask1Id"));
 
         List<HistoricActivityInstance> historicActivityInstancesBefore = null;
         List<HistoricTaskInstance> historicTaskInstancesBefore = null;
@@ -671,7 +700,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Migrate process
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId());
+                .migrateToProcessDefinition(version2ProcessDef.getId());
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -679,38 +708,41 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         List<Execution> executionsAfter = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executionsAfter.size()); //includes root execution
+        assertThat(executionsAfter).hasSize(2); //includes root execution
         executionsAfter.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version2ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId()));
 
         List<Task> tasksAfter = taskService.createTaskQuery().list();
-        assertEquals(1, tasksAfter.size());
-        assertEquals(version2ProcessDef.getId(), tasksAfter.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasksAfter.get(0).getTaskDefinitionKey()); //AutoMapped by Id
+        assertThat(tasksAfter)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version2ProcessDef.getId(), "userTask1Id")); //AutoMapped by Id
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            List<HistoricActivityInstance> historicActivityInstancesAfter = historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc().list();
-            assertEquals(historicActivityInstancesBefore.size(), historicActivityInstancesAfter.size());
+            List<HistoricActivityInstance> historicActivityInstancesAfter = historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc()
+                    .list();
+            assertThat(historicActivityInstancesAfter).hasSize(historicActivityInstancesBefore.size());
             assertThat(historicActivityInstancesBefore)
-                .usingElementComparatorIgnoringFields("revision", "processDefinitionId")
-                .containsExactlyInAnyOrderElementsOf(historicActivityInstancesAfter);
+                    .usingElementComparatorIgnoringFields("revision", "processDefinitionId")
+                    .containsExactlyInAnyOrderElementsOf(historicActivityInstancesAfter);
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTaskInstancesAfter = historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().list();
 
-                assertEquals(historicTaskInstancesBefore.size(), historicTaskInstancesAfter.size());
+                assertThat(historicTaskInstancesAfter).hasSize(historicTaskInstancesBefore.size());
                 assertThat(historicTaskInstancesBefore)
-                    .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "originalPersistentState", "lastUpdateTime")
-                    .containsExactlyInAnyOrderElementsOf(historicTaskInstancesAfter);
+                        .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "originalPersistentState", "lastUpdateTime")
+                        .containsExactlyInAnyOrderElementsOf(historicTaskInstancesAfter);
             }
         }
 
         //The first process version only had one activity, there should be a second activity in the process now
         taskService.complete(tasksAfter.get(0).getId());
         tasksAfter = taskService.createTaskQuery().list();
-        assertEquals(1, tasksAfter.size());
-        assertEquals("userTask2Id", tasksAfter.get(0).getTaskDefinitionKey());
+        assertThat(tasksAfter)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("userTask2Id");
+
         taskService.complete(tasksAfter.get(0).getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -720,34 +752,38 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Almost all tests use UserTask, thus are direct migrations, but this one checks explicitly for changes in History
         //Deploy first version of the process
-        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("MP");
 
         //Deploy second version of the process
-        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-simple-process.bpmn20.xml");
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-            .processDefinitionKey("MP")
-            .list();
+                .processDefinitionKey("MP")
+                .list();
 
-        assertEquals(2, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(2);
         processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        assertEquals(processDefinitions.get(0).getId(), version1ProcessDef.getId());
-        assertEquals(processDefinitions.get(1).getId(), version2ProcessDef.getId());
+        assertThat(version1ProcessDef.getId()).isEqualTo(processDefinitions.get(0).getId());
+        assertThat(version2ProcessDef.getId()).isEqualTo(processDefinitions.get(1).getId());
 
         List<Execution> executionsBefore = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executionsBefore.size()); //includes root execution
+        assertThat(executionsBefore).hasSize(2); //includes root execution
         executionsBefore.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version1ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version1ProcessDef.getId()));
 
         List<Task> tasksBefore = taskService.createTaskQuery().list();
-        assertEquals(1, tasksBefore.size());
-        assertEquals(version1ProcessDef.getId(), tasksBefore.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasksBefore.get(0).getTaskDefinitionKey());
-        assertThat(tasksBefore).extracting(Task::getAssignee).containsNull();
+        assertThat(tasksBefore)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version1ProcessDef.getId(), "userTask1Id"));
+        assertThat(tasksBefore)
+                .extracting(Task::getAssignee)
+                .containsNull();
 
         List<HistoricActivityInstance> historicActivityInstancesBefore = null;
         List<HistoricTaskInstance> historicTaskInstancesBefore = null;
@@ -761,8 +797,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Migrate process
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(version2ProcessDef.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask1Id").withNewAssignee("kermit"));
+                .migrateToProcessDefinition(version2ProcessDef.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "userTask1Id").withNewAssignee("kermit"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -770,71 +806,79 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         List<Execution> executionsAfter = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executionsAfter.size()); //includes root execution
+        assertThat(executionsAfter).hasSize(2); //includes root execution
         executionsAfter.stream()
-            .map(e -> (ExecutionEntity) e)
-            .forEach(e -> assertEquals(version2ProcessDef.getId(), e.getProcessDefinitionId()));
+                .map(e -> (ExecutionEntity) e)
+                .forEach(e -> assertThat(e.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId()));
 
         List<Task> tasksAfter = taskService.createTaskQuery().list();
-        assertEquals(1, tasksAfter.size());
-        assertEquals(version2ProcessDef.getId(), tasksAfter.get(0).getProcessDefinitionId());
-        assertEquals("userTask1Id", tasksAfter.get(0).getTaskDefinitionKey()); //AutoMapped by Id
-        assertThat(tasksAfter).extracting(Task::getAssignee).containsOnly("kermit");
+        assertThat(tasksAfter)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey, Task::getAssignee)
+                .containsExactly(tuple(version2ProcessDef.getId(), "userTask1Id", "kermit")); //AutoMapped by Id
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            List<HistoricActivityInstance> historicActivityInstancesAfter = historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc().list();
-            assertEquals(historicActivityInstancesBefore.size(), historicActivityInstancesAfter.size());
+            List<HistoricActivityInstance> historicActivityInstancesAfter = historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc()
+                    .list();
+            assertThat(historicActivityInstancesAfter).hasSize(historicActivityInstancesBefore.size());
             assertThat(historicActivityInstancesBefore)
-                .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "assignee", "originalPersistentState")
-                .containsExactlyInAnyOrderElementsOf(historicActivityInstancesAfter);
+                    .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "assignee", "originalPersistentState")
+                    .containsExactlyInAnyOrderElementsOf(historicActivityInstancesAfter);
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTaskInstancesAfter = historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().list();
 
-                assertEquals(historicTaskInstancesBefore.size(), historicTaskInstancesAfter.size());
+                assertThat(historicTaskInstancesAfter).hasSize(historicTaskInstancesBefore.size());
                 assertThat(historicTaskInstancesBefore)
-                    .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "assignee", "originalPersistentState", "lastUpdateTime")
-                    .containsExactlyInAnyOrderElementsOf(historicTaskInstancesAfter);
+                        .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "assignee", "originalPersistentState", "lastUpdateTime")
+                        .containsExactlyInAnyOrderElementsOf(historicTaskInstancesAfter);
             }
         }
 
         //The first process version only had one activity, there should be a second activity in the process now
         taskService.complete(tasksAfter.get(0).getId());
         tasksAfter = taskService.createTaskQuery().list();
-        assertEquals(1, tasksAfter.size());
-        assertEquals("userTask2Id", tasksAfter.get(0).getTaskDefinitionKey());
+        assertThat(tasksAfter)
+                .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
+                .containsExactly(tuple(version2ProcessDef.getId(), "userTask2Id"));
+
         taskService.complete(tasksAfter.get(0).getId());
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
     public void testSimpleMigrationWithinSimpleSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
-        ProcessDefinition procDefTwoTasks = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefTwoTasks = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-inside-subprocess.bpmn20.xml");
 
         //Start an instance of a process with one task inside a subProcess
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm and move inside the subProcess
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions).hasSize(2); //includes root execution
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         //Should be only one task
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("BeforeSubProcess");
         completeTask(task);
 
-        List<Execution> executionsBeforeMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executionsBeforeMigration.size()); //Includes subProcess
-        assertThat(executionsBeforeMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess1");
+        List<Execution> executionsBeforeMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsBeforeMigration)  //Includes subProcess
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess1");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("InsideSimpleSubProcess1");
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefTwoTasks.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess1", "InsideSimpleSubProcess2"));
+                .migrateToProcessDefinition(procDefTwoTasks.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess1", "InsideSimpleSubProcess2"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -842,10 +886,14 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm and move inside the subProcess
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executionsAfterMigration.size()); //includes subProcess
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess2");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefTwoTasks.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess2"); //includes subProcess
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefTwoTasks.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefTwoTasks, processInstance, "subProcess", "SimpleSubProcess", "SimpleSubProcess");
@@ -868,16 +916,20 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testSimpleMigrationWithinSimpleSubProcess2() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
-        ProcessDefinition procDefTwoTasks = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefTwoTasks = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-inside-subprocess.bpmn20.xml");
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefTwoTasks.getId());
 
         //Confirm and move inside the subProcess
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefTwoTasks.getId());
+        assertThat(executions).hasSize(2); //includes root execution
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefTwoTasks.getId());
 
         //Move to the second task inside the SubProcess
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -889,14 +941,16 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("InsideSimpleSubProcess2");
 
-        List<Execution> executionsBeforeMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executionsBeforeMigration.size()); //Includes subProcess
-        assertThat(executionsBeforeMigration).extracting("activityId").containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess2");
+        List<Execution> executionsBeforeMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsBeforeMigration)
+                .extracting("activityId")
+                .containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess2"); // Includes subProcess
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess2", "InsideSimpleSubProcess1"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess2", "InsideSimpleSubProcess1"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -904,20 +958,24 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm and move inside the subProcess
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executionsAfterMigration.size()); //includes subProcess
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess1");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess1");  // Includes subProcess
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefOneTask, processInstance, "subProcess", "SimpleSubProcess", "SimpleSubProcess");
             checkActivityInstances(procDefOneTask, processInstance, "userTask", "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "InsideSimpleSubProcess1");
+                    "InsideSimpleSubProcess1",
+                    "InsideSimpleSubProcess1");
 
             checkTaskInstance(procDefOneTask, processInstance, "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "InsideSimpleSubProcess1");
+                    "InsideSimpleSubProcess1",
+                    "InsideSimpleSubProcess1");
         }
 
         completeProcessInstanceTasks(processInstance.getId());
@@ -925,31 +983,34 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefOneTask, processInstance, "subProcess", "SimpleSubProcess", "SimpleSubProcess");
             checkActivityInstances(procDefOneTask, processInstance, "userTask", "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "InsideSimpleSubProcess1",
-                "AfterSubProcess");
+                    "InsideSimpleSubProcess1",
+                    "InsideSimpleSubProcess1",
+                    "AfterSubProcess");
 
             checkTaskInstance(procDefOneTask, processInstance, "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "InsideSimpleSubProcess1",
-                "AfterSubProcess");
+                    "InsideSimpleSubProcess1",
+                    "InsideSimpleSubProcess1",
+                    "AfterSubProcess");
         }
-
 
         assertProcessEnded(processInstance.getId());
     }
 
     @Test
     public void testSimpleMigrationIntoEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
-        ProcessDefinition procDefTwoTasks = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefTwoTasks = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-inside-subprocess.bpmn20.xml");
 
         //Start and instance of the recent first version of the process for migration and one for reference
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions).hasSize(2); //includes root execution
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         //Confirm migration point before the subProcess
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -957,8 +1018,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefTwoTasks.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("BeforeSubProcess", "InsideSimpleSubProcess2"));
+                .migrateToProcessDefinition(procDefTwoTasks.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("BeforeSubProcess", "InsideSimpleSubProcess2"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -966,29 +1027,37 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm and move inside the subProcess
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executionsAfterMigration.size()); //includes subProcess
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess2");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefTwoTasks.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration).hasSize(2);
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("SimpleSubProcess", "InsideSimpleSubProcess2");   //includes subProcess
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefTwoTasks.getId());
 
         completeProcessInstanceTasks(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History - should contain one SubProcess and 2 userTask Activities since the migratedUser task moved forward inside the last task of the subProcess
             HistoricActivityInstance subProcess = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("subProcess")
-                .singleResult();
+                    .processInstanceId(processInstance.getId())
+                    .activityType("subProcess")
+                    .singleResult();
             assertThat(subProcess).extracting(HistoricActivityInstance::getActivityId).isEqualTo("SimpleSubProcess");
             assertThat(subProcess).extracting(HistoricActivityInstance::getProcessDefinitionId).isEqualTo(procDefTwoTasks.getId());
 
             List<HistoricActivityInstance> userTasks = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertEquals(2, userTasks.size());
-            assertThat(userTasks).extracting(HistoricActivityInstance::getActivityId).containsOnly("AfterSubProcess", "InsideSimpleSubProcess2");
-            assertThat(userTasks).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procDefTwoTasks.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(userTasks)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("AfterSubProcess", "InsideSimpleSubProcess2");
+            assertThat(userTasks)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procDefTwoTasks.getId());
         }
 
         assertProcessEnded(processInstance.getId());
@@ -996,16 +1065,20 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testSimpleMigrationOutOfEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
-        ProcessDefinition procDefTwoTasks = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/two-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefTwoTasks = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/two-tasks-inside-subprocess.bpmn20.xml");
 
         //Start an instance of the definition with two task inside the subProcess
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefTwoTasks.getId());
 
         //Confirm and move inside the subProcess
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefTwoTasks.getId());
+        assertThat(executions).hasSize(2); //includes root execution
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefTwoTasks.getId());
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("BeforeSubProcess");
@@ -1018,8 +1091,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess2", "BeforeSubProcess"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess2", "BeforeSubProcess"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1027,20 +1100,24 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm and move inside the subProcess
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executionsAfterMigration.size()); //No subProcess
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("BeforeSubProcess");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("BeforeSubProcess"); //No subProcess
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefOneTask, processInstance, "subProcess", "SimpleSubProcess");
             checkActivityInstances(procDefOneTask, processInstance, "userTask", "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "BeforeSubProcess");
+                    "InsideSimpleSubProcess1",
+                    "BeforeSubProcess");
 
             checkTaskInstance(procDefOneTask, processInstance, "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "BeforeSubProcess");
+                    "InsideSimpleSubProcess1",
+                    "BeforeSubProcess");
         }
 
         completeProcessInstanceTasks(processInstance.getId());
@@ -1048,16 +1125,16 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefOneTask, processInstance, "subProcess", "SimpleSubProcess", "SimpleSubProcess");
             checkActivityInstances(procDefOneTask, processInstance, "userTask", "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "AfterSubProcess");
+                    "InsideSimpleSubProcess1",
+                    "BeforeSubProcess",
+                    "InsideSimpleSubProcess1",
+                    "AfterSubProcess");
 
             checkTaskInstance(procDefOneTask, processInstance, "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "BeforeSubProcess",
-                "InsideSimpleSubProcess1",
-                "AfterSubProcess");
+                    "InsideSimpleSubProcess1",
+                    "BeforeSubProcess",
+                    "InsideSimpleSubProcess1",
+                    "AfterSubProcess");
         }
 
         assertProcessEnded(processInstance.getId());
@@ -1065,24 +1142,28 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityFromProcessRootIntoNestedEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
-        ProcessDefinition procDefNested = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-nested-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefNested = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-nested-subprocess.bpmn20.xml");
 
         //Start an instance of the definition with two task inside the subProcess
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions).hasSize(2); //includes root execution
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("BeforeSubProcess");
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefNested.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("BeforeSubProcess", "InsideNestedSubProcess"));
+                .migrateToProcessDefinition(procDefNested.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("BeforeSubProcess", "InsideNestedSubProcess"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1090,10 +1171,14 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("OuterSubProcess", "SimpleSubProcess", "InsideNestedSubProcess");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefNested.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("OuterSubProcess", "SimpleSubProcess", "InsideNestedSubProcess");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefNested.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefNested, processInstance, "subProcess", "OuterSubProcess", "SimpleSubProcess");
@@ -1117,24 +1202,28 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityFromProcessRootIntoNestedEmbeddedSubProcessWithDataObject() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess-with-data-object.bpmn20.xml");
-        ProcessDefinition procDefNested = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-nested-subprocess-with-data-object.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess-with-data-object.bpmn20.xml");
+        ProcessDefinition procDefNested = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-nested-subprocess-with-data-object.bpmn20.xml");
 
         //Start an instance of the definition with two task inside the subProcess
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions).hasSize(2); //includes root execution
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("BeforeSubProcess");
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefNested.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("BeforeSubProcess", "InsideNestedSubProcess"));
+                .migrateToProcessDefinition(procDefNested.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("BeforeSubProcess", "InsideNestedSubProcess"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1142,17 +1231,22 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("OuterSubProcess", "SimpleSubProcess", "InsideNestedSubProcess");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefNested.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("OuterSubProcess", "SimpleSubProcess", "InsideNestedSubProcess");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefNested.getId());
 
         //Should contain the dataObject of the new embedded process definition
-        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("SimpleSubProcess").singleResult();
-        assertNotNull(runtimeService.getVariableLocal(nestedSubProcess.getId(), "dataScopeNested", String.class));
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("SimpleSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "dataScopeNested", String.class)).isNotNull();
         DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "dataScopeNested");
-        assertNotNull(nameDataObject);
-        assertEquals("nestedSubProcess", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("nestedSubProcess");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefNested, processInstance, "subProcess", "OuterSubProcess", "SimpleSubProcess");
@@ -1176,16 +1270,20 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityFromEmbeddedSubProcessIntoNestedEmbeddedSubProcess() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
-        ProcessDefinition procDefNested = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-nested-subprocess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess.bpmn20.xml");
+        ProcessDefinition procDefNested = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-nested-subprocess.bpmn20.xml");
 
         //Start an instance of the definition with two task inside the subProcess
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm and move inside the subProcess
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions).hasSize(2); //includes root execution
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("BeforeSubProcess");
@@ -1196,8 +1294,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefNested.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess1", "InsideNestedSubProcess"));
+                .migrateToProcessDefinition(procDefNested.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess1", "InsideNestedSubProcess"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1205,10 +1303,14 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm - we move from a subProcess to a nestedSubProcess with the same name (SimpleSubProcess), the original is not created, but cancelled and created from the new model
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executionsAfterMigration.size()); //2 subProcesses and 1 userTask
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("OuterSubProcess", "SimpleSubProcess", "InsideNestedSubProcess");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefNested.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("OuterSubProcess", "SimpleSubProcess", "InsideNestedSubProcess"); //2 subProcesses and 1 userTask
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefNested.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefNested, processInstance, "subProcess", "SimpleSubProcess", "OuterSubProcess", "SimpleSubProcess");
@@ -1232,16 +1334,20 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityFromEmbeddedSubProcessIntoNestedEmbeddedSubProcessWithDataObject() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess-with-data-object.bpmn20.xml");
-        ProcessDefinition procDefNested = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-tasks-nested-subprocess-with-data-object.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-inside-subprocess-with-data-object.bpmn20.xml");
+        ProcessDefinition procDefNested = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-tasks-nested-subprocess-with-data-object.bpmn20.xml");
 
         //Start an instance of the definition with two task inside the subProcess
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm and move inside the subProcess
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size()); //includes root execution
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions).hasSize(2); //includes root execution
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("BeforeSubProcess");
@@ -1250,16 +1356,17 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("InsideSimpleSubProcess1");
 
-        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("SimpleSubProcess").singleResult();
-        assertNotNull(runtimeService.getVariableLocal(subProcessExecution.getId(), "dataScope", String.class));
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("SimpleSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "dataScope", String.class)).isNotNull();
         DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "dataScope");
-        assertNotNull(nameDataObject);
-        assertEquals("subProcess", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("subProcess");
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefNested.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess1", "InsideNestedSubProcess"));
+                .migrateToProcessDefinition(procDefNested.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("InsideSimpleSubProcess1", "InsideNestedSubProcess"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1267,18 +1374,22 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm - we move from a subProcess to a nestedSubProcess with the same name (SimpleSubProcess), the original is not created, but cancelled and created from the new model
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executionsAfterMigration.size()); //2 subProcesses and 1 userTask
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("OuterSubProcess", "SimpleSubProcess", "InsideNestedSubProcess");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefNested.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("OuterSubProcess", "SimpleSubProcess", "InsideNestedSubProcess"); //2 subProcesses and 1 userTask
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefNested.getId());
 
         //Confirm we have the dataObject of the subProcess in the new definition (its a new SubProcess execution nonetheless)
         subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("SimpleSubProcess").singleResult();
         assertThat(runtimeService.getVariablesLocal(subProcessExecution.getId())).containsOnlyKeys("dataScopeNested");
         assertThat(runtimeService.getDataObjectsLocal(subProcessExecution.getId())).containsOnlyKeys("dataScopeNested");
         nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "dataScopeNested");
-        assertNotNull(nameDataObject);
-        assertEquals("nestedSubProcess", nameDataObject.getValue());
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("nestedSubProcess");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefNested, processInstance, "subProcess", "SimpleSubProcess", "OuterSubProcess", "SimpleSubProcess");
@@ -1303,7 +1414,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     //-- Timers
     @Test
     public void testMigrateActivityToActivityWithTimerInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
         ProcessDefinition procDefOWithTimer = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml");
 
         //Start the processInstance without timer
@@ -1311,21 +1423,24 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executions.size());
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         changeStateEventListener.clear();
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOWithTimer.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "firstTask"));
+                .migrateToProcessDefinition(procDefOWithTimer.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "firstTask"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1333,27 +1448,35 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsOnly("firstTask", "boundaryTimerEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefOWithTimer.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("firstTask", "boundaryTimerEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOWithTimer.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("firstTask");
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         Execution execution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         Job job = managementService.createTimerJobQuery().executionId(execution.getId()).singleResult();
-        assertThat(job).isEqualToIgnoringGivenFields(timerJob, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
+        assertThat(job)
+                .isEqualToIgnoringGivenFields(timerJob, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.TIMER_SCHEDULED);
-        Optional<FlowableEvent> timerEvent = changeStateEventListener.getEvents().stream().filter(event -> event.getType().equals(FlowableEngineEventType.TIMER_SCHEDULED)).findFirst();
-        assertTrue(timerEvent.isPresent());
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.TIMER_SCHEDULED);
+        Optional<FlowableEvent> timerEvent = changeStateEventListener.getEvents().stream()
+                .filter(event -> event.getType().equals(FlowableEngineEventType.TIMER_SCHEDULED)).findFirst();
+        assertThat(timerEvent.isPresent()).isTrue();
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) timerEvent.get();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefOWithTimer, processInstance, "userTask", "firstTask");
@@ -1367,11 +1490,15 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             //Check History
             List<HistoricActivityInstance> taskExecutions = historyService.createHistoricActivityInstanceQuery()
-                .processInstanceId(processInstance.getId())
-                .activityType("userTask")
-                .list();
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getActivityId).containsExactlyInAnyOrder("firstTask", "secondTask");
-            assertThat(taskExecutions).extracting(HistoricActivityInstance::getProcessDefinitionId).containsOnly(procDefOWithTimer.getId());
+                    .processInstanceId(processInstance.getId())
+                    .activityType("userTask")
+                    .list();
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getActivityId)
+                    .containsExactlyInAnyOrder("firstTask", "secondTask");
+            assertThat(taskExecutions)
+                    .extracting(HistoricActivityInstance::getProcessDefinitionId)
+                    .containsOnly(procDefOWithTimer.getId());
 
             checkTaskInstance(procDefOWithTimer, processInstance, "firstTask", "secondTask");
         }
@@ -1382,31 +1509,36 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     @Test
     public void testMigrateActivityWithTimerToActivityWithoutTimerInNewDefinition() {
         ProcessDefinition procDefOWithTimer = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml");
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance with timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOWithTimer.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("firstTask", "boundaryTimerEvent");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOWithTimer.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("firstTask", "boundaryTimerEvent");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOWithTimer.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("firstTask");
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         Execution execution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         Job job = managementService.createTimerJobQuery().executionId(execution.getId()).singleResult();
-        assertThat(job).isEqualToIgnoringGivenFields(timerJob, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
+        assertThat(job)
+                .isEqualToIgnoringGivenFields(timerJob, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
 
         changeStateEventListener.clear();
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("firstTask", "userTask1Id"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("firstTask", "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1414,10 +1546,14 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsOnly("userTask1Id");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefOneTask, processInstance, "userTask", "userTask1Id");
@@ -1435,13 +1571,16 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         // Verify JOB cancellation event
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.JOB_CANCELED);
-        Optional<FlowableEvent> jobCancelEvent = changeStateEventListener.getEvents().stream().filter(event -> event.getType().equals(FlowableEngineEventType.JOB_CANCELED)).findFirst();
-        assertTrue(jobCancelEvent.isPresent());
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.JOB_CANCELED);
+        Optional<FlowableEvent> jobCancelEvent = changeStateEventListener.getEvents().stream()
+                .filter(event -> event.getType().equals(FlowableEngineEventType.JOB_CANCELED)).findFirst();
+        assertThat(jobCancelEvent.isPresent()).isTrue();
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) jobCancelEvent.get();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1456,20 +1595,23 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executions.size());
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("firstTask", "boundaryTimerEvent");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTimer.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("firstTask", "boundaryTimerEvent");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTimer.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("firstTask");
         Job timerJob1 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob1);
+        assertThat(timerJob1).isNotNull();
 
         changeStateEventListener.clear();
 
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefTwoTimers.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("firstTask", "secondTask"));
+                .migrateToProcessDefinition(procDefTwoTimers.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("firstTask", "secondTask"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1477,31 +1619,40 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("secondTask", "secondTimerEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefTwoTimers.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("secondTask", "secondTimerEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefTwoTimers.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("secondTask");
         Job timerJob2 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob2);
+        assertThat(timerJob2).isNotNull();
         Execution execution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         Job job = managementService.createTimerJobQuery().executionId(execution.getId()).singleResult();
-        assertThat(job).isEqualToIgnoringGivenFields(timerJob2, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
-        assertThat(timerJob1).isNotEqualTo(timerJob2).extracting(Job::getExecutionId);
+        assertThat(job)
+                .isEqualToIgnoringGivenFields(timerJob2, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
+        assertThat(timerJob1)
+                .extracting(Job::getExecutionId)
+                .isNotEqualTo(timerJob2);
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.JOB_CANCELED, FlowableEngineEventType.TIMER_SCHEDULED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.JOB_CANCELED, FlowableEngineEventType.TIMER_SCHEDULED);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) iterator.next();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
         entityEvent = (FlowableEngineEntityEvent) iterator.next();
         timer = (Job) entityEvent.getEntity();
-        assertEquals("secondTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("secondTimerEvent");
 
         //Complete the process
         job = managementService.moveTimerToExecutableJob(timerJob2.getId());
@@ -1515,7 +1666,6 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         completeProcessInstanceTasks(processInstance.getId());
 
-
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefTwoTimers, processInstance, "userTask", "secondTask", "thirdTask");
 
@@ -1528,7 +1678,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     @Test
     public void testMigrateActivityInsideEmbeddedSubProcessWithTimerToActivityOutsideEmbeddedSubProcessWithoutTimerInNewDefinition() {
         ProcessDefinition procDefSubProcWithTimer = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml");
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefSubProcWithTimer.getId());
@@ -1539,21 +1690,24 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executions.size());
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefSubProcWithTimer.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefSubProcWithTimer.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask");
         Job timerJob1 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob1);
+        assertThat(timerJob1).isNotNull();
         assertThat(timerJob1).extracting(Job::getProcessDefinitionId).isEqualTo(procDefSubProcWithTimer.getId());
         assertThat(timerJob1).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("subTask", "userTask1Id"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("subTask", "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1561,24 +1715,30 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
 
         Job timerJob2 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob2);
+        assertThat(timerJob2).isNull();
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.JOB_CANCELED, FlowableEngineEventType.ACTIVITY_CANCELLED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.JOB_CANCELED, FlowableEngineEventType.ACTIVITY_CANCELLED);
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) iterator.next();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
         assertThat(activityEvent).extracting(FlowableActivityEvent::getActivityId).isEqualTo("subProcess");
 
@@ -1602,7 +1762,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityToActivityInsideEmbeddedSubProcessWithTimerInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
         ProcessDefinition procDefSubProcWithTimer = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml");
 
         //Start the processInstance without timer
@@ -1610,8 +1771,12 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1619,8 +1784,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefSubProcWithTimer.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subTask"));
+                .migrateToProcessDefinition(procDefSubProcWithTimer.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subTask"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1628,23 +1793,29 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefSubProcWithTimer.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration).
+                extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefSubProcWithTimer.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefSubProcWithTimer.getId());
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procDefSubProcWithTimer.getId());
         assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_STARTED, FlowableEngineEventType.TIMER_SCHEDULED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_STARTED, FlowableEngineEventType.TIMER_SCHEDULED);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
@@ -1652,7 +1823,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) iterator.next();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefSubProcWithTimer, processInstance, "userTask", "subTask");
@@ -1674,7 +1845,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityToActivityInsideEmbeddedSubProcessWithTimerInNewDefinitionAndExecuteTimer() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
         ProcessDefinition procDefSubProcWithTimer = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml");
 
         //Start the processInstance without timer
@@ -1682,8 +1854,12 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1691,8 +1867,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefSubProcWithTimer.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subTask"));
+                .migrateToProcessDefinition(procDefSubProcWithTimer.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subTask"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1700,23 +1876,29 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefSubProcWithTimer.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefSubProcWithTimer.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefSubProcWithTimer.getId());
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procDefSubProcWithTimer.getId());
         assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_STARTED, FlowableEngineEventType.TIMER_SCHEDULED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_STARTED, FlowableEngineEventType.TIMER_SCHEDULED);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
@@ -1724,7 +1906,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) iterator.next();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
         //We will trigger the timer instead of the completing the task, it goes straight to the end
 
@@ -1743,7 +1925,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityWithTimerInsideEmbeddedSubProcessToActivityWithoutTimerInsideEmbeddedSubProcessInNewDefinition() {
-        ProcessDefinition procVersion1 = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-with-timer-inside-embedded-subprocess.bpmn20.xml");
+        ProcessDefinition procVersion1 = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-with-timer-inside-embedded-subprocess.bpmn20.xml");
         ProcessDefinition procVersion2 = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml");
 
         //Start the processInstance without timer
@@ -1752,21 +1935,25 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procVersion1.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
+        assertThat(executions)
+                .extracting("processDefinitionId").
+                containsOnly(procVersion1.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procVersion1.getId());
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procVersion1.getId());
         assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procVersion2.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("subTask", "subTask2"));
+                .migrateToProcessDefinition(procVersion2.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("subTask", "subTask2"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1774,26 +1961,32 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(2, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subTask2");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procVersion2.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subTask2");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procVersion2.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask2");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procVersion2.getId());
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.JOB_CANCELED, FlowableEngineEventType.ACTIVITY_CANCELLED, FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.JOB_CANCELED, FlowableEngineEventType.ACTIVITY_CANCELLED, FlowableEngineEventType.ACTIVITY_STARTED);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) iterator.next();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
         assertThat(activityEvent).extracting(FlowableActivityEvent::getActivityId).isEqualTo("subProcess");
@@ -1801,7 +1994,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         activityEvent = (FlowableActivityEvent) iterator.next();
         assertThat(activityEvent).extracting(FlowableActivityEvent::getActivityId).isEqualTo("subProcess");
 
-        assertFalse(iterator.hasNext());
+        assertThat(iterator.hasNext()).isFalse();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procVersion2, processInstance, "userTask", "taskBefore", "subTask2");
@@ -1823,16 +2016,22 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityToActivityWithTimerInsideEmbeddedSubProcessInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procDefTimerTaskInSubProcess = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procDefTimerTaskInSubProcess = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1840,8 +2039,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefTimerTaskInSubProcess.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subTask"));
+                .migrateToProcessDefinition(procDefTimerTaskInSubProcess.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subTask"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1849,27 +2048,34 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefTimerTaskInSubProcess.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefTimerTaskInSubProcess.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefTimerTaskInSubProcess.getId());
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procDefTimerTaskInSubProcess.getId());
         assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
         //Job is attached to the activity
         Execution timerExecution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         Job timerFromTask = managementService.createTimerJobQuery().executionId(timerExecution.getId()).singleResult();
-        assertThat(timerJob).isEqualToIgnoringGivenFields(timerFromTask, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
+        assertThat(timerJob)
+                .isEqualToIgnoringGivenFields(timerFromTask, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_STARTED, FlowableEngineEventType.TIMER_SCHEDULED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_STARTED, FlowableEngineEventType.TIMER_SCHEDULED);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
@@ -1877,7 +2083,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) iterator.next();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procDefTimerTaskInSubProcess, processInstance, "userTask", "subTask");
@@ -1899,16 +2105,22 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateActivityToActivityWithTimerInsideEmbeddedSubProcessInNewDefinitionAndExecuteTimer() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procDefTimerTaskInSubProcess = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procDefTimerTaskInSubProcess = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
@@ -1916,8 +2128,8 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefTimerTaskInSubProcess.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subTask"));
+                .migrateToProcessDefinition(procDefTimerTaskInSubProcess.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "subTask"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -1925,27 +2137,34 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, executionsAfterMigration.size());
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefTimerTaskInSubProcess.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "subTask", "boundaryTimerEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefTimerTaskInSubProcess.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("subTask");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefTimerTaskInSubProcess.getId());
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procDefTimerTaskInSubProcess.getId());
         assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
         //Job is attached to the activity
         Execution timerExecution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         Job timerFromTask = managementService.createTimerJobQuery().executionId(timerExecution.getId()).singleResult();
-        assertThat(timerJob).isEqualToIgnoringGivenFields(timerFromTask, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
+        assertThat(timerJob)
+                .isEqualToIgnoringGivenFields(timerFromTask, "originalPersistentState", "customValuesByteArrayRef", "exceptionByteArrayRef");
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_STARTED, FlowableEngineEventType.TIMER_SCHEDULED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_STARTED, FlowableEngineEventType.TIMER_SCHEDULED);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
@@ -1953,7 +2172,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) iterator.next();
         Job timer = (Job) entityEvent.getEntity();
-        assertEquals("boundaryTimerEvent", getJobActivityId(timer));
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
         //We will trigger the timer instead of the completing the task, it goes straight to the end of the subProcess, skipping one task
         Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
@@ -1972,27 +2191,33 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     //-- Intermediate Signal Catch Events
     @Test
     public void testMigrateSimpleActivityToIntermediateSignalCatchingEventInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "intermediateCatchEvent"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "intermediateCatchEvent"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -2000,20 +2225,28 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("intermediateCatchEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType)
+                .containsExactly(tuple("intermediateCatchEvent", "signal"));
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_CANCELLED, FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_CANCELLED, FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
@@ -2029,14 +2262,18 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         runtimeService.signalEventReceived("someSignal");
 
         executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("afterCatchEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("afterCatchEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("afterCatchEvent");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procWithSignal, processInstance, "userTask", "userTask1Id", "afterCatchEvent");
@@ -2060,8 +2297,10 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateIntermediateSignalCatchingEventToSimpleActivityInNewDefinition() {
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml");
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignal.getId());
@@ -2073,19 +2312,24 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("intermediateCatchEvent");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType)
+                .containsExactly(tuple("intermediateCatchEvent", "signal"));
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("intermediateCatchEvent", "userTask1Id"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("intermediateCatchEvent", "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -2093,9 +2337,14 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
@@ -2105,8 +2354,10 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         assertThat(eventSubscriptions).isEmpty();
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_STARTED);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
@@ -2135,8 +2386,10 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateIntermediateSignalCatchingEventToIntermediateSignalCatchingEventInNewDefinition() {
-        ProcessDefinition procWithSignalVer1 = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml");
-        ProcessDefinition procWithSignalVer2 = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/simple-intermediate-signal-catch-event.bpmn20.xml");
+        ProcessDefinition procWithSignalVer1 = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml");
+        ProcessDefinition procWithSignalVer2 = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/simple-intermediate-signal-catch-event.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignalVer1.getId());
@@ -2148,19 +2401,23 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignalVer1.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("intermediateCatchEvent");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignalVer1.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
-
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType)
+                .containsExactly(tuple("intermediateCatchEvent", "signal"));
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignalVer2.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("intermediateCatchEvent", "newIntermediateCatchEvent"));
+                .migrateToProcessDefinition(procWithSignalVer2.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("intermediateCatchEvent", "newIntermediateCatchEvent"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -2168,20 +2425,28 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("newIntermediateCatchEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procWithSignalVer2.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("newIntermediateCatchEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignalVer2.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("newIntermediateCatchEvent");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("signal");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType)
+                .containsExactly(tuple("newIntermediateCatchEvent", "signal"));
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_SIGNAL_WAITING);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableSignalEvent signalEvent = (FlowableSignalEvent) iterator.next();
@@ -2193,14 +2458,18 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         runtimeService.signalEventReceived("someNewSignal");
 
         executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("afterNewCatchEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procWithSignalVer2.getId());
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("afterNewCatchEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignalVer2.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("afterNewCatchEvent");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignalVer2.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procWithSignalVer2, processInstance, "userTask", "beforeCatchEvent", "afterNewCatchEvent");
@@ -2225,27 +2494,33 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     //-- Intermediate Message Catch Events
     @Test
     public void testMigrateSimpleActivityToIntermediateMessageCatchingEventInNewDefinition() {
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefOneTask.getId());
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        assertThat(executions).
+                extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignal.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "intermediateCatchEvent"));
+                .migrateToProcessDefinition(procWithSignal.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("userTask1Id", "intermediateCatchEvent"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -2253,20 +2528,28 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("intermediateCatchEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType)
+                .containsExactly(tuple("intermediateCatchEvent", "message"));
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_CANCELLED, FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_CANCELLED, FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableActivityEvent activityEvent = (FlowableActivityEvent) iterator.next();
@@ -2279,18 +2562,23 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         assertThat(signalEvent).extracting(FlowableMessageEvent::getMessageName).isEqualTo("someMessage");
 
         //Trigger the event
-        Execution messageCatchExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("intermediateCatchEvent").singleResult();
+        Execution messageCatchExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("intermediateCatchEvent")
+                .singleResult();
         runtimeService.messageEventReceived("someMessage", messageCatchExecution.getId());
 
         executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("afterCatchEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("afterCatchEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("afterCatchEvent");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procWithSignal, processInstance, "userTask", "userTask1Id", "afterCatchEvent");
@@ -2314,8 +2602,10 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateIntermediateMessageCatchingEventToSimpleActivityInNewDefinition() {
-        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml");
-        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
+        ProcessDefinition procWithSignal = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml");
+        ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignal.getId());
@@ -2327,19 +2617,24 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignal.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("intermediateCatchEvent");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignal.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType)
+                .containsExactly(tuple("intermediateCatchEvent", "message"));
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procDefOneTask.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("intermediateCatchEvent", "userTask1Id"));
+                .migrateToProcessDefinition(procDefOneTask.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("intermediateCatchEvent", "userTask1Id"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -2347,9 +2642,14 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("userTask1Id");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procDefOneTask.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("userTask1Id");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procDefOneTask.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
@@ -2359,8 +2659,10 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         assertThat(eventSubscriptions).isEmpty();
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED, FlowableEngineEventType.ACTIVITY_STARTED);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED, FlowableEngineEventType.ACTIVITY_STARTED);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableActivityEvent signalEvent = (FlowableMessageEvent) iterator.next();
@@ -2394,8 +2696,10 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
     @Test
     public void testMigrateIntermediateMessageCatchingEventToIntermediateMessageCatchingEventInNewDefinition() {
-        ProcessDefinition procWithSignalVer1 = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml");
-        ProcessDefinition procWithSignalVer2 = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/simple-intermediate-message-catch-event.bpmn20.xml");
+        ProcessDefinition procWithSignalVer1 = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml");
+        ProcessDefinition procWithSignalVer2 = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/simple-intermediate-message-catch-event.bpmn20.xml");
 
         //Start the processInstance without timer
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procWithSignalVer1.getId());
@@ -2407,19 +2711,24 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executions).extracting(Execution::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(executions).extracting("processDefinitionId").containsOnly(procWithSignalVer1.getId());
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("intermediateCatchEvent");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignalVer1.getId());
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("intermediateCatchEvent");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType)
+                .containsExactly(tuple("intermediateCatchEvent", "message"));
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
-            .migrateToProcessDefinition(procWithSignalVer2.getId())
-            .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("intermediateCatchEvent", "intermediateNewCatchEvent"));
+                .migrateToProcessDefinition(procWithSignalVer2.getId())
+                .addActivityMigrationMapping(ActivityMigrationMapping.createMappingFor("intermediateCatchEvent", "intermediateNewCatchEvent"));
 
         ProcessInstanceMigrationValidationResult processInstanceMigrationResult = processInstanceMigrationBuilder.validateMigration(processInstance.getId());
         assertThat(processInstanceMigrationResult.isMigrationValid()).isTrue();
@@ -2427,20 +2736,28 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         processInstanceMigrationBuilder.migrate(processInstance.getId());
 
         //Confirm
-        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("intermediateNewCatchEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procWithSignalVer2.getId());
+        List<Execution> executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions()
+                .list();
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("intermediateNewCatchEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignalVer2.getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
 
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertThat(eventSubscriptions).extracting(EventSubscription::getActivityId).containsExactly("intermediateNewCatchEvent");
-        assertThat(eventSubscriptions).extracting(EventSubscription::getEventType).containsExactly("message");
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getActivityId, EventSubscription::getEventType)
+                .containsExactly(tuple("intermediateNewCatchEvent", "message"));
 
         // Verify events
-        assertTrue(changeStateEventListener.hasEvents());
-        assertThat(changeStateEventListener.getEvents()).extracting(FlowableEvent::getType).containsExactly(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED, FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
+        assertThat(changeStateEventListener.hasEvents()).isTrue();
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(FlowableEvent::getType)
+                .containsExactly(FlowableEngineEventType.ACTIVITY_MESSAGE_CANCELLED, FlowableEngineEventType.ACTIVITY_MESSAGE_WAITING);
 
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         FlowableMessageEvent signalEvent = (FlowableMessageEvent) iterator.next();
@@ -2454,18 +2771,23 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         assertThat(signalEvent).extracting(FlowableMessageEvent::getMessageName).isEqualTo("someNewMessage");
 
         //Trigger the event
-        Execution messageCatchExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("intermediateNewCatchEvent").singleResult();
+        Execution messageCatchExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId())
+                .activityId("intermediateNewCatchEvent").singleResult();
         runtimeService.messageEventReceived("someNewMessage", messageCatchExecution.getId());
 
         executionsAfterMigration = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertThat(executionsAfterMigration).extracting(Execution::getActivityId).containsExactly("afterNewCatchEvent");
-        assertThat(executionsAfterMigration).extracting("processDefinitionId").containsOnly(procWithSignalVer2.getId());
+        assertThat(executionsAfterMigration)
+                .extracting(Execution::getActivityId)
+                .containsExactly("afterNewCatchEvent");
+        assertThat(executionsAfterMigration)
+                .extracting("processDefinitionId")
+                .containsOnly(procWithSignalVer2.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("afterNewCatchEvent");
         assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignalVer2.getId());
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
-        assertTrue(eventSubscriptions.isEmpty());
+        assertThat(eventSubscriptions).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             checkActivityInstances(procWithSignalVer2, processInstance, "userTask", "beforeCatchEvent", "afterNewCatchEvent");
@@ -2497,28 +2819,29 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).onlyChildExecutions().singleResult();
         runtimeService.trigger(execution.getId());
 
-        assertThat((List)runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
+        assertThat((List) runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
 
-        ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
+        ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
 
         processMigrationService.createProcessInstanceMigrationBuilder().preUpgradeScript(new Script("groovy",
-            "import com.fasterxml.jackson.databind.ObjectMapper\n"
-            + "import com.fasterxml.jackson.databind.node.ArrayNode\n"
-            + "import org.flowable.engine.impl.context.Context\n"
-            + "\n"
-            + "List<String> list  = execution.getVariable('listVariable')\n"
-            + "\n"
-            + "ObjectMapper mapper = Context.getProcessEngineConfiguration().getObjectMapper()\n"
-            + "\n"
-            + "ArrayNode jsonArray = mapper.createArrayNode()\n"
-            + "list.each {jsonArray.add(it)}\n"
-            + "\n"
-            + "execution.setVariable(\"listVariable\", jsonArray)"))
-            .migrateToProcessDefinition(targetProcessDefinition.getId())
-            .migrate(processInstanceToMigrate.getId());
+                "import com.fasterxml.jackson.databind.ObjectMapper\n"
+                        + "import com.fasterxml.jackson.databind.node.ArrayNode\n"
+                        + "import org.flowable.engine.impl.context.Context\n"
+                        + "\n"
+                        + "List<String> list  = execution.getVariable('listVariable')\n"
+                        + "\n"
+                        + "ObjectMapper mapper = Context.getProcessEngineConfiguration().getObjectMapper()\n"
+                        + "\n"
+                        + "ArrayNode jsonArray = mapper.createArrayNode()\n"
+                        + "list.each {jsonArray.add(it)}\n"
+                        + "\n"
+                        + "execution.setVariable(\"listVariable\", jsonArray)"))
+                .migrateToProcessDefinition(targetProcessDefinition.getId())
+                .migrate(processInstanceToMigrate.getId());
 
         assertThatProcessVariableConverted(processInstanceToMigrate, execution);
-        
+
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             // serializable - when starting the process instance
             // serializable - when triggering the received task (the value is updated so new detail is created)
@@ -2537,16 +2860,18 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).onlyChildExecutions().singleResult();
         runtimeService.trigger(execution.getId());
 
-        assertThat((List)runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
+        assertThat((List) runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
 
-        ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
+        ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
 
-        processMigrationService.createProcessInstanceMigrationBuilder().preUpgradeJavaDelegate("org.flowable.engine.test.api.runtime.migration.ConvertProcessVariable")
-            .migrateToProcessDefinition(targetProcessDefinition.getId())
-            .migrate(processInstanceToMigrate.getId());
+        processMigrationService.createProcessInstanceMigrationBuilder()
+                .preUpgradeJavaDelegate("org.flowable.engine.test.api.runtime.migration.ConvertProcessVariable")
+                .migrateToProcessDefinition(targetProcessDefinition.getId())
+                .migrate(processInstanceToMigrate.getId());
 
         assertThatProcessVariableConverted(processInstanceToMigrate, execution);
-        
+
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             // serializable - when starting the process instance
             // serializable - when triggering the received task (the value is updated so new detail is created)
@@ -2565,23 +2890,23 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         variables.put("listVariable", new ArrayList());
         variables.put("convertProcessVariable", new ConvertProcessVariable()); // using instead of beans. Not nice, but it uses similar resolver as beans
         ProcessInstance processInstanceToMigrate = runtimeService
-            .startProcessInstanceByKey("MP", variables);
+                .startProcessInstanceByKey("MP", variables);
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).onlyChildExecutions()
-            .singleResult();
+                .singleResult();
         runtimeService.trigger(execution.getId());
 
         assertThat((List) runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
 
         ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy",
-            "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
+                "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
 
         processMigrationService.createProcessInstanceMigrationBuilder()
-            .preUpgradeJavaDelegateExpression("${convertProcessVariable}")
-            .migrateToProcessDefinition(targetProcessDefinition.getId())
-            .migrate(processInstanceToMigrate.getId());
+                .preUpgradeJavaDelegateExpression("${convertProcessVariable}")
+                .migrateToProcessDefinition(targetProcessDefinition.getId())
+                .migrate(processInstanceToMigrate.getId());
 
         assertThatProcessVariableConverted(processInstanceToMigrate, execution);
-        
+
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             // serializable - when starting the process instance (listVariable)
             // serializable - when starting the process instance (convertProcessVariable)
@@ -2602,28 +2927,29 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).onlyChildExecutions().singleResult();
         runtimeService.trigger(execution.getId());
 
-        assertThat((List)runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
+        assertThat((List) runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
 
-        ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
+        ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
 
         processMigrationService.createProcessInstanceMigrationBuilder().postUpgradeScript(new Script("groovy",
-            "import com.fasterxml.jackson.databind.ObjectMapper\n"
-                + "import com.fasterxml.jackson.databind.node.ArrayNode\n"
-                + "import org.flowable.engine.impl.context.Context\n"
-                + "\n"
-                + "List<String> list  = execution.getVariable('listVariable')\n"
-                + "\n"
-                + "ObjectMapper mapper = Context.getProcessEngineConfiguration().getObjectMapper()\n"
-                + "\n"
-                + "ArrayNode jsonArray = mapper.createArrayNode()\n"
-                + "list.each {jsonArray.add(it)}\n"
-                + "\n"
-                + "execution.setVariable(\"listVariable\", jsonArray)"))
-            .migrateToProcessDefinition(targetProcessDefinition.getId())
-            .migrate(processInstanceToMigrate.getId());
+                "import com.fasterxml.jackson.databind.ObjectMapper\n"
+                        + "import com.fasterxml.jackson.databind.node.ArrayNode\n"
+                        + "import org.flowable.engine.impl.context.Context\n"
+                        + "\n"
+                        + "List<String> list  = execution.getVariable('listVariable')\n"
+                        + "\n"
+                        + "ObjectMapper mapper = Context.getProcessEngineConfiguration().getObjectMapper()\n"
+                        + "\n"
+                        + "ArrayNode jsonArray = mapper.createArrayNode()\n"
+                        + "list.each {jsonArray.add(it)}\n"
+                        + "\n"
+                        + "execution.setVariable(\"listVariable\", jsonArray)"))
+                .migrateToProcessDefinition(targetProcessDefinition.getId())
+                .migrate(processInstanceToMigrate.getId());
 
         assertThatProcessVariableConverted(processInstanceToMigrate, execution);
-        
+
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             // serializable - when starting the process instance
             // serializable - when triggering the received task (the value is updated so new detail is created)
@@ -2642,16 +2968,18 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).onlyChildExecutions().singleResult();
         runtimeService.trigger(execution.getId());
 
-        assertThat((List)runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
+        assertThat((List) runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
 
-        ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy", "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
+        ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
 
-        processMigrationService.createProcessInstanceMigrationBuilder().postUpgradeJavaDelegate("org.flowable.engine.test.api.runtime.migration.ConvertProcessVariable")
-            .migrateToProcessDefinition(targetProcessDefinition.getId())
-            .migrate(processInstanceToMigrate.getId());
+        processMigrationService.createProcessInstanceMigrationBuilder()
+                .postUpgradeJavaDelegate("org.flowable.engine.test.api.runtime.migration.ConvertProcessVariable")
+                .migrateToProcessDefinition(targetProcessDefinition.getId())
+                .migrate(processInstanceToMigrate.getId());
 
         assertThatProcessVariableConverted(processInstanceToMigrate, execution);
-        
+
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             // serializable - when starting the process instance
             // serializable - when triggering the received task (the value is updated so new detail is created)
@@ -2670,23 +2998,23 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         variables.put("listVariable", new ArrayList());
         variables.put("convertProcessVariable", new ConvertProcessVariable()); // using instead of beans. Not nice, but it uses similar resolver as beans
         ProcessInstance processInstanceToMigrate = runtimeService
-            .startProcessInstanceByKey("MP", variables);
+                .startProcessInstanceByKey("MP", variables);
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstanceToMigrate.getId()).onlyChildExecutions()
-            .singleResult();
+                .singleResult();
         runtimeService.trigger(execution.getId());
 
         assertThat((List) runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).contains("new value");
 
         ProcessDefinition targetProcessDefinition = deployProcessDefinition("my deploy",
-            "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
+                "org/flowable/engine/test/api/runtime/migration/json-variable-process.bpmn20.xml");
 
         processMigrationService.createProcessInstanceMigrationBuilder()
-            .postUpgradeJavaDelegateExpression("${convertProcessVariable}")
-            .migrateToProcessDefinition(targetProcessDefinition.getId())
-            .migrate(processInstanceToMigrate.getId());
+                .postUpgradeJavaDelegateExpression("${convertProcessVariable}")
+                .migrateToProcessDefinition(targetProcessDefinition.getId())
+                .migrate(processInstanceToMigrate.getId());
 
         assertThatProcessVariableConverted(processInstanceToMigrate, execution);
-        
+
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             assertThatVariablesTypeHistoryIs(processInstanceToMigrate, "serializable", "serializable", "serializable", "json", "json");
         }
@@ -2694,24 +3022,25 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
     }
 
     private void assertThatVariablesTypeHistoryIs(ProcessInstance processInstanceToMigrate, String... values) {
-        List<HistoricDetail> updateList = historyService.createHistoricDetailQuery().processInstanceId(processInstanceToMigrate.getId()).variableUpdates().list();
+        List<HistoricDetail> updateList = historyService.createHistoricDetailQuery().processInstanceId(processInstanceToMigrate.getId()).variableUpdates()
+                .list();
 
         Collections.sort(updateList, Comparator.comparingInt(histDetail -> Integer.parseInt(histDetail.getId())));
-        assertThat(updateList).
-            extracting(historicDetail -> ((HistoricDetailVariableInstanceUpdateEntity) historicDetail).getVariableType().getTypeName()).
-            containsExactly(values);
+        assertThat(updateList)
+                .extracting(historicDetail -> ((HistoricDetailVariableInstanceUpdateEntity) historicDetail).getVariableType().getTypeName())
+                .containsExactly(values);
     }
 
     private void assertThatProcessVariableConverted(ProcessInstance processInstanceToMigrate, Execution execution) {
-        assertThat((ArrayNode)runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).
-            extracting(jsonNode -> jsonNode.asText()).
-            containsExactly("new value");
+        assertThat((ArrayNode) runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable"))
+                .extracting(jsonNode -> jsonNode.asText())
+                .containsExactly("new value");
 
         runtimeService.trigger(execution.getId());
 
-        assertThat((ArrayNode)runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable")).
-            extracting(jsonNode -> jsonNode.asText()).
-            containsExactly("new value", "new value 2");
+        assertThat((ArrayNode) runtimeService.getVariable(processInstanceToMigrate.getId(), "listVariable"))
+                .extracting(jsonNode -> jsonNode.asText())
+                .containsExactly("new value", "new value 2");
 
         runtimeService.trigger(execution.getId());
 


### PR DESCRIPTION
These are all the test files in the `org.flowable.engine.test.api.runtime.migration` package.

There are lots of changes and I attempted to apply a consistent style but because of the large 
number of lines there are like still some inconsistencies.