### PR TITLE
fix decision table result for hit policies with multiple entries

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -777,6 +777,8 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     protected boolean handleCmmnEngineExecutorsAfterEngineCreate = true;
 
+    protected boolean alwaysUseArraysForDmnMultiHitPolicies = true;
+
     public static CmmnEngineConfiguration createCmmnEngineConfigurationFromResourceDefault() {
         return createCmmnEngineConfigurationFromResource("flowable.cmmn.cfg.xml", "cmmnEngineConfiguration");
     }
@@ -3742,5 +3744,12 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
         return this;
     }
 
+    public boolean isAlwaysUseArraysForDmnMultiHitPolicies() {
+        return alwaysUseArraysForDmnMultiHitPolicies;
+    }
 
+    public CmmnEngineConfiguration setAlwaysUseArraysForDmnMultiHitPolicies(boolean alwaysUseArraysForDmnMultiHitPolicies) {
+        this.alwaysUseArraysForDmnMultiHitPolicies = alwaysUseArraysForDmnMultiHitPolicies;
+        return this;
+    }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/DecisionTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/DecisionTaskActivityBehavior.java
@@ -139,8 +139,9 @@ public class DecisionTaskActivityBehavior extends TaskActivityBehavior implement
                             externalRef, planItemInstanceEntity, cmmnEngineConfiguration.getObjectMapper());
             
         } else {
-            setVariablesOnPlanItemInstance(decisionExecutionAuditContainer.getDecisionResult(), externalRef, 
-                            planItemInstanceEntity, cmmnEngineConfiguration.getObjectMapper(), decisionExecutionAuditContainer.isMultipleResults());
+            boolean multipleResults = decisionExecutionAuditContainer.isMultipleResults() && cmmnEngineConfiguration.isAlwaysUseArraysForDmnMultiHitPolicies();
+            setVariablesOnPlanItemInstance(decisionExecutionAuditContainer.getDecisionResult(), externalRef,
+                            planItemInstanceEntity, cmmnEngineConfiguration.getObjectMapper(), multipleResults);
         }
 
         CommandContextUtil.getAgenda().planCompletePlanItemInstanceOperation(planItemInstanceEntity);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/DecisionTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/DecisionTaskActivityBehavior.java
@@ -140,22 +140,24 @@ public class DecisionTaskActivityBehavior extends TaskActivityBehavior implement
             
         } else {
             setVariablesOnPlanItemInstance(decisionExecutionAuditContainer.getDecisionResult(), externalRef, 
-                            planItemInstanceEntity, cmmnEngineConfiguration.getObjectMapper());
+                            planItemInstanceEntity, cmmnEngineConfiguration.getObjectMapper(), decisionExecutionAuditContainer.isMultipleResults());
         }
 
         CommandContextUtil.getAgenda().planCompletePlanItemInstanceOperation(planItemInstanceEntity);
     }
 
