### PR TITLE
Use assertj fluent style in flowable-json-converter module.

### DIFF
--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/AbstractConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/AbstractConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 
@@ -44,10 +42,10 @@ public abstract class AbstractConverterTest {
     }
 
     protected EventDefinition extractEventDefinition(FlowElement flowElement) {
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof Event);
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(Event.class);
         Event event = (Event) flowElement;
-        assertFalse(event.getEventDefinitions().isEmpty());
+        assertThat(event.getEventDefinitions()).isNotEmpty();
         return event.getEventDefinitions().get(0);
     }
 

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/AssociationLinkConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/AssociationLinkConverterTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -22,9 +21,10 @@ import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.CompensateEventDefinition;
 import org.flowable.bpmn.model.EventDefinition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AssociationLinkConverterTest extends AbstractConverterTest {
+
     @Override
     protected String getResource() {
         return "test.association.json";
@@ -35,12 +35,12 @@ public class AssociationLinkConverterTest extends AbstractConverterTest {
         final BpmnModel bpmnModel = readJsonFile();
         final List<BoundaryEvent> boundaryEvents =
                 bpmnModel.getMainProcess().findFlowElementsOfType(BoundaryEvent.class);
-        assertEquals(1, boundaryEvents.size());
+        assertThat(boundaryEvents).hasSize(1);
         final List<EventDefinition> eventDefinitions = boundaryEvents.get(0).getEventDefinitions();
-        assertEquals(1, eventDefinitions.size());
-        assertTrue(eventDefinitions.get(0) instanceof CompensateEventDefinition);
+        assertThat(eventDefinitions).hasSize(1);
+        assertThat(eventDefinitions.get(0)).isInstanceOf(CompensateEventDefinition.class);
         final List<Association> associations =
                 bpmnModel.getMainProcess().findAssociationsWithSourceRefRecursive("userTask1");
-        assertEquals(1, associations.size());
+        assertThat(associations).hasSize(1);
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/BoundaryEventAssociationConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/BoundaryEventAssociationConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,16 +12,14 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.Association;
 import org.flowable.bpmn.model.AssociationDirection;
 import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.ScriptTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BoundaryEventAssociationConverterTest extends AbstractConverterTest {
 
@@ -39,45 +37,42 @@ public class BoundaryEventAssociationConverterTest extends AbstractConverterTest
     private void validateModel(BpmnModel model) {
 
         BoundaryEvent compensateElement1 = (BoundaryEvent) model.getMainProcess().getFlowElement("COMP_1", true);
-        assertFalse(compensateElement1.isCancelActivity());
-        assertEquals("SCRIPT_1", compensateElement1.getAttachedToRefId());
+        assertThat(compensateElement1.isCancelActivity()).isFalse();
+        assertThat(compensateElement1.getAttachedToRefId()).isEqualTo("SCRIPT_1");
         Association comp1ToCompscript11 = (Association) model.getMainProcess().getArtifact("COMP1_TO_COMPSCRIPT11");
-        assertEquals(compensateElement1.getId(),comp1ToCompscript11.getSourceRef());
-        assertEquals("COMP_SCRIPT_11",comp1ToCompscript11.getTargetRef());
-        assertEquals(AssociationDirection.NONE,comp1ToCompscript11.getAssociationDirection());
-
+        assertThat(comp1ToCompscript11.getSourceRef()).isEqualTo(compensateElement1.getId());
+        assertThat(comp1ToCompscript11.getTargetRef()).isEqualTo("COMP_SCRIPT_11");
+        assertThat(comp1ToCompscript11.getAssociationDirection()).isEqualTo(AssociationDirection.NONE);
 
         BoundaryEvent compensateElement2 = (BoundaryEvent) model.getMainProcess().getFlowElement("COMP_2", true);
-        assertFalse(compensateElement2.isCancelActivity());
-        assertEquals("SCRIPT_2", compensateElement2.getAttachedToRefId());
+        assertThat(compensateElement2.isCancelActivity()).isFalse();
+        assertThat(compensateElement2.getAttachedToRefId()).isEqualTo("SCRIPT_2");
         Association comp1ToCompscript21 = (Association) model.getMainProcess().getArtifact("COMP2_TO_COMPSCRIPT21");
-        assertEquals(compensateElement2.getId(),comp1ToCompscript21.getSourceRef());
-        assertEquals("COMP_SCRIPT_21",comp1ToCompscript21.getTargetRef());
-        assertEquals(AssociationDirection.NONE,comp1ToCompscript21.getAssociationDirection());
+        assertThat(comp1ToCompscript21.getSourceRef()).isEqualTo(compensateElement2.getId());
+        assertThat(comp1ToCompscript21.getTargetRef()).isEqualTo("COMP_SCRIPT_21");
+        assertThat(comp1ToCompscript21.getAssociationDirection()).isEqualTo(AssociationDirection.NONE);
 
         BoundaryEvent compensateElement3 = (BoundaryEvent) model.getMainProcess().getFlowElement("COMP_3", true);
-        assertFalse(compensateElement2.isCancelActivity());
-        assertEquals("SCRIPT_3", compensateElement3.getAttachedToRefId());
+        assertThat(compensateElement2.isCancelActivity()).isFalse();
+        assertThat(compensateElement3.getAttachedToRefId()).isEqualTo("SCRIPT_3");
         Association comp1ToCompscript31 = (Association) model.getMainProcess().getArtifact("COMP3_TO_COMPSCRIPT31");
-        assertEquals(compensateElement3.getId(),comp1ToCompscript31.getSourceRef());
-        assertEquals("COMP_SCRIPT_31",comp1ToCompscript31.getTargetRef());
-        assertEquals(AssociationDirection.NONE,comp1ToCompscript31.getAssociationDirection());
+        assertThat(comp1ToCompscript31.getSourceRef()).isEqualTo(compensateElement3.getId());
+        assertThat(comp1ToCompscript31.getTargetRef()).isEqualTo("COMP_SCRIPT_31");
+        assertThat(comp1ToCompscript31.getAssociationDirection()).isEqualTo(AssociationDirection.NONE);
 
+        ScriptTask scriptTask1 = (ScriptTask) model.getMainProcess().getFlowElement("SCRIPT_1", true);
+        assertThat(scriptTask1.isForCompensation()).isFalse();
+        ScriptTask scriptTask2 = (ScriptTask) model.getMainProcess().getFlowElement("SCRIPT_2", true);
+        assertThat(scriptTask2.isForCompensation()).isFalse();
+        ScriptTask scriptTask3 = (ScriptTask) model.getMainProcess().getFlowElement("SCRIPT_3", true);
+        assertThat(scriptTask3.isForCompensation()).isFalse();
 
-        ScriptTask scriptTask1 = (ScriptTask) model.getMainProcess().getFlowElement("SCRIPT_1",true);
-        assertFalse(scriptTask1.isForCompensation());
-        ScriptTask scriptTask2 = (ScriptTask) model.getMainProcess().getFlowElement("SCRIPT_2",true);
-        assertFalse(scriptTask2.isForCompensation());
-        ScriptTask scriptTask3 = (ScriptTask) model.getMainProcess().getFlowElement("SCRIPT_3",true);
-        assertFalse(scriptTask3.isForCompensation());
-
-
-        ScriptTask compScript11 = (ScriptTask) model.getMainProcess().getFlowElement("COMP_SCRIPT_11",true);
-        assertTrue(compScript11.isForCompensation());
-        ScriptTask compScript21 = (ScriptTask) model.getMainProcess().getFlowElement("COMP_SCRIPT_21",true);
-        assertTrue(compScript21.isForCompensation());
-        ScriptTask compScript31 = (ScriptTask) model.getMainProcess().getFlowElement("COMP_SCRIPT_31",true);
-        assertTrue(compScript31.isForCompensation());
+        ScriptTask compScript11 = (ScriptTask) model.getMainProcess().getFlowElement("COMP_SCRIPT_11", true);
+        assertThat(compScript11.isForCompensation()).isTrue();
+        ScriptTask compScript21 = (ScriptTask) model.getMainProcess().getFlowElement("COMP_SCRIPT_21", true);
+        assertThat(compScript21.isForCompensation()).isTrue();
+        ScriptTask compScript31 = (ScriptTask) model.getMainProcess().getFlowElement("COMP_SCRIPT_31", true);
+        assertThat(compScript31.isForCompensation()).isTrue();
 
     }
 

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/BoundaryEventConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/BoundaryEventConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
@@ -22,7 +20,7 @@ import org.flowable.bpmn.model.ErrorEventDefinition;
 import org.flowable.bpmn.model.MessageEventDefinition;
 import org.flowable.bpmn.model.SignalEventDefinition;
 import org.flowable.bpmn.model.TimerEventDefinition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BoundaryEventConverterTest extends AbstractConverterTest {
 
@@ -48,28 +46,28 @@ public class BoundaryEventConverterTest extends AbstractConverterTest {
 
         BoundaryEvent errorElement = (BoundaryEvent) model.getMainProcess().getFlowElement("errorEvent", true);
         ErrorEventDefinition errorEvent = (ErrorEventDefinition) extractEventDefinition(errorElement);
-        assertTrue(errorElement.isCancelActivity()); // always true
-        assertEquals("errorRef", errorEvent.getErrorCode());
-        assertEquals("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE", errorElement.getAttachedToRefId());
+        assertThat(errorElement.isCancelActivity()).isTrue(); // always true
+        assertThat(errorEvent.getErrorCode()).isEqualTo("errorRef");
+        assertThat(errorElement.getAttachedToRefId()).isEqualTo("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE");
 
         BoundaryEvent signalElement = (BoundaryEvent) model.getMainProcess().getFlowElement("signalEvent", true);
         SignalEventDefinition signalEvent = (SignalEventDefinition) extractEventDefinition(signalElement);
-        assertFalse(signalElement.isCancelActivity());
-        assertEquals("signalRef", signalEvent.getSignalRef());
-        assertEquals("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE", errorElement.getAttachedToRefId());
+        assertThat(signalElement.isCancelActivity()).isFalse();
+        assertThat(signalEvent.getSignalRef()).isEqualTo("signalRef");
+        assertThat(errorElement.getAttachedToRefId()).isEqualTo("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE");
 
         BoundaryEvent messageElement = (BoundaryEvent) model.getMainProcess().getFlowElement("messageEvent", true);
         MessageEventDefinition messageEvent = (MessageEventDefinition) extractEventDefinition(messageElement);
-        assertFalse(messageElement.isCancelActivity());
-        assertEquals("messageRef", messageEvent.getMessageRef());
-        assertEquals("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE", errorElement.getAttachedToRefId());
+        assertThat(messageElement.isCancelActivity()).isFalse();
+        assertThat(messageEvent.getMessageRef()).isEqualTo("messageRef");
+        assertThat(errorElement.getAttachedToRefId()).isEqualTo("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE");
 
         BoundaryEvent timerElement = (BoundaryEvent) model.getMainProcess().getFlowElement("timerEvent", true);
         TimerEventDefinition timerEvent = (TimerEventDefinition) extractEventDefinition(timerElement);
-        assertFalse(timerElement.isCancelActivity());
-        assertEquals("PT5M", timerEvent.getTimeDuration());
-        assertEquals("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE", errorElement.getAttachedToRefId());
-        assertEquals("myCalendarName", ((TimerEventDefinition) extractEventDefinition(timerElement)).getCalendarName());
+        assertThat(timerElement.isCancelActivity()).isFalse();
+        assertThat(timerEvent.getTimeDuration()).isEqualTo("PT5M");
+        assertThat(errorElement.getAttachedToRefId()).isEqualTo("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE");
+        assertThat(((TimerEventDefinition) extractEventDefinition(timerElement)).getCalendarName()).isEqualTo("myCalendarName");
 
     }
 

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/BoundaryEventGraphicInfoTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/BoundaryEventGraphicInfoTest.java
@@ -13,24 +13,25 @@
  */
 package org.flowable.editor.language;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+
 import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.GraphicInfo;
 import org.flowable.editor.language.json.converter.BpmnJsonConverter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.io.InputStream;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 /**
  * Created by David Pardo
  */
 public class BoundaryEventGraphicInfoTest extends AbstractConverterTest {
+
     private static final String TIMER_BOUNDERY_ID = "sid-4F284555-6D97-4F67-A926-C96F552A4404";
     private static final String USER_TASK_ID = "sid-6A39AD39-C7BB-4D92-896B-CBF37D5D449B";
 
@@ -43,7 +44,7 @@ public class BoundaryEventGraphicInfoTest extends AbstractConverterTest {
     }
 
     @Test
-    public void dockerInfoShouldRemainIntact() throws  Exception{
+    public void dockerInfoShouldRemainIntact() throws Exception {
         InputStream stream = this.getClass().getClassLoader().getResourceAsStream(getResource());
         JsonNode model = new ObjectMapper().readTree(stream);
         BpmnModel bpmnModel = new BpmnJsonConverter().convertToBpmnModel(model);
@@ -51,13 +52,13 @@ public class BoundaryEventGraphicInfoTest extends AbstractConverterTest {
         validate(model);
     }
 
-    protected void validate(JsonNode model){
+    protected void validate(JsonNode model) {
         ArrayNode node = (ArrayNode) model.path("childShapes");
         JsonNode boundaryEventNode = null;
 
-        for(JsonNode shape: node){
+        for (JsonNode shape : node) {
             String resourceId = shape.path("resourceId").asText();
-            if(TIMER_BOUNDERY_ID.equals(resourceId)){
+            if (TIMER_BOUNDERY_ID.equals(resourceId)) {
                 boundaryEventNode = shape;
             }
         }
@@ -67,27 +68,27 @@ public class BoundaryEventGraphicInfoTest extends AbstractConverterTest {
         Double y = boundaryEventNode.path("dockers").get(0).path("y").asDouble();
 
         //the modeler does not store a mathematical correct docker point.
-        assertThat(x,is(50.0));
-        assertThat(y,is(80.0));
+        assertThat(x).isEqualTo(50.0);
+        assertThat(y).isEqualTo(80.0);
     }
 
     protected void validate(BpmnModel model) {
         BoundaryEvent event = (BoundaryEvent) model.getFlowElement(TIMER_BOUNDERY_ID);
-        assertThat(event.getAttachedToRefId(), is(USER_TASK_ID));
+        assertThat(event.getAttachedToRefId()).isEqualTo(USER_TASK_ID);
 
         //check graphicinfo boundary
         GraphicInfo giBoundary = model.getGraphicInfo(TIMER_BOUNDERY_ID);
-        assertThat(giBoundary.getX(), is(334.2201675394047));
-        assertThat(giBoundary.getY(), is(199.79587432571776));
-        assertThat(giBoundary.getHeight(), is(31.0));
-        assertThat(giBoundary.getWidth(), is(31.0));
+        assertThat(giBoundary.getX()).isEqualTo(334.2201675394047);
+        assertThat(giBoundary.getY()).isEqualTo(199.79587432571776);
+        assertThat(giBoundary.getHeight()).isEqualTo(31.0);
+        assertThat(giBoundary.getWidth()).isEqualTo(31.0);
 
         //check graphicinfo task
         GraphicInfo giTaskOne = model.getGraphicInfo(USER_TASK_ID);
-        assertThat(giTaskOne.getX(),is(300.0));
-        assertThat(giTaskOne.getY(),is(135.0));
-        assertThat(giTaskOne.getWidth(),is(100.0));
-        assertThat(giTaskOne.getHeight(),is(80.0));
+        assertThat(giTaskOne.getX()).isEqualTo(300.0);
+        assertThat(giTaskOne.getY()).isEqualTo(135.0);
+        assertThat(giTaskOne.getWidth()).isEqualTo(100.0);
+        assertThat(giTaskOne.getHeight()).isEqualTo(80.0);
     }
 
     @Override

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CallActivityConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CallActivityConverterTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -22,7 +21,7 @@ import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.CallActivity;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.IOParameter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CallActivityConverterTest extends AbstractConverterTest {
 
@@ -46,33 +45,31 @@ public class CallActivityConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("callactivity", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof CallActivity);
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(CallActivity.class);
         CallActivity callActivity = (CallActivity) flowElement;
-        assertEquals("callactivity", callActivity.getId());
-        assertEquals("Call activity", callActivity.getName());
+        assertThat(callActivity.getId()).isEqualTo("callactivity");
+        assertThat(callActivity.getName()).isEqualTo("Call activity");
 
-        assertEquals("processId", callActivity.getCalledElement());
-        assertEquals("id", callActivity.getCalledElementType());
-        assertTrue(callActivity.getFallbackToDefaultTenant());
-        assertTrue(callActivity.isInheritVariables());
-        assertTrue(callActivity.isSameDeployment());
-        assertTrue(callActivity.isInheritBusinessKey());
-        assertTrue(callActivity.isUseLocalScopeForOutParameters());
+        assertThat(callActivity.getCalledElement()).isEqualTo("processId");
+        assertThat(callActivity.getCalledElementType()).isEqualTo("id");
+        assertThat(callActivity.getFallbackToDefaultTenant()).isTrue();
+        assertThat(callActivity.isInheritVariables()).isTrue();
+        assertThat(callActivity.isSameDeployment()).isTrue();
+        assertThat(callActivity.isInheritBusinessKey()).isTrue();
+        assertThat(callActivity.isUseLocalScopeForOutParameters()).isTrue();
 
         List<IOParameter> parameters = callActivity.getInParameters();
-        assertEquals(2, parameters.size());
-        IOParameter parameter = parameters.get(0);
-        assertEquals("test", parameter.getSource());
-        assertEquals("test", parameter.getTarget());
-        parameter = parameters.get(1);
-        assertEquals("${test}", parameter.getSourceExpression());
-        assertEquals("test", parameter.getTarget());
+        assertThat(parameters)
+                .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
+                .containsExactly(
+                        tuple("test", "test", null),
+                        tuple(null, "test", "${test}")
+                );
 
         parameters = callActivity.getOutParameters();
-        assertEquals(1, parameters.size());
-        parameter = parameters.get(0);
-        assertEquals("test", parameter.getSource());
-        assertEquals("test", parameter.getTarget());
+        assertThat(parameters)
+                .extracting(IOParameter::getSource, IOParameter::getTarget)
+                .containsExactly(tuple("test", "test"));
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CatchEventConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CatchEventConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,8 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.EventDefinition;
@@ -21,7 +20,7 @@ import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.MessageEventDefinition;
 import org.flowable.bpmn.model.SignalEventDefinition;
 import org.flowable.bpmn.model.TimerEventDefinition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CatchEventConverterTest extends AbstractConverterTest {
 
@@ -47,21 +46,21 @@ public class CatchEventConverterTest extends AbstractConverterTest {
 
         FlowElement timerElement = model.getMainProcess().getFlowElement("timer_evt", true);
         EventDefinition timerEvent = extractEventDefinition(timerElement);
-        assertTrue(timerEvent instanceof TimerEventDefinition);
+        assertThat(timerEvent).isInstanceOf(TimerEventDefinition.class);
         TimerEventDefinition ted = (TimerEventDefinition) timerEvent;
-        assertEquals("PT5M", ted.getTimeDuration());
+        assertThat(ted.getTimeDuration()).isEqualTo("PT5M");
 
         FlowElement signalElement = model.getMainProcess().getFlowElement("signal_evt", true);
         EventDefinition signalEvent = extractEventDefinition(signalElement);
-        assertTrue(signalEvent instanceof SignalEventDefinition);
+        assertThat(signalEvent).isInstanceOf(SignalEventDefinition.class);
         SignalEventDefinition sed = (SignalEventDefinition) signalEvent;
-        assertEquals("signal_ref", sed.getSignalRef());
+        assertThat(sed.getSignalRef()).isEqualTo("signal_ref");
 
         FlowElement messageElement = model.getMainProcess().getFlowElement("message_evt", true);
         EventDefinition messageEvent = extractEventDefinition(messageElement);
-        assertTrue(messageEvent instanceof MessageEventDefinition);
+        assertThat(messageEvent).isInstanceOf(MessageEventDefinition.class);
         MessageEventDefinition med = (MessageEventDefinition) messageEvent;
-        assertEquals("message_ref", med.getMessageRef());
+        assertThat(med.getMessageRef()).isEqualTo("message_ref");
 
     }
 

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CollapsebleSubprocessTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CollapsebleSubprocessTest.java
@@ -12,10 +12,8 @@
  */
 package org.flowable.editor.language;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.util.List;
 
@@ -25,7 +23,7 @@ import org.flowable.bpmn.model.GraphicInfo;
 import org.flowable.bpmn.model.SequenceFlow;
 import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by Pardo David on 6/01/2017.
@@ -43,19 +41,19 @@ public class CollapsebleSubprocessTest extends AbstractConverterTest {
     private static final double PRECISION = 0.1d;
 
     @Test
-    public void testItShouldBePossibleToConvertModelerJsonToJava() throws Exception{
+    public void testItShouldBePossibleToConvertModelerJsonToJava() throws Exception {
         BpmnModel bpmnModel = readJsonFile();
         validateModel(bpmnModel);
     }
 
     @Test
-    public void itShouldBePossibleToConvertJavaToJson() throws Exception{
+    public void itShouldBePossibleToConvertJavaToJson() throws Exception {
         BpmnModel bpmnModel = readJsonFile();
         bpmnModel = convertToJsonAndBack(bpmnModel);
         validateModel(bpmnModel);
     }
 
-    private void validateModel(BpmnModel bpmnModel){
+    private void validateModel(BpmnModel bpmnModel) {
         //temp vars
         GraphicInfo gi = null;
         GraphicInfo start = null;
@@ -64,76 +62,75 @@ public class CollapsebleSubprocessTest extends AbstractConverterTest {
 
         //validate parent
         gi = bpmnModel.getGraphicInfo(START_EVENT);
-        assertThat(gi.getX(),is(73.0));
-        assertThat(gi.getY(),is(96.0));
-        assertThat(gi.getWidth(),is(30.0));
-        assertThat(gi.getHeight(),is(30.0));
+        assertThat(gi.getX()).isEqualTo(73.0);
+        assertThat(gi.getY()).isEqualTo(96.0);
+        assertThat(gi.getWidth()).isEqualTo(30.0);
+        assertThat(gi.getHeight()).isEqualTo(30.0);
 
         flowLocationGraphicInfo = bpmnModel.getFlowLocationGraphicInfo(SEQUENCEFLOW_TO_COLLAPSEDSUBPROCESS);
-        assertThat(flowLocationGraphicInfo.size(),is(2));
+        assertThat(flowLocationGraphicInfo).hasSize(2);
 
         gi = bpmnModel.getGraphicInfo(COLLAPSEDSUBPROCESS);
-        assertThat(gi.getExpanded(),is(false));
+        assertThat(gi.getExpanded()).isFalse();
 
         //the intersection points are not full values so its a strange double here...
         start = flowLocationGraphicInfo.get(0);
-        assertEquals(102.99814034216989, start.getX(), PRECISION);
-        assertEquals(111.23619118649086, start.getY(), PRECISION);
+        assertThat(start.getX()).isCloseTo(102.99814034216989, offset(PRECISION));
+        assertThat(start.getY()).isCloseTo(111.23619118649086, offset(PRECISION));
 
         end = flowLocationGraphicInfo.get(1);
-        assertEquals(165.0, end.getX(),PRECISION);
-        assertEquals(112.21259842519686, end.getY(), PRECISION);
+        assertThat(end.getX()).isCloseTo(165.0, offset(PRECISION));
+        assertThat(end.getY()).isCloseTo(112.21259842519686, offset(PRECISION));
 
         //validate graphic infos
         FlowElement flowElement = bpmnModel.getFlowElement(IN_CSB_START_EVENT);
-        assertThat(flowElement,instanceOf(StartEvent.class));
+        assertThat(flowElement).isInstanceOf(StartEvent.class);
 
         gi = bpmnModel.getGraphicInfo(IN_CSB_START_EVENT);
-        assertThat(gi.getX(),is(90.0));
-        assertThat(gi.getY(),is(135.0));
-        assertThat(gi.getWidth(),is(30.0));
-        assertThat(gi.getHeight(),is(30.0));
-
+        assertThat(gi.getX()).isEqualTo(90.0);
+        assertThat(gi.getY()).isEqualTo(135.0);
+        assertThat(gi.getWidth()).isEqualTo(30.0);
+        assertThat(gi.getHeight()).isEqualTo(30.0);
 
         flowElement = bpmnModel.getFlowElement(IN_CSB_SEQUENCEFLOW_TO_USERTASK);
-        assertThat(flowElement,instanceOf(SequenceFlow.class));
-        assertThat(flowElement.getName(),is("to ut"));
+        assertThat(flowElement).isInstanceOf(SequenceFlow.class);
+        assertThat(flowElement.getName()).isEqualTo("to ut");
 
         flowLocationGraphicInfo = bpmnModel.getFlowLocationGraphicInfo(IN_CSB_SEQUENCEFLOW_TO_USERTASK);
-        assertThat(flowLocationGraphicInfo.size(),is(2));
+        assertThat(flowLocationGraphicInfo).hasSize(2);
 
         start = flowLocationGraphicInfo.get(0);
-        assertEquals(120.0, start.getX(), PRECISION);
-        assertEquals(150.0, start.getY(), PRECISION);
+        assertThat(start.getX()).isCloseTo(120.0, offset(PRECISION));
+        assertThat(start.getY()).isCloseTo(150.0, offset(PRECISION));
 
         end = flowLocationGraphicInfo.get(1);
-        assertEquals(232.0, end.getX(), PRECISION);
-        assertThat(end.getY(),is(150.0));
+        assertThat(end.getX()).isCloseTo(232.0, offset(PRECISION));
+        assertThat(end.getY()).isEqualTo(150.0);
 
         flowElement = bpmnModel.getFlowElement(IN_CSB_USERTASK);
-        assertThat(flowElement,instanceOf(UserTask.class));
-        assertThat(flowElement.getName(),is("User task 1"));
+        assertThat(flowElement).isInstanceOf(UserTask.class);
+        assertThat(flowElement.getName()).isEqualTo("User task 1");
 
         gi = bpmnModel.getGraphicInfo(IN_CSB_USERTASK);
-        assertThat(gi.getX(),is(232.0));
-        assertThat(gi.getY(),is(110.0));
-        assertThat(gi.getWidth(),is(100.0));
-        assertThat(gi.getHeight(),is(80.0));
+        assertThat(gi.getX()).isEqualTo(232.0);
+        assertThat(gi.getY()).isEqualTo(110.0);
+        assertThat(gi.getWidth()).isEqualTo(100.0);
+        assertThat(gi.getHeight()).isEqualTo(80.0);
 
         flowElement = bpmnModel.getFlowElement(IN_CSB_SEQUENCEFLOW_TO_END);
-        assertThat(flowElement,instanceOf(SequenceFlow.class));
-        assertThat(flowElement.getName(),is("to end"));
+        assertThat(flowElement).isInstanceOf(SequenceFlow.class);
+        assertThat(flowElement.getName()).isEqualTo("to end");
 
         flowLocationGraphicInfo = bpmnModel.getFlowLocationGraphicInfo(IN_CSB_SEQUENCEFLOW_TO_END);
-        assertThat(flowLocationGraphicInfo.size() , is(2));
+        assertThat(flowLocationGraphicInfo).hasSize(2);
 
         start = flowLocationGraphicInfo.get(0);
-        assertEquals(332.0, start.getX(), PRECISION);
-        assertEquals(150.0, start.getY(), PRECISION);
+        assertThat(start.getX()).isCloseTo(332.0, offset(PRECISION));
+        assertThat(start.getY()).isCloseTo(150.0, offset(PRECISION));
 
         end = flowLocationGraphicInfo.get(1);
-        assertThat(end.getX(),is(435.0));
-        assertThat(end.getY(),is(150.0));
+        assertThat(end.getX()).isEqualTo(435.0);
+        assertThat(end.getY()).isEqualTo(150.0);
     }
 
     @Override

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CollapsedSubWithSubSequenceFlowTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CollapsedSubWithSubSequenceFlowTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,47 +12,48 @@
  */
 package org.flowable.editor.language;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.SubProcess;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies if the sequenceflows are correctly stored when a subprocess is inside
- * and collapseable subprocess.
- *
+ * and collapsible subprocess.
+ * <p>
  * Created by Pardo David on 1/03/2017.
  */
 public class CollapsedSubWithSubSequenceFlowTest extends AbstractConverterTest {
+
     private static final String EXPANED_SUBPROCESS_IN_CP = "sid-65F96E4B-9E0D-462D-AFD4-3FFAD5F7F9B6";
     private static final String COLLAPSED_SUBPROCESS = "sid-44B96119-5A3B-4850-BDAC-2D4A2AECEA0A";
+
     @Test
-    public void oneWay() throws Exception{
+    public void oneWay() throws Exception {
         BpmnModel bpmnModel = readJsonFile();
         validateModel(bpmnModel);
     }
 
     @Test
-    public void twoWay() throws Exception{
+    public void twoWay() throws Exception {
         BpmnModel bpmnModel = readJsonFile();
         bpmnModel = convertToJsonAndBack(bpmnModel);
         validateModel(bpmnModel);
     }
 
-    private void validateModel(BpmnModel model){
+    private void validateModel(BpmnModel model) {
         //It appears that the sequenceflows of the expanded subprocess are also stored as a child of the collapsed subprocess...
         //this lead to duplications when writing back to json...
         SubProcess collapsedSubprocess = (SubProcess) model.getFlowElement(COLLAPSED_SUBPROCESS);
         Collection<FlowElement> flowElements = collapsedSubprocess.getFlowElements();
-        assertThat(flowElements.size(),is(5)); //start - sf - sub - sf - end
+        assertThat(flowElements).hasSize(5); //start - sf - sub - sf - end
 
         SubProcess subProcess = (SubProcess) model.getFlowElement(EXPANED_SUBPROCESS_IN_CP);
-        assertThat(subProcess.getFlowElements().size(),is(5)); //start-sf-task-sf-end
+        assertThat(subProcess.getFlowElements()).hasSize(5); //start-sf-task-sf-end
 
     }
 

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CompleteConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CompleteConverterTest.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
@@ -23,9 +23,7 @@ import org.flowable.bpmn.model.ReceiveTask;
 import org.flowable.bpmn.model.SignalEventDefinition;
 import org.flowable.bpmn.model.SubProcess;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
-
-import java.util.Arrays;
+import org.junit.jupiter.api.Test;
 
 public class CompleteConverterTest extends AbstractConverterTest {
 
@@ -49,32 +47,32 @@ public class CompleteConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("userTask1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof UserTask);
-        assertEquals("userTask1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(UserTask.class);
+        assertThat(flowElement.getId()).isEqualTo("userTask1");
 
         flowElement = model.getMainProcess().getFlowElement("catchsignal", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof IntermediateCatchEvent);
-        assertEquals("catchsignal", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(IntermediateCatchEvent.class);
+        assertThat(flowElement.getId()).isEqualTo("catchsignal");
         IntermediateCatchEvent catchEvent = (IntermediateCatchEvent) flowElement;
-        assertEquals(1, catchEvent.getEventDefinitions().size());
-        assertTrue(catchEvent.getEventDefinitions().get(0) instanceof SignalEventDefinition);
+        assertThat(catchEvent.getEventDefinitions()).hasSize(1);
+        assertThat(catchEvent.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);
         SignalEventDefinition signalEvent = (SignalEventDefinition) catchEvent.getEventDefinitions().get(0);
-        assertEquals("testSignal", signalEvent.getSignalRef());
+        assertThat(signalEvent.getSignalRef()).isEqualTo("testSignal");
 
         flowElement = model.getMainProcess().getFlowElement("subprocess", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof SubProcess);
-        assertEquals("subprocess", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(SubProcess.class);
+        assertThat(flowElement.getId()).isEqualTo("subprocess");
         SubProcess subProcess = (SubProcess) flowElement;
 
         flowElement = subProcess.getFlowElement("receiveTask");
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ReceiveTask);
-        assertEquals("receiveTask", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ReceiveTask.class);
+        assertThat(flowElement.getId()).isEqualTo("receiveTask");
 
-        assertEquals(Arrays.asList("user1","user2"), model.getMainProcess().getCandidateStarterUsers());
-        assertEquals(Arrays.asList("group1","group2"), model.getMainProcess().getCandidateStarterGroups());
+        assertThat(model.getMainProcess().getCandidateStarterUsers()).isEqualTo(Arrays.asList("user1", "user2"));
+        assertThat(model.getMainProcess().getCandidateStarterGroups()).isEqualTo(Arrays.asList("group1", "group2"));
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CompleteConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/CompleteConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,8 +13,6 @@
 package org.flowable.editor.language;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Arrays;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
@@ -72,7 +70,7 @@ public class CompleteConverterTest extends AbstractConverterTest {
         assertThat(flowElement).isInstanceOf(ReceiveTask.class);
         assertThat(flowElement.getId()).isEqualTo("receiveTask");
 
-        assertThat(model.getMainProcess().getCandidateStarterUsers()).isEqualTo(Arrays.asList("user1", "user2"));
-        assertThat(model.getMainProcess().getCandidateStarterGroups()).isEqualTo(Arrays.asList("group1", "group2"));
+        assertThat(model.getMainProcess().getCandidateStarterUsers()).containsExactly("user1", "user2");
+        assertThat(model.getMainProcess().getCandidateStarterGroups()).containsExactly("group1", "group2");
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/DecisionTaskConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/DecisionTaskConverterTest.java
@@ -14,15 +14,12 @@ package org.flowable.editor.language;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FieldExtension;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.ServiceTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DecisionTaskConverterTest extends AbstractConverterTest {
 
@@ -46,18 +43,18 @@ public class DecisionTaskConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("decisiontask", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ServiceTask);
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ServiceTask.class);
         ServiceTask serviceTask = (ServiceTask) flowElement;
-        assertEquals("decisiontask", serviceTask.getId());
-        assertEquals("decision task", serviceTask.getName());
+        assertThat(serviceTask.getId()).isEqualTo("decisiontask");
+        assertThat(serviceTask.getName()).isEqualTo("decision task");
 
         assertThat(serviceTask.getFieldExtensions())
-            .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
-            .as("fieldName, stringValue")
-            .contains(
-                tuple("fallbackToDefaultTenant", "true"),
-                tuple("decisionTaskThrowErrorOnNoHits", "true")
-            );
+                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
+                .as("fieldName, stringValue")
+                .contains(
+                        tuple("fallbackToDefaultTenant", "true"),
+                        tuple("decisionTaskThrowErrorOnNoHits", "true")
+                );
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventNonInterruptingSubProcessConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventNonInterruptingSubProcessConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,17 +12,14 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.EventSubProcess;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EventNonInterruptingSubProcessConverterTest extends AbstractConverterTest {
 
@@ -46,22 +43,22 @@ public class EventNonInterruptingSubProcessConverterTest extends AbstractConvert
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("task1");
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof UserTask);
-        assertEquals("task1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(UserTask.class);
+        assertThat(flowElement.getId()).isEqualTo("task1");
 
         FlowElement eventSubProcessElement = model.getMainProcess().getFlowElement("eventSubProcess");
-        assertNotNull(eventSubProcessElement);
-        assertTrue(eventSubProcessElement instanceof EventSubProcess);
+        assertThat(eventSubProcessElement).isNotNull();
+        assertThat(eventSubProcessElement).isInstanceOf(EventSubProcess.class);
         EventSubProcess eventSubProcess = (EventSubProcess) eventSubProcessElement;
-        assertEquals("eventSubProcess", eventSubProcess.getId());
+        assertThat(eventSubProcess.getId()).isEqualTo("eventSubProcess");
 
         FlowElement signalStartEvent = eventSubProcess.getFlowElement("eventSignalStart");
-        assertNotNull(signalStartEvent);
-        assertTrue(signalStartEvent instanceof StartEvent);
+        assertThat(signalStartEvent).isNotNull();
+        assertThat(signalStartEvent).isInstanceOf(StartEvent.class);
         StartEvent startEvent = (StartEvent) signalStartEvent;
-        assertEquals("eventSignalStart", startEvent.getId());
-        assertFalse(startEvent.isInterrupting());
-        assertEquals(eventSubProcess.getId(), startEvent.getSubProcess().getId());
+        assertThat(startEvent.getId()).isEqualTo("eventSignalStart");
+        assertThat(startEvent.isInterrupting()).isFalse();
+        assertThat(startEvent.getSubProcess().getId()).isEqualTo(eventSubProcess.getId());
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventProcessConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventProcessConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,7 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -21,7 +21,7 @@ import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.ExtensionElement;
 import org.flowable.bpmn.model.StartEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EventProcessConverterTest extends AbstractConverterTest {
 
@@ -45,25 +45,25 @@ public class EventProcessConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         List<StartEvent> startEvents = model.getMainProcess().findFlowElementsOfType(StartEvent.class);
-        assertEquals(1, startEvents.size());
-        assertEquals(0, startEvents.get(0).getEventDefinitions().size());
+        assertThat(startEvents).hasSize(1);
+        assertThat(startEvents.get(0).getEventDefinitions()).isEmpty();
         Map<String, List<ExtensionElement>> extensionMap = startEvents.get(0).getExtensionElements();
-        assertEquals("myEvent", extensionMap.get("eventType").get(0).getElementText());
-        assertEquals("My event name", extensionMap.get("eventName").get(0).getElementText());
-        assertEquals("testChannel", extensionMap.get("channelKey").get(0).getElementText());
-        assertEquals("My test channel", extensionMap.get("channelName").get(0).getElementText());
-        assertEquals("jms", extensionMap.get("channelType").get(0).getElementText());
-        assertEquals("testQueue", extensionMap.get("channelDestination").get(0).getElementText());
-        
+        assertThat(extensionMap.get("eventType").get(0).getElementText()).isEqualTo("myEvent");
+        assertThat(extensionMap.get("eventName").get(0).getElementText()).isEqualTo("My event name");
+        assertThat(extensionMap.get("channelKey").get(0).getElementText()).isEqualTo("testChannel");
+        assertThat(extensionMap.get("channelName").get(0).getElementText()).isEqualTo("My test channel");
+        assertThat(extensionMap.get("channelType").get(0).getElementText()).isEqualTo("jms");
+        assertThat(extensionMap.get("channelDestination").get(0).getElementText()).isEqualTo("testQueue");
+
         List<BoundaryEvent> boundaryEvents = model.getMainProcess().findFlowElementsOfType(BoundaryEvent.class);
-        assertEquals(1, boundaryEvents.size());
-        assertEquals(0, boundaryEvents.get(0).getEventDefinitions().size());
+        assertThat(boundaryEvents).hasSize(1);
+        assertThat(boundaryEvents.get(0).getEventDefinitions()).isEmpty();
         extensionMap = boundaryEvents.get(0).getExtensionElements();
-        assertEquals("boundaryEvent", extensionMap.get("eventType").get(0).getElementText());
-        assertEquals("Boundary event", extensionMap.get("eventName").get(0).getElementText());
-        assertEquals("boundaryChannel", extensionMap.get("channelKey").get(0).getElementText());
-        assertEquals("Boundary channel", extensionMap.get("channelName").get(0).getElementText());
-        assertEquals("jms", extensionMap.get("channelType").get(0).getElementText());
-        assertEquals("boundaryQueue", extensionMap.get("channelDestination").get(0).getElementText());
+        assertThat(extensionMap.get("eventType").get(0).getElementText()).isEqualTo("boundaryEvent");
+        assertThat(extensionMap.get("eventName").get(0).getElementText()).isEqualTo("Boundary event");
+        assertThat(extensionMap.get("channelKey").get(0).getElementText()).isEqualTo("boundaryChannel");
+        assertThat(extensionMap.get("channelName").get(0).getElementText()).isEqualTo("Boundary channel");
+        assertThat(extensionMap.get("channelType").get(0).getElementText()).isEqualTo("jms");
+        assertThat(extensionMap.get("channelDestination").get(0).getElementText()).isEqualTo("boundaryQueue");
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventSubProcessConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventSubProcessConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,16 +12,14 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.EventSubProcess;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EventSubProcessConverterTest extends AbstractConverterTest {
 
@@ -45,22 +43,22 @@ public class EventSubProcessConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("task1");
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof UserTask);
-        assertEquals("task1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(UserTask.class);
+        assertThat(flowElement.getId()).isEqualTo("task1");
 
         FlowElement eventSubProcessElement = model.getMainProcess().getFlowElement("eventSubProcess");
-        assertNotNull(eventSubProcessElement);
-        assertTrue(eventSubProcessElement instanceof EventSubProcess);
+        assertThat(eventSubProcessElement).isNotNull();
+        assertThat(eventSubProcessElement).isInstanceOf(EventSubProcess.class);
         EventSubProcess eventSubProcess = (EventSubProcess) eventSubProcessElement;
-        assertEquals("eventSubProcess", eventSubProcess.getId());
+        assertThat(eventSubProcess.getId()).isEqualTo("eventSubProcess");
 
         FlowElement signalStartEvent = eventSubProcess.getFlowElement("eventSignalStart");
-        assertNotNull(signalStartEvent);
-        assertTrue(signalStartEvent instanceof StartEvent);
+        assertThat(signalStartEvent).isNotNull();
+        assertThat(signalStartEvent).isInstanceOf(StartEvent.class);
         StartEvent startEvent = (StartEvent) signalStartEvent;
-        assertEquals("eventSignalStart", startEvent.getId());
-        assertTrue(startEvent.isInterrupting());
-        assertEquals(eventSubProcess.getId(), startEvent.getSubProcess().getId());
+        assertThat(startEvent.getId()).isEqualTo("eventSignalStart");
+        assertThat(startEvent.isInterrupting()).isTrue();
+        assertThat(startEvent.getSubProcess().getId()).isEqualTo(eventSubProcess.getId());
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventSubprocessSequenceFlowTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/EventSubprocessSequenceFlowTest.java
@@ -12,59 +12,58 @@
  */
 package org.flowable.editor.language;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.util.List;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.EventSubProcess;
 import org.flowable.bpmn.model.GraphicInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by Pardo David on 21/02/2017.
  */
 public class EventSubprocessSequenceFlowTest extends AbstractConverterTest {
+
     private static final String EVENT_SUBPROCESS_ID = "sid-3AE5DD30-CE0E-4660-871F-A515E39EECA6";
     private static final String FROM_SE_TO_TASK = "sid-45B32336-D4E3-4576-8377-2D81C0EE02C4";
 
     private static final double PRECISION = 0.1;
 
     @Test
-    public void oneWay() throws Exception{
+    public void oneWay() throws Exception {
         BpmnModel bpmnModel = readJsonFile();
         validate(bpmnModel);
     }
 
     @Test
-    public void twoWay() throws Exception{
+    public void twoWay() throws Exception {
         BpmnModel bpmnModel = readJsonFile();
         bpmnModel = convertToJsonAndBack(bpmnModel);
         validate(bpmnModel);
     }
 
-    private void validate(BpmnModel model){
+    private void validate(BpmnModel model) {
         EventSubProcess eventSubProcess = (EventSubProcess) model.getFlowElement(EVENT_SUBPROCESS_ID);
 
         //assert that there where 5 sequenceflows registered.
-        assertThat(model.getFlowLocationMap().size(),is(5));
+        assertThat(model.getFlowLocationMap()).hasSize(5);
 
         List<GraphicInfo> graphicInfo = model.getFlowLocationGraphicInfo(FROM_SE_TO_TASK);
         GraphicInfo start = graphicInfo.get(0);
-        assertEquals(180.5, start.getX(), PRECISION); //75.0+105.5 (parent + interception point)
-        assertEquals(314.0, start.getY(), PRECISION); //230.0 + 99.0 - 15.0 (parent + lower right y - bounds y)
+        assertThat(start.getX()).isCloseTo(180.5, offset(PRECISION)); //75.0+105.5 (parent + interception point)
+        assertThat(start.getY()).isCloseTo(314.0, offset(PRECISION)); //230.0 + 99.0 - 15.0 (parent + lower right y - bounds y)
 
         GraphicInfo end = graphicInfo.get(1);
-        assertEquals(225.5, end.getX(), PRECISION); //75.0 +150.5
-        assertEquals(314.0, end.getY(), PRECISION); //230.0 + 44.0 + 40
+        assertThat(end.getX()).isCloseTo(225.5, offset(PRECISION)); //75.0 +150.5
+        assertThat(end.getY()).isCloseTo(314.0, offset(PRECISION)); //230.0 + 44.0 + 40
     }
 
     @Override
     protected String getResource() {
         return "test.eventsubprocesssequenceflow.json";
     }
-
 
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/FlowNodeConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/FlowNodeConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -23,7 +21,7 @@ import org.flowable.bpmn.model.ExclusiveGateway;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.InclusiveGateway;
 import org.flowable.bpmn.model.SequenceFlow;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowNodeConverterTest extends AbstractConverterTest {
 
@@ -37,28 +35,30 @@ public class FlowNodeConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("sid-B074A0DD-934A-4053-A537-20ADF0781023", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ExclusiveGateway);
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ExclusiveGateway.class);
         ExclusiveGateway exclusiveGateway = (ExclusiveGateway) flowElement;
         List<SequenceFlow> sequenceFlows = exclusiveGateway.getOutgoingFlows();
-        assertEquals(2, sequenceFlows.size());
-        assertTrue(sequenceFlows.get(0).getId().equals("sid-07A7E174-8857-4DE9-A7CD-A041706D79C3") || sequenceFlows.get(0).getId().equals("sid-C2068B1E-9A82-41C9-B876-C58E2736C186"));
-        assertTrue(sequenceFlows.get(1).getId().equals("sid-07A7E174-8857-4DE9-A7CD-A041706D79C3") || sequenceFlows.get(1).getId().equals("sid-C2068B1E-9A82-41C9-B876-C58E2736C186"));
-        assertEquals("sid-B074A0DD-934A-4053-A537-20ADF0781023", sequenceFlows.get(0).getSourceRef());
-        assertEquals("sid-B074A0DD-934A-4053-A537-20ADF0781023", sequenceFlows.get(1).getSourceRef());
-        assertEquals("sid-07A7E174-8857-4DE9-A7CD-A041706D79C3", exclusiveGateway.getDefaultFlow());
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getId)
+                .containsExactlyInAnyOrder("sid-07A7E174-8857-4DE9-A7CD-A041706D79C3", "sid-C2068B1E-9A82-41C9-B876-C58E2736C186");
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getSourceRef)
+                .containsExactly("sid-B074A0DD-934A-4053-A537-20ADF0781023", "sid-B074A0DD-934A-4053-A537-20ADF0781023");
+        assertThat(exclusiveGateway.getDefaultFlow()).isEqualTo("sid-07A7E174-8857-4DE9-A7CD-A041706D79C3");
 
         flowElement = model.getMainProcess().getFlowElement("sid-F9AABCC8-8E36-428F-A4C3-32DC991E64F5", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof InclusiveGateway);
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(InclusiveGateway.class);
         InclusiveGateway inclusiveGateway = (InclusiveGateway) flowElement;
         sequenceFlows = inclusiveGateway.getOutgoingFlows();
-        assertEquals(2, sequenceFlows.size());
-        assertTrue(sequenceFlows.get(0).getId().equals("sid-849DE573-3063-4DFB-A729-39DFBF3DFB35") || sequenceFlows.get(0).getId().equals("sid-10913B58-DFB0-462B-B0EE-0EC4118D70A5"));
-        assertTrue(sequenceFlows.get(1).getId().equals("sid-849DE573-3063-4DFB-A729-39DFBF3DFB35") || sequenceFlows.get(1).getId().equals("sid-10913B58-DFB0-462B-B0EE-0EC4118D70A5"));
-        assertEquals("sid-F9AABCC8-8E36-428F-A4C3-32DC991E64F5", sequenceFlows.get(0).getSourceRef());
-        assertEquals("sid-F9AABCC8-8E36-428F-A4C3-32DC991E64F5", sequenceFlows.get(1).getSourceRef());
-        assertEquals("sid-849DE573-3063-4DFB-A729-39DFBF3DFB35", inclusiveGateway.getDefaultFlow());
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getId)
+                .containsExactlyInAnyOrder("sid-849DE573-3063-4DFB-A729-39DFBF3DFB35", "sid-10913B58-DFB0-462B-B0EE-0EC4118D70A5");
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getSourceRef)
+                .containsExactly("sid-F9AABCC8-8E36-428F-A4C3-32DC991E64F5", "sid-F9AABCC8-8E36-428F-A4C3-32DC991E64F5");
+        assertThat(inclusiveGateway.getDefaultFlow()).isEqualTo("sid-849DE573-3063-4DFB-A729-39DFBF3DFB35");
     }
 
     @Override

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/FlowNodeInSubProcessConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/FlowNodeInSubProcessConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -23,7 +21,7 @@ import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.ParallelGateway;
 import org.flowable.bpmn.model.SequenceFlow;
 import org.flowable.bpmn.model.SubProcess;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowNodeInSubProcessConverterTest extends AbstractConverterTest {
 
@@ -37,17 +35,18 @@ public class FlowNodeInSubProcessConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("subprocess1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof SubProcess);
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(SubProcess.class);
         SubProcess subProcess = (SubProcess) flowElement;
         ParallelGateway gateway = (ParallelGateway) subProcess.getFlowElement("sid-A0E0B174-36DF-4C4F-A952-311CC3C031FC");
-        assertNotNull(gateway);
+        assertThat(gateway).isNotNull();
         List<SequenceFlow> sequenceFlows = gateway.getOutgoingFlows();
-        assertEquals(2, sequenceFlows.size());
-        assertTrue(sequenceFlows.get(0).getId().equals("sid-9C669980-C274-4A48-BF7F-B9C5CA577DD2") || sequenceFlows.get(0).getId().equals("sid-A299B987-396F-46CA-8D63-85991FBFCE6E"));
-        assertTrue(sequenceFlows.get(1).getId().equals("sid-9C669980-C274-4A48-BF7F-B9C5CA577DD2") || sequenceFlows.get(1).getId().equals("sid-A299B987-396F-46CA-8D63-85991FBFCE6E"));
-        assertEquals("sid-A0E0B174-36DF-4C4F-A952-311CC3C031FC", sequenceFlows.get(0).getSourceRef());
-        assertEquals("sid-A0E0B174-36DF-4C4F-A952-311CC3C031FC", sequenceFlows.get(1).getSourceRef());
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getId)
+                .containsExactlyInAnyOrder("sid-9C669980-C274-4A48-BF7F-B9C5CA577DD2", "sid-A299B987-396F-46CA-8D63-85991FBFCE6E");
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getSourceRef)
+                .containsExactly("sid-A0E0B174-36DF-4C4F-A952-311CC3C031FC", "sid-A0E0B174-36DF-4C4F-A952-311CC3C031FC");
     }
 
     @Override

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/FlowNodeMultipleOutgoingFlowsConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/FlowNodeMultipleOutgoingFlowsConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -22,7 +20,7 @@ import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.ParallelGateway;
 import org.flowable.bpmn.model.SequenceFlow;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowNodeMultipleOutgoingFlowsConverterTest extends AbstractConverterTest {
 
@@ -36,35 +34,35 @@ public class FlowNodeMultipleOutgoingFlowsConverterTest extends AbstractConverte
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("parallel1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ParallelGateway);
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ParallelGateway.class);
         ParallelGateway gateway = (ParallelGateway) flowElement;
         List<SequenceFlow> sequenceFlows = gateway.getOutgoingFlows();
-        assertEquals(3, sequenceFlows.size());
-        assertTrue(sequenceFlows.get(0).getId().equals("sid-B9EE4ECE-BF72-4C25-B768-8295906E5CF8") || sequenceFlows.get(0).getId().equals("sid-D2491B73-0382-4EC2-AAAC-C8FD129E4CBE")
-                || sequenceFlows.get(0).getId().equals("sid-7036D56C-E8EF-493B-ADEC-57EED4C6CE1F"));
-        assertTrue(sequenceFlows.get(1).getId().equals("sid-B9EE4ECE-BF72-4C25-B768-8295906E5CF8") || sequenceFlows.get(1).getId().equals("sid-D2491B73-0382-4EC2-AAAC-C8FD129E4CBE")
-                || sequenceFlows.get(1).getId().equals("sid-7036D56C-E8EF-493B-ADEC-57EED4C6CE1F"));
-        assertTrue(sequenceFlows.get(2).getId().equals("sid-B9EE4ECE-BF72-4C25-B768-8295906E5CF8") || sequenceFlows.get(2).getId().equals("sid-D2491B73-0382-4EC2-AAAC-C8FD129E4CBE")
-                || sequenceFlows.get(2).getId().equals("sid-7036D56C-E8EF-493B-ADEC-57EED4C6CE1F"));
-        assertEquals("parallel1", sequenceFlows.get(0).getSourceRef());
-        assertEquals("parallel1", sequenceFlows.get(1).getSourceRef());
-        assertEquals("parallel1", sequenceFlows.get(2).getSourceRef());
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getId)
+                .containsExactlyInAnyOrder(
+                        "sid-B9EE4ECE-BF72-4C25-B768-8295906E5CF8",
+                        "sid-D2491B73-0382-4EC2-AAAC-C8FD129E4CBE",
+                        "sid-7036D56C-E8EF-493B-ADEC-57EED4C6CE1F"
+                );
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getSourceRef)
+                .containsExactly("parallel1", "parallel1", "parallel1");
         flowElement = model.getMainProcess().getFlowElement("parallel2", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ParallelGateway);
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ParallelGateway.class);
         gateway = (ParallelGateway) flowElement;
         sequenceFlows = gateway.getIncomingFlows();
-        assertEquals(3, sequenceFlows.size());
-        assertTrue(sequenceFlows.get(0).getId().equals("sid-4C19E041-42FA-485D-9D09-D47CCD9DB270") || sequenceFlows.get(0).getId().equals("sid-05A991A6-0296-4867-ACBA-EF9EEC68FB8A")
-                || sequenceFlows.get(0).getId().equals("sid-C546AC84-379D-4094-9DC3-548593F2EA0D"));
-        assertTrue(sequenceFlows.get(1).getId().equals("sid-4C19E041-42FA-485D-9D09-D47CCD9DB270") || sequenceFlows.get(1).getId().equals("sid-05A991A6-0296-4867-ACBA-EF9EEC68FB8A")
-                || sequenceFlows.get(1).getId().equals("sid-C546AC84-379D-4094-9DC3-548593F2EA0D"));
-        assertTrue(sequenceFlows.get(2).getId().equals("sid-4C19E041-42FA-485D-9D09-D47CCD9DB270") || sequenceFlows.get(2).getId().equals("sid-05A991A6-0296-4867-ACBA-EF9EEC68FB8A")
-                || sequenceFlows.get(2).getId().equals("sid-C546AC84-379D-4094-9DC3-548593F2EA0D"));
-        assertEquals("parallel2", sequenceFlows.get(0).getTargetRef());
-        assertEquals("parallel2", sequenceFlows.get(1).getTargetRef());
-        assertEquals("parallel2", sequenceFlows.get(2).getTargetRef());
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getId)
+                .containsExactlyInAnyOrder(
+                        "sid-4C19E041-42FA-485D-9D09-D47CCD9DB270",
+                        "sid-05A991A6-0296-4867-ACBA-EF9EEC68FB8A",
+                        "sid-C546AC84-379D-4094-9DC3-548593F2EA0D"
+                );
+        assertThat(sequenceFlows)
+                .extracting(SequenceFlow::getTargetRef)
+                .containsExactly("parallel2", "parallel2", "parallel2");
     }
 
     @Override

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/FormPropertiesConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/FormPropertiesConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,10 +12,8 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,7 +26,7 @@ import org.flowable.bpmn.model.FormProperty;
 import org.flowable.bpmn.model.FormValue;
 import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FormPropertiesConverterTest extends AbstractConverterTest {
 
@@ -52,19 +50,19 @@ public class FormPropertiesConverterTest extends AbstractConverterTest {
     }
 
     private void validateModel(BpmnModel model) {
-        assertEquals("formPropertiesProcess", model.getMainProcess().getId());
-        assertEquals("User registration", model.getMainProcess().getName());
-        assertTrue(model.getMainProcess().isExecutable());
+        assertThat(model.getMainProcess().getId()).isEqualTo("formPropertiesProcess");
+        assertThat(model.getMainProcess().getName()).isEqualTo("User registration");
+        assertThat(model.getMainProcess().isExecutable()).isTrue();
 
         FlowElement startFlowElement = model.getMainProcess().getFlowElement("startNode", true);
-        assertNotNull(startFlowElement);
-        assertTrue(startFlowElement instanceof StartEvent);
+        assertThat(startFlowElement).isNotNull();
+        assertThat(startFlowElement).isInstanceOf(StartEvent.class);
         StartEvent startEvent = (StartEvent) startFlowElement;
 
         List<FormProperty> formProperties = startEvent.getFormProperties();
 
-        assertNotNull(formProperties);
-        assertEquals("Invalid form properties list: ", 8, formProperties.size());
+        assertThat(formProperties).isNotNull();
+        assertThat(formProperties.size()).as("Invalid form properties list: ").isEqualTo(8);
 
         for (FormProperty formProperty : formProperties) {
             if (formProperty.getId().equals("new_property_1")) {
@@ -99,14 +97,14 @@ public class FormPropertiesConverterTest extends AbstractConverterTest {
         }
 
         FlowElement userFlowElement = model.getMainProcess().getFlowElement("userTask", true);
-        assertNotNull(userFlowElement);
-        assertTrue(userFlowElement instanceof UserTask);
+        assertThat(userFlowElement).isNotNull();
+        assertThat(userFlowElement).isInstanceOf(UserTask.class);
         UserTask userTask = (UserTask) userFlowElement;
 
         formProperties = userTask.getFormProperties();
 
-        assertNotNull(formProperties);
-        assertEquals("Invalid form properties list: ", 8, formProperties.size());
+        assertThat(formProperties).isNotNull();
+        assertThat(formProperties.size()).as("Invalid form properties list: ").isEqualTo(8);
 
         for (FormProperty formProperty : formProperties) {
             if (formProperty.getId().equals("new_property_1")) {
@@ -143,10 +141,10 @@ public class FormPropertiesConverterTest extends AbstractConverterTest {
     }
 
     private void checkFormProperty(FormProperty formProperty, String name, boolean shouldBeRequired, boolean shouldBeReadable, boolean shouldBeWritable) {
-        assertEquals(name, formProperty.getName());
-        assertEquals(shouldBeRequired, formProperty.isRequired());
-        assertEquals(shouldBeReadable, formProperty.isReadable());
-        assertEquals(shouldBeWritable, formProperty.isWriteable());
+        assertThat(formProperty.getName()).isEqualTo(name);
+        assertThat(formProperty.isRequired()).isEqualTo(shouldBeRequired);
+        assertThat(formProperty.isReadable()).isEqualTo(shouldBeReadable);
+        assertThat(formProperty.isWriteable()).isEqualTo(shouldBeWritable);
     }
 
     private void checkFormPropertyFormValues(List<Map<String, Object>> formValues) {
@@ -171,6 +169,6 @@ public class FormPropertiesConverterTest extends AbstractConverterTest {
         expectedFormValues.add(formValue3);
         expectedFormValues.add(formValue4);
 
-        assertEquals(expectedFormValues, formValues);
+        assertThat(formValues).isEqualTo(expectedFormValues);
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/GatewayAsncAndExclusiveConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/GatewayAsncAndExclusiveConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,13 +12,12 @@
  */
 package org.flowable.editor.language;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Gateway;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji
@@ -39,20 +38,20 @@ public class GatewayAsncAndExclusiveConverterTest extends AbstractConverterTest 
     private void validateModel(BpmnModel model) {
 
         Gateway gateway1 = (Gateway) model.getMainProcess().getFlowElement("p1", true);
-        assertTrue(gateway1.isExclusive());
-        assertTrue(gateway1.isAsynchronous());
+        assertThat(gateway1.isExclusive()).isTrue();
+        assertThat(gateway1.isAsynchronous()).isTrue();
 
         Gateway gateway2 = (Gateway) model.getMainProcess().getFlowElement("p2", true);
-        assertFalse(gateway2.isExclusive());
-        assertTrue(gateway2.isAsynchronous());
+        assertThat(gateway2.isExclusive()).isFalse();
+        assertThat(gateway2.isAsynchronous()).isTrue();
 
         UserTask userTask1 = (UserTask) model.getMainProcess().getFlowElement("shareniu-1", true);
-        assertFalse(userTask1.isExclusive());
-        assertFalse(userTask1.isAsynchronous());
+        assertThat(userTask1.isExclusive()).isFalse();
+        assertThat(userTask1.isAsynchronous()).isFalse();
 
         UserTask userTask2 = (UserTask) model.getMainProcess().getFlowElement("shareniu-2", true);
-        assertTrue(userTask2.isExclusive());
-        assertTrue(userTask2.isAsynchronous());
+        assertThat(userTask2.isExclusive()).isTrue();
+        assertThat(userTask2.isAsynchronous()).isTrue();
     }
 
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/HttpServiceTaskConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/HttpServiceTaskConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -23,7 +21,7 @@ import org.flowable.bpmn.model.FieldExtension;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.HttpServiceTask;
 import org.flowable.bpmn.model.ServiceTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HttpServiceTaskConverterTest extends AbstractConverterTest {
 
@@ -47,14 +45,14 @@ public class HttpServiceTaskConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("servicetask", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof HttpServiceTask);
-        assertEquals("servicetask", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(HttpServiceTask.class);
+        assertThat(flowElement.getId()).isEqualTo("servicetask");
         ServiceTask serviceTask = (ServiceTask) flowElement;
-        assertEquals("servicetask", serviceTask.getId());
-        assertEquals("REST", serviceTask.getName());
+        assertThat(serviceTask.getId()).isEqualTo("servicetask");
+        assertThat(serviceTask.getName()).isEqualTo("REST");
 
         List<FieldExtension> fields = serviceTask.getFieldExtensions();
-        assertEquals(2, fields.size());
+        assertThat(fields).hasSize(2);
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/MultiInstanceConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/MultiInstanceConverterTest.java
@@ -12,12 +12,11 @@
  */
 package org.flowable.editor.language;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.bpmn.model.Activity;
 import org.flowable.bpmn.model.BpmnModel;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class MultiInstanceConverterTest extends AbstractConverterTest {
 
@@ -41,12 +40,12 @@ public class MultiInstanceConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         Activity activity = (Activity) model.getFlowElement("multi-instance");
-        assertTrue(activity.getLoopCharacteristics().isSequential());
-        assertEquals("3", activity.getLoopCharacteristics().getLoopCardinality());
-        assertEquals("instanceVar", activity.getLoopCharacteristics().getElementVariable());
-        assertEquals("collection", activity.getLoopCharacteristics().getInputDataItem());
-        assertEquals("index", activity.getLoopCharacteristics().getElementIndexVariable());
-        assertEquals("completionCondition", activity.getLoopCharacteristics().getCompletionCondition());
+        assertThat(activity.getLoopCharacteristics().isSequential()).isTrue();
+        assertThat(activity.getLoopCharacteristics().getLoopCardinality()).isEqualTo("3");
+        assertThat(activity.getLoopCharacteristics().getElementVariable()).isEqualTo("instanceVar");
+        assertThat(activity.getLoopCharacteristics().getInputDataItem()).isEqualTo("collection");
+        assertThat(activity.getLoopCharacteristics().getElementIndexVariable()).isEqualTo("index");
+        assertThat(activity.getLoopCharacteristics().getCompletionCondition()).isEqualTo("completionCondition");
     }
 
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/NotExecutableConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/NotExecutableConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,11 +12,10 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BpmnModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NotExecutableConverterTest extends AbstractConverterTest {
 
@@ -39,8 +38,8 @@ public class NotExecutableConverterTest extends AbstractConverterTest {
     }
 
     private void validateModel(BpmnModel model) {
-        assertEquals("simpleProcess", model.getMainProcess().getId());
-        assertEquals("Simple process", model.getMainProcess().getName());
-        assertFalse(model.getMainProcess().isExecutable());
+        assertThat(model.getMainProcess().getId()).isEqualTo("simpleProcess");
+        assertThat(model.getMainProcess().getName()).isEqualTo("Simple process");
+        assertThat(model.getMainProcess().isExecutable()).isFalse();
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/NotExecutablePoolConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/NotExecutablePoolConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,13 +12,13 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Pool;
 import org.flowable.bpmn.model.Process;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NotExecutablePoolConverterTest extends AbstractConverterTest {
 
@@ -45,17 +45,14 @@ public class NotExecutablePoolConverterTest extends AbstractConverterTest {
         String idPool = "idPool";
         String idProcess = "poolProcess";
 
-        assertEquals(1, model.getPools().size());
-
-        Pool pool = model.getPool(idPool);
-        assertEquals(idPool, pool.getId());
-        assertEquals(idProcess, pool.getProcessRef());
-        assertFalse(pool.isExecutable());
+        assertThat(model.getPools())
+                .extracting(Pool::getId, Pool::getProcessRef, Pool::isExecutable)
+                .containsExactly(tuple(idPool, idProcess, false));
 
         Process process = model.getProcess(idPool);
-        assertEquals(idProcess, process.getId());
-        assertFalse(process.isExecutable());
-        assertEquals(3, process.getLanes().size());
+        assertThat(process.getId()).isEqualTo(idProcess);
+        assertThat(process.isExecutable()).isFalse();
+        assertThat(process.getLanes()).hasSize(3);
 
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/PoolConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/PoolConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,15 +12,14 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Lane;
 import org.flowable.bpmn.model.Pool;
 import org.flowable.bpmn.model.Process;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PoolConverterTest extends AbstractConverterTest {
 
@@ -47,56 +46,52 @@ public class PoolConverterTest extends AbstractConverterTest {
         String idPool = "idPool";
         String idProcess = "poolProcess";
 
-        assertEquals(1, model.getPools().size());
-
-        Pool pool = model.getPool(idPool);
-        assertEquals(idPool, pool.getId());
-        assertEquals(idProcess, pool.getProcessRef());
-        assertTrue(pool.isExecutable());
+        assertThat(model.getPools())
+                .extracting(Pool::getId, Pool::getProcessRef, Pool::isExecutable)
+                .containsExactly(tuple(idPool, idProcess, true));
 
         Process process = model.getProcess(idPool);
-        assertEquals(idProcess, process.getId());
-        assertTrue(process.isExecutable());
-        assertEquals(3, process.getLanes().size());
+        assertThat(process.getId()).isEqualTo(idProcess);
+        assertThat(process.isExecutable()).isTrue();
+
+        assertThat(process.getLanes())
+                .extracting(Lane::getId, Lane::getName)
+                .containsExactly(
+                        tuple("idLane1", "Lane 1"),
+                        tuple("idLane2", "Lane 2"),
+                        tuple("idLane3", "Lane 3")
+                );
 
         Lane lane = process.getLanes().get(0);
-        assertEquals("idLane1", lane.getId());
-        assertEquals("Lane 1", lane.getName());
-        assertEquals(7, lane.getFlowReferences().size());
-        assertTrue(lane.getFlowReferences().contains("startevent"));
-        assertTrue(lane.getFlowReferences().contains("usertask1"));
-        assertTrue(lane.getFlowReferences().contains("usertask6"));
-        assertTrue(lane.getFlowReferences().contains("endevent"));
+        assertThat(lane.getFlowReferences()).hasSize(7);
+        assertThat(lane.getFlowReferences())
+                .contains("startevent", "usertask1", "usertask6", "endevent");
 
         lane = process.getLanes().get(1);
-        assertEquals("idLane2", lane.getId());
-        assertEquals("Lane 2", lane.getName());
-        assertEquals(4, lane.getFlowReferences().size());
-        assertTrue(lane.getFlowReferences().contains("usertask2"));
-        assertTrue(lane.getFlowReferences().contains("usertask5"));
+        assertThat(lane.getFlowReferences()).hasSize(4);
+        assertThat(lane.getFlowReferences())
+                .contains("usertask2", "usertask5");
 
         lane = process.getLanes().get(2);
-        assertEquals("idLane3", lane.getId());
-        assertEquals("Lane 3", lane.getName());
-        assertEquals(4, lane.getFlowReferences().size());
-        assertTrue(lane.getFlowReferences().contains("usertask3"));
-        assertTrue(lane.getFlowReferences().contains("usertask4"));
+        assertThat(lane.getFlowReferences()).hasSize(4);
+        assertThat(lane.getFlowReferences())
+                .contains("usertask3", "usertask4");
 
-        assertNotNull(process.getFlowElement("startevent", true));
-        assertNotNull(process.getFlowElement("usertask1", true));
-        assertNotNull(process.getFlowElement("usertask2", true));
-        assertNotNull(process.getFlowElement("usertask3", true));
-        assertNotNull(process.getFlowElement("usertask4", true));
-        assertNotNull(process.getFlowElement("usertask5", true));
-        assertNotNull(process.getFlowElement("usertask6", true));
-        assertNotNull(process.getFlowElement("endevent", true));
+        assertThat(process.getFlowElement("startevent", true)).isNotNull();
+        assertThat(process.getFlowElement("usertask1", true)).isNotNull();
+        assertThat(process.getFlowElement("usertask2", true)).isNotNull();
+        assertThat(process.getFlowElement("usertask3", true)).isNotNull();
+        assertThat(process.getFlowElement("usertask4", true)).isNotNull();
+        assertThat(process.getFlowElement("usertask5", true)).isNotNull();
+        assertThat(process.getFlowElement("usertask6", true)).isNotNull();
+        assertThat(process.getFlowElement("endevent", true)).isNotNull();
 
-        assertNotNull(process.getFlowElement("flow1", true));
-        assertNotNull(process.getFlowElement("flow2", true));
-        assertNotNull(process.getFlowElement("flow3", true));
-        assertNotNull(process.getFlowElement("flow4", true));
-        assertNotNull(process.getFlowElement("flow5", true));
-        assertNotNull(process.getFlowElement("flow6", true));
-        assertNotNull(process.getFlowElement("flow7", true));
+        assertThat(process.getFlowElement("flow1", true)).isNotNull();
+        assertThat(process.getFlowElement("flow2", true)).isNotNull();
+        assertThat(process.getFlowElement("flow3", true)).isNotNull();
+        assertThat(process.getFlowElement("flow4", true)).isNotNull();
+        assertThat(process.getFlowElement("flow5", true)).isNotNull();
+        assertThat(process.getFlowElement("flow6", true)).isNotNull();
+        assertThat(process.getFlowElement("flow7", true)).isNotNull();
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/PoolDataObjectTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/PoolDataObjectTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,8 +12,8 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -22,7 +22,7 @@ import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.Pool;
 import org.flowable.bpmn.model.Process;
 import org.flowable.bpmn.model.ValuedDataObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PoolDataObjectTest extends AbstractConverterTest {
 
@@ -49,24 +49,19 @@ public class PoolDataObjectTest extends AbstractConverterTest {
         String idPool = "pool1";
         String idProcess = "process_pool1";
 
-        assertEquals(1, model.getPools().size());
-
-        Pool pool = model.getPool(idPool);
-        assertEquals(idPool, pool.getId());
-        assertEquals(idProcess, pool.getProcessRef());
-        assertTrue(pool.isExecutable());
+        assertThat(model.getPools())
+                .extracting(Pool::getId, Pool::getProcessRef, Pool::isExecutable)
+                .containsExactly(tuple(idPool, idProcess, true));
 
         Process process = model.getProcess(idPool);
-        assertEquals(idProcess, process.getId());
-        assertTrue(process.isExecutable());
+        assertThat(process.getId()).isEqualTo(idProcess);
+        assertThat(process.isExecutable()).isTrue();
         List<ValuedDataObject> dataObjects = process.getDataObjects();
-        assertEquals(1,dataObjects.size());
+        assertThat(dataObjects).hasSize(1);
 
         List<FlowableListener> executionListeners = process.getExecutionListeners();
-        assertEquals(1,executionListeners.size());
-        assertEquals("shareniu_signal",model.getSignal("shareniu_signal").getId());
+        assertThat(executionListeners).hasSize(1);
+        assertThat(model.getSignal("shareniu_signal").getId()).isEqualTo("shareniu_signal");
     }
-
-
 
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ScopedConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ScopedConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -23,7 +21,7 @@ import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.SubProcess;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ScopedConverterTest extends AbstractConverterTest {
 
@@ -47,33 +45,33 @@ public class ScopedConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("outerSubProcess", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof SubProcess);
-        assertEquals("outerSubProcess", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(SubProcess.class);
+        assertThat(flowElement.getId()).isEqualTo("outerSubProcess");
         SubProcess outerSubProcess = (SubProcess) flowElement;
         List<BoundaryEvent> eventList = outerSubProcess.getBoundaryEvents();
-        assertEquals(1, eventList.size());
-        BoundaryEvent boundaryEvent = eventList.get(0);
-        assertEquals("outerBoundaryEvent", boundaryEvent.getId());
+        assertThat(eventList)
+                .extracting(BoundaryEvent::getId)
+                .containsExactly("outerBoundaryEvent");
 
         FlowElement subElement = outerSubProcess.getFlowElement("innerSubProcess");
-        assertNotNull(subElement);
-        assertTrue(subElement instanceof SubProcess);
-        assertEquals("innerSubProcess", subElement.getId());
+        assertThat(subElement).isNotNull();
+        assertThat(subElement).isInstanceOf(SubProcess.class);
+        assertThat(subElement.getId()).isEqualTo("innerSubProcess");
         SubProcess innerSubProcess = (SubProcess) subElement;
         eventList = innerSubProcess.getBoundaryEvents();
-        assertEquals(1, eventList.size());
-        boundaryEvent = eventList.get(0);
-        assertEquals("innerBoundaryEvent", boundaryEvent.getId());
+        assertThat(eventList)
+                .extracting(BoundaryEvent::getId)
+                .containsExactly("innerBoundaryEvent");
 
         FlowElement taskElement = innerSubProcess.getFlowElement("usertask");
-        assertNotNull(taskElement);
-        assertTrue(taskElement instanceof UserTask);
+        assertThat(taskElement).isNotNull();
+        assertThat(taskElement).isInstanceOf(UserTask.class);
         UserTask userTask = (UserTask) taskElement;
-        assertEquals("usertask", userTask.getId());
+        assertThat(userTask.getId()).isEqualTo("usertask");
         eventList = userTask.getBoundaryEvents();
-        assertEquals(1, eventList.size());
-        boundaryEvent = eventList.get(0);
-        assertEquals("taskBoundaryEvent", boundaryEvent.getId());
+        assertThat(eventList)
+                .extracting(BoundaryEvent::getId)
+                .containsExactly("taskBoundaryEvent");
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ServiceTaskConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ServiceTaskConverterTest.java
@@ -12,9 +12,10 @@
  */
 package org.flowable.editor.language;
 
-import static junit.framework.TestCase.assertTrue;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FieldExtension;
@@ -23,10 +24,7 @@ import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.ImplementationType;
 import org.flowable.bpmn.model.MapExceptionEntry;
 import org.flowable.bpmn.model.ServiceTask;
-import org.junit.Test;
-
-import java.util.List;
-
+import org.junit.jupiter.api.Test;
 
 public class ServiceTaskConverterTest extends AbstractConverterTest {
 
@@ -50,45 +48,37 @@ public class ServiceTaskConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("servicetask", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ServiceTask);
-        assertEquals("servicetask", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ServiceTask.class);
+        assertThat(flowElement.getId()).isEqualTo("servicetask");
         ServiceTask serviceTask = (ServiceTask) flowElement;
-        assertEquals("servicetask", serviceTask.getId());
-        assertEquals("Service task", serviceTask.getName());
-        assertEquals("${skipExpression}", serviceTask.getSkipExpression());
+        assertThat(serviceTask.getId()).isEqualTo("servicetask");
+        assertThat(serviceTask.getName()).isEqualTo("Service task");
+        assertThat(serviceTask.getSkipExpression()).isEqualTo("${skipExpression}");
 
         List<FieldExtension> fields = serviceTask.getFieldExtensions();
-        assertEquals(2, fields.size());
-        FieldExtension field = fields.get(0);
-        assertEquals("testField", field.getFieldName());
-        assertEquals("test", field.getStringValue());
-        field = fields.get(1);
-        assertEquals("testField2", field.getFieldName());
-        assertEquals("${test}", field.getExpression());
+        assertThat(fields)
+                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue, FieldExtension::getExpression)
+                .containsExactly(
+                        tuple("testField", "test", null),
+                        tuple("testField2", null, "${test}")
+                );
 
         List<MapExceptionEntry> exceptions = serviceTask.getMapExceptions();
-        assertEquals(2, exceptions.size());
-        MapExceptionEntry exception = exceptions.get(0);
-        assertEquals("java", exception.getErrorCode());
-        exception = exceptions.get(1);
-        assertEquals("java", exception.getErrorCode());
-        assertEquals("MyClass", exception.getClassName());
-        assertTrue(exception.isAndChildren());
+        assertThat(exceptions)
+                .extracting(MapExceptionEntry::getErrorCode, MapExceptionEntry::getClassName, MapExceptionEntry::isAndChildren)
+                .containsExactly(
+                        tuple("java", null, false),
+                        tuple("java", "MyClass", true)
+                );
 
         List<FlowableListener> listeners = serviceTask.getExecutionListeners();
-        assertEquals(3, listeners.size());
-        FlowableListener listener = listeners.get(0);
-        assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, listener.getImplementationType());
-        assertEquals("org.test.TestClass", listener.getImplementation());
-        assertEquals("start", listener.getEvent());
-        listener = listeners.get(1);
-        assertEquals(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION, listener.getImplementationType());
-        assertEquals("${testExpression}", listener.getImplementation());
-        assertEquals("end", listener.getEvent());
-        listener = listeners.get(2);
-        assertEquals(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION, listener.getImplementationType());
-        assertEquals("${delegateExpression}", listener.getImplementation());
-        assertEquals("start", listener.getEvent());
+        assertThat(listeners)
+                .extracting(FlowableListener::getImplementationType, FlowableListener::getImplementation, FlowableListener::getEvent)
+                .containsExactly(
+                        tuple(ImplementationType.IMPLEMENTATION_TYPE_CLASS, "org.test.TestClass", "start"),
+                        tuple(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION, "${testExpression}", "end"),
+                        tuple(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION, "${delegateExpression}", "start")
+                );
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ServiceTaskFailedJobRetryTimeCycleConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ServiceTaskFailedJobRetryTimeCycleConverterTest.java
@@ -12,39 +12,39 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.ServiceTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Iveta Champoeva
  */
 public class ServiceTaskFailedJobRetryTimeCycleConverterTest extends AbstractConverterTest {
 
-	@Test
-	public void convertJsonToModel() throws Exception {
-		BpmnModel bpmnModel = readJsonFile();
-		validateModel(bpmnModel);
-	}
+    @Test
+    public void convertJsonToModel() throws Exception {
+        BpmnModel bpmnModel = readJsonFile();
+        validateModel(bpmnModel);
+    }
 
-	@Test
-	public void doubleConversionValidation() throws Exception {
-		BpmnModel bpmnModel = readJsonFile();
-		bpmnModel = convertToJsonAndBack(bpmnModel);
-		validateModel(bpmnModel);
-	}
+    @Test
+    public void doubleConversionValidation() throws Exception {
+        BpmnModel bpmnModel = readJsonFile();
+        bpmnModel = convertToJsonAndBack(bpmnModel);
+        validateModel(bpmnModel);
+    }
 
-	@Override
-	protected String getResource() {
-		return "test.servicetaskfailedjobretrytimecyclemodel.json";
-	}
+    @Override
+    protected String getResource() {
+        return "test.servicetaskfailedjobretrytimecyclemodel.json";
+    }
 
-	private void validateModel(BpmnModel model) {
-		FlowElement flowElement = model.getMainProcess().getFlowElement("shareniuservice", true);
-		ServiceTask serviceTask = (ServiceTask) flowElement;
-		assertEquals("R0/PT0M", serviceTask.getFailedJobRetryTimeCycleValue());
-	}
+    private void validateModel(BpmnModel model) {
+        FlowElement flowElement = model.getMainProcess().getFlowElement("shareniuservice", true);
+        ServiceTask serviceTask = (ServiceTask) flowElement;
+        assertThat(serviceTask.getFailedJobRetryTimeCycleValue()).isEqualTo("R0/PT0M");
+    }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ServiceTaskUseLocalScopeForResultVariableConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ServiceTaskUseLocalScopeForResultVariableConverterTest.java
@@ -12,14 +12,13 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.ServiceTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 /**
  * @author Zheng Ji
  */
@@ -45,12 +44,11 @@ public class ServiceTaskUseLocalScopeForResultVariableConverterTest extends Abst
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("shareniuservice", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ServiceTask);
-        assertEquals("shareniuservice", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ServiceTask.class);
+        assertThat(flowElement.getId()).isEqualTo("shareniuservice");
         ServiceTask serviceTask = (ServiceTask) flowElement;
-        assertEquals("shareniuservice", serviceTask.getId());
-        assertTrue(serviceTask.isUseLocalScopeForResultVariable());
-
+        assertThat(serviceTask.getId()).isEqualTo("shareniuservice");
+        assertThat(serviceTask.isUseLocalScopeForResultVariable()).isTrue();
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ShellTaskConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ShellTaskConverterTest.java
@@ -12,22 +12,18 @@
  */
 package org.flowable.editor.language;
 
-import org.flowable.bpmn.model.BpmnModel;
-import org.flowable.bpmn.model.FieldExtension;
-import org.flowable.bpmn.model.FlowElement;
-import org.flowable.bpmn.model.ServiceTask;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.FieldExtension;
+import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.ServiceTask;
+import org.junit.jupiter.api.Test;
 
 public class ShellTaskConverterTest extends AbstractConverterTest {
 
@@ -68,21 +64,21 @@ public class ShellTaskConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("servicetask", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ServiceTask);
-        assertEquals("servicetask", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ServiceTask.class);
+        assertThat(flowElement.getId()).isEqualTo("servicetask");
         ServiceTask serviceTask = (ServiceTask) flowElement;
-        assertEquals("servicetask", serviceTask.getId());
-        assertEquals("Shell", serviceTask.getName());
+        assertThat(serviceTask.getId()).isEqualTo("servicetask");
+        assertThat(serviceTask.getName()).isEqualTo("Shell");
 
         List<FieldExtension> fields = serviceTask.getFieldExtensions();
         Collection<String> expectedField = new HashSet<>(EXPECTED_FIELDS);
         for (FieldExtension field : fields) {
-            assertTrue(expectedField.contains(field.getFieldName()));
-            assertTrue(expectedField.contains(field.getStringValue()));
-            assertThat(field.getStringValue(), is(field.getFieldName()));
+            assertThat(expectedField.contains(field.getFieldName())).isTrue();
+            assertThat(expectedField.contains(field.getStringValue())).isTrue();
+            assertThat(field.getStringValue()).isEqualTo(field.getFieldName());
             expectedField.remove(field.getFieldName());
         }
-        assertThat(expectedField.size(), is(0));
+        assertThat(expectedField).isEmpty();
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/SignalEventAsncConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/SignalEventAsncConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,7 +12,6 @@
  */
 package org.flowable.editor.language;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -21,7 +20,7 @@ import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.EventDefinition;
 import org.flowable.bpmn.model.SignalEventDefinition;
 import org.flowable.bpmn.model.ThrowEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji
@@ -44,13 +43,13 @@ public class SignalEventAsncConverterTest extends AbstractConverterTest {
         ThrowEvent throwEvent = (ThrowEvent) model.getMainProcess().getFlowElement("throwEvent", true);
         List<EventDefinition> eventDefinitions = throwEvent.getEventDefinitions();
         assertThat(eventDefinitions).isNotNull();
-        assertThat(eventDefinitions.size()).isNotEqualTo(0);
+        assertThat(eventDefinitions).isNotEmpty();
 
         EventDefinition eventDefinition = eventDefinitions.get(0);
         assertThat(eventDefinitions).isNotNull();
 
-        SignalEventDefinition signalEventDefinition= (SignalEventDefinition) eventDefinition;
-        assertTrue(signalEventDefinition.isAsync());
+        SignalEventDefinition signalEventDefinition = (SignalEventDefinition) eventDefinition;
+        assertThat(signalEventDefinition.isAsync()).isTrue();
     }
 
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/SimpleConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/SimpleConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.EventDefinition;
@@ -22,7 +20,7 @@ import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.IntermediateCatchEvent;
 import org.flowable.bpmn.model.SequenceFlow;
 import org.flowable.bpmn.model.TimerEventDefinition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SimpleConverterTest extends AbstractConverterTest {
 
@@ -45,31 +43,31 @@ public class SimpleConverterTest extends AbstractConverterTest {
     }
 
     private void validateModel(BpmnModel model) {
-        assertEquals("simpleProcess", model.getMainProcess().getId());
-        assertEquals("Simple process", model.getMainProcess().getName());
-        assertTrue(model.getMainProcess().isExecutable());
+        assertThat(model.getMainProcess().getId()).isEqualTo("simpleProcess");
+        assertThat(model.getMainProcess().getName()).isEqualTo("Simple process");
+        assertThat(model.getMainProcess().isExecutable()).isTrue();
 
         FlowElement flowElement = model.getMainProcess().getFlowElement("flow1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof SequenceFlow);
-        assertEquals("flow1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(SequenceFlow.class);
+        assertThat(flowElement.getId()).isEqualTo("flow1");
 
         flowElement = model.getMainProcess().getFlowElement("catchEvent", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof IntermediateCatchEvent);
-        assertEquals("catchEvent", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(IntermediateCatchEvent.class);
+        assertThat(flowElement.getId()).isEqualTo("catchEvent");
         IntermediateCatchEvent catchEvent = (IntermediateCatchEvent) flowElement;
-        assertEquals(1, catchEvent.getEventDefinitions().size());
+        assertThat(catchEvent.getEventDefinitions()).hasSize(1);
         EventDefinition eventDefinition = catchEvent.getEventDefinitions().get(0);
-        assertTrue(eventDefinition instanceof TimerEventDefinition);
+        assertThat(eventDefinition).isInstanceOf(TimerEventDefinition.class);
         TimerEventDefinition timerDefinition = (TimerEventDefinition) eventDefinition;
-        assertEquals("PT5M", timerDefinition.getTimeDuration());
+        assertThat(timerDefinition.getTimeDuration()).isEqualTo("PT5M");
 
         flowElement = model.getMainProcess().getFlowElement("flow1Condition", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof SequenceFlow);
-        assertEquals("flow1Condition", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(SequenceFlow.class);
+        assertThat(flowElement.getId()).isEqualTo("flow1Condition");
         SequenceFlow flow = (SequenceFlow) flowElement;
-        assertEquals("${number <= 1}", flow.getConditionExpression());
+        assertThat(flow.getConditionExpression()).isEqualTo("${number <= 1}");
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/StartEventConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/StartEventConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,18 +12,18 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
-import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.FormProperty;
 import org.flowable.bpmn.model.ImplementationType;
 import org.flowable.bpmn.model.StartEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StartEventConverterTest extends AbstractConverterTest {
 
@@ -48,41 +48,31 @@ public class StartEventConverterTest extends AbstractConverterTest {
     private void validateModel(BpmnModel model) {
 
         FlowElement flowElement = model.getMainProcess().getFlowElement("start", true);
-        assertTrue(flowElement instanceof StartEvent);
+        assertThat(flowElement).isInstanceOf(StartEvent.class);
 
         StartEvent startEvent = (StartEvent) flowElement;
-        assertEquals("start", startEvent.getId());
-        assertEquals("startName", startEvent.getName());
-        assertEquals("startFormKey", startEvent.getFormKey());
-        assertTrue(startEvent.isSameDeployment());
-        assertEquals("formFieldValidationValue", startEvent.getValidateFormFields());
-        assertEquals("startInitiator", startEvent.getInitiator());
-        assertEquals("startDoc", startEvent.getDocumentation());
+        assertThat(startEvent.getId()).isEqualTo("start");
+        assertThat(startEvent.getName()).isEqualTo("startName");
+        assertThat(startEvent.getFormKey()).isEqualTo("startFormKey");
+        assertThat(startEvent.isSameDeployment()).isTrue();
+        assertThat(startEvent.getValidateFormFields()).isEqualTo("formFieldValidationValue");
+        assertThat(startEvent.getInitiator()).isEqualTo("startInitiator");
+        assertThat(startEvent.getDocumentation()).isEqualTo("startDoc");
 
-        assertEquals(2, startEvent.getExecutionListeners().size());
-        FlowableListener executionListener = startEvent.getExecutionListeners().get(0);
-        assertEquals("start", executionListener.getEvent());
-        assertEquals("org.test.TestClass", executionListener.getImplementation());
-        assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, executionListener.getImplementationType());
-
-        executionListener = startEvent.getExecutionListeners().get(1);
-        assertEquals("end", executionListener.getEvent());
-        assertEquals("${someExpression}", executionListener.getImplementation());
-        assertEquals(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION, executionListener.getImplementationType());
+        assertThat(startEvent.getExecutionListeners())
+                .extracting(FlowableListener::getEvent, FlowableListener::getImplementation, FlowableListener::getImplementationType)
+                .containsExactly(
+                        tuple("start", "org.test.TestClass", ImplementationType.IMPLEMENTATION_TYPE_CLASS),
+                        tuple("end", "${someExpression}", ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION)
+                );
 
         List<FormProperty> formProperties = startEvent.getFormProperties();
-        assertEquals(2, formProperties.size());
-
-        FormProperty formProperty = formProperties.get(0);
-        assertEquals("startFormProp1", formProperty.getId());
-        assertEquals("startFormProp1", formProperty.getName());
-        assertEquals("string", formProperty.getType());
-
-        formProperty = formProperties.get(1);
-        assertEquals("startFormProp2", formProperty.getId());
-        assertEquals("startFormProp2", formProperty.getName());
-        assertEquals("boolean", formProperty.getType());
-
+        assertThat(formProperties)
+                .extracting(FormProperty::getId, FormProperty::getName, FormProperty::getType)
+                .containsExactly(
+                        tuple("startFormProp1", "startFormProp1", "string"),
+                        tuple("startFormProp2", "startFormProp2", "boolean")
+                );
     }
 
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/SubProcessConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/SubProcessConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
@@ -23,7 +21,7 @@ import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.SubProcess;
 import org.flowable.bpmn.model.TimerEventDefinition;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubProcessConverterTest extends AbstractConverterTest {
 
@@ -47,34 +45,34 @@ public class SubProcessConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("start1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof StartEvent);
-        assertEquals("start1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(StartEvent.class);
+        assertThat(flowElement.getId()).isEqualTo("start1");
 
         flowElement = model.getMainProcess().getFlowElement("userTask1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof UserTask);
-        assertEquals("userTask1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(UserTask.class);
+        assertThat(flowElement.getId()).isEqualTo("userTask1");
         UserTask userTask = (UserTask) flowElement;
-        assertEquals(1, userTask.getCandidateUsers().size());
-        assertEquals(1, userTask.getCandidateGroups().size());
-        assertEquals(2, userTask.getFormProperties().size());
+        assertThat(userTask.getCandidateUsers()).hasSize(1);
+        assertThat(userTask.getCandidateGroups()).hasSize(1);
+        assertThat(userTask.getFormProperties()).hasSize(2);
 
         flowElement = model.getMainProcess().getFlowElement("subprocess1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof SubProcess);
-        assertEquals("subprocess1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(SubProcess.class);
+        assertThat(flowElement.getId()).isEqualTo("subprocess1");
         SubProcess subProcess = (SubProcess) flowElement;
-        assertEquals(5, subProcess.getFlowElements().size());
+        assertThat(subProcess.getFlowElements()).hasSize(5);
 
         flowElement = model.getMainProcess().getFlowElement("boundaryEvent1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof BoundaryEvent);
-        assertEquals("boundaryEvent1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(BoundaryEvent.class);
+        assertThat(flowElement.getId()).isEqualTo("boundaryEvent1");
         BoundaryEvent boundaryEvent = (BoundaryEvent) flowElement;
-        assertNotNull(boundaryEvent.getAttachedToRef());
-        assertEquals("subprocess1", boundaryEvent.getAttachedToRef().getId());
-        assertEquals(1, boundaryEvent.getEventDefinitions().size());
-        assertTrue(boundaryEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition);
+        assertThat(boundaryEvent.getAttachedToRef()).isNotNull();
+        assertThat(boundaryEvent.getAttachedToRef().getId()).isEqualTo("subprocess1");
+        assertThat(boundaryEvent.getEventDefinitions()).hasSize(1);
+        assertThat(boundaryEvent.getEventDefinitions().get(0)).isInstanceOf(TimerEventDefinition.class);
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ThrowCompensationEventTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ThrowCompensationEventTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -24,7 +21,7 @@ import org.flowable.bpmn.model.CompensateEventDefinition;
 import org.flowable.bpmn.model.EventDefinition;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.ThrowEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by alireza on 06/11/2016.
@@ -46,16 +43,16 @@ public class ThrowCompensationEventTest extends AbstractConverterTest {
         modelShouldHaveAThrowEventContainingCompensationEventDefinition(convertToJsonAndBack(readJsonFile()));
     }
 
-    private void modelShouldHaveAThrowEventContainingCompensationEventDefinition(BpmnModel model){
+    private void modelShouldHaveAThrowEventContainingCompensationEventDefinition(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("throwCompensationEvent");
-        assertNotNull(flowElement);
-        assertThat(flowElement, instanceOf(ThrowEvent.class));
-        ThrowEvent throwEvent = (ThrowEvent)flowElement;
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(ThrowEvent.class);
+        ThrowEvent throwEvent = (ThrowEvent) flowElement;
 
         final List<EventDefinition> eventDefinitions = throwEvent.getEventDefinitions();
-        assertNotNull(eventDefinitions);
-        assertEquals(1, eventDefinitions.size());
-        assertThat(eventDefinitions.get(0), instanceOf(CompensateEventDefinition.class));
-        assertEquals("activity_ref", ((CompensateEventDefinition)eventDefinitions.get(0)).getActivityRef());
+        assertThat(eventDefinitions).isNotNull();
+        assertThat(eventDefinitions).hasSize(1);
+        assertThat(eventDefinitions.get(0)).isInstanceOf(CompensateEventDefinition.class);
+        assertThat(((CompensateEventDefinition) eventDefinitions.get(0)).getActivityRef()).isEqualTo("activity_ref");
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/UserTaskConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/UserTaskConverterTest.java
@@ -12,22 +12,21 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.FieldExtension;
 import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.FlowableListener;
 import org.flowable.bpmn.model.FormProperty;
 import org.flowable.bpmn.model.ImplementationType;
 import org.flowable.bpmn.model.SequenceFlow;
 import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.UserTask;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UserTaskConverterTest extends AbstractConverterTest {
 
@@ -51,73 +50,70 @@ public class UserTaskConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("usertask", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof UserTask);
-        assertEquals("usertask", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(UserTask.class);
+        assertThat(flowElement.getId()).isEqualTo("usertask");
         UserTask userTask = (UserTask) flowElement;
-        assertEquals("usertask", userTask.getId());
-        assertEquals("User task", userTask.getName());
-        assertEquals("testKey", userTask.getFormKey());
-        assertEquals("formFieldValidationValue", userTask.getValidateFormFields());
-        assertEquals("40", userTask.getPriority());
-        assertEquals("2012-11-01", userTask.getDueDate());
-        assertEquals("myCalendarName", userTask.getBusinessCalendarName());
-        assertEquals("defaultCategory", userTask.getCategory());
-        assertEquals("${skipExpression}", userTask.getSkipExpression());
+        assertThat(userTask.getId()).isEqualTo("usertask");
+        assertThat(userTask.getName()).isEqualTo("User task");
+        assertThat(userTask.getFormKey()).isEqualTo("testKey");
+        assertThat(userTask.getValidateFormFields()).isEqualTo("formFieldValidationValue");
+        assertThat(userTask.getPriority()).isEqualTo("40");
+        assertThat(userTask.getDueDate()).isEqualTo("2012-11-01");
+        assertThat(userTask.getBusinessCalendarName()).isEqualTo("myCalendarName");
+        assertThat(userTask.getCategory()).isEqualTo("defaultCategory");
+        assertThat(userTask.getSkipExpression()).isEqualTo("${skipExpression}");
 
-        assertEquals("kermit", userTask.getAssignee());
-        assertEquals(2, userTask.getCandidateUsers().size());
-        assertTrue(userTask.getCandidateUsers().contains("kermit"));
-        assertTrue(userTask.getCandidateUsers().contains("fozzie"));
-        assertEquals(2, userTask.getCandidateGroups().size());
-        assertTrue(userTask.getCandidateGroups().contains("management"));
-        assertTrue(userTask.getCandidateGroups().contains("sales"));
+        assertThat(userTask.getAssignee()).isEqualTo("kermit");
+
+        assertThat(userTask.getCandidateUsers())
+                .containsOnly("kermit", "fozzie");
+        ;
+        assertThat(userTask.getCandidateGroups())
+                .containsOnly("management", "sales");
 
         List<FormProperty> formProperties = userTask.getFormProperties();
-        assertEquals(2, formProperties.size());
+        assertThat(formProperties)
+                .extracting(FormProperty::getId, FormProperty::getName, FormProperty::getType)
+                .containsExactly(
+                        tuple("formId", "formName", "string"),
+                        tuple("formId2", "anotherName", "long")
+                );
         FormProperty formProperty = formProperties.get(0);
-        assertEquals("formId", formProperty.getId());
-        assertEquals("formName", formProperty.getName());
-        assertEquals("string", formProperty.getType());
-        assertEquals("variable", formProperty.getVariable());
-        assertEquals("${expression}", formProperty.getExpression());
+        assertThat(formProperty.getVariable()).isEqualTo("variable");
+        assertThat(formProperty.getExpression()).isEqualTo("${expression}");
         formProperty = formProperties.get(1);
-        assertEquals("formId2", formProperty.getId());
-        assertEquals("anotherName", formProperty.getName());
-        assertEquals("long", formProperty.getType());
-        assertTrue(StringUtils.isEmpty(formProperty.getVariable()));
-        assertTrue(StringUtils.isEmpty(formProperty.getExpression()));
+        assertThat(formProperty.getVariable()).isBlank();   // one time null, next time ""
+        assertThat(formProperty.getExpression()).isBlank();
 
         List<FlowableListener> listeners = userTask.getTaskListeners();
-        assertEquals(3, listeners.size());
+        assertThat(listeners)
+                .extracting(FlowableListener::getImplementationType, FlowableListener::getImplementation, FlowableListener::getEvent)
+                .containsExactly(
+                        tuple(ImplementationType.IMPLEMENTATION_TYPE_CLASS, "org.test.TestClass", "create"),
+                        tuple(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION, "${someExpression}", "assignment"),
+                        tuple(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION, "${someDelegateExpression}", "complete")
+                );
         FlowableListener listener = listeners.get(0);
-        assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, listener.getImplementationType());
-        assertEquals("org.test.TestClass", listener.getImplementation());
-        assertEquals("create", listener.getEvent());
-        assertEquals(2, listener.getFieldExtensions().size());
-        assertEquals("testField", listener.getFieldExtensions().get(0).getFieldName());
-        assertEquals("test", listener.getFieldExtensions().get(0).getStringValue());
-        listener = listeners.get(1);
-        assertEquals(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION, listener.getImplementationType());
-        assertEquals("${someExpression}", listener.getImplementation());
-        assertEquals("assignment", listener.getEvent());
-        listener = listeners.get(2);
-        assertEquals(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION, listener.getImplementationType());
-        assertEquals("${someDelegateExpression}", listener.getImplementation());
-        assertEquals("complete", listener.getEvent());
+        assertThat(listener.getFieldExtensions())
+                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
+                .containsExactly(
+                        tuple("testField", "test"),
+                        tuple("testField2", null)
+                );
 
         flowElement = model.getMainProcess().getFlowElement("start", true);
-        assertTrue(flowElement instanceof StartEvent);
+        assertThat(flowElement).isInstanceOf(StartEvent.class);
 
         StartEvent startEvent = (StartEvent) flowElement;
-        assertEquals(1, startEvent.getOutgoingFlows().size());
+        assertThat(startEvent.getOutgoingFlows()).hasSize(1);
 
         flowElement = model.getMainProcess().getFlowElement("flow1", true);
-        assertTrue(flowElement instanceof SequenceFlow);
+        assertThat(flowElement).isInstanceOf(SequenceFlow.class);
 
         SequenceFlow flow = (SequenceFlow) flowElement;
-        assertEquals("flow1", flow.getId());
-        assertNotNull(flow.getSourceRef());
-        assertNotNull(flow.getTargetRef());
+        assertThat(flow.getId()).isEqualTo("flow1");
+        assertThat(flow.getSourceRef()).isNotNull();
+        assertThat(flow.getTargetRef()).isNotNull();
     }
 }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ValuedDataObjectConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/ValuedDataObjectConverterTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -32,7 +30,7 @@ import org.flowable.bpmn.model.StartEvent;
 import org.flowable.bpmn.model.StringDataObject;
 import org.flowable.bpmn.model.SubProcess;
 import org.flowable.bpmn.model.ValuedDataObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValuedDataObjectConverterTest extends AbstractConverterTest {
 
@@ -56,111 +54,111 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("start1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof StartEvent);
-        assertEquals("start1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(StartEvent.class);
+        assertThat(flowElement.getId()).isEqualTo("start1");
 
         // verify main process data objects
         List<ValuedDataObject> dataObjects = model.getMainProcess().getDataObjects();
-        assertEquals(12, dataObjects.size());
+        assertThat(dataObjects).hasSize(12);
         for (ValuedDataObject dObj : dataObjects) {
             if ("dObj1".equals(dObj.getId())) {
-                assertEquals(StringDataObject.class, dObj.getClass());
-                assertEquals("StringTest", dObj.getName());
-                assertTrue(dObj.getValue() instanceof String);
-                assertEquals("xsd:string", dObj.getItemSubjectRef().getStructureRef());
-                assertEquals("Testing123", dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(StringDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("StringTest");
+                assertThat(dObj.getValue()).isInstanceOf(String.class);
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:string");
+                assertThat(dObj.getValue()).isEqualTo("Testing123");
             } else if ("dObj2".equals(dObj.getId())) {
-                assertEquals(BooleanDataObject.class, dObj.getClass());
-                assertEquals("BooleanTest", dObj.getName());
-                assertEquals("xsd:boolean", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Boolean);
-                assertEquals(Boolean.TRUE, dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(BooleanDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("BooleanTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:boolean");
+                assertThat(dObj.getValue()).isInstanceOf(Boolean.class);
+                assertThat(dObj.getValue()).isEqualTo(Boolean.TRUE);
             } else if ("dObj3".equals(dObj.getId())) {
-                assertEquals(DateDataObject.class, dObj.getClass());
-                assertEquals("DateTest", dObj.getName());
-                assertEquals("xsd:datetime", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Date);
+                assertThat(dObj.getClass()).isEqualTo(DateDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("DateTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:datetime");
+                assertThat(dObj.getValue()).isInstanceOf(Date.class);
                 GregorianCalendar dateCal = new GregorianCalendar();
                 dateCal.setTime((Date) dObj.getValue());
-                assertEquals(2013, dateCal.get(Calendar.YEAR));
-                assertEquals(8, dateCal.get(Calendar.MONTH));
-                assertEquals(16, dateCal.get(Calendar.DAY_OF_MONTH));
-                assertEquals(11, dateCal.get(Calendar.HOUR_OF_DAY));
-                assertEquals(23, dateCal.get(Calendar.MINUTE));
+                assertThat(dateCal.get(Calendar.YEAR)).isEqualTo(2013);
+                assertThat(dateCal.get(Calendar.MONTH)).isEqualTo(8);
+                assertThat(dateCal.get(Calendar.DAY_OF_MONTH)).isEqualTo(16);
+                assertThat(dateCal.get(Calendar.HOUR_OF_DAY)).isEqualTo(11);
+                assertThat(dateCal.get(Calendar.MINUTE)).isEqualTo(23);
             } else if ("dObj4".equals(dObj.getId())) {
-                assertEquals(DoubleDataObject.class, dObj.getClass());
-                assertEquals("DoubleTest", dObj.getName());
-                assertEquals("xsd:double", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Double);
-                assertEquals(123456789d, dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(DoubleDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("DoubleTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:double");
+                assertThat(dObj.getValue()).isInstanceOf(Double.class);
+                assertThat(dObj.getValue()).isEqualTo(123456789d);
             } else if ("dObj5".equals(dObj.getId())) {
-                assertEquals(IntegerDataObject.class, dObj.getClass());
-                assertEquals("IntegerTest", dObj.getName());
-                assertEquals("xsd:int", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Integer);
-                assertEquals(123, dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(IntegerDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("IntegerTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:int");
+                assertThat(dObj.getValue()).isInstanceOf(Integer.class);
+                assertThat(dObj.getValue()).isEqualTo(123);
             } else if ("dObj6".equals(dObj.getId())) {
-                assertEquals(LongDataObject.class, dObj.getClass());
-                assertEquals("LongTest", dObj.getName());
-                assertEquals("xsd:long", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Long);
-                assertEquals((long) -123456, dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(LongDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("LongTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:long");
+                assertThat(dObj.getValue()).isInstanceOf(Long.class);
+                assertThat(dObj.getValue()).isEqualTo((long) -123456);
             }
         }
 
         flowElement = model.getMainProcess().getFlowElement("subprocess1", true);
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof SubProcess);
-        assertEquals("subprocess1", flowElement.getId());
+        assertThat(flowElement).isNotNull();
+        assertThat(flowElement).isInstanceOf(SubProcess.class);
+        assertThat(flowElement.getId()).isEqualTo("subprocess1");
         SubProcess subProcess = (SubProcess) flowElement;
-        assertEquals(17, subProcess.getFlowElements().size());
+        assertThat(subProcess.getFlowElements()).hasSize(17);
 
         // verify subprocess data objects
         dataObjects = ((SubProcess) flowElement).getDataObjects();
-        assertEquals(12, dataObjects.size());
+        assertThat(dataObjects).hasSize(12);
         for (ValuedDataObject dObj : dataObjects) {
             if ("dObj1".equals(dObj.getId())) {
-                assertEquals(StringDataObject.class, dObj.getClass());
-                assertEquals("SubStringTest", dObj.getName());
-                assertTrue(dObj.getValue() instanceof String);
-                assertEquals("xsd:string", dObj.getItemSubjectRef().getStructureRef());
-                assertEquals("Testing456", dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(StringDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("SubStringTest");
+                assertThat(dObj.getValue()).isInstanceOf(String.class);
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:string");
+                assertThat(dObj.getValue()).isEqualTo("Testing456");
             } else if ("dObj2".equals(dObj.getId())) {
-                assertEquals(BooleanDataObject.class, dObj.getClass());
-                assertEquals("SubBooleanTest", dObj.getName());
-                assertEquals("xsd:boolean", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Boolean);
-                assertEquals(Boolean.FALSE, dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(BooleanDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("SubBooleanTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:boolean");
+                assertThat(dObj.getValue()).isInstanceOf(Boolean.class);
+                assertThat(dObj.getValue()).isEqualTo(Boolean.FALSE);
             } else if ("dObj3".equals(dObj.getId())) {
-                assertEquals(DateDataObject.class, dObj.getClass());
-                assertEquals("SubDateTest", dObj.getName());
-                assertEquals("xsd:datetime", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Date);
+                assertThat(dObj.getClass()).isEqualTo(DateDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("SubDateTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:datetime");
+                assertThat(dObj.getValue()).isInstanceOf(Date.class);
                 GregorianCalendar dateCal = new GregorianCalendar();
                 dateCal.setTime((Date) dObj.getValue());
-                assertEquals(2013, dateCal.get(Calendar.YEAR));
-                assertEquals(10, dateCal.get(Calendar.MONTH));
-                assertEquals(11, dateCal.get(Calendar.DAY_OF_MONTH));
+                assertThat(dateCal.get(Calendar.YEAR)).isEqualTo(2013);
+                assertThat(dateCal.get(Calendar.MONTH)).isEqualTo(10);
+                assertThat(dateCal.get(Calendar.DAY_OF_MONTH)).isEqualTo(11);
             } else if ("dObj4".equals(dObj.getId())) {
-                assertEquals(DoubleDataObject.class, dObj.getClass());
-                assertEquals("SubDoubleTest", dObj.getName());
-                assertEquals("xsd:double", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Double);
-                assertEquals(678912345d, dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(DoubleDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("SubDoubleTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:double");
+                assertThat(dObj.getValue()).isInstanceOf(Double.class);
+                assertThat(dObj.getValue()).isEqualTo(678912345d);
             } else if ("dObj5".equals(dObj.getId())) {
-                assertEquals(IntegerDataObject.class, dObj.getClass());
-                assertEquals("SubIntegerTest", dObj.getName());
-                assertEquals("xsd:int", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Integer);
-                assertEquals(45, dObj.getValue());
+                assertThat(dObj.getClass()).isEqualTo(IntegerDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("SubIntegerTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:int");
+                assertThat(dObj.getValue()).isInstanceOf(Integer.class);
+                assertThat(dObj.getValue()).isEqualTo(45);
             } else if ("dObj6".equals(dObj.getId())) {
-                assertEquals(LongDataObject.class, dObj.getClass());
-                assertEquals("SubLongTest", dObj.getName());
-                assertEquals("xsd:long", dObj.getItemSubjectRef().getStructureRef());
-                assertTrue(dObj.getValue() instanceof Long);
-                assertEquals(456123L, dObj.getValue());
-                assertEquals(1, dObj.getExtensionElements().size());
+                assertThat(dObj.getClass()).isEqualTo(LongDataObject.class);
+                assertThat(dObj.getName()).isEqualTo("SubLongTest");
+                assertThat(dObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:long");
+                assertThat(dObj.getValue()).isInstanceOf(Long.class);
+                assertThat(dObj.getValue()).isEqualTo(456123L);
+                assertThat(dObj.getExtensionElements()).hasSize(1);
             }
         }
     }

--- a/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/json/converter/BpmnJsonConverterTest.java
+++ b/modules/flowable-json-converter/src/test/java/org/flowable/editor/language/json/converter/BpmnJsonConverterTest.java
@@ -12,15 +12,15 @@
  */
 package org.flowable.editor.language.json.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class tests {@link BpmnJsonConverter} implementation
@@ -35,8 +35,8 @@ public class BpmnJsonConverterTest {
         // Arrange
         Path2D line = new Path2D.Double(Path2D.WIND_NON_ZERO, 3);
         line.moveTo(1, 10);
-        line.lineTo(20-1, 10);
-        line.lineTo(20-1 + SMALL_DELTA, 10 + SMALL_DELTA);
+        line.lineTo(20 - 1, 10);
+        line.lineTo(20 - 1 + SMALL_DELTA, 10 + SMALL_DELTA);
         line.closePath();
         Ellipse2D.Double circle = new Ellipse2D.Double(4, 8, 4, 4);
 
@@ -45,12 +45,12 @@ public class BpmnJsonConverterTest {
         intersectionArea.intersect(new Area(circle));
 
         // Assert
-        assertFalse(intersectionArea.isEmpty());
+        assertThat(intersectionArea.isEmpty()).isFalse();
         Rectangle2D bounds2D = intersectionArea.getBounds2D();
-        assertEquals(4d,  bounds2D.getX(), PRECISION);
-        assertEquals(10d,  bounds2D.getY(), PRECISION);
-        assertEquals(8d, bounds2D.getX() + bounds2D.getWidth(), PRECISION);
-        assertEquals(10d, bounds2D.getY() + bounds2D.getHeight(), PRECISION);
+        assertThat(bounds2D.getX()).isCloseTo(4d, offset(PRECISION));
+        assertThat(bounds2D.getY()).isCloseTo(10d, offset(PRECISION));
+        assertThat(bounds2D.getX() + bounds2D.getWidth()).isCloseTo(8d, offset(PRECISION));
+        assertThat(bounds2D.getY() + bounds2D.getHeight()).isCloseTo(10d, offset(PRECISION));
     }
 
     @Test
@@ -68,11 +68,11 @@ public class BpmnJsonConverterTest {
         intersectionArea.intersect(new Area(rectangle));
 
         // Assert
-        assertFalse(intersectionArea.isEmpty());
+        assertThat(intersectionArea.isEmpty()).isFalse();
         Rectangle2D bounds2D = intersectionArea.getBounds2D();
-        assertEquals(4d, bounds2D.getX(), PRECISION);
-        assertEquals(10d, bounds2D.getY(), PRECISION);
-        assertEquals(8d, bounds2D.getX() + bounds2D.getWidth(), PRECISION);
-        assertEquals(10d, bounds2D.getY() + bounds2D.getHeight(), PRECISION);
+        assertThat(bounds2D.getX()).isCloseTo(4d, offset(PRECISION));
+        assertThat(bounds2D.getY()).isCloseTo(10d, offset(PRECISION));
+        assertThat(bounds2D.getX() + bounds2D.getWidth()).isCloseTo(8d, offset(PRECISION));
+        assertThat(bounds2D.getY() + bounds2D.getHeight()).isCloseTo(10d, offset(PRECISION));
     }
 }


### PR DESCRIPTION
All test files in the `flowable-json-converter` module.

Converted a mixture of Junit 4 and 5 and assertj code into all Junit 5 and assertj statements.

