### PR TITLE
Move the same statement(s) at end of both then/else clauses to end of if

### DIFF
--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/FileSystemContentStorage.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/fs/FileSystemContentStorage.java
@@ -305,22 +305,18 @@ public class FileSystemContentStorage implements ContentStorage {
                 if (newFolder.mkdirs()) {
                     return newFolder;
                 }
-
-                // File already existed, repeat the process again to find the next
-                // available folder
-                LOGGER.debug("Next folder already created, retrying...");
-                return getFirstAvailableFolder(--maxRetries);
             } else {
                 File newFolder = new File(currentMaxFolder.getParentFile(), String.valueOf(lastIndex + 1));
                 if (newFolder.mkdir()) {
                     return newFolder;
                 }
 
-                // File already existed, repeat the process again to find the next
-                // available folder
-                LOGGER.debug("Next folder already created, retrying...");
-                return getFirstAvailableFolder(--maxRetries);
             }
+
+            // File already existed, repeat the process again to find the next
+            // available folder
+            LOGGER.debug("Next folder already created, retrying...");
+            return getFirstAvailableFolder(--maxRetries);
         }
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/BoundaryCancelEventActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/BoundaryCancelEventActivityBehavior.java
@@ -61,9 +61,7 @@ public class BoundaryCancelEventActivityBehavior extends BoundaryEventActivityBe
         EventSubscriptionService eventSubscriptionService = CommandContextUtil.getEventSubscriptionService(commandContext);
         List<CompensateEventSubscriptionEntity> eventSubscriptions = eventSubscriptionService.findCompensateEventSubscriptionsByExecutionId(subProcessExecution.getParentId());
 
-        if (eventSubscriptions.isEmpty()) {
-            leave(execution);
-        } else {
+        if (!eventSubscriptions.isEmpty()) {
 
             String deleteReason = DeleteReason.BOUNDARY_EVENT_INTERRUPTING + "(" + boundaryEvent.getId() + ")";
 
@@ -82,7 +80,7 @@ public class BoundaryCancelEventActivityBehavior extends BoundaryEventActivityBe
                     }
                 }
             }
-            leave(execution);
         }
+        leave(execution);
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/IntermediateThrowCompensationEventActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/IntermediateThrowCompensationEventActivityBehavior.java
@@ -130,12 +130,10 @@ public class IntermediateThrowCompensationEventActivityBehavior extends FlowNode
 
         }
 
-        if (eventSubscriptions.isEmpty()) {
-            leave(execution);
-        } else {
+        if (!eventSubscriptions.isEmpty()) {
             // TODO: implement async (waitForCompletion=false in bpmn)
             ScopeUtil.throwCompensationEvent(eventSubscriptions, execution, false);
-            leave(execution);
         }
+        leave(execution);
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/ProcessInstanceEndHistoryJsonTransformer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/ProcessInstanceEndHistoryJsonTransformer.java
@@ -55,9 +55,7 @@ public class ProcessInstanceEndHistoryJsonTransformer extends AbstractNeedsProce
             if (startTime != null && endTime != null) {
                 historicProcessInstance.setDurationInMillis(endTime.getTime() - startTime.getTime());
             }
-    
-            dispatchEvent(commandContext, FlowableEventBuilder.createEntityEvent(FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_ENDED, historicProcessInstance));
-        
+
         } else {
             historicProcessInstance = historicProcessInstanceEntityManager.create();
             historicProcessInstance.setId(getStringFromJson(historicalData, HistoryJsonConstants.ID));
@@ -95,9 +93,9 @@ public class ProcessInstanceEndHistoryJsonTransformer extends AbstractNeedsProce
             }
             
             historicProcessInstanceEntityManager.update(historicProcessInstance, false);
-    
-            dispatchEvent(commandContext, FlowableEventBuilder.createEntityEvent(FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_ENDED, historicProcessInstance));
+
         }
