### PR TITLE
Use assertj fluent style in flowable-idm-spring module.

### DIFF
--- a/modules/flowable-idm-spring/src/test/java/org/flowable/spring/test/authentication/SpringPasswordEncoderTest.java
+++ b/modules/flowable-idm-spring/src/test/java/org/flowable/spring/test/authentication/SpringPasswordEncoderTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,10 +12,7 @@
  */
 package org.flowable.spring.test.authentication;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 
 import org.flowable.idm.api.IdmIdentityService;
 import org.flowable.idm.api.PasswordEncoder;
@@ -23,20 +20,20 @@ import org.flowable.idm.api.User;
 import org.flowable.idm.engine.IdmEngineConfiguration;
 import org.flowable.idm.engine.IdmEngines;
 import org.flowable.idm.spring.authentication.SpringEncoder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.StandardPasswordEncoder;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * @author faizal-manan
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:org/flowable/spring/test/engine/springIdmEngineWithPasswordEncoder-context.xml")
 public class SpringPasswordEncoderTest {
 
@@ -44,7 +41,7 @@ public class SpringPasswordEncoderTest {
 
     @Autowired
     private IdmEngineConfiguration autoWiredIdmIdmEngineConfiguration;
-    
+
     @Autowired
     private IdmIdentityService autoWiredIdmIdentityService;
 
@@ -54,7 +51,7 @@ public class SpringPasswordEncoderTest {
 
         autoWiredIdmIdmEngineConfiguration.setPasswordEncoder(new SpringEncoder(new StandardPasswordEncoder()));
         validatePassword();
-        
+
         autoWiredIdmIdmEngineConfiguration.setPasswordEncoder(passwordEncoder);
     }
 
@@ -65,10 +62,10 @@ public class SpringPasswordEncoderTest {
         IdmEngineConfiguration defaultIdmEngineConfiguration = IdmEngines.getDefaultIdmEngine().getIdmEngineConfiguration();
 
         assertThat(defaultIdmEngineConfiguration.getPasswordEncoder())
-            .isInstanceOf(SpringEncoder.class)
-            .isEqualTo(passwordEncoder);
+                .isInstanceOf(SpringEncoder.class)
+                .isEqualTo(passwordEncoder);
         assertThat(passwordEncoder).isInstanceOfSatisfying(SpringEncoder.class,
-            encoder -> assertThat(encoder.getSpringEncodingProvider()).isInstanceOf(BCryptPasswordEncoder.class));
+                encoder -> assertThat(encoder.getSpringEncodingProvider()).isInstanceOf(BCryptPasswordEncoder.class));
 
     }
 
@@ -80,9 +77,9 @@ public class SpringPasswordEncoderTest {
         User johndoe = autoWiredIdmIdentityService.createUserQuery().userId("johndoe").list().get(0);
         LOGGER.info("Hash Password = {}", johndoe.getPassword());
 
-        assertNotEquals("xxx", johndoe.getPassword());
-        assertTrue(autoWiredIdmIdentityService.checkPassword("johndoe", "xxx"));
-        assertFalse(autoWiredIdmIdentityService.checkPassword("johndoe", "invalid pwd"));
+        assertThat(johndoe.getPassword()).isNotEqualTo("xxx");
+        assertThat(autoWiredIdmIdentityService.checkPassword("johndoe", "xxx")).isTrue();
+        assertThat(autoWiredIdmIdentityService.checkPassword("johndoe", "invalid pwd")).isFalse();
 
         autoWiredIdmIdentityService.deleteUser("johndoe");
 

--- a/modules/flowable-idm-spring/src/test/java/org/flowable/spring/test/engine/SpringIdmEngineTest.java
+++ b/modules/flowable-idm-spring/src/test/java/org/flowable/spring/test/engine/SpringIdmEngineTest.java
@@ -12,27 +12,27 @@
  */
 package org.flowable.spring.test.engine;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.idm.engine.IdmEngines;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Spring process engine base test
  * 
  * @author Henry Yan
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:org/flowable/spring/test/engine/springIdmEngine-context.xml")
 public class SpringIdmEngineTest {
 
     @Test
     public void testGetEngineFromCache() {
-        assertNotNull(IdmEngines.getDefaultIdmEngine());
-        assertNotNull(IdmEngines.getIdmEngine("default"));
+        assertThat(IdmEngines.getDefaultIdmEngine()).isNotNull();
+        assertThat(IdmEngines.getIdmEngine("default")).isNotNull();
     }
 
 }


### PR DESCRIPTION
All test files in the `flowable-idm-spring` module.

Converted a mixture of Junit 4 and 5 and assertj code into all Junit 5 and assertj statements.

