### PR TITLE
Cache maven repository to speed-up github actions builds.

### DIFF
--- a/.github/workflows/java-ea.yml
+++ b/.github/workflows/java-ea.yml
@@ -14,6 +14,12 @@ jobs:
       - uses: actions/checkout@v2-beta
         with:
           fetch-depth: 10
+      - name: Cache Maven Repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Install
         # If installing the JDK is in a different step then wrong java would be used
         # Need to do install first in order for the OSGi tests to work

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,12 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+    - name: Cache Maven Repository
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Install
       # Need to do install first in order for the OSGi tests to work
       run: ./mvnw install -V -B --no-transfer-progress -DskipTests=true -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
Every time a pom changes the cache is invalidated. Failed builds do not affect the cache. This should avoid the cache corruption problems on travis ci.