+        dispatchEvent(commandContext, FlowableEventBuilder.createEntityEvent(FlowableEngineEventType.HISTORIC_PROCESS_INSTANCE_ENDED, historicProcessInstance));
     }
     
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/CommentEntityImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/CommentEntityImpl.java
@@ -65,11 +65,10 @@ public class CommentEntityImpl extends AbstractBpmnEngineNoRevisionEntity implem
         for (String part : messageParts) {
             if (part != null) {
                 stringBuilder.append(part.replace(MESSAGE_PARTS_MARKER, " | "));
-                stringBuilder.append(MESSAGE_PARTS_MARKER);
             } else {
                 stringBuilder.append("null");
-                stringBuilder.append(MESSAGE_PARTS_MARKER);
             }
+            stringBuilder.append(MESSAGE_PARTS_MARKER);
         }
         for (int i = 0; i < MESSAGE_PARTS_MARKER.length(); i++) {
             stringBuilder.deleteCharAt(stringBuilder.length() - 1);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityImpl.java
@@ -676,7 +676,6 @@ public class ExecutionEntityImpl extends AbstractBpmnEngineVariableScopeEntity i
                 VariableInstanceEntity variable = getSpecificVariable(variableName);
                 if (variable != null) {
                     updateVariableInstance(variable, value, sourceExecution);
-                    usedVariablesCache.put(variableName, variable);
                 } else {
 
                     VariableScopeImpl parent = getParentVariableScope();
@@ -690,8 +689,8 @@ public class ExecutionEntityImpl extends AbstractBpmnEngineVariableScopeEntity i
                     }
 
                     variable = createVariableInstance(variableName, value, sourceExecution);
-                    usedVariablesCache.put(variableName, variable);
                 }
+                usedVariablesCache.put(variableName, variable);
 
             }
 
@@ -726,8 +725,6 @@ public class ExecutionEntityImpl extends AbstractBpmnEngineVariableScopeEntity i
                 updateVariableInstance(variableInstance, value, sourceExecution);
             }
 
-            return null;
-
         } else {
 
             if (usedVariablesCache.containsKey(variableName)) {
@@ -746,9 +743,8 @@ public class ExecutionEntityImpl extends AbstractBpmnEngineVariableScopeEntity i
 
             }
 
-            return null;
-
         }
+        return null;
     }
     
     @Override

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BpmnJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BpmnJsonConverter.java
@@ -403,12 +403,10 @@ public class BpmnJsonConverter implements EditorJsonConstants, StencilConstants,
                 }
             }
 
-            processMessageFlows(model, shapesArrayNode);
-
         } else {
             processFlowElements(model.getMainProcess(), model, shapesArrayNode, formKeyMap, decisionTableKeyMap, 0.0, 0.0);
-            processMessageFlows(model, shapesArrayNode);
         }
+        processMessageFlows(model, shapesArrayNode);
 
         modelNode.set(EDITOR_CHILD_SHAPES, shapesArrayNode);
         return modelNode;

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/VariableScopeImpl.java
@@ -137,7 +137,6 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
             for (String variableName : variableNamesToFetch) {
                 requestedVariables.put(variableName, allVariables.get(variableName));
             }
-            return requestedVariables;
 
         } else {
 
@@ -153,9 +152,8 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
                 requestedVariables.put(variable.getName(), variable.getValue());
             }
 
-            return requestedVariables;
-
         }
+        return requestedVariables;
 
     }
 
@@ -184,7 +182,6 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
             for (String variableName : variableNamesToFetch) {
                 requestedVariables.put(variableName, allVariables.get(variableName));
             }
-            return requestedVariables;
 
         } else {
 
@@ -200,9 +197,8 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
                 requestedVariables.put(variable.getName(), variable);
             }
 
-            return requestedVariables;
-
         }
+        return requestedVariables;
 
     }
 
@@ -306,8 +302,6 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
                 return parentScope.getVariableInstance(variableName, true);
             }
 
-            return null;
-
         } else {
 
             if (variableInstances != null && variableInstances.containsKey(variableName)) {
@@ -326,9 +320,8 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
                 return parentScope.getVariableInstance(variableName, false);
             }
 
-            return null;
-
         }
+        return null;
     }
 
     protected abstract VariableInstanceEntity getSpecificVariable(String variableName);
@@ -372,7 +365,6 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
             if (variableInstance != null) {
                 return variableInstance;
             }
-            return null;
 
         } else {
 
@@ -389,8 +381,8 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
                 return variable;
             }
 
-            return null;
         }
+        return null;
     }
 
     @Override
@@ -719,7 +711,6 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
                 VariableInstanceEntity variable = getSpecificVariable(variableName);
                 if (variable != null) {
                     updateVariableInstance(variable, value);
-                    usedVariablesCache.put(variableName, variable);
                 } else {
 
                     VariableScopeImpl parent = getParentVariableScope();
@@ -729,9 +720,9 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
                     }
 
                     variable = createVariableInstance(variableName, value);
-                    usedVariablesCache.put(variableName, variable);
 
                 }
+                usedVariablesCache.put(variableName, variable);
 
             }
 
@@ -773,8 +764,6 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
                 updateVariableInstance(variableInstance, value);
             }
 
-            return null;
-
         } else {
 
             if (usedVariablesCache.containsKey(variableName)) {
@@ -793,9 +782,8 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
 
             }
 
-            return null;
-
         }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Found occurrences of the same statement(s) at end of both `then`/`else` clauses of an `if` statement.
Moved a single copy of the code to after the end of the `if`.