-    protected void setVariablesOnPlanItemInstance(List<Map<String, Object>> executionResult, String decisionKey, 
-                    PlanItemInstanceEntity planItemInstanceEntity, ObjectMapper objectMapper) {
+    protected void setVariablesOnPlanItemInstance(List<Map<String, Object>> executionResult, String decisionKey,
+                                                  PlanItemInstanceEntity planItemInstanceEntity, ObjectMapper objectMapper,
+                                                  boolean multipleResults) {
         
-        if (executionResult == null || executionResult.isEmpty()) {
+        if (executionResult == null || (executionResult.isEmpty() && !multipleResults)) {
             return;
         }
 
         // multiple rule results
         // put on execution as JSON array; each entry contains output id (key) and output value (value)
-        if (executionResult.size() > 1) {
+        // this should be always done for decision tables of type rule order and output order
+        if (executionResult.size() > 1 || multipleResults) {
             ArrayNode ruleResultNode = objectMapper.createArrayNode();
 
             for (Map<String, Object> ruleResult : executionResult) {

--- a/modules/flowable-dmn-api/src/main/java/org/flowable/dmn/api/DecisionExecutionAuditContainer.java
+++ b/modules/flowable-dmn-api/src/main/java/org/flowable/dmn/api/DecisionExecutionAuditContainer.java
@@ -43,6 +43,7 @@ public class DecisionExecutionAuditContainer {
     protected Map<String, Object> inputVariables;
     protected Map<String, String> inputVariableTypes;
     protected List<Map<String, Object>> decisionResult = new ArrayList<>();
+    protected boolean multipleResults = false;
     protected Map<String, String> decisionResultTypes = new HashMap<>();
     protected Map<Integer, RuleExecutionAuditContainer> ruleExecutions = new HashMap<>();
     protected Boolean failed = Boolean.FALSE;
@@ -132,7 +133,15 @@ public class DecisionExecutionAuditContainer {
     public void setDecisionResult(List<Map<String, Object>> decisionResult) {
         this.decisionResult = decisionResult;
     }
-    
+
+    public boolean isMultipleResults() {
+        return multipleResults;
+    }
+
+    public void setMultipleResults(boolean multipleResults) {
+        this.multipleResults = multipleResults;
+    }
+
     public void addDecisionResultObject(Map<String, Object> decisionResultObject) {
         this.decisionResult.add(decisionResultObject);
     }

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
@@ -17,7 +17,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
+import java.util.Map;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.flowable.cmmn.api.CmmnRuntimeService;
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
@@ -503,6 +507,60 @@ public class DecisionTaskTest {
         } finally {
             deleteAllDmnDeployments();
         }
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/runtime/DecisionTaskTest.oneDecisionTaskCase.cmmn",
+            "org/flowable/cmmn/test/runtime/DecisionTaskTest.outputOrder.dmn"})
+    public void withOutputOrder_ensureListOfItemIsReturnedEvenIfOnlyOneRowIsHit() {
+        CaseInstance caseInstance = this.cmmnRule.getCmmnRuntimeService().createCaseInstanceBuilder()
+                .caseDefinitionKey("oneDecisionTaskCase")
+                .variable("testInput", "second")
+                .start();
+        Map<String, Object> processVariables = caseInstance.getCaseVariables();
+        Object resultObject = processVariables.get("DecisionTable");
+        assertThat(resultObject).isInstanceOf(ArrayNode.class);
+        ArrayNode result = (ArrayNode) resultObject;
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isInstanceOf(ObjectNode.class);
+        assertThat(result.get(0).get("testOutput")).isInstanceOf(DoubleNode.class);
+        assertThat(result.get(0).get("testOutput").asDouble()).isEqualTo(2.0);
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/runtime/DecisionTaskTest.oneDecisionTaskCase.cmmn",
+            "org/flowable/cmmn/test/runtime/DecisionTaskTest.ruleOrder.dmn"})
+    public void withRuleOrder_ensureListOfItemIsReturnedEvenIfOnlyOneRowIsHit() {
+        CaseInstance caseInstance = this.cmmnRule.getCmmnRuntimeService().createCaseInstanceBuilder()
+                .caseDefinitionKey("oneDecisionTaskCase")
+                .variable("testInput", "second")
+                .start();
+        Map<String, Object> processVariables = caseInstance.getCaseVariables();
+        Object resultObject = processVariables.get("DecisionTable");
+        assertThat(resultObject).isInstanceOf(ArrayNode.class);
+        ArrayNode result = (ArrayNode) resultObject;
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isInstanceOf(ObjectNode.class);
+        assertThat(result.get(0).get("testOutput")).isInstanceOf(DoubleNode.class);
+        assertThat(result.get(0).get("testOutput").asDouble()).isEqualTo(2.0);
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/runtime/DecisionTaskTest.oneDecisionTaskCase.cmmn",
+            "org/flowable/cmmn/test/runtime/DecisionTaskTest.ruleOrder.dmn"})
+    public void withRuleOrder_ensureListOfItemIsReturnedEvenIfNoRowIsHit() {
+        CaseInstance caseInstance = this.cmmnRule.getCmmnRuntimeService().createCaseInstanceBuilder()
+                .caseDefinitionKey("oneDecisionTaskCase")
+                .variable("testInput", "fourth")
+                .start();
+        Map<String, Object> processVariables = caseInstance.getCaseVariables();
+        Object resultObject = processVariables.get("DecisionTable");
+        assertThat(resultObject).isInstanceOf(ArrayNode.class);
+        ArrayNode result = (ArrayNode) resultObject;
+        assertThat(result).hasSize(0);
     }
 
     // Helper methodes

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
@@ -518,8 +518,8 @@ public class DecisionTaskTest {
                 .caseDefinitionKey("oneDecisionTaskCase")
                 .variable("testInput", "second")
                 .start();
-        Map<String, Object> processVariables = caseInstance.getCaseVariables();
-        Object resultObject = processVariables.get("DecisionTable");
+        Map<String, Object> caseVariables = caseInstance.getCaseVariables();
+        Object resultObject = caseVariables.get("DecisionTable");
         assertThat(resultObject).isInstanceOf(ArrayNode.class);
         ArrayNode result = (ArrayNode) resultObject;
         assertThat(result).hasSize(1);
@@ -537,8 +537,8 @@ public class DecisionTaskTest {
                 .caseDefinitionKey("oneDecisionTaskCase")
                 .variable("testInput", "second")
                 .start();
-        Map<String, Object> processVariables = caseInstance.getCaseVariables();
-        Object resultObject = processVariables.get("DecisionTable");
+        Map<String, Object> caseVariables = caseInstance.getCaseVariables();
+        Object resultObject = caseVariables.get("DecisionTable");
         assertThat(resultObject).isInstanceOf(ArrayNode.class);
         ArrayNode result = (ArrayNode) resultObject;
         assertThat(result).hasSize(1);
@@ -551,13 +551,30 @@ public class DecisionTaskTest {
     @CmmnDeployment(resources = {
             "org/flowable/cmmn/test/runtime/DecisionTaskTest.oneDecisionTaskCase.cmmn",
             "org/flowable/cmmn/test/runtime/DecisionTaskTest.ruleOrder.dmn"})
+    public void withRuleOrderAndBackwardCompatibilityFlag_ensureListOfItemIsReturnedEvenIfOnlyOneRowIsHit() {
+        this.cmmnRule.getCmmnEngineConfiguration().setAlwaysUseArraysForDmnMultiHitPolicies(false);
+        CaseInstance caseInstance = this.cmmnRule.getCmmnRuntimeService().createCaseInstanceBuilder()
+                .caseDefinitionKey("oneDecisionTaskCase")
+                .variable("testInput", "second")
+                .start();
+        Map<String, Object> caseVariables = caseInstance.getCaseVariables();
+        Object resultObject = caseVariables.get("DecisionTable");
+        assertThat(resultObject).isNull();
+        assertThat(caseVariables.get("testOutput")).isEqualTo(2.0);
+        this.cmmnRule.getCmmnEngineConfiguration().setAlwaysUseArraysForDmnMultiHitPolicies(true);
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/runtime/DecisionTaskTest.oneDecisionTaskCase.cmmn",
+            "org/flowable/cmmn/test/runtime/DecisionTaskTest.ruleOrder.dmn"})
     public void withRuleOrder_ensureListOfItemIsReturnedEvenIfNoRowIsHit() {
         CaseInstance caseInstance = this.cmmnRule.getCmmnRuntimeService().createCaseInstanceBuilder()
                 .caseDefinitionKey("oneDecisionTaskCase")
                 .variable("testInput", "fourth")
                 .start();
-        Map<String, Object> processVariables = caseInstance.getCaseVariables();
-        Object resultObject = processVariables.get("DecisionTable");
+        Map<String, Object> caseVariables = caseInstance.getCaseVariables();
+        Object resultObject = caseVariables.get("DecisionTable");
         assertThat(resultObject).isInstanceOf(ArrayNode.class);
         ArrayNode result = (ArrayNode) resultObject;
         assertThat(result).hasSize(0);

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DmnTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DmnTaskTest.java
@@ -1,0 +1,112 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.dmn.test.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.flowable.engine.ProcessEngineConfiguration;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.ConfigurationResource;
+import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.FlowableTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Valentin Zickner
+ */
+@FlowableTest
+@ConfigurationResource("org/flowable/bpmn/test/runtime/DmnTaskTest.cfg.xml")
+public class DmnTaskTest {
+
+    protected RuntimeService runtimeService;
+
+    @BeforeEach
+    void setUp(ProcessEngineConfiguration processEngineConfiguration) {
+        runtimeService = processEngineConfiguration.getRuntimeService();
+    }
+
+    @Test
+    @Deployment(resources = {
+            "org/flowable/bpmn/test/runtime/DmnTaskTest.oneDecisionTaskProcess.bpmn20.xml",
+            "org/flowable/bpmn/test/runtime/DmnTaskTest.firstHit.dmn"})
+    void withFirstHitPolicy_ensureItemIsReturned() {
+        ProcessInstance processInstance = this.runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneDecisionTaskProcess")
+                .variable("testInput", "second")
+                .start();
+        Map<String, Object> processVariables = processInstance.getProcessVariables();
+        assertThat(processVariables.get("testOutput")).isEqualTo(2d);
+    }
+
+    @Test
+    @Deployment(resources = {
+            "org/flowable/bpmn/test/runtime/DmnTaskTest.oneDecisionTaskProcess.bpmn20.xml",
+            "org/flowable/bpmn/test/runtime/DmnTaskTest.outputOrder.dmn"})
+    void withOutputOrder_ensureListOfItemIsReturnedEvenIfOnlyOneRowIsHit() {
+        ProcessInstance processInstance = this.runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneDecisionTaskProcess")
+                .variable("testInput", "second")
+                .start();
+        Map<String, Object> processVariables = processInstance.getProcessVariables();
+        Object resultObject = processVariables.get("DecisionTable");
+        assertThat(resultObject).isInstanceOf(ArrayNode.class);
+        ArrayNode result = (ArrayNode) resultObject;
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isInstanceOf(ObjectNode.class);
+        assertThat(result.get(0).get("testOutput")).isInstanceOf(DoubleNode.class);
+        assertThat(result.get(0).get("testOutput").asDouble()).isEqualTo(2.0);
+    }
+
+    @Test
+    @Deployment(resources = {
+            "org/flowable/bpmn/test/runtime/DmnTaskTest.oneDecisionTaskProcess.bpmn20.xml",
+            "org/flowable/bpmn/test/runtime/DmnTaskTest.ruleOrder.dmn"})
+    void withRuleOrder_ensureListOfItemIsReturnedEvenIfOnlyOneRowIsHit() {
+        ProcessInstance processInstance = this.runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneDecisionTaskProcess")
+                .variable("testInput", "second")
+                .start();
+        Map<String, Object> processVariables = processInstance.getProcessVariables();
+        Object resultObject = processVariables.get("DecisionTable");
+        assertThat(resultObject).isInstanceOf(ArrayNode.class);
+        ArrayNode result = (ArrayNode) resultObject;
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isInstanceOf(ObjectNode.class);
+        assertThat(result.get(0).get("testOutput")).isInstanceOf(DoubleNode.class);
+        assertThat(result.get(0).get("testOutput").asDouble()).isEqualTo(2.0);
+    }
+
+    @Test
+    @Deployment(resources = {
+            "org/flowable/bpmn/test/runtime/DmnTaskTest.oneDecisionTaskProcess.bpmn20.xml",
+            "org/flowable/bpmn/test/runtime/DmnTaskTest.ruleOrder.dmn"})
+    void withRuleOrder_ensureListOfItemIsReturnedEvenIfNoRowIsHit() {
+        ProcessInstance processInstance = this.runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneDecisionTaskProcess")
+                .variable("testInput", "fourth")
+                .start();
+        Map<String, Object> processVariables = processInstance.getProcessVariables();
+        Object resultObject = processVariables.get("DecisionTable");
+        assertThat(resultObject).isInstanceOf(ArrayNode.class);
+        ArrayNode result = (ArrayNode) resultObject;
+        assertThat(result).hasSize(0);
+    }
+
+}

--- a/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.cfg.xml
+++ b/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.cfg.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="dataSource" class="org.flowable.common.engine.impl.test.ClosingDataSource">
+        <constructor-arg>
+            <bean class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+                <constructor-arg>
+                    <bean class="com.zaxxer.hikari.HikariConfig">
+                        <property name="jdbcUrl" value="${jdbc.url:jdbc:h2:mem:flowable;DB_CLOSE_DELAY=1000}" />
+                        <property name="driverClassName" value="${jdbc.driver:org.h2.Driver}" />
+                        <property name="username"  value="${jdbc.username:sa}" />
+                        <property name="password" value="${jdbc.password:}" />
+                    </bean>
+                </constructor-arg>
+            </bean>
+        </constructor-arg>
+    </bean>
+
+    <bean id="processEngineConfiguration" class="org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+        <property name="dataSource" ref="dataSource"/>
+
+        <property name="engineLifecycleListeners">
+            <list>
+                <ref bean="dataSource"/>
+            </list>
+        </property>
+        <property name="databaseSchemaUpdate" value="true" />
+        <property name="configurators">
+            <list>
+                <bean class="org.flowable.dmn.engine.configurator.DmnEngineConfigurator">
+                    <property name="dmnEngineConfiguration" ref="dmnEngineConfiguration" />
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="dmnEngineConfiguration" class="org.flowable.dmn.engine.DmnEngineConfiguration">
+        <property name="historyEnabled" value="true" />
+        <property name="dataSource" ref="dataSource"/>
+        <property name="engineLifecycleListeners">
+            <list>
+                <ref bean="dataSource"/>
+            </list>
+        </property>
+        <property name="databaseSchemaUpdate" value="true" />
+    </bean>
+</beans>

--- a/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.firstHit.dmn
+++ b/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.firstHit.dmn
@@ -1,0 +1,36 @@
+<definitions xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" id="definition_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" name="First Hit" namespace="http://www.flowable.org/dmn">
+  <decision id="DecisionTable" name="First Hit">
+    <decisionTable id="decisionTable_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" hitPolicy="FIRST">
+      <input label="Test Input">
+        <inputExpression id="inputExpression_1" typeRef="string">
+          <text>testInput</text>
+        </inputExpression>
+      </input>
+      <output id="outputExpression_2" label="Test Output" name="testOutput" typeRef="number"></output>
+      <rule>
+        <inputEntry id="inputEntry_1_1">
+          <text><![CDATA[== "first"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_1">
+          <text><![CDATA[1]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_2">
+          <text><![CDATA[== "second"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_2">
+          <text><![CDATA[2]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_3">
+          <text><![CDATA[== "third"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_3">
+          <text><![CDATA[3]]></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.oneDecisionTaskProcess.bpmn20.xml
+++ b/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.oneDecisionTaskProcess.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:flowable="http://flowable.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="oneDecisionTaskProcess" name="The One Decision Task Process">
+    <documentation>This is a process for testing purposes</documentation>
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theDecisionTask" />
+    <serviceTask id="theDecisionTask" flowable:type="dmn">
+      <extensionElements>
+        <flowable:field name="decisionTableReferenceKey">
+          <flowable:string><![CDATA[DecisionTable]]></flowable:string>
+        </flowable:field>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow2" sourceRef="theDecisionTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>

--- a/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.outputOrder.dmn
+++ b/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.outputOrder.dmn
@@ -1,0 +1,40 @@
+<definitions xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" id="definition_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" name="First Hit" namespace="http://www.flowable.org/dmn">
+  <decision id="DecisionTable" name="Output Order">
+    <decisionTable id="decisionTable_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" hitPolicy="OUTPUT ORDER">
+      <input label="Test Input">
+        <inputExpression id="inputExpression_1" typeRef="string">
+          <text>testInput</text>
+        </inputExpression>
+      </input>
+      <output id="outputExpression_2" label="Test Output" name="testOutput" typeRef="number">
+        <outputValues>
+          <text>"3","2","1"</text>
+        </outputValues>
+      </output>
+      <rule>
+        <inputEntry id="inputEntry_1_1">
+          <text><![CDATA[== "first"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_1">
+          <text><![CDATA[1]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_2">
+          <text><![CDATA[== "second"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_2">
+          <text><![CDATA[2]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_3">
+          <text><![CDATA[== "third"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_3">
+          <text><![CDATA[3]]></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.ruleOrder.dmn
+++ b/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/bpmn/test/runtime/DmnTaskTest.ruleOrder.dmn
@@ -1,0 +1,36 @@
+<definitions xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" id="definition_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" name="First Hit" namespace="http://www.flowable.org/dmn">
+  <decision id="DecisionTable" name="Rule Order">
+    <decisionTable id="decisionTable_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" hitPolicy="RULE ORDER">
+      <input label="Test Input">
+        <inputExpression id="inputExpression_1" typeRef="string">
+          <text>testInput</text>
+        </inputExpression>
+      </input>
+      <output id="outputExpression_2" label="Test Output" name="testOutput" typeRef="number"></output>
+      <rule>
+        <inputEntry id="inputEntry_1_1">
+          <text><![CDATA[== "first"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_1">
+          <text><![CDATA[1]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_2">
+          <text><![CDATA[== "second"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_2">
+          <text><![CDATA[2]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_3">
+          <text><![CDATA[== "third"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_3">
+          <text><![CDATA[3]]></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/cmmn/test/runtime/DecisionTaskTest.oneDecisionTaskCase.cmmn
+++ b/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/cmmn/test/runtime/DecisionTaskTest.oneDecisionTaskCase.cmmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL"
+             xmlns:flowable="http://flowable.org/cmmn"
+             targetNamespace="http://flowable.org/cmmn">
+
+    <case id="oneDecisionTaskCase">
+        <casePlanModel id="myPlanModel" name="My CasePlanModel">
+
+            <planItem id="planItem1" name="Task One" definitionRef="decisionTask" />
+
+            <decisionTask id="decisionTask" name="dmn" isBlocking="false" decisionRef="decisionTableInternal"/>
+
+
+        </casePlanModel>
+    </case>
+
+    <decision id="decisionTableInternal" name="Simple decision table" externalRef="DecisionTable"/>
+
+</definitions>

--- a/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/cmmn/test/runtime/DecisionTaskTest.outputOrder.dmn
+++ b/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/cmmn/test/runtime/DecisionTaskTest.outputOrder.dmn
@@ -1,0 +1,40 @@
+<definitions xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" id="definition_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" name="First Hit" namespace="http://www.flowable.org/dmn">
+  <decision id="DecisionTable" name="Output Order">
+    <decisionTable id="decisionTable_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" hitPolicy="OUTPUT ORDER">
+      <input label="Test Input">
+        <inputExpression id="inputExpression_1" typeRef="string">
+          <text>testInput</text>
+        </inputExpression>
+      </input>
+      <output id="outputExpression_2" label="Test Output" name="testOutput" typeRef="number">
+        <outputValues>
+          <text>"3","2","1"</text>
+        </outputValues>
+      </output>
+      <rule>
+        <inputEntry id="inputEntry_1_1">
+          <text><![CDATA[== "first"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_1">
+          <text><![CDATA[1]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_2">
+          <text><![CDATA[== "second"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_2">
+          <text><![CDATA[2]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_3">
+          <text><![CDATA[== "third"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_3">
+          <text><![CDATA[3]]></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/cmmn/test/runtime/DecisionTaskTest.ruleOrder.dmn
+++ b/modules/flowable-dmn-engine-configurator/src/test/resources/org/flowable/cmmn/test/runtime/DecisionTaskTest.ruleOrder.dmn
@@ -1,0 +1,36 @@
+<definitions xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/" id="definition_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" name="First Hit" namespace="http://www.flowable.org/dmn">
+  <decision id="DecisionTable" name="Rule Order">
+    <decisionTable id="decisionTable_DMN_MODEL-826de8bf-8b94-4386-83f8-a9fb0da4514b" hitPolicy="RULE ORDER">
+      <input label="Test Input">
+        <inputExpression id="inputExpression_1" typeRef="string">
+          <text>testInput</text>
+        </inputExpression>
+      </input>
+      <output id="outputExpression_2" label="Test Output" name="testOutput" typeRef="number"></output>
+      <rule>
+        <inputEntry id="inputEntry_1_1">
+          <text><![CDATA[== "first"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_1">
+          <text><![CDATA[1]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_2">
+          <text><![CDATA[== "second"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_2">
+          <text><![CDATA[2]]></text>
+        </outputEntry>
+      </rule>
+      <rule>
+        <inputEntry id="inputEntry_1_3">
+          <text><![CDATA[== "third"]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_2_3">
+          <text><![CDATA[3]]></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/AbstractHitPolicy.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/AbstractHitPolicy.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.engine.impl.el.ELExecutionContext;
 
 /**
@@ -24,6 +25,15 @@ import org.flowable.dmn.engine.impl.el.ELExecutionContext;
  * (Abstact) base class for all Hit Policy behaviors
  */
 public abstract class AbstractHitPolicy implements ContinueEvaluatingBehavior, ComposeRuleResultBehavior, ComposeDecisionResultBehavior {
+
+    protected boolean multipleResults = false;
+
+    public AbstractHitPolicy() {
+    }
+
+    public AbstractHitPolicy(boolean multipleResults) {
+        this.multipleResults = multipleResults;
+    }
 
     /**
      * Returns the name for the specific Hit Policy behavior
@@ -53,6 +63,8 @@ public abstract class AbstractHitPolicy implements ContinueEvaluatingBehavior, C
     @Override
     public void composeDecisionResults(ELExecutionContext executionContext) {
         List<Map<String, Object>> decisionResults = new ArrayList<>(executionContext.getRuleResults().values());
-        executionContext.getAuditContainer().setDecisionResult(decisionResults);
+        DecisionExecutionAuditContainer auditContainer = executionContext.getAuditContainer();
+        auditContainer.setDecisionResult(decisionResults);
+        auditContainer.setMultipleResults(multipleResults);
     }
 }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyOutputOrder.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyOutputOrder.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.flowable.common.engine.api.FlowableException;
+import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.engine.impl.el.ELExecutionContext;
 import org.flowable.dmn.engine.impl.util.CommandContextUtil;
 import org.flowable.dmn.model.HitPolicy;
@@ -28,6 +29,10 @@ import org.flowable.dmn.model.HitPolicy;
  * @author Yvo Swillens
  */
 public class HitPolicyOutputOrder extends AbstractHitPolicy implements ComposeDecisionResultBehavior {
+
+    public HitPolicyOutputOrder() {
+        super(true);
+    }
 
     @Override
     public String getHitPolicyName() {
@@ -74,6 +79,8 @@ public class HitPolicyOutputOrder extends AbstractHitPolicy implements ComposeDe
             }
         });
 
-        executionContext.getAuditContainer().setDecisionResult(ruleResults);
+        DecisionExecutionAuditContainer auditContainer = executionContext.getAuditContainer();
+        auditContainer.setDecisionResult(ruleResults);
+        auditContainer.setMultipleResults(true);
     }
 }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyRuleOrder.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyRuleOrder.java
@@ -19,6 +19,10 @@ import org.flowable.dmn.model.HitPolicy;
  */
 public class HitPolicyRuleOrder extends AbstractHitPolicy implements ComposeDecisionResultBehavior {
 
+    public HitPolicyRuleOrder() {
+        super(true);
+    }
+
     @Override
     public String getHitPolicyName() {
         return HitPolicy.RULE_ORDER.getValue();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngineConfiguration.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngineConfiguration.java
@@ -130,6 +130,8 @@ public abstract class ProcessEngineConfiguration extends AbstractEngineConfigura
     protected ProcessDiagramGenerator processDiagramGenerator;
 
     protected boolean isCreateDiagramOnDeploy = true;
+
+    protected boolean alwaysUseArraysForDmnMultiHitPolicies = true;
     
     /**
      *  include the sequence flow name in case there's no Label DI, 
@@ -788,6 +790,15 @@ public abstract class ProcessEngineConfiguration extends AbstractEngineConfigura
 
     public ProcessEngineConfiguration setHistoryCleaningManager(HistoryCleaningManager historyCleaningManager) {
         this.historyCleaningManager = historyCleaningManager;
+        return this;
+    }
+
+    public boolean isAlwaysUseArraysForDmnMultiHitPolicies() {
+        return alwaysUseArraysForDmnMultiHitPolicies;
+    }
+
+    public ProcessEngineConfiguration setAlwaysUseArraysForDmnMultiHitPolicies(boolean alwaysUseArraysForDmnMultiHitPolicies) {
+        this.alwaysUseArraysForDmnMultiHitPolicies = alwaysUseArraysForDmnMultiHitPolicies;
         return this;
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/DmnActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/DmnActivityBehavior.java
@@ -144,7 +144,7 @@ public class DmnActivityBehavior extends TaskActivityBehavior {
             
         } else {
             setVariablesOnExecution(decisionExecutionAuditContainer.getDecisionResult(), finaldecisionTableKeyValue, 
-                            execution, processEngineConfiguration.getObjectMapper());
+                            execution, processEngineConfiguration.getObjectMapper(), decisionExecutionAuditContainer.isMultipleResults());
         }
 
         leave(execution);
@@ -180,14 +180,15 @@ public class DmnActivityBehavior extends TaskActivityBehavior {
         executeDecisionBuilder.parentDeploymentId(parentDeploymentId);
     }
 
-    protected void setVariablesOnExecution(List<Map<String, Object>> executionResult, String decisionKey, DelegateExecution execution, ObjectMapper objectMapper) {
-        if (executionResult == null || executionResult.isEmpty()) {
+    protected void setVariablesOnExecution(List<Map<String, Object>> executionResult, String decisionKey, DelegateExecution execution, ObjectMapper objectMapper, boolean multipleResults) {
+        if (executionResult == null || (executionResult.isEmpty() && !multipleResults)) {
             return;
         }
 
         // multiple rule results
         // put on execution as JSON array; each entry contains output id (key) and output value (value)
-        if (executionResult.size() > 1) {
+        // this should be always done for decision tables of type rule order and output order
+        if (executionResult.size() > 1 || multipleResults) {
             ArrayNode ruleResultNode = objectMapper.createArrayNode();
 
             for (Map<String, Object> ruleResult : executionResult) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/DmnActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/DmnActivityBehavior.java
@@ -143,8 +143,9 @@ public class DmnActivityBehavior extends TaskActivityBehavior {
                             finaldecisionTableKeyValue, execution, processEngineConfiguration.getObjectMapper());
             
         } else {
-            setVariablesOnExecution(decisionExecutionAuditContainer.getDecisionResult(), finaldecisionTableKeyValue, 
-                            execution, processEngineConfiguration.getObjectMapper(), decisionExecutionAuditContainer.isMultipleResults());
+            boolean multipleResults = decisionExecutionAuditContainer.isMultipleResults() && processEngineConfiguration.isAlwaysUseArraysForDmnMultiHitPolicies();
+            setVariablesOnExecution(decisionExecutionAuditContainer.getDecisionResult(), finaldecisionTableKeyValue,
+                            execution, processEngineConfiguration.getObjectMapper(), multipleResults);
         }
 
         leave(execution);


### PR DESCRIPTION
Behavior before:
  Execution a decision table with the hit policy rule order and output order resulted in either an array or the element, depending on how many rows are hit.
  The user of the Decision/DMN task now needs to lookup which of both exists and pick it accordingly.

Behavior after:
  For decision table with the hit policy rule order and output order the result is always returned as an array. Independent on how much entries are hit.

#### Check List:
* Unit tests: YES 
* Documentation: NO
