### PR TITLE
Exception Mapping in ServiceTaskExpression permit throwing checked Ex…

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskExpressionActivityBehavior.java
@@ -117,8 +117,8 @@ public class ServiceTaskExpressionActivityBehavior extends TaskActivityBehavior 
                 if (cause instanceof BpmnError) {
                     error = (BpmnError) cause;
                     break;
-                } else if (cause instanceof RuntimeException) {
-                    if (ErrorPropagation.mapException((RuntimeException) cause, (ExecutionEntity) execution, mapExceptions)) {
+                } else if (cause instanceof Exception) {
+                    if (ErrorPropagation.mapException((Exception) cause, (ExecutionEntity) execution, mapExceptions)) {
                         return;
                     }
                 }


### PR DESCRIPTION
In flowable 6, only unchecked exceptions can be used for the exception mapping feature. 
But if you have an expression like `${myBean.myMethod(..)}`, you typically refer to an external Java API, which declares also checked exceptions (which you propably want to catch in an boundaryerrorevent). If so, I have to rewrite my code to declare everywhere unchecked exceptions or to throw a new BpmnError().

So, I see not reason, why only unchecked exceptions are allowed here.

