### PR TITLE
Use assertj fluent style in flowable-idm-engine.

### DIFF
--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/ForceCloseMybatisConnectionPoolTest.java
@@ -12,27 +12,25 @@
  */
 package org.flowable.idm.engine.test.api.identity;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.flowable.idm.engine.IdmEngine;
 import org.flowable.idm.engine.impl.cfg.StandaloneInMemIdmEngineConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji
  */
 public class ForceCloseMybatisConnectionPoolTest {
 
-
     @Test
     public void testForceCloseMybatisConnectionPoolTrue() {
 
         // given
         // that the AbstractEngineConfiguration is configured with forceCloseMybatisConnectionPool = true
-        StandaloneInMemIdmEngineConfiguration standaloneInMemIdmEngineConfiguration =  new StandaloneInMemIdmEngineConfiguration();
+        StandaloneInMemIdmEngineConfiguration standaloneInMemIdmEngineConfiguration = new StandaloneInMemIdmEngineConfiguration();
         standaloneInMemIdmEngineConfiguration.setJdbcUrl("jdbc:h2:mem:flowable-idm-" + this.getClass().getName());
         standaloneInMemIdmEngineConfiguration.setForceCloseMybatisConnectionPool(true);
         standaloneInMemIdmEngineConfiguration.setDatabaseSchemaUpdate("drop-create");
@@ -41,14 +39,14 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemIdmEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         // then
         // if the  engine is closed
         idmEngine.close();
 
         // the idle connections are closed
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
     }
 
     @Test
@@ -56,7 +54,7 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         // given
         // that the AbstractEngineConfiguration is configured with forceCloseMybatisConnectionPool = false
-        StandaloneInMemIdmEngineConfiguration standaloneInMemIdmEngineConfiguration =  new StandaloneInMemIdmEngineConfiguration();
+        StandaloneInMemIdmEngineConfiguration standaloneInMemIdmEngineConfiguration = new StandaloneInMemIdmEngineConfiguration();
         standaloneInMemIdmEngineConfiguration.setJdbcUrl("jdbc:h2:mem:flowable-idm-" + this.getClass().getName());
         standaloneInMemIdmEngineConfiguration.setForceCloseMybatisConnectionPool(false);
         standaloneInMemIdmEngineConfiguration.setDatabaseSchemaUpdate("drop-create");
@@ -65,17 +63,17 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemIdmEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         // then
         // if the  engine is closed
         idmEngine.close();
 
         // the idle connections are not closed
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         pooledDataSource.forceCloseAll();
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
     }
 
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/GetPropertiesTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/GetPropertiesTest.java
@@ -12,23 +12,23 @@
  */
 package org.flowable.idm.engine.test.api.identity;
 
