### PR TITLE
OIDC SSO authentication

### DIFF
--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/java/org/flowable/ui/idm/application/FlowableIdmApplication.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/java/org/flowable/ui/idm/application/FlowableIdmApplication.java
@@ -12,12 +12,19 @@
  */
 package org.flowable.ui.idm.application;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.flowable.ui.idm.conf.ApplicationConfiguration;
+import org.flowable.ui.idm.model.SSOUserInfo;
+import org.flowable.ui.idm.rest.app.SSOHandler;
 import org.flowable.ui.idm.servlet.AppDispatcherServletConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.util.MultiValueMap;
 
 /**
  * @author Filip Hrisafov
@@ -31,6 +38,25 @@ public class FlowableIdmApplication extends SpringBootServletInitializer {
 
     public static void main(String[] args) {
         SpringApplication.run(FlowableIdmApplication.class, args);
+    }
+
+    @Bean
+    public SSOHandler ssoHandler() {
+        return new SSOHandler() {
+
+            @Override
+            public boolean isActive(){
+                return false;
+            }
+            @Override
+            public SSOUserInfo handleSsoReturn(HttpServletRequest request, HttpServletResponse response, MultiValueMap<String, String> body) {
+                return null;
+            }
+            @Override
+            public String getExternalUrl(String idmUrl) {
+                return null;
+            }
+        };
     }
 
 }

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/java/org/flowable/ui/idm/application/KeyCloakSSOHandler.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/java/org/flowable/ui/idm/application/KeyCloakSSOHandler.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.ui.idm.application;
 
 import java.util.AbstractMap;

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/i18n/en.json
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/i18n/en.json
@@ -39,6 +39,7 @@
         "PASSWORD": "Password",
         "PASSWORD-PLACEHOLDER": "Enter your password",
         "INVALID-CREDENTIALS": "Invalid credentials",
+        "EXTERNAL-SERVICE": "Log in with an external service",
         "ACTION": {
             "CONFIRM": "Sign in"
         }

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/common/services/authentication-service.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/common/services/authentication-service.js
@@ -187,6 +187,16 @@ flowableApp.factory('AuthenticationSharedService', ['$rootScope', '$http', 'auth
 
           return deferred.promise;
         },
+
+        getSsoUrl: function (param) {
+            $http.get(FLOWABLE.CONFIG.contextRoot + '/app/sso/external', {
+                ignoreAuthModule: 'ignoreAuthModule'
+            }).success(function (data, status, headers, config) {
+                if ( data != null && data.length > 0 && param.success ){
+                    param.success(data, status, headers, config);
+                }
+            });
+        },
           
         login: function (param) {
             var data ="j_username=" + encodeURIComponent(param.username) +"&j_password=" + encodeURIComponent(param.password) +"&_spring_security_remember_me=true&submit=Login";

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/controllers.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/controllers.js
@@ -10,12 +10,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-flowableApp.controller('LoginController', ['$scope', '$location', 'AuthenticationSharedService', '$timeout',
-    function ($scope, $location, AuthenticationSharedService, $timeout) {
+flowableApp.controller('LoginController', ['$scope', '$location', '$cookies', 'AuthenticationSharedService', '$timeout',
+    function ($scope, $location, $cookies, AuthenticationSharedService, $timeout) {
 
         $scope.model = {
             loading: false
         };
+
+        // default values
+        if ( !('redirectUrl' in $location.search()) ) {
+            delete $cookies.redirectUrl;
+        }
+        $scope.hasExternalAuth = false;
+
+        AuthenticationSharedService.getSsoUrl({
+            success: function(data) {
+                $scope.ssoUrl = data;
+                $scope.hasExternalAuth = true;
+
+                if( 'redirectUrl' in $location.search() ){
+                    var redirectUrl = $location.search()['redirectUrl'];
+                    if( redirectUrl != null && redirectUrl.length > 0 ){
+                        $cookies.redirectUrl = redirectUrl;
+                    }
+                }
+            }
+        });
+
         $scope.login = function () {
 
             $scope.model.loading = true;

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/controllers.js
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/scripts/controllers.js
@@ -36,7 +36,6 @@ flowableApp.controller('LoginController', ['$scope', '$location', '$cookies', 'A
                 }
             }
         });
-
         $scope.login = function () {
 
             $scope.model.loading = true;

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/styles/style-idm.css
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/styles/style-idm.css
@@ -147,6 +147,9 @@
     color: #e74c3c;
     padding: 10px;
 }
+.external-auth {
+    margin-top: 1rem;
+}
 
 /**
  Colors:

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/views/login.html
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/main/resources/static/views/login.html
@@ -24,6 +24,10 @@
                     <p translate="LOGIN.INVALID-CREDENTIALS"></p>
                 </div>
             </form>
+            <div ng-if="hasExternalAuth" class="external-auth">
+                <a href="{{ ssoUrl }}" translate="LOGIN.EXTERNAL-SERVICE"></a>
+            </div>
         </div>
+
     </div>
 </div>

--- a/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/ui/idm/conf/SecurityConfiguration.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-conf/src/main/java/org/flowable/ui/idm/conf/SecurityConfiguration.java
@@ -145,8 +145,7 @@ public class SecurityConfiguration {
                     .addHeaderWriter(new XXssProtectionHeaderWriter())
                     .and()
                     .authorizeRequests()
-                    .antMatchers("/*").permitAll()
-                    .antMatchers("/app/rest/authenticate").permitAll()
+                    .antMatchers("/*", "/app/rest/authenticate", "/app/sso/*").permitAll()
                     .antMatchers("/app/**").hasAuthority(DefaultPrivileges.ACCESS_IDM);
 
             // Custom login form configurer to allow for non-standard HTTP-methods (eg. LOCK)

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOAuthentication.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOAuthentication.java
@@ -1,0 +1,59 @@
+package org.flowable.ui.idm.model;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.flowable.idm.api.User;
+import org.flowable.ui.common.security.FlowableAppUser;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+public class SSOAuthentication implements Authentication {
+
+    private FlowableAppUser user;
+
+    public SSOAuthentication(User user) {
+        this.user = new FlowableAppUser(user, user.getId(), Collections.emptyList());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+    @Override
+    public String getCredentials() {
+        return user.getPassword();
+    }
+    @Override
+    public User getDetails() {
+        return user.getUserObject();
+    }
+    @Override
+    public FlowableAppUser getPrincipal() {
+        return user;
+    }
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+    @Override
+    public void setAuthenticated(boolean b) throws IllegalArgumentException {
+
+    }
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof SSOAuthentication && user.getUserObject().getId().equals(((SSOAuthentication) o).user.getUserObject().getId());
+    }
+    @Override
+    public String toString() {
+        return user.toString();
+    }
+    @Override
+    public int hashCode() {
+        return user.getUserObject().hashCode();
+    }
+    @Override
+    public String getName() {
+        return user.getUsername();
+    }
+}

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOAuthentication.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOAuthentication.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.ui.idm.model;
 
 import java.util.Collection;

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOUserInfo.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOUserInfo.java
@@ -1,0 +1,88 @@
+package org.flowable.ui.idm.model;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.json.JSONObject;
+import org.springframework.http.converter.json.GsonFactoryBean;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SSOUserInfo {
+
+    private String id;
+    private String firstName;
+    private String lastName;
+    private String email;
+
+    private String tenant;
+    private List<String> privileges;
+
+    public SSOUserInfo(){
+    }
+
+    public SSOUserInfo(String id, String firstName, String lastName, String email) {
+        this(id, firstName, lastName, email, null, id);
+    }
+
+    public SSOUserInfo(String id, String firstName, String lastName, String email, String tenant) {
+        this(id, firstName, lastName, email, null, tenant);
+    }
+
+    public SSOUserInfo(String id, String firstName, String lastName, String email, List<String> privileges) {
+        this(id, firstName, lastName, email, privileges, id);
+    }
+
+    public SSOUserInfo(String id, String firstName, String lastName, String email, List<String> privileges, String tenant) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+
+        this.privileges = privileges;
+        this.tenant = tenant;
+    }
+
+    public String getId() {
+        return id;
+    }
+    public String getFirstName() {
+        return firstName;
+    }
+    public String getLastName() {
+        return lastName;
+    }
+    public String getEmail() {
+        return email;
+    }
+    public String getTenant() {
+        return tenant;
+    }
+    public List<String> getPrivileges() {
+        return privileges;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
+    }
+    public void setPrivileges(List<String> privileges) {
+        this.privileges = privileges;
+    }
+}

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOUserInfo.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOUserInfo.java
@@ -1,16 +1,8 @@
 package org.flowable.ui.idm.model;
 
-import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
-import org.json.JSONObject;
-import org.springframework.http.converter.json.GsonFactoryBean;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SSOUserInfo {

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOUserInfo.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/model/SSOUserInfo.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.ui.idm.model;
 
 import java.util.List;

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/EmptySSOHandler.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/EmptySSOHandler.java
@@ -1,0 +1,25 @@
+package org.flowable.ui.idm.rest.app;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.flowable.ui.idm.model.SSOUserInfo;
+import org.springframework.util.MultiValueMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmptySSOHandler implements SSOHandler {
+
+    @Override
+    public boolean isActive() {
+        return false;
+    }
+    @Override
+    public SSOUserInfo handleSsoReturn(HttpServletRequest request, HttpServletResponse response, MultiValueMap<String, String> body) {
+        return null;
+    }
+    @Override
+    public String getExternalUrl(String idmUrl) {
+        return null;
+    }
+}

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/EmptySSOHandler.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/EmptySSOHandler.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.ui.idm.rest.app;
 
 import javax.servlet.http.HttpServletRequest;

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/IdmSSOResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/IdmSSOResource.java
@@ -1,0 +1,181 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.ui.idm.rest.app;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.flowable.idm.api.Privilege;
+import org.flowable.idm.api.User;
+import org.flowable.ui.common.service.exception.NotFoundException;
+import org.flowable.ui.idm.model.SSOAuthentication;
+import org.flowable.ui.idm.model.SSOUserInfo;
+import org.flowable.ui.idm.model.UserInformation;
+import org.flowable.ui.idm.service.PrivilegeService;
+import org.flowable.ui.idm.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.authentication.RememberMeServices;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.google.common.net.HttpHeaders;
+
+/**
+ * @author Matthias De Bie
+ * <p>
+ * TODO: update user before logging in
+ * TODO: make a config option to automatically redirect to sso in stead of idm
+ */
+@RestController
+@RequestMapping("/app")
+public class IdmSSOResource {
+
+    @Autowired
+    protected UserService userService;
+
+    @Autowired
+    protected PrivilegeService privilegeService;
+
+    @Autowired
+    protected SSOHandler ssoHandler;
+
+    @Autowired
+    protected RememberMeServices rememberMeServices;
+
+    @RequestMapping(value = "/sso/external", method = RequestMethod.GET)
+    public void getSsoExternalUrl(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        String urlBase = request.getRequestURL().toString().replace("/sso/external", "/sso/return");
+
+        if (urlBase.startsWith("http://") && "https".equals(request.getHeader(HttpHeaders.X_FORWARDED_PROTO))) {
+            urlBase = urlBase.replace("http://", "https://");
+        }
+
+        if (ssoHandler.isActive()) {
+            response.getWriter().write(
+                ssoHandler.getExternalUrl(urlBase)
+            );
+            response.flushBuffer();
+        }
+    }
+
+    @RequestMapping(value = "/sso/return", method = RequestMethod.GET)
+    public void onSsoReturnGet(HttpServletRequest request, HttpServletResponse response) {
+        handleSSOReturn(request, response, null);
+    }
+
+    @RequestMapping(value = "/sso/return", method = RequestMethod.POST)
+    public void onSsoReturn(@RequestBody MultiValueMap<String, String> body, HttpServletRequest request, HttpServletResponse response) {
+        handleSSOReturn(request, response, body);
+    }
+
+    private void handleSSOReturn(HttpServletRequest request, HttpServletResponse response, MultiValueMap<String, String> body) {
+        SSOUserInfo ssoUserInfo = ssoHandler.handleSsoReturn(request, response, body);
+
+        if (ssoUserInfo != null) {
+            try {
+                UserInformation userInfo = userService.getUserInformation(ssoUserInfo.getId());
+                loginWithSso(request, response, userInfo.getUser());
+
+            } catch (NotFoundException e) {
+                // userInfo not found: create new account
+                createSsoAccount(request, response, ssoUserInfo);
+
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        }
+    }
+
+    private static Logger LOGGER = LoggerFactory.getLogger(IdmSSOResource.class);
+
+    private void loginWithSso(HttpServletRequest request, HttpServletResponse response, User user) throws IOException {
+        String redirectTo = request.getRequestURL().toString().replace("/app/sso/return", "");
+
+        if (request.getCookies() != null) {
+            Optional<Cookie> optional = Arrays.stream(request.getCookies())
+                .filter(cookie -> "redirectUrl".equals(cookie.getName()))
+                .findFirst();
+
+            if (optional.isPresent()) {
+                redirectTo = URLDecoder.decode(optional.get().getValue());
+            }
+        }
+
+        response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+        response.setHeader("Location", redirectTo);
+        rememberMeServices.loginSuccess(request, response, new SSOAuthentication(user));
+        response.getOutputStream().flush();
+    }
+
+    private void createSsoAccount(HttpServletRequest request, HttpServletResponse response, SSOUserInfo userInfo) {
+        userService.createNewUser(
+            userInfo.getId(),
+            userInfo.getFirstName(),
+            userInfo.getLastName(),
+            userInfo.getEmail(),
+            UUID.randomUUID().toString()
+            // userInfo.getTenant()   !! This depends on PR 1444 !!
+        );
+
+        if (userInfo.getPrivileges() != null) {
+
+            for (Privilege priv : privilegeService.findPrivileges()) {
+                if (userInfo.getPrivileges().contains(priv.getName())) {
+                    LOGGER.debug("privilege added: {}", priv.getName());
+                    privilegeService.addUserPrivilege(priv.getId(), userInfo.getId());
+                }
+            }
+
+            try {
+                loginWithSso(request, response, userService.getUserInformation(userInfo.getId()).getUser());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+
+            response.setContentType(MediaType.TEXT_HTML_VALUE);
+
+            try {
+                OutputStreamWriter osw = new OutputStreamWriter(response.getOutputStream(), StandardCharsets.UTF_8);
+
+                osw.append("<div style='display: flex; justify-content: center; align-items: center; width: 100%; height: 100vh; padding: 0; margin: 0;'>");
+                osw.append("<h1>Please wait for an admin to approve your account.</h1>");
+                osw.append("</div>");
+
+                osw.flush();
+                osw.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/KeyCloakSSOHandler.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/KeyCloakSSOHandler.java
@@ -1,0 +1,151 @@
+package org.flowable.ui.idm.rest.app;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.flowable.ui.idm.model.SSOUserInfo;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Custom implementation of a SSOHandler. This one uses Keycloak
+ *
+ * @author mattydebie
+ */
+@Component
+public class KeyCloakSSOHandler implements SSOHandler {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(KeyCloakSSOHandler.class);
+
+    @Value("${flowable.sso.keycloak.url.auth:#{null}}")
+    private String ssoExternalUrl;
+
+    @Value("${flowable.sso.keycloak.client-id:#{null}}")
+    private String ssoClientId;
+
+    @Value("${flowable.sso.keycloak.client-secret:#{null}}")
+    private String ssoClientSecret;
+
+    @Value("${flowable.sso.keycloak.url.token:#{null}}")
+    private String ssoTokenUrl;
+
+    @Value("${flowable.sso.keycloak.url.info:#{null}}")
+    private String ssoUserInfoUrl;
+
+    private String redirectUri = null;
+
+    private String state = UUID.randomUUID().toString();
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public SSOUserInfo handleSsoReturn(HttpServletRequest request, HttpServletResponse response, MultiValueMap<String, String> body) {
+        LOGGER.debug("SSOhandler = {}", KeyCloakSSOHandler.class);
+
+        String stateReturned = request.getParameter("state");
+
+        if (!stateReturned.equals(state)) {
+            LOGGER.error("Return sso 'state' did not match original state");
+            return null;
+        }
+
+        String access_token = getAccessToken(request.getParameter("code"));
+        return getUserInfo(access_token);
+    }
+
+    @Override
+    public String getExternalUrl(String redirectUri) {
+        this.redirectUri = redirectUri;
+        this.state = UUID.randomUUID().toString();
+        return ssoExternalUrl
+            + "?response_type=code"
+            + "&client_id=" + ssoClientId
+            + "&scope=all"
+            + "&state=" + state
+            + "&redirect_uri=" + redirectUri
+            + "&response_mode=query";
+    }
+
+    private String getAccessToken(String code) {
+        // request access token
+        MultiValueMap<String, String> json = createMap(
+            new AbstractMap.SimpleEntry<>("client_id", ssoClientId),
+            new AbstractMap.SimpleEntry<>("client_secret", ssoClientSecret),
+            new AbstractMap.SimpleEntry<>("code", code),
+            new AbstractMap.SimpleEntry<>("grant_type", "authorization_code"),
+            new AbstractMap.SimpleEntry<>("redirect_uri", redirectUri)
+        );
+
+        RestTemplate template = new RestTemplate();
+        String s = template.postForObject(ssoTokenUrl,
+            getHttpEntity(json),
+            String.class);
+
+        JSONObject response = new JSONObject(s);
+        return response.getString("access_token");
+    }
+
+    private SSOUserInfo getUserInfo(String accessToken) {
+        RestTemplate template = new RestTemplate();
+        JSONObject json;
+
+        MultiValueMap<String, String> body = createMap(
+            new AbstractMap.SimpleEntry<>("access_token", accessToken)
+        );
+
+        String resp = template.postForObject(ssoUserInfoUrl, getHttpEntity(body), String.class);
+
+        json = new JSONObject(resp);
+
+        List<String> privs = new ArrayList<>();
+        for (Object priv : json.getJSONArray("privileges")) {
+            privs.add(priv.toString());
+        }
+
+        return new SSOUserInfo(
+            json.getString("preferred_username"),
+            json.getString("given_name"),
+            json.getString("family_name"),
+            json.getString("email"),
+            privs,
+            json.getString("tenant")
+        );
+
+    }
+
+    private HttpEntity<MultiValueMap<String, String>> getHttpEntity(MultiValueMap<String, String> body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        return new HttpEntity<>(body, headers);
+    }
+
+    private MultiValueMap<String, String> createMap(AbstractMap.SimpleEntry<String, String>... values) {
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>(values.length);
+
+        for (AbstractMap.SimpleEntry<String, String> entry : values) {
+            map.add(entry.getKey(), entry.getValue());
+        }
+
+        return map;
+    }
+}

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/SSOHandler.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/SSOHandler.java
@@ -1,0 +1,43 @@
+package org.flowable.ui.idm.rest.app;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.flowable.ui.idm.model.SSOUserInfo;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * Handler for login in or registering through a custom defined SSO.
+ *
+ * @author mattydebie
+ */
+public interface SSOHandler {
+
+    /**
+     * This is purely to use when no SSO is present.
+     * When overriding the SSOHandler, make #isActive() return true to show the 'login with external service' link on the login page.
+     *
+     * @return bool,    wheter to use the SSO or not
+     */
+    boolean isActive();
+
+    /**
+     * This is the method where all the custom logic is present.
+     * the #IdmSSOResource calls this method and expects an SSOUserInfo to continue
+     *
+     * @param request   HttpServletRequest
+     * @param response  HttpServletResponse
+     * @param body      Map or null, depends on whether the sso returns with a POST or a GET
+     * @return          SSOUserInfo
+     */
+    SSOUserInfo handleSsoReturn(HttpServletRequest request, HttpServletResponse response, MultiValueMap<String, String> body);
+
+    /**
+     * Method that returns the full URL to the custom implemented SSO.
+     *
+     * @param idmUrl    String, current url; used as redirectUrl for the SSO
+     * @return          String, url to external SSO
+     */
+    String getExternalUrl(String idmUrl);
+
+}

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/SSOHandler.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/SSOHandler.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.ui.idm.rest.app;
 
 import javax.servlet.http.HttpServletRequest;


### PR DESCRIPTION
This PR should be the followup of PR #1447 as proposed there

It introduces some interfaces and abstract classes for several OIDC authentication providers and includes an implementation for Keycloak

Changes/improvements compared to the previous PR:
* Starting from current master
* Cleanup with more configurable properties and better error handling (if certain claims are not available for ex.)
* Other OIDC handlers can be implemented in custom libraries like we did, extending this ones

The OIDC implementation uses an OpenID Connect implementation on Spring Security. This was previously also already the case.

Additional properties in application.properties:
* flowable.sso.provider=keycloak -> enable using the KeycloakSsoHandler
* flowable.sso.keycloak.url.auth -> authorization endpoint
* flowable.sso.keycloak.url.token -> token endpoint
* flowable.sso.keycloak.url.info -> user info endpoint
* flowable.sso.keycloak.cient-id
* flowable.sso.keycloak.cient-secret
* flowable.sso.keycloak.scope -> the oauth scope needed to receive all necessary claims about a user, no scope will be requested if this property is missing
* flowable.sso.keycloak.userinfo.tenant -> the tenant attribute or claim for the user coming from Keycloak
* flowable.sso.keycloak.userinfo.client_roles -> the privileges claim for the user coming from Keycloak

In your realm on Keycloak you should configure an additional client using following settings

* access type -> confidential
* standard flow enabled
* implicit flow disabled
* enter the valid redirect url -> the path for the KeycloakSsoHandler is (ex. https://your.flowable.instance/flowable-idm/sso/return)
* add client roles which can be assigned to users
  * access-idm
  * access-admin
  * access-modeler
  * access-task
  * access-rest
* add extra mappers
  * tenant -> an optional claim of JSON type string, available in userinfo and access token
  * privileges -> an optional multi-valued claim of JSON type string, containing the assigned client roles listed above, also available in userinfo and access token

The KeycloakSsoHandler will register new users in flowable-idm if they don't exist yet and update existing ones. Currently the handler gets all info from the userinfo endpoint, also tenant and privileges, but this should also be read from the JWT access token if available there; we'll improve this soon.

Tenant and privileges claims are optional now, but:
* if no privileges, you'll need to set the privileges manually in flowabe-idm for each user or they wont have any access
* if no tenant, the user will be able to access all tenants (default behavior in flowable)

Future improvements:
* also allow JWT token to read claims
* use OIDC discovery via well-known url
* allow granting access to multiple tenants -> see inuits/flowable-engine tenant-mapping branch