-import org.flowable.idm.engine.test.ResourceFlowableIdmTestCase;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
-
+import org.flowable.idm.engine.test.ResourceFlowableIdmTestCase;
+import org.junit.jupiter.api.Test;
 
 public class GetPropertiesTest extends ResourceFlowableIdmTestCase {
 
     public GetPropertiesTest() {
         super("flowable.idm.cfg.xml");
     }
+
     @Test
     public void testIdmManagementServiceGetProperties() {
         Map<String, String> properties = idmManagementService.getProperties();
-        assertNotNull(properties);
+        assertThat(properties).isNotNull();
     }
 
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/GroupQueryEscapeClauseTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/GroupQueryEscapeClauseTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.idm.engine.test.api.identity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.GroupQuery;
@@ -42,14 +42,14 @@ public class GroupQueryEscapeClauseTest extends ResourceFlowableIdmTestCase {
     @Test
     public void testQueryByNameLike() {
         GroupQuery query = idmIdentityService.createGroupQuery().groupNameLike("%|%%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("muppets", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("muppets");
 
         query = idmIdentityService.createGroupQuery().groupNameLike("%|_%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("frogs", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("frogs");
     }
 
     private Group createGroup(String id, String name, String type) {

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/GroupQueryTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/GroupQueryTest.java
@@ -165,16 +165,15 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
 
         query = query.orderByGroupId().asc();
         List<Group> groups = query.list();
-        assertThat(groups).hasSize(3);
-        assertThat(groups.get(0).getId()).isEqualTo("admin");
-        assertThat(groups.get(1).getId()).isEqualTo("frogs");
-        assertThat(groups.get(2).getId()).isEqualTo("muppets");
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("admin", "frogs", "muppets");
 
         query = query.groupType("user");
         groups = query.list();
-        assertThat(groups).hasSize(2);
-        assertThat(groups.get(0).getId()).isEqualTo("frogs");
-        assertThat(groups.get(1).getId()).isEqualTo("muppets");
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("frogs", "muppets");
     }
 
     @Test
@@ -189,21 +188,19 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
     @Test
     public void testQueryByGroupMembers() {
         List<Group> groups = idmIdentityService.createGroupQuery().groupMembers(Arrays.asList("kermit", "fozzie")).orderByGroupId().asc().list();
-        assertThat(groups).hasSize(4);
-        assertThat(groups.get(0).getId()).isEqualTo("admin");
-        assertThat(groups.get(1).getId()).isEqualTo("frogs");
-        assertThat(groups.get(2).getId()).isEqualTo("mammals");
-        assertThat(groups.get(3).getId()).isEqualTo("muppets");
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("admin", "frogs", "mammals", "muppets");
 
         groups = idmIdentityService.createGroupQuery().groupMembers(Arrays.asList("fozzie")).orderByGroupId().asc().list();
-        assertThat(groups).hasSize(2);
-        assertThat(groups.get(0).getId()).isEqualTo("mammals");
-        assertThat(groups.get(1).getId()).isEqualTo("muppets");
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("mammals", "muppets");
 
         groups = idmIdentityService.createGroupQuery().groupMembers(Arrays.asList("kermit", "fozzie")).orderByGroupId().asc().listPage(1, 2);
-        assertThat(groups).hasSize(2);
-        assertThat(groups.get(0).getId()).isEqualTo("frogs");
-        assertThat(groups.get(1).getId()).isEqualTo("mammals");
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("frogs", "mammals");
     }
 
     @Test
@@ -230,17 +227,13 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
         // Multiple sortings
         GroupQuery query = idmIdentityService.createGroupQuery().orderByGroupType().asc().orderByGroupName().desc();
         List<Group> groups = query.list();
-        assertThat(query.count()).isEqualTo(4);
+        assertThat(groups)
+                .extracting(Group::getType)
+                .containsExactly("security", "user", "user", "user");
 
-        assertThat(groups.get(0).getType()).isEqualTo("security");
-        assertThat(groups.get(1).getType()).isEqualTo("user");
-        assertThat(groups.get(2).getType()).isEqualTo("user");
-        assertThat(groups.get(3).getType()).isEqualTo("user");
-
-        assertThat(groups.get(0).getId()).isEqualTo("admin");
-        assertThat(groups.get(1).getId()).isEqualTo("muppets");
-        assertThat(groups.get(2).getId()).isEqualTo("mammals");
-        assertThat(groups.get(3).getId()).isEqualTo("frogs");
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("admin", "muppets", "mammals", "frogs");
     }
 
     @Test

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/GroupQueryTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/GroupQueryTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,10 +13,8 @@
 
 package org.flowable.idm.engine.test.api.identity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -84,11 +82,8 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
         GroupQuery query = idmIdentityService.createGroupQuery().groupId("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createGroupQuery().groupId(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().groupId(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -105,11 +100,8 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
         GroupQuery query = idmIdentityService.createGroupQuery().groupName("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createGroupQuery().groupName(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().groupName(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -129,11 +121,8 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
         GroupQuery query = idmIdentityService.createGroupQuery().groupNameLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createGroupQuery().groupNameLike(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().groupNameLike(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -162,11 +151,8 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
         GroupQuery query = idmIdentityService.createGroupQuery().groupType("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createGroupQuery().groupType(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().groupType(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -179,16 +165,16 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
 
         query = query.orderByGroupId().asc();
         List<Group> groups = query.list();
-        assertEquals(3, groups.size());
-        assertEquals("admin", groups.get(0).getId());
-        assertEquals("frogs", groups.get(1).getId());
-        assertEquals("muppets", groups.get(2).getId());
+        assertThat(groups).hasSize(3);
+        assertThat(groups.get(0).getId()).isEqualTo("admin");
+        assertThat(groups.get(1).getId()).isEqualTo("frogs");
+        assertThat(groups.get(2).getId()).isEqualTo("muppets");
 
         query = query.groupType("user");
         groups = query.list();
-        assertEquals(2, groups.size());
-        assertEquals("frogs", groups.get(0).getId());
-        assertEquals("muppets", groups.get(1).getId());
+        assertThat(groups).hasSize(2);
+        assertThat(groups.get(0).getId()).isEqualTo("frogs");
+        assertThat(groups.get(1).getId()).isEqualTo("muppets");
     }
 
     @Test
@@ -196,133 +182,113 @@ public class GroupQueryTest extends PluggableFlowableIdmTestCase {
         GroupQuery query = idmIdentityService.createGroupQuery().groupMember("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createGroupQuery().groupMember(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().groupMember(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
-    
+
     @Test
     public void testQueryByGroupMembers() {
         List<Group> groups = idmIdentityService.createGroupQuery().groupMembers(Arrays.asList("kermit", "fozzie")).orderByGroupId().asc().list();
-        assertEquals(4, groups.size());
-        assertEquals("admin", groups.get(0).getId());
-        assertEquals("frogs", groups.get(1).getId());
-        assertEquals("mammals", groups.get(2).getId());
-        assertEquals("muppets", groups.get(3).getId());
-        
+        assertThat(groups).hasSize(4);
+        assertThat(groups.get(0).getId()).isEqualTo("admin");
+        assertThat(groups.get(1).getId()).isEqualTo("frogs");
+        assertThat(groups.get(2).getId()).isEqualTo("mammals");
+        assertThat(groups.get(3).getId()).isEqualTo("muppets");
+
         groups = idmIdentityService.createGroupQuery().groupMembers(Arrays.asList("fozzie")).orderByGroupId().asc().list();
-        assertEquals(2, groups.size());
-        assertEquals("mammals", groups.get(0).getId());
-        assertEquals("muppets", groups.get(1).getId());
-        
+        assertThat(groups).hasSize(2);
+        assertThat(groups.get(0).getId()).isEqualTo("mammals");
+        assertThat(groups.get(1).getId()).isEqualTo("muppets");
+
         groups = idmIdentityService.createGroupQuery().groupMembers(Arrays.asList("kermit", "fozzie")).orderByGroupId().asc().listPage(1, 2);
-        assertEquals(2, groups.size());
-        assertEquals("frogs", groups.get(0).getId());
-        assertEquals("mammals", groups.get(1).getId());
+        assertThat(groups).hasSize(2);
+        assertThat(groups.get(0).getId()).isEqualTo("frogs");
+        assertThat(groups.get(1).getId()).isEqualTo("mammals");
     }
-    
+
     @Test
     public void testQueryByInvalidGroupMember() {
         GroupQuery query = idmIdentityService.createGroupQuery().groupMembers(Arrays.asList("invalid"));
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createGroupQuery().groupMembers(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().groupMembers(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQuerySorting() {
         // asc
-        assertEquals(4, idmIdentityService.createGroupQuery().orderByGroupId().asc().count());
-        assertEquals(4, idmIdentityService.createGroupQuery().orderByGroupName().asc().count());
-        assertEquals(4, idmIdentityService.createGroupQuery().orderByGroupType().asc().count());
+        assertThat(idmIdentityService.createGroupQuery().orderByGroupId().asc().count()).isEqualTo(4);
+        assertThat(idmIdentityService.createGroupQuery().orderByGroupName().asc().count()).isEqualTo(4);
+        assertThat(idmIdentityService.createGroupQuery().orderByGroupType().asc().count()).isEqualTo(4);
 
         // desc
-        assertEquals(4, idmIdentityService.createGroupQuery().orderByGroupId().desc().count());
-        assertEquals(4, idmIdentityService.createGroupQuery().orderByGroupName().desc().count());
-        assertEquals(4, idmIdentityService.createGroupQuery().orderByGroupType().desc().count());
+        assertThat(idmIdentityService.createGroupQuery().orderByGroupId().desc().count()).isEqualTo(4);
+        assertThat(idmIdentityService.createGroupQuery().orderByGroupName().desc().count()).isEqualTo(4);
+        assertThat(idmIdentityService.createGroupQuery().orderByGroupType().desc().count()).isEqualTo(4);
 
         // Multiple sortings
         GroupQuery query = idmIdentityService.createGroupQuery().orderByGroupType().asc().orderByGroupName().desc();
         List<Group> groups = query.list();
-        assertEquals(4, query.count());
+        assertThat(query.count()).isEqualTo(4);
 
-        assertEquals("security", groups.get(0).getType());
-        assertEquals("user", groups.get(1).getType());
-        assertEquals("user", groups.get(2).getType());
-        assertEquals("user", groups.get(3).getType());
+        assertThat(groups.get(0).getType()).isEqualTo("security");
+        assertThat(groups.get(1).getType()).isEqualTo("user");
+        assertThat(groups.get(2).getType()).isEqualTo("user");
+        assertThat(groups.get(3).getType()).isEqualTo("user");
 
-        assertEquals("admin", groups.get(0).getId());
-        assertEquals("muppets", groups.get(1).getId());
-        assertEquals("mammals", groups.get(2).getId());
-        assertEquals("frogs", groups.get(3).getId());
+        assertThat(groups.get(0).getId()).isEqualTo("admin");
+        assertThat(groups.get(1).getId()).isEqualTo("muppets");
+        assertThat(groups.get(2).getId()).isEqualTo("mammals");
+        assertThat(groups.get(3).getId()).isEqualTo("frogs");
     }
 
     @Test
     public void testQueryInvalidSortingUsage() {
-        try {
-            idmIdentityService.createGroupQuery().orderByGroupId().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
-
-        try {
-            idmIdentityService.createGroupQuery().orderByGroupId().orderByGroupName().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().orderByGroupName().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     private void verifyQueryResults(GroupQuery query, int countExpected) {
-        assertEquals(countExpected, query.list().size());
-        assertEquals(countExpected, query.count());
+        assertThat(query.list()).hasSize(countExpected);
+        assertThat(query.count()).isEqualTo(countExpected);
 
         if (countExpected == 1) {
-            assertNotNull(query.singleResult());
+            assertThat(query.singleResult()).isNotNull();
         } else if (countExpected > 1) {
             verifySingleResultFails(query);
         } else if (countExpected == 0) {
-            assertNull(query.singleResult());
+            assertThat(query.singleResult()).isNull();
         }
     }
 
     private void verifySingleResultFails(GroupQuery query) {
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testNativeQuery() {
-        assertEquals("ACT_ID_GROUP", idmManagementService.getTableName(Group.class));
-        assertEquals("ACT_ID_GROUP", idmManagementService.getTableName(GroupEntity.class));
+        assertThat(idmManagementService.getTableName(Group.class)).isEqualTo("ACT_ID_GROUP");
+        assertThat(idmManagementService.getTableName(GroupEntity.class)).isEqualTo("ACT_ID_GROUP");
         String tableName = idmManagementService.getTableName(Group.class);
         String baseQuerySql = "SELECT * FROM " + tableName;
 
-        assertEquals(4, idmIdentityService.createNativeGroupQuery().sql(baseQuerySql).list().size());
+        assertThat(idmIdentityService.createNativeGroupQuery().sql(baseQuerySql).list()).hasSize(4);
 
-        assertEquals(1, idmIdentityService.createNativeGroupQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "admin").list().size());
+        assertThat(idmIdentityService.createNativeGroupQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "admin").list()).hasSize(1);
 
-        assertEquals(
-            3,
-            idmIdentityService
+        assertThat(idmIdentityService
                 .createNativeGroupQuery()
                 .sql(
-                    "SELECT aig.* from " + tableName + " aig" + " inner join ACT_ID_MEMBERSHIP aim on aig.ID_ = aim.GROUP_ID_ "
-                        + " inner join ACT_ID_USER aiu on aiu.ID_ = aim.USER_ID_ where aiu.ID_ = #{id}")
-                .parameter("id", "kermit").list().size());
+                        "SELECT aig.* from " + tableName + " aig" + " inner join ACT_ID_MEMBERSHIP aim on aig.ID_ = aim.GROUP_ID_ "
+                                + " inner join ACT_ID_USER aiu on aiu.ID_ = aim.USER_ID_ where aiu.ID_ = #{id}")
+                .parameter("id", "kermit").list()).hasSize(3);
 
         // paging
-        assertEquals(2, idmIdentityService.createNativeGroupQuery().sql(baseQuerySql).listPage(0, 2).size());
-        assertEquals(3, idmIdentityService.createNativeGroupQuery().sql(baseQuerySql).listPage(1, 3).size());
-        assertEquals(1, idmIdentityService.createNativeGroupQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "admin").listPage(0, 1).size());
+        assertThat(idmIdentityService.createNativeGroupQuery().sql(baseQuerySql).listPage(0, 2)).hasSize(2);
+        assertThat(idmIdentityService.createNativeGroupQuery().sql(baseQuerySql).listPage(1, 3)).hasSize(3);
+        assertThat(idmIdentityService.createNativeGroupQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "admin").listPage(0, 1)).hasSize(1);
     }
 
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/IdentityServiceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,14 +14,7 @@
 package org.flowable.idm.engine.test.api.identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Date;
 import java.util.List;
@@ -48,13 +41,13 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.saveUser(user);
 
         idmIdentityService.setUserInfo("testuser", "myinfo", "myvalue");
-        assertEquals("myvalue", idmIdentityService.getUserInfo("testuser", "myinfo"));
+        assertThat(idmIdentityService.getUserInfo("testuser", "myinfo")).isEqualTo("myvalue");
 
         idmIdentityService.setUserInfo("testuser", "myinfo", "myvalue2");
-        assertEquals("myvalue2", idmIdentityService.getUserInfo("testuser", "myinfo"));
+        assertThat(idmIdentityService.getUserInfo("testuser", "myinfo")).isEqualTo("myvalue2");
 
         idmIdentityService.deleteUserInfo("testuser", "myinfo");
-        assertNull(idmIdentityService.getUserInfo("testuser", "myinfo"));
+        assertThat(idmIdentityService.getUserInfo("testuser", "myinfo")).isNull();
 
         idmIdentityService.deleteUser(user.getId());
     }
@@ -63,14 +56,13 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
     public void testCreateExistingUser() {
         User user = idmIdentityService.newUser("testuser");
         idmIdentityService.saveUser(user);
-        try {
+
+        // Expected exception while saving new user with the same name as an existing one.
+        assertThatThrownBy(() -> {
             User secondUser = idmIdentityService.newUser("testuser");
             idmIdentityService.saveUser(secondUser);
-            fail("Exception should have been thrown");
-        } catch (RuntimeException re) {
-            // Expected exception while saving new user with the same name as an
-            // existing one.
-        }
+        })
+                .isInstanceOf(RuntimeException.class);
 
         idmIdentityService.deleteUser(user.getId());
     }
@@ -92,9 +84,9 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.saveUser(user);
 
         user = idmIdentityService.createUserQuery().userId("johndoe").singleResult();
-        assertEquals("Jane", user.getFirstName());
-        assertEquals("Donnel", user.getLastName());
-        assertEquals("updated@alfresco.com", user.getEmail());
+        assertThat(user.getFirstName()).isEqualTo("Jane");
+        assertThat(user.getLastName()).isEqualTo("Donnel");
+        assertThat(user.getEmail()).isEqualTo("updated@alfresco.com");
 
         idmIdentityService.deleteUser(user.getId());
     }
@@ -114,66 +106,66 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         // Fetch and update the user
         user = idmIdentityService.createUserQuery().userId("testuser").singleResult();
         assertThat(user)
-            .returns("John", User::getFirstName)
-            .returns("Doe", User::getLastName)
-            .returns("John Doe", User::getDisplayName)
-            .returns("testuser@flowable.com", User::getEmail)
-            .returns(initialPassword, User::getPassword);
+                .returns("John", User::getFirstName)
+                .returns("Doe", User::getLastName)
+                .returns("John Doe", User::getDisplayName)
+                .returns("testuser@flowable.com", User::getEmail)
+                .returns(initialPassword, User::getPassword);
 
         user.setFirstName("Jane");
         idmIdentityService.saveUser(user);
 
         user = idmIdentityService.createUserQuery().userId("testuser").singleResult();
         assertThat(user)
-            .returns("Jane", User::getFirstName)
-            .returns("Doe", User::getLastName)
-            .returns("John Doe", User::getDisplayName)
-            .returns("testuser@flowable.com", User::getEmail)
-            .returns(initialPassword, User::getPassword);
+                .returns("Jane", User::getFirstName)
+                .returns("Doe", User::getLastName)
+                .returns("John Doe", User::getDisplayName)
+                .returns("testuser@flowable.com", User::getEmail)
+                .returns(initialPassword, User::getPassword);
 
         user.setLastName("Doelle");
         idmIdentityService.saveUser(user);
 
         user = idmIdentityService.createUserQuery().userId("testuser").singleResult();
         assertThat(user)
-            .returns("Jane", User::getFirstName)
-            .returns("Doelle", User::getLastName)
-            .returns("John Doe", User::getDisplayName)
-            .returns("testuser@flowable.com", User::getEmail)
-            .returns(initialPassword, User::getPassword);
+                .returns("Jane", User::getFirstName)
+                .returns("Doelle", User::getLastName)
+                .returns("John Doe", User::getDisplayName)
+                .returns("testuser@flowable.com", User::getEmail)
+                .returns(initialPassword, User::getPassword);
 
         user.setDisplayName("Jane Doelle");
         idmIdentityService.saveUser(user);
 
         user = idmIdentityService.createUserQuery().userId("testuser").singleResult();
         assertThat(user)
-            .returns("Jane", User::getFirstName)
-            .returns("Doelle", User::getLastName)
-            .returns("Jane Doelle", User::getDisplayName)
-            .returns("testuser@flowable.com", User::getEmail)
-            .returns(initialPassword, User::getPassword);
+                .returns("Jane", User::getFirstName)
+                .returns("Doelle", User::getLastName)
+                .returns("Jane Doelle", User::getDisplayName)
+                .returns("testuser@flowable.com", User::getEmail)
+                .returns(initialPassword, User::getPassword);
 
         user.setEmail("janedoelle@flowable.com");
         idmIdentityService.saveUser(user);
 
         user = idmIdentityService.createUserQuery().userId("testuser").singleResult();
         assertThat(user)
-            .returns("Jane", User::getFirstName)
-            .returns("Doelle", User::getLastName)
-            .returns("Jane Doelle", User::getDisplayName)
-            .returns("janedoelle@flowable.com", User::getEmail)
-            .returns(initialPassword, User::getPassword);
+                .returns("Jane", User::getFirstName)
+                .returns("Doelle", User::getLastName)
+                .returns("Jane Doelle", User::getDisplayName)
+                .returns("janedoelle@flowable.com", User::getEmail)
+                .returns(initialPassword, User::getPassword);
 
         user.setPassword("test-pass");
         idmIdentityService.saveUser(user);
 
         user = idmIdentityService.createUserQuery().userId("testuser").singleResult();
         assertThat(user)
-            .returns("Jane", User::getFirstName)
-            .returns("Doelle", User::getLastName)
-            .returns("Jane Doelle", User::getDisplayName)
-            .returns("janedoelle@flowable.com", User::getEmail)
-            .returns(initialPassword, User::getPassword);
+                .returns("Jane", User::getFirstName)
+                .returns("Doelle", User::getLastName)
+                .returns("Jane Doelle", User::getDisplayName)
+                .returns("janedoelle@flowable.com", User::getEmail)
+                .returns(initialPassword, User::getPassword);
 
         idmIdentityService.deleteUser(user.getId());
     }
@@ -192,14 +184,14 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
 
         // Fetch and update the user
         user = idmIdentityService.createUserQuery().userId("johndoe").singleResult();
-        assertArrayEquals("niceface".getBytes(), picture.getBytes(), "byte arrays differ");
-        assertEquals("image/string", picture.getMimeType());
+        assertThat(picture.getBytes()).as("byte arrays differ").isEqualTo("niceface".getBytes());
+        assertThat(picture.getMimeType()).isEqualTo("image/string");
 
         // interface definition states that setting picture to null should delete it
         idmIdentityService.setUserPicture(userId, null);
-        assertNull(idmIdentityService.getUserPicture(userId), "it should be possible to nullify user picture");
+        assertThat(idmIdentityService.getUserPicture(userId)).as("it should be possible to nullify user picture").isNull();
         user = idmIdentityService.createUserQuery().userId("johndoe").singleResult();
-        assertNull(idmIdentityService.getUserPicture(userId), "it should be possible to delete user picture");
+        assertThat(idmIdentityService.getUserPicture(userId)).as("it should be possible to delete user picture").isNull();
 
         idmIdentityService.deleteUser(user.getId());
     }
@@ -215,7 +207,7 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.saveGroup(group);
 
         group = idmIdentityService.createGroupQuery().groupId("sales").singleResult();
-        assertEquals("Updated", group.getName());
+        assertThat(group.getName()).isEqualTo("Updated");
 
         idmIdentityService.deleteGroup(group.getId());
     }
@@ -223,13 +215,13 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
     @Test
     public void findUserByUnexistingId() {
         User user = idmIdentityService.createUserQuery().userId("unexistinguser").singleResult();
-        assertNull(user);
+        assertThat(user).isNull();
     }
 
     @Test
     public void findGroupByUnexistingId() {
         Group group = idmIdentityService.createGroupQuery().groupId("unexistinggroup").singleResult();
-        assertNull(group);
+        assertThat(group).isNull();
     }
 
     @Test
@@ -237,12 +229,8 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         User johndoe = idmIdentityService.newUser("johndoe");
         idmIdentityService.saveUser(johndoe);
 
-        try {
-            idmIdentityService.createMembership(johndoe.getId(), "unexistinggroup");
-            fail("Expected exception");
-        } catch (RuntimeException re) {
-            // Exception expected
-        }
+        assertThatThrownBy(() -> idmIdentityService.createMembership(johndoe.getId(), "unexistinggroup"))
+                .isInstanceOf(RuntimeException.class);
 
         idmIdentityService.deleteUser(johndoe.getId());
     }
@@ -252,12 +240,8 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         Group sales = idmIdentityService.newGroup("sales");
         idmIdentityService.saveGroup(sales);
 
-        try {
-            idmIdentityService.createMembership("unexistinguser", sales.getId());
-            fail("Expected exception");
-        } catch (RuntimeException re) {
-            // Exception expected
-        }
+        assertThatThrownBy(() -> idmIdentityService.createMembership("unexistinguser", sales.getId()))
+                .isInstanceOf(RuntimeException.class);
 
         idmIdentityService.deleteGroup(sales.getId());
     }
@@ -272,11 +256,8 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         // Create the membership
         idmIdentityService.createMembership(johndoe.getId(), sales.getId());
 
-        try {
-            idmIdentityService.createMembership(johndoe.getId(), sales.getId());
-        } catch (RuntimeException re) {
-            // Expected exception, membership already exists
-        }
+        assertThatThrownBy(() -> idmIdentityService.createMembership(johndoe.getId(), sales.getId()))
+                .isInstanceOf(RuntimeException.class);
 
         idmIdentityService.deleteGroup(sales.getId());
         idmIdentityService.deleteUser(johndoe.getId());
@@ -284,76 +265,55 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
 
     @Test
     public void testSaveGroupNullArgument() {
-        try {
-            idmIdentityService.saveGroup(null);
-            fail("FlowableException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("group is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.saveGroup(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("group is null");
     }
 
     @Test
     public void testSaveUserNullArgument() {
-        try {
-            idmIdentityService.saveUser(null);
-            fail("FlowableException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("user is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.saveUser(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("user is null");
     }
 
     @Test
     public void testFindGroupByIdNullArgument() {
-        try {
-            idmIdentityService.createGroupQuery().groupId(null).singleResult();
-            fail("FlowableException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("id is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().groupId(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("id is null");
     }
 
     @Test
     public void testCreateMembershipNullArguments() {
-        try {
-            idmIdentityService.createMembership(null, "group");
-            fail("FlowableException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("userId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.createMembership(null, "group"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("userId is null");
 
-        try {
-            idmIdentityService.createMembership("userId", null);
-            fail("FlowableException expected");
-        } catch (FlowableException ae) {
-            assertTextPresent("groupId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.createMembership("userId", null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("groupId is null");
     }
 
     @Test
     public void testFindGroupsByUserIdNullArguments() {
-        try {
-            idmIdentityService.createGroupQuery().groupMember(null).singleResult();
-            fail("FlowableException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("userId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.createGroupQuery().groupMember(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("userId is null");
     }
 
     @Test
     public void testFindUsersByGroupUnexistingGroup() {
         List<User> users = idmIdentityService.createUserQuery().memberOfGroup("unexistinggroup").list();
-        assertNotNull(users);
-        assertTrue(users.isEmpty());
+        assertThat(users).isNotNull();
+        assertThat(users.isEmpty()).isTrue();
     }
 
     @Test
     public void testDeleteGroupNullArguments() {
-        try {
-            idmIdentityService.deleteGroup(null);
-            fail("FlowableException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("groupId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.deleteGroup(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("groupId is null");
     }
 
     @Test
@@ -367,13 +327,13 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.createMembership(johndoe.getId(), sales.getId());
 
         List<Group> groups = idmIdentityService.createGroupQuery().groupMember(johndoe.getId()).list();
-        assertEquals(1, groups.size());
-        assertEquals("sales", groups.get(0).getId());
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getId()).isEqualTo("sales");
 
         // Delete the membership and check members of sales group
         idmIdentityService.deleteMembership(johndoe.getId(), sales.getId());
         groups = idmIdentityService.createGroupQuery().groupMember(johndoe.getId()).list();
-        assertTrue(groups.isEmpty());
+        assertThat(groups.isEmpty()).isTrue();
 
         idmIdentityService.deleteGroup("sales");
         idmIdentityService.deleteUser("johndoe");
@@ -414,29 +374,20 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
 
     @Test
     public void testDeleteMemberschipNullArguments() {
-        try {
-            idmIdentityService.deleteMembership(null, "group");
-            fail("FlowableException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("userId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.deleteMembership(null, "group"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("userId is null");
 
-        try {
-            idmIdentityService.deleteMembership("user", null);
-            fail("FlowableException expected");
-        } catch (FlowableException ae) {
-            assertTextPresent("groupId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.deleteMembership("user", null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("groupId is null");
     }
 
     @Test
     public void testDeleteUserNullArguments() {
-        try {
-            idmIdentityService.deleteUser(null);
-            fail("FlowableException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("userId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> idmIdentityService.deleteUser(null))
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("userId is null");
     }
 
     @Test
@@ -448,9 +399,9 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
 
     @Test
     public void testCheckPasswordNullSafe() {
-        assertFalse(idmIdentityService.checkPassword("userId", null));
-        assertFalse(idmIdentityService.checkPassword(null, "passwd"));
-        assertFalse(idmIdentityService.checkPassword(null, null));
+        assertThat(idmIdentityService.checkPassword("userId", null)).isFalse();
+        assertThat(idmIdentityService.checkPassword(null, "passwd")).isFalse();
+        assertThat(idmIdentityService.checkPassword(null, null)).isFalse();
     }
 
     @Test
@@ -466,19 +417,19 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         user.setFirstName("John Doe");
         idmIdentityService.saveUser(user);
         User johndoe = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
-        assertNotEquals("xxx", johndoe.getPassword());
-        assertEquals("John Doe", johndoe.getFirstName());
-        assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));
+        assertThat(johndoe.getPassword()).isNotEqualTo("xxx");
+        assertThat(johndoe.getFirstName()).isEqualTo("John Doe");
+        assertThat(idmIdentityService.checkPassword("johndoe", "xxx")).isTrue();
 
         user = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
         user.setPassword("yyy");
         idmIdentityService.saveUser(user);
-        assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));
+        assertThat(idmIdentityService.checkPassword("johndoe", "xxx")).isTrue();
 
         user = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
         user.setPassword("yyy");
         idmIdentityService.updateUserPassword(user);
-        assertTrue(idmIdentityService.checkPassword("johndoe", "yyy"));
+        assertThat(idmIdentityService.checkPassword("johndoe", "yyy")).isTrue();
 
         idmIdentityService.deleteUser("johndoe");
     }
@@ -494,15 +445,11 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         user1.setFirstName("name one");
         idmIdentityService.saveUser(user1);
 
-        try {
-
+        assertThatThrownBy(() -> {
             user2.setFirstName("name two");
             idmIdentityService.saveUser(user2);
-
-            fail("Expected an exception");
-        } catch (FlowableOptimisticLockingException e) {
-            // Expected an exception
-        }
+        })
+                .isExactlyInstanceOf(FlowableOptimisticLockingException.class);
 
         idmIdentityService.deleteUser(user.getId());
     }
@@ -518,15 +465,11 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         group1.setName("name one");
         idmIdentityService.saveGroup(group1);
 
-        try {
-
+        assertThatThrownBy(() -> {
             group2.setName("name two");
             idmIdentityService.saveGroup(group2);
-
-            fail("Expected an exception");
-        } catch (FlowableOptimisticLockingException e) {
-            // Expected an exception
-        }
+        })
+                .isExactlyInstanceOf(FlowableOptimisticLockingException.class);
 
         idmIdentityService.deleteGroup(group.getId());
     }
@@ -541,16 +484,16 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.saveToken(token);
 
         Token token1 = idmIdentityService.createTokenQuery().singleResult();
-        assertEquals("myToken", token1.getId());
-        assertEquals("myValue", token1.getTokenValue());
-        assertEquals("127.0.0.1", token1.getIpAddress());
-        assertNull(token1.getUserAgent());
+        assertThat(token1.getId()).isEqualTo("myToken");
+        assertThat(token1.getTokenValue()).isEqualTo("myValue");
+        assertThat(token1.getIpAddress()).isEqualTo("127.0.0.1");
+        assertThat(token1.getUserAgent()).isNull();
 
         token1.setUserAgent("myAgent");
         idmIdentityService.saveToken(token1);
 
         token1 = idmIdentityService.createTokenQuery().singleResult();
-        assertEquals("myAgent", token1.getUserAgent());
+        assertThat(token1.getUserAgent()).isEqualTo("myAgent");
 
         idmIdentityService.deleteToken(token1.getId());
     }
@@ -566,15 +509,11 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         token1.setUserAgent("name one");
         idmIdentityService.saveToken(token1);
 
-        try {
-
+        assertThatThrownBy(() -> {
             token2.setUserAgent("name two");
             idmIdentityService.saveToken(token2);
-
-            fail("Expected an exception");
-        } catch (FlowableOptimisticLockingException e) {
-            // Expected an exception
-        }
+        })
+                .isExactlyInstanceOf(FlowableOptimisticLockingException.class);
 
         idmIdentityService.deleteToken(token.getId());
     }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PasswordEncoderTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PasswordEncoderTest.java
@@ -113,7 +113,7 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
         PasswordEncoder passwordEncoder = idmEngineConfiguration.getPasswordEncoder();
         idmEngineConfiguration.setPasswordEncoder(new CustomPasswordEncoder());
         PasswordEncoder customPasswordEncoder = idmEngineConfiguration.getPasswordEncoder();
-        assertThat(customPasswordEncoder instanceof CustomPasswordEncoder).isTrue();
+        assertThat(customPasswordEncoder).isInstanceOf(CustomPasswordEncoder.class);
 
         idmEngineConfiguration.setPasswordEncoder(passwordEncoder);
     }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PasswordEncoderTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PasswordEncoderTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.idm.engine.test.api.identity;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.idm.api.PasswordEncoder;
 import org.flowable.idm.api.PasswordSalt;
@@ -45,12 +43,11 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
         User johndoe = idmIdentityService.createUserQuery().userId("johndoe").list().get(0);
         LOGGER.info("Hash Password = {}", johndoe.getPassword());
 
-        assertNotEquals("xxx", johndoe.getPassword());
-        assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));
-        assertFalse(idmIdentityService.checkPassword("johndoe", "invalid pwd"));
+        assertThat(johndoe.getPassword()).isNotEqualTo("xxx");
+        assertThat(idmIdentityService.checkPassword("johndoe", "xxx")).isTrue();
+        assertThat(idmIdentityService.checkPassword("johndoe", "invalid pwd")).isFalse();
 
         idmIdentityService.deleteUser("johndoe");
-
     }
 
     @Test
@@ -94,7 +91,7 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.saveUser(user);
 
         String noSalt = idmIdentityService.createUserQuery().userId("johndoe").list().get(0).getPassword();
-        assertTrue(idmIdentityService.checkPassword("johndoe", "xxx"));
+        assertThat(idmIdentityService.checkPassword("johndoe", "xxx")).isTrue();
         idmIdentityService.deleteUser("johndoe");
 
         idmEngineConfiguration.setPasswordSalt(new PasswordSaltImpl("salt"));
@@ -103,9 +100,9 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.saveUser(user);
 
         String salt = idmIdentityService.createUserQuery().userId("johndoe1").list().get(0).getPassword();
-        assertTrue(idmIdentityService.checkPassword("johndoe1", "xxx"));
+        assertThat(idmIdentityService.checkPassword("johndoe1", "xxx")).isTrue();
 
-        assertNotEquals(noSalt, salt);
+        assertThat(salt).isNotEqualTo(noSalt);
         idmIdentityService.deleteUser("johndoe1");
 
         idmEngineConfiguration.setPasswordEncoder(passwordEncoder);
@@ -116,11 +113,10 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
         PasswordEncoder passwordEncoder = idmEngineConfiguration.getPasswordEncoder();
         idmEngineConfiguration.setPasswordEncoder(new CustomPasswordEncoder());
         PasswordEncoder customPasswordEncoder = idmEngineConfiguration.getPasswordEncoder();
-        assertTrue(customPasswordEncoder instanceof CustomPasswordEncoder);
+        assertThat(customPasswordEncoder instanceof CustomPasswordEncoder).isTrue();
 
         idmEngineConfiguration.setPasswordEncoder(passwordEncoder);
     }
-
 
     class CustomPasswordEncoder implements PasswordEncoder {
 
@@ -134,6 +130,5 @@ public class PasswordEncoderTest extends PluggableFlowableIdmTestCase {
             return false;
         }
     }
-
 
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PrivilegesTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PrivilegesTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,8 @@
  */
 package org.flowable.idm.engine.test.api.identity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,131 +74,122 @@ public class PrivilegesTest extends PluggableFlowableIdmTestCase {
 
     @Test
     public void testCreateDuplicatePrivilege() {
-        try {
-            idmIdentityService.createPrivilege("access admin application");
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createPrivilege("access admin application"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testGetUsers() {
         String privilegeId = idmIdentityService.createPrivilegeQuery().privilegeName("access admin application").singleResult().getId();
         List<User> users = idmIdentityService.getUsersWithPrivilege(privilegeId);
-        assertEquals(1, users.size());
-        assertEquals("mispiggy", users.get(0).getId());
+        assertThat(users).hasSize(1);
+        assertThat(users.get(0).getId()).isEqualTo("mispiggy");
 
-        assertEquals(0, idmIdentityService.getUsersWithPrivilege("does not exist").size());
+        assertThat(idmIdentityService.getUsersWithPrivilege("does not exist")).isEmpty();
 
-        try {
-            idmIdentityService.getUsersWithPrivilege(null);
-            fail();
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.getUsersWithPrivilege(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testGetGroups() {
         String privilegeId = idmIdentityService.createPrivilegeQuery().privilegeName("access modeler application").singleResult().getId();
         List<Group> groups = idmIdentityService.getGroupsWithPrivilege(privilegeId);
-        assertEquals(2, groups.size());
-        assertEquals("admins", groups.get(0).getId());
-        assertEquals("engineering", groups.get(1).getId());
+        assertThat(groups).hasSize(2);
+        assertThat(groups.get(0).getId()).isEqualTo("admins");
+        assertThat(groups.get(1).getId()).isEqualTo("engineering");
 
-        assertEquals(0, idmIdentityService.getGroupsWithPrivilege("does not exist").size());
+        assertThat(idmIdentityService.getGroupsWithPrivilege("does not exist")).isEmpty();
 
-        try {
-            idmIdentityService.getGroupsWithPrivilege(null);
-            fail();
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.getGroupsWithPrivilege(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryAll() {
         List<Privilege> privileges = idmIdentityService.createPrivilegeQuery().list();
-        assertEquals(3, privileges.size());
-        assertEquals(3L, idmIdentityService.createPrivilegeQuery().count());
+        assertThat(privileges).hasSize(3);
+        assertThat(idmIdentityService.createPrivilegeQuery().count()).isEqualTo(3L);
     }
 
     @Test
     public void testQueryByName() {
         List<Privilege> privileges = idmIdentityService.createPrivilegeQuery().privilegeName("access admin application").list();
-        assertEquals(1, privileges.size());
+        assertThat(privileges).hasSize(1);
 
-        assertEquals(1, idmIdentityService.getUsersWithPrivilege(privileges.get(0).getId()).size());
-        assertEquals(1, idmIdentityService.getGroupsWithPrivilege(privileges.get(0).getId()).size());
+        assertThat(idmIdentityService.getUsersWithPrivilege(privileges.get(0).getId())).hasSize(1);
+        assertThat(idmIdentityService.getGroupsWithPrivilege(privileges.get(0).getId())).hasSize(1);
     }
 
     @Test
     public void testQueryByInvalidName() {
-        assertEquals(0, idmIdentityService.createPrivilegeQuery().privilegeName("does not exist").list().size());
+        assertThat(idmIdentityService.createPrivilegeQuery().privilegeName("does not exist").list()).isEmpty();
     }
 
     @Test
     public void testQueryByUserId() {
         List<Privilege> privileges = idmIdentityService.createPrivilegeQuery().userId("kermit").list();
-        assertEquals(1, privileges.size());
+        assertThat(privileges).hasSize(1);
 
         Privilege privilege = privileges.get(0);
-        assertEquals("access modeler application", privilege.getName());
+        assertThat(privilege.getName()).isEqualTo("access modeler application");
     }
 
     @Test
     public void testQueryByInvalidUserId() {
-        assertEquals(0, idmIdentityService.createPrivilegeQuery().userId("does not exist").list().size());
+        assertThat(idmIdentityService.createPrivilegeQuery().userId("does not exist").list()).isEmpty();
     }
 
     @Test
     public void testQueryByGroupId() {
         List<Privilege> privileges = idmIdentityService.createPrivilegeQuery().groupId("admins").list();
-        assertEquals(2, privileges.size());
+        assertThat(privileges).hasSize(2);
     }
 
     @Test
     public void testQueryByInvalidGroupId() {
-        assertEquals(0, idmIdentityService.createPrivilegeQuery().groupId("does not exist").list().size());
+        assertThat(idmIdentityService.createPrivilegeQuery().groupId("does not exist").list()).isEmpty();
     }
-    
+
     @Test
     public void testQueryByGroupIds() {
         List<Privilege> privileges = idmIdentityService.createPrivilegeQuery().groupIds(Arrays.asList("admins")).list();
-        assertEquals(2, privileges.size());
-        
+        assertThat(privileges).hasSize(2);
+
         privileges = idmIdentityService.createPrivilegeQuery().groupIds(Arrays.asList("admins", "engineering")).list();
-        assertEquals(2, privileges.size());
-        
+        assertThat(privileges).hasSize(2);
+
         privileges = idmIdentityService.createPrivilegeQuery().groupIds(Arrays.asList("engineering")).list();
-        assertEquals(1, privileges.size());
-        
+        assertThat(privileges).hasSize(1);
+
         privileges = idmIdentityService.createPrivilegeQuery().groupIds(Arrays.asList("admins", "engineering")).listPage(0, 1);
-        assertEquals(1, privileges.size());
-        
+        assertThat(privileges).hasSize(1);
+
         privileges = idmIdentityService.createPrivilegeQuery().groupIds(Arrays.asList("admins", "engineering")).listPage(1, 1);
-        assertEquals(1, privileges.size());
+        assertThat(privileges).hasSize(1);
     }
-    
+
     @Test
     public void testQueryByInvalidGroupIds() {
-        assertEquals(0, idmIdentityService.createPrivilegeQuery().groupIds(Arrays.asList("does not exist")).list().size());
+        assertThat(idmIdentityService.createPrivilegeQuery().groupIds(Arrays.asList("does not exist")).list()).isEmpty();
     }
 
     @Test
     public void testNativeQuery() {
-        assertEquals("ACT_ID_PRIV", idmManagementService.getTableName(Privilege.class));
-        assertEquals("ACT_ID_PRIV", idmManagementService.getTableName(PrivilegeEntity.class));
+        assertThat(idmManagementService.getTableName(Privilege.class)).isEqualTo("ACT_ID_PRIV");
+        assertThat(idmManagementService.getTableName(PrivilegeEntity.class)).isEqualTo("ACT_ID_PRIV");
 
         String tableName = idmManagementService.getTableName(PrivilegeEntity.class);
         String baseQuerySql = "SELECT * FROM " + tableName + " where NAME_ = #{name}";
 
-        assertEquals(1, idmIdentityService.createNativeUserQuery().sql(baseQuerySql).parameter("name", "access admin application").list().size());
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).parameter("name", "access admin application").list()).hasSize(1);
     }
 
     @Test
     public void testGetPrivilegeMappings() {
         Privilege modelerPrivilege = idmIdentityService.createPrivilegeQuery().privilegeName("access modeler application").singleResult();
         List<PrivilegeMapping> privilegeMappings = idmIdentityService.getPrivilegeMappingsByPrivilegeId(modelerPrivilege.getId());
-        assertEquals(3, privilegeMappings.size());
+        assertThat(privilegeMappings).hasSize(3);
         List<String> users = new ArrayList<>();
         List<String> groups = new ArrayList<>();
 
@@ -212,23 +202,19 @@ public class PrivilegesTest extends PluggableFlowableIdmTestCase {
             }
         }
 
-        assertTrue(users.contains("kermit"));
-        assertTrue(groups.contains("admins"));
-        assertTrue(groups.contains("engineering"));
+        assertThat(users.contains("kermit")).isTrue();
+        assertThat(groups.contains("admins")).isTrue();
+        assertThat(groups.contains("engineering")).isTrue();
     }
 
     @Test
     public void testPrivilegeUniqueName() {
         Privilege privilege = idmIdentityService.createPrivilege("test");
-        
-        try {
-            idmIdentityService.createPrivilege("test");
-            fail();
-        } catch (Exception e) { 
-            e.printStackTrace();
-        }
-        
+
+        assertThatThrownBy(() -> idmIdentityService.createPrivilege("test"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+
         idmIdentityService.deletePrivilege(privilege.getId());
     }
-    
+
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PrivilegesTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PrivilegesTest.java
@@ -82,8 +82,9 @@ public class PrivilegesTest extends PluggableFlowableIdmTestCase {
     public void testGetUsers() {
         String privilegeId = idmIdentityService.createPrivilegeQuery().privilegeName("access admin application").singleResult().getId();
         List<User> users = idmIdentityService.getUsersWithPrivilege(privilegeId);
-        assertThat(users).hasSize(1);
-        assertThat(users.get(0).getId()).isEqualTo("mispiggy");
+        assertThat(users)
+                .extracting(User::getId)
+                .containsExactly("mispiggy");
 
         assertThat(idmIdentityService.getUsersWithPrivilege("does not exist")).isEmpty();
 
@@ -95,9 +96,9 @@ public class PrivilegesTest extends PluggableFlowableIdmTestCase {
     public void testGetGroups() {
         String privilegeId = idmIdentityService.createPrivilegeQuery().privilegeName("access modeler application").singleResult().getId();
         List<Group> groups = idmIdentityService.getGroupsWithPrivilege(privilegeId);
-        assertThat(groups).hasSize(2);
-        assertThat(groups.get(0).getId()).isEqualTo("admins");
-        assertThat(groups.get(1).getId()).isEqualTo("engineering");
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("admins", "engineering");
 
         assertThat(idmIdentityService.getGroupsWithPrivilege("does not exist")).isEmpty();
 

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/TokenQueryTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/TokenQueryTest.java
@@ -291,9 +291,9 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         // Combined with criteria
         TokenQuery query = idmIdentityService.createTokenQuery().userAgentLike("%firefox%").orderByTokenDate().asc();
         List<Token> tokens = query.list();
-        assertThat(tokens).hasSize(2);
-        assertThat(tokens.get(0).getUserAgent()).isEqualTo("firefox");
-        assertThat(tokens.get(1).getUserAgent()).isEqualTo("firefox2");
+        assertThat(tokens)
+                .extracting(Token::getUserAgent)
+                .containsExactly("firefox", "firefox2");
     }
 
     @Test

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/TokenQueryTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/TokenQueryTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,10 +13,8 @@
 
 package org.flowable.idm.engine.test.api.identity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -89,11 +87,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().tokenId("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().tokenId(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().tokenId(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -102,7 +97,7 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         Token result = query.singleResult();
-        assertEquals("aaaa", result.getTokenValue());
+        assertThat(result.getTokenValue()).isEqualTo("aaaa");
     }
 
     @Test
@@ -110,11 +105,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().tokenValue("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().tokenValue(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().tokenValue(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -126,8 +118,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         Token result = query.singleResult();
         Calendar tokenCal = new GregorianCalendar();
         tokenCal.setTime(result.getTokenDate());
-        assertEquals(2015, tokenCal.get(Calendar.YEAR));
-        assertEquals(1, tokenCal.get(Calendar.MONTH));
+        assertThat(tokenCal.get(Calendar.YEAR)).isEqualTo(2015);
+        assertThat(tokenCal.get(Calendar.MONTH)).isEqualTo(1);
     }
 
     @Test
@@ -139,8 +131,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         Token result = query.singleResult();
         Calendar tokenCal = new GregorianCalendar();
         tokenCal.setTime(result.getTokenDate());
-        assertEquals(2017, tokenCal.get(Calendar.YEAR));
-        assertEquals(1, tokenCal.get(Calendar.MONTH));
+        assertThat(tokenCal.get(Calendar.YEAR)).isEqualTo(2017);
+        assertThat(tokenCal.get(Calendar.MONTH)).isEqualTo(1);
     }
 
     @Test
@@ -149,7 +141,7 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         Token result = query.singleResult();
-        assertEquals("127.0.0.1", result.getIpAddress());
+        assertThat(result.getIpAddress()).isEqualTo("127.0.0.1");
     }
 
     @Test
@@ -157,11 +149,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().ipAddress("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().ipAddress(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().ipAddress(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -178,11 +167,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().ipAddressLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().ipAddressLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().ipAddressLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -191,7 +177,7 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         Token result = query.singleResult();
-        assertEquals("chrome", result.getUserAgent());
+        assertThat(result.getUserAgent()).isEqualTo("chrome");
     }
 
     @Test
@@ -199,11 +185,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().userAgent("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().userAgent(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().userAgent(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -220,11 +203,9 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().userAgentLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().userAgentLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().userAgentLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+
     }
 
     @Test
@@ -233,7 +214,7 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         Token result = query.singleResult();
-        assertEquals("user1", result.getUserId());
+        assertThat(result.getUserId()).isEqualTo("user1");
     }
 
     @Test
@@ -241,11 +222,9 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().userId("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().userId(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().userId(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+
     }
 
     @Test
@@ -262,11 +241,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().userIdLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().userIdLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().userIdLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -275,7 +251,7 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         Token result = query.singleResult();
-        assertEquals("test", result.getTokenData());
+        assertThat(result.getTokenData()).isEqualTo("test");
     }
 
     @Test
@@ -283,11 +259,8 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().tokenData("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().tokenData(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().tokenData(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -301,82 +274,71 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         TokenQuery query = idmIdentityService.createTokenQuery().tokenDataLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createTokenQuery().tokenDataLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().tokenDataLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQuerySorting() {
         // asc
-        assertEquals(3, idmIdentityService.createTokenQuery().orderByTokenId().asc().count());
-        assertEquals(3, idmIdentityService.createTokenQuery().orderByTokenDate().asc().count());
+        assertThat(idmIdentityService.createTokenQuery().orderByTokenId().asc().count()).isEqualTo(3);
+        assertThat(idmIdentityService.createTokenQuery().orderByTokenDate().asc().count()).isEqualTo(3);
 
         // desc
-        assertEquals(3, idmIdentityService.createTokenQuery().orderByTokenId().desc().count());
-        assertEquals(3, idmIdentityService.createTokenQuery().orderByTokenDate().desc().count());
+        assertThat(idmIdentityService.createTokenQuery().orderByTokenId().desc().count()).isEqualTo(3);
+        assertThat(idmIdentityService.createTokenQuery().orderByTokenDate().desc().count()).isEqualTo(3);
 
         // Combined with criteria
         TokenQuery query = idmIdentityService.createTokenQuery().userAgentLike("%firefox%").orderByTokenDate().asc();
         List<Token> tokens = query.list();
-        assertEquals(2, tokens.size());
-        assertEquals("firefox", tokens.get(0).getUserAgent());
-        assertEquals("firefox2", tokens.get(1).getUserAgent());
+        assertThat(tokens).hasSize(2);
+        assertThat(tokens.get(0).getUserAgent()).isEqualTo("firefox");
+        assertThat(tokens.get(1).getUserAgent()).isEqualTo("firefox2");
     }
 
     @Test
     public void testQueryInvalidSortingUsage() {
-        try {
-            idmIdentityService.createTokenQuery().orderByTokenId().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().orderByTokenId().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
 
-        try {
-            idmIdentityService.createTokenQuery().orderByTokenId().orderByTokenDate().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createTokenQuery().orderByTokenId().orderByTokenDate().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     private void verifyQueryResults(TokenQuery query, int countExpected) {
-        assertEquals(countExpected, query.list().size());
-        assertEquals(countExpected, query.count());
+        assertThat(query.list()).hasSize(countExpected);
+        assertThat(query.count()).isEqualTo(countExpected);
 
         if (countExpected == 1) {
-            assertNotNull(query.singleResult());
+            assertThat(query.singleResult()).isNotNull();
         } else if (countExpected > 1) {
             verifySingleResultFails(query);
         } else if (countExpected == 0) {
-            assertNull(query.singleResult());
+            assertThat(query.singleResult()).isNull();
         }
     }
 
     private void verifySingleResultFails(TokenQuery query) {
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testNativeQuery() {
-        assertEquals("ACT_ID_TOKEN", idmManagementService.getTableName(Token.class));
-        assertEquals("ACT_ID_TOKEN", idmManagementService.getTableName(TokenEntity.class));
+        assertThat(idmManagementService.getTableName(Token.class)).isEqualTo("ACT_ID_TOKEN");
+        assertThat(idmManagementService.getTableName(TokenEntity.class)).isEqualTo("ACT_ID_TOKEN");
         String tableName = idmManagementService.getTableName(Token.class);
         String baseQuerySql = "SELECT * FROM " + tableName;
 
-        assertEquals(3, idmIdentityService.createNativeUserQuery().sql(baseQuerySql).list().size());
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).list()).hasSize(3);
 
-        assertEquals(1, idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "1111").list().size());
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "1111").list()).hasSize(1);
 
         // paging
-        assertEquals(2, idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(0, 2).size());
-        assertEquals(2, idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(1, 3).size());
-        assertEquals(1, idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "1111").listPage(0, 1).size());
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(0, 2)).hasSize(2);
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(1, 3)).hasSize(2);
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "1111").listPage(0, 1).size())
+                .isEqualTo(1);
     }
 
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserEntityTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserEntityTest.java
@@ -12,16 +12,14 @@
  */
 package org.flowable.idm.engine.test.api.identity;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.idm.api.Picture;
 import org.flowable.idm.engine.impl.persistence.entity.UserEntityImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Arkadiy Gornovoy
- *
  */
 public class UserEntityTest {
 
@@ -31,15 +29,15 @@ public class UserEntityTest {
         Picture picture = new Picture(null, null);
         // even though parameters were null, picture object is not null
         userEntity.setPicture(picture);
-        assertTrue(userEntity.getHasSavePictureBeenCalled());
-        assertFalse(userEntity.getHasDeletePictureBeenCalled());
+        assertThat(userEntity.getHasSavePictureBeenCalled()).isTrue();
+        assertThat(userEntity.getHasDeletePictureBeenCalled()).isFalse();
     }
 
     @Test
     public void testSetPicture_pictureShouldBeDeletedWhenNull() {
         TestableUserEntity userEntity = new TestableUserEntity();
         userEntity.setPicture(null);
-        assertTrue(userEntity.getHasDeletePictureBeenCalled());
+        assertThat(userEntity.getHasDeletePictureBeenCalled()).isTrue();
     }
 
     @SuppressWarnings("serial")

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserQueryEscapeClauseTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserQueryEscapeClauseTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,7 +12,7 @@
  */
 package org.flowable.idm.engine.test.api.identity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.idm.api.User;
 import org.flowable.idm.api.UserQuery;
@@ -51,62 +51,62 @@ public class UserQueryEscapeClauseTest extends ResourceFlowableIdmTestCase {
     @Test
     public void testQueryByFirstNameLike() {
         UserQuery query = idmIdentityService.createUserQuery().userFirstNameLike("%|%%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("kermit", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("kermit");
 
         query = idmIdentityService.createUserQuery().userFirstNameLike("%|_%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("fozzie", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("fozzie");
     }
 
     @Test
     public void testQueryByLastNameLike() {
         UserQuery query = idmIdentityService.createUserQuery().userLastNameLike("%|%%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("kermit", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("kermit");
 
         query = idmIdentityService.createUserQuery().userLastNameLike("%|_%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("fozzie", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("fozzie");
     }
 
     @Test
     public void testQueryByFullNameLike() {
         UserQuery query = idmIdentityService.createUserQuery().userFullNameLike("%og|%%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("kermit", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("kermit");
 
         query = idmIdentityService.createUserQuery().userFullNameLike("%it|%%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("kermit", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("kermit");
 
         query = idmIdentityService.createUserQuery().userFullNameLike("%ar|_%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("fozzie", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("fozzie");
 
         query = idmIdentityService.createUserQuery().userFullNameLike("%ie|_%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("fozzie", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("fozzie");
     }
 
     @Test
     public void testQueryByEmailLike() {
         UserQuery query = idmIdentityService.createUserQuery().userEmailLike("%|%%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("kermit", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("kermit");
 
         query = idmIdentityService.createUserQuery().userEmailLike("%|_%");
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
-        assertEquals("fozzie", query.singleResult().getId());
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.singleResult().getId()).isEqualTo("fozzie");
     }
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserQueryTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserQueryTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,10 +13,8 @@
 
 package org.flowable.idm.engine.test.api.identity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -87,11 +85,8 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().userId("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().userId(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().userId(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -106,7 +101,7 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         User result = query.singleResult();
-        assertEquals("gonzo", result.getId());
+        assertThat(result.getId()).isEqualTo("gonzo");
     }
 
     @Test
@@ -114,11 +109,8 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().userFirstName("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().userFirstName(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().userFirstName(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -135,11 +127,8 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().userFirstNameLike("%mispiggy%");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().userFirstNameLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().userFirstNameLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -157,7 +146,7 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         User result = query.singleResult();
-        assertEquals("fozzie", result.getId());
+        assertThat(result.getId()).isEqualTo("fozzie");
     }
 
     @Test
@@ -165,11 +154,8 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().userLastName("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().userLastName(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().userLastName(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -225,11 +211,8 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().userLastNameLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().userLastNameLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().userLastNameLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -238,7 +221,7 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         User result = query.singleResult();
-        assertEquals("fozzie", result.getId());
+        assertThat(result.getId()).isEqualTo("fozzie");
     }
 
     @Test
@@ -246,11 +229,8 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().userDisplayName("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().userDisplayName(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().userDisplayName(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -282,11 +262,8 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().userEmail("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().userEmail(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().userEmail(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -303,48 +280,39 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().userEmailLike("%invalid%");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().userEmailLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().userEmailLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQuerySorting() {
         // asc
-        assertEquals(3, idmIdentityService.createUserQuery().orderByUserId().asc().count());
-        assertEquals(3, idmIdentityService.createUserQuery().orderByUserEmail().asc().count());
-        assertEquals(3, idmIdentityService.createUserQuery().orderByUserFirstName().asc().count());
-        assertEquals(3, idmIdentityService.createUserQuery().orderByUserLastName().asc().count());
+        assertThat(idmIdentityService.createUserQuery().orderByUserId().asc().count()).isEqualTo(3);
+        assertThat(idmIdentityService.createUserQuery().orderByUserEmail().asc().count()).isEqualTo(3);
+        assertThat(idmIdentityService.createUserQuery().orderByUserFirstName().asc().count()).isEqualTo(3);
+        assertThat(idmIdentityService.createUserQuery().orderByUserLastName().asc().count()).isEqualTo(3);
 
         // desc
-        assertEquals(3, idmIdentityService.createUserQuery().orderByUserId().desc().count());
-        assertEquals(3, idmIdentityService.createUserQuery().orderByUserEmail().desc().count());
-        assertEquals(3, idmIdentityService.createUserQuery().orderByUserFirstName().desc().count());
-        assertEquals(3, idmIdentityService.createUserQuery().orderByUserLastName().desc().count());
+        assertThat(idmIdentityService.createUserQuery().orderByUserId().desc().count()).isEqualTo(3);
+        assertThat(idmIdentityService.createUserQuery().orderByUserEmail().desc().count()).isEqualTo(3);
+        assertThat(idmIdentityService.createUserQuery().orderByUserFirstName().desc().count()).isEqualTo(3);
+        assertThat(idmIdentityService.createUserQuery().orderByUserLastName().desc().count()).isEqualTo(3);
 
         // Combined with criteria
         UserQuery query = idmIdentityService.createUserQuery().userLastNameLike("%ea%").orderByUserFirstName().asc();
         List<User> users = query.list();
-        assertEquals(2, users.size());
-        assertEquals("Fozzie", users.get(0).getFirstName());
-        assertEquals("Gonzo", users.get(1).getFirstName());
+        assertThat(users).hasSize(2);
+        assertThat(users.get(0).getFirstName()).isEqualTo("Fozzie");
+        assertThat(users.get(1).getFirstName()).isEqualTo("Gonzo");
     }
 
     @Test
     public void testQueryInvalidSortingUsage() {
-        try {
-            idmIdentityService.createUserQuery().orderByUserId().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().orderByUserId().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
 
-        try {
-            idmIdentityService.createUserQuery().orderByUserId().orderByUserEmail().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().orderByUserId().orderByUserEmail().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -356,7 +324,7 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         verifyQueryResults(query, 1);
 
         User result = query.singleResult();
-        assertEquals("kermit", result.getId());
+        assertThat(result.getId()).isEqualTo("kermit");
     }
 
     @Test
@@ -364,49 +332,44 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         UserQuery query = idmIdentityService.createUserQuery().memberOfGroup("invalid");
         verifyQueryResults(query, 0);
 
-        try {
-            idmIdentityService.createUserQuery().memberOfGroup(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> idmIdentityService.createUserQuery().memberOfGroup(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     private void verifyQueryResults(UserQuery query, int countExpected) {
-        assertEquals(countExpected, query.list().size());
-        assertEquals(countExpected, query.count());
+        assertThat(query.list()).hasSize(countExpected);
+        assertThat(query.count()).isEqualTo(countExpected);
 
         if (countExpected == 1) {
-            assertNotNull(query.singleResult());
+            assertThat(query.singleResult()).isNotNull();
         } else if (countExpected > 1) {
             verifySingleResultFails(query);
         } else if (countExpected == 0) {
-            assertNull(query.singleResult());
+            assertThat(query.singleResult()).isNull();
         }
     }
 
     private void verifySingleResultFails(UserQuery query) {
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testNativeQuery() {
-        assertEquals("ACT_ID_USER", idmManagementService.getTableName(User.class));
-        assertEquals("ACT_ID_USER", idmManagementService.getTableName(UserEntity.class));
+        assertThat(idmManagementService.getTableName(User.class)).isEqualTo("ACT_ID_USER");
+        assertThat(idmManagementService.getTableName(UserEntity.class)).isEqualTo("ACT_ID_USER");
         String tableName = idmManagementService.getTableName(User.class);
         String baseQuerySql = "SELECT * FROM " + tableName;
 
-        assertEquals(3, idmIdentityService.createNativeUserQuery().sql(baseQuerySql).list().size());
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).list()).hasSize(3);
 
-        assertEquals(1, idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").list().size());
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").list()).hasSize(1);
 
         // paging
-        assertEquals(2, idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(0, 2).size());
-        assertEquals(2, idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(1, 3).size());
-        assertEquals(1, idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").listPage(0, 1).size());
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(0, 2)).hasSize(2);
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(1, 3)).hasSize(2);
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").listPage(0, 1).size())
+                .isEqualTo(1);
     }
 
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserQueryTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserQueryTest.java
@@ -301,9 +301,9 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         // Combined with criteria
         UserQuery query = idmIdentityService.createUserQuery().userLastNameLike("%ea%").orderByUserFirstName().asc();
         List<User> users = query.list();
-        assertThat(users).hasSize(2);
-        assertThat(users.get(0).getFirstName()).isEqualTo("Fozzie");
-        assertThat(users.get(1).getFirstName()).isEqualTo("Gonzo");
+        assertThat(users)
+                .extracting(User::getFirstName)
+                .containsExactly("Fozzie", "Gonzo");
     }
 
     @Test


### PR DESCRIPTION
All test files in the `org.flowable.idm.engine.test` package are included.

Converted a mixture of Junit 4 and 5 and `assertj` code into all Junit 5 and  `assertj` statements.

