### PR TITLE
Use assertj fluent style in flowable-rest module.

### DIFF
--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,6 @@
 package org.flowable.rest.service.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 
@@ -36,7 +35,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Test for REST-operation related to the historic process instance query resource.
- * 
+ *
  * @author Tijs Rademakers
  */
 public class HistoricProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
@@ -174,13 +173,13 @@ public class HistoricProcessInstanceQueryResourceTest extends BaseSpringRestTest
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(2, dataNode.size());
+        assertThat(dataNode).hasSize(2);
         JsonNode valueNode = dataNode.get(0);
-        assertEquals(processInstance.getId(), valueNode.get("id").asText());
-        assertEquals(processInstance2.getId(), dataNode.get(1).get("id").asText());
-        
-        assertEquals("The One Task Process", valueNode.get("processDefinitionName").asText());
-        assertEquals("One task process description", valueNode.get("processDefinitionDescription").asText());
+        assertThat(valueNode.get("id").asText()).isEqualTo(processInstance.getId());
+        assertThat(dataNode.get(1).get("id").asText()).isEqualTo(processInstance2.getId());
+
+        assertThat(valueNode.get("processDefinitionName").asText()).isEqualTo("The One Task Process");
+        assertThat(valueNode.get("processDefinitionDescription").asText()).isEqualTo("One task process description");
         assertThat(valueNode.has("startTime")).as("has startTime").isTrue();
         assertThat(valueNode.get("startUserId").textValue()).as("startUserId").isEqualTo(processInstance.getStartUserId());
     }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserCollectionResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,9 +13,8 @@
 
 package org.flowable.rest.service.api.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +23,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.assertj.core.api.Assertions;
 import org.flowable.engine.test.Deployment;
 import org.flowable.idm.api.User;
 import org.flowable.rest.service.BaseSpringRestTestCase;
@@ -33,6 +31,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Frederik Heremans
@@ -63,10 +63,10 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             savedUsers.add(user2);
 
             User user3 = identityService.createUserQuery().userId("kermit").singleResult();
-            assertNotNull(user3);
-            
+            assertThat(user3).isNotNull();
+
             User user4 = identityService.createUserQuery().userId("aSalesUser").singleResult();
-            assertNotNull(user4);
+            assertThat(user4).isNotNull();
 
             // Test filter-less
             String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION);
@@ -139,21 +139,25 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testuser", responseNode.get("id").textValue());
-            assertEquals("Frederik", responseNode.get("firstName").textValue());
-            assertEquals("Heremans", responseNode.get("lastName").textValue());
-            assertEquals("Frederik Heremans", responseNode.get("displayName").textValue());
-            assertEquals("no-reply@activiti.org", responseNode.get("email").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER, "testuser")));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id: 'testuser',"
+                            + "firstName: 'Frederik',"
+                            + "lastName: 'Heremans',"
+                            + "displayName: 'Frederik Heremans',"
+                            + "email: 'no-reply@activiti.org',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER, "testuser") + "'"
+                            + "}");
 
             User createdUser = identityService.createUserQuery().userId("testuser").singleResult();
-            assertNotNull(createdUser);
-            Assertions.assertThat(createdUser.getFirstName()).isEqualTo("Frederik");
-            Assertions.assertThat(createdUser.getLastName()).isEqualTo("Heremans");
-            Assertions.assertThat(createdUser.getDisplayName()).isEqualTo("Frederik Heremans");
-            Assertions.assertThat(createdUser.getPassword()).isEqualTo("test");
-            Assertions.assertThat(createdUser.getEmail()).isEqualTo("no-reply@activiti.org");
+            assertThat(createdUser).isNotNull();
+            assertThat(createdUser.getFirstName()).isEqualTo("Frederik");
+            assertThat(createdUser.getLastName()).isEqualTo("Heremans");
+            assertThat(createdUser.getDisplayName()).isEqualTo("Frederik Heremans");
+            assertThat(createdUser.getPassword()).isEqualTo("test");
+            assertThat(createdUser.getEmail()).isEqualTo("no-reply@activiti.org");
         } finally {
             try {
                 identityService.deleteUser("testuser");

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserPictureResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserPictureResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,8 +14,6 @@
 package org.flowable.rest.service.api.identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -57,14 +55,15 @@ public class UserPictureResourceTest extends BaseSpringRestTestCase {
             Picture thePicture = new Picture("this is the picture raw byte stream".getBytes(), "image/png");
             identityService.setUserPicture(newUser.getId(), thePicture);
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_PICTURE, newUser.getId())), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_PICTURE, newUser.getId())), HttpStatus.SC_OK);
 
             try (InputStream contentStream = response.getEntity().getContent()) {
                 assertThat(contentStream).hasContent("this is the picture raw byte stream");
             }
 
             // Check if media-type is correct
-            assertEquals("image/png", response.getEntity().getContentType().getValue());
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("image/png");
             closeResponse(response);
 
         } finally {
@@ -81,7 +80,8 @@ public class UserPictureResourceTest extends BaseSpringRestTestCase {
      */
     @Test
     public void testGetPictureForUnexistingUser() throws Exception {
-        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_PICTURE, "unexisting")), HttpStatus.SC_NOT_FOUND));
+        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_PICTURE, "unexisting")),
+                HttpStatus.SC_NOT_FOUND));
     }
 
     /**
@@ -98,10 +98,11 @@ public class UserPictureResourceTest extends BaseSpringRestTestCase {
             identityService.saveUser(newUser);
             savedUser = newUser;
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_PICTURE, newUser.getId())), HttpStatus.SC_NOT_FOUND);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_PICTURE, newUser.getId())), HttpStatus.SC_NOT_FOUND);
 
             // response content type application/json;charset=UTF-8
-            assertEquals("application/json", response.getEntity().getContentType().getValue().split(";")[0]);
+            assertThat(response.getEntity().getContentType().getValue().split(";")[0]).isEqualTo("application/json");
             closeResponse(response);
 
         } finally {
@@ -125,13 +126,14 @@ public class UserPictureResourceTest extends BaseSpringRestTestCase {
             savedUser = newUser;
 
             HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_PICTURE, newUser.getId()));
-            httpPut.setEntity(HttpMultipartHelper.getMultiPartEntity("myPicture.png", "image/png", new ByteArrayInputStream("this is the picture raw byte stream".getBytes()), null));
+            httpPut.setEntity(HttpMultipartHelper
+                    .getMultiPartEntity("myPicture.png", "image/png", new ByteArrayInputStream("this is the picture raw byte stream".getBytes()), null));
             closeResponse(executeBinaryRequest(httpPut, HttpStatus.SC_NO_CONTENT));
 
             Picture picture = identityService.getUserPicture(newUser.getId());
-            assertNotNull(picture);
-            assertEquals("image/png", picture.getMimeType());
-            assertEquals("this is the picture raw byte stream", new String(picture.getBytes()));
+            assertThat(picture).isNotNull();
+            assertThat(picture.getMimeType()).isEqualTo("image/png");
+            assertThat(new String(picture.getBytes())).isEqualTo("this is the picture raw byte stream");
 
         } finally {
 
@@ -157,13 +159,15 @@ public class UserPictureResourceTest extends BaseSpringRestTestCase {
             additionalFields.put("mimeType", MediaType.IMAGE_PNG.toString());
 
             HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_PICTURE, newUser.getId()));
-            httpPut.setEntity(HttpMultipartHelper.getMultiPartEntity("myPicture.png", "image/png", new ByteArrayInputStream("this is the picture raw byte stream".getBytes()), additionalFields));
+            httpPut.setEntity(HttpMultipartHelper
+                    .getMultiPartEntity("myPicture.png", "image/png", new ByteArrayInputStream("this is the picture raw byte stream".getBytes()),
+                            additionalFields));
             closeResponse(executeBinaryRequest(httpPut, HttpStatus.SC_NO_CONTENT));
 
             Picture picture = identityService.getUserPicture(newUser.getId());
-            assertNotNull(picture);
-            assertEquals("image/png", picture.getMimeType());
-            assertEquals("this is the picture raw byte stream", new String(picture.getBytes()));
+            assertThat(picture).isNotNull();
+            assertThat(picture.getMimeType()).isEqualTo("image/png");
+            assertThat(new String(picture.getBytes())).isEqualTo("this is the picture raw byte stream");
 
         } finally {
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ModelResourceSourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ModelResourceSourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,11 @@
  */
 
 package org.flowable.rest.service.api.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -23,12 +28,6 @@ import org.flowable.rest.service.BaseSpringRestTestCase;
 import org.flowable.rest.service.HttpMultipartHelper;
 import org.flowable.rest.service.api.RestUrls;
 import org.junit.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Frederik Heremans
@@ -51,7 +50,7 @@ public class ModelResourceSourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
 
             // Check "OK" status
-            assertEquals("application/octet-stream", response.getEntity().getContentType().getValue());
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/octet-stream");
             try (InputStream contentStream = response.getEntity().getContent()) {
                 assertThat(contentStream).hasContent("This is the editor source");
             }
@@ -103,7 +102,7 @@ public class ModelResourceSourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
 
             // Check "OK" status
-            assertEquals("application/octet-stream", response.getEntity().getContentType().getValue());
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/octet-stream");
             try (InputStream contentStream = response.getEntity().getContent()) {
                 assertThat(contentStream).hasContent("This is the extra editor source");
             }
@@ -162,10 +161,11 @@ public class ModelResourceSourceTest extends BaseSpringRestTestCase {
             repositoryService.saveModel(model);
 
             HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL_SOURCE, model.getId()));
-            httpPut.setEntity(HttpMultipartHelper.getMultiPartEntity("sourcefile", "application/octet-stream", new ByteArrayInputStream("This is the new editor source".getBytes()), null));
+            httpPut.setEntity(HttpMultipartHelper
+                    .getMultiPartEntity("sourcefile", "application/octet-stream", new ByteArrayInputStream("This is the new editor source".getBytes()), null));
             closeResponse(executeBinaryRequest(httpPut, HttpStatus.SC_NO_CONTENT));
 
-            assertEquals("This is the new editor source", new String(repositoryService.getModelEditorSource(model.getId())));
+            assertThat(new String(repositoryService.getModelEditorSource(model.getId()))).isEqualTo("This is the new editor source");
 
         } finally {
             try {
@@ -187,10 +187,12 @@ public class ModelResourceSourceTest extends BaseSpringRestTestCase {
             repositoryService.saveModel(model);
 
             HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL_SOURCE_EXTRA, model.getId()));
-            httpPut.setEntity(HttpMultipartHelper.getMultiPartEntity("sourcefile", "application/octet-stream", new ByteArrayInputStream("This is the new extra editor source".getBytes()), null));
+            httpPut.setEntity(HttpMultipartHelper
+                    .getMultiPartEntity("sourcefile", "application/octet-stream", new ByteArrayInputStream("This is the new extra editor source".getBytes()),
+                            null));
             closeResponse(executeBinaryRequest(httpPut, HttpStatus.SC_NO_CONTENT));
 
-            assertEquals("This is the new extra editor source", new String(repositoryService.getModelEditorSourceExtra(model.getId())));
+            assertThat(new String(repositoryService.getModelEditorSourceExtra(model.getId()))).isEqualTo("This is the new extra editor source");
 
         } finally {
             try {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceQueryResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,6 @@
 package org.flowable.rest.service.api.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 
@@ -35,7 +34,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Test for all REST-operations related to the process instance query resource.
- * 
+ *
  * @author Frederik Heremans
  */
 public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
@@ -169,11 +168,11 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         JsonNode rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
         JsonNode dataNode = rootNode.get("data");
-        assertEquals(3, dataNode.size());
+        assertThat(dataNode).hasSize(3);
 
-        assertEquals(processInstance3.getId(), dataNode.get(0).get("id").asText());
-        assertEquals(processInstance2.getId(), dataNode.get(1).get("id").asText());
-        assertEquals(processInstance1.getId(), dataNode.get(2).get("id").asText());
+        assertThat(dataNode.get(0).get("id").asText()).isEqualTo(processInstance3.getId());
+        assertThat(dataNode.get(1).get("id").asText()).isEqualTo(processInstance2.getId());
+        assertThat(dataNode.get(2).get("id").asText()).isEqualTo(processInstance1.getId());
 
         // Check paging size
         requestNode = objectMapper.createObjectNode();
@@ -185,7 +184,7 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
         dataNode = rootNode.get("data");
-        assertEquals(1, dataNode.size());
+        assertThat(dataNode).hasSize(1);
 
         // Check paging start and size
         requestNode = objectMapper.createObjectNode();
@@ -199,11 +198,11 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
         dataNode = rootNode.get("data");
-        assertEquals(1, dataNode.size());
+        assertThat(dataNode).hasSize(1);
         JsonNode valueNode = dataNode.get(0);
-        assertEquals(processInstance2.getId(), valueNode.get("id").asText());
-        assertEquals("The One Task Process", valueNode.get("processDefinitionName").asText());
-        assertEquals("One task process description", valueNode.get("processDefinitionDescription").asText());
+        assertThat(valueNode.get("id").asText()).isEqualTo(processInstance2.getId());
+        assertThat(valueNode.get("processDefinitionName").asText()).isEqualTo("The One Task Process");
+        assertThat(valueNode.get("processDefinitionDescription").asText()).isEqualTo("One task process description");
         assertThat(valueNode.has("startTime")).as("has startTime").isTrue();
         assertThat(valueNode.get("startUserId").textValue()).as("startUserId").isEqualTo(processInstance2.getStartUserId());
     }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceVariableResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceVariableResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,10 +15,6 @@ package org.flowable.rest.service.api.runtime;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -53,7 +49,7 @@ import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to a single task variable.
- * 
+ *
  * @author Frederik Heremans
  * @author Filip Hrisafov
  */
@@ -69,25 +65,36 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         runtimeService.setVariable(processInstance.getId(), "variable", "processValue");
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")),
+        CloseableHttpResponse response = executeRequest(new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")),
                 HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("processValue", responseNode.get("value").asText());
-        assertEquals("variable", responseNode.get("name").asText());
-        assertEquals("string", responseNode.get("type").asText());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "name: 'variable',"
+                        + "type: 'string',"
+                        + "value: 'processValue',"
+                        + "scope: null"
+                        + "}");
 
         // Illegal scope
-        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable") + "?scope=illegal"),
+        closeResponse(executeRequest(new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")
+                                + "?scope=illegal"),
                 HttpStatus.SC_BAD_REQUEST));
 
         // Unexisting process
-        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, "unexisting", "variable")), HttpStatus.SC_NOT_FOUND));
+        closeResponse(executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, "unexisting", "variable")),
+                HttpStatus.SC_NOT_FOUND));
 
         // Unexisting variable
-        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "unexistingVariable")),
+        closeResponse(executeRequest(new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "unexistingVariable")),
                 HttpStatus.SC_NOT_FOUND));
     }
 
@@ -101,20 +108,21 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         runtimeService.setVariable(processInstance.getId(), "variable", now);
 
         CloseableHttpResponse response = executeRequest(
-            new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")),
-            HttpStatus.SC_OK);
+                new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")),
+                HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
 
         closeResponse(response);
         assertThat(responseNode).isNotNull();
         assertThatJson(responseNode)
-            .when(Option.IGNORING_EXTRA_FIELDS)
-            .isEqualTo("{"
-                + "  name: 'variable',"
-                + "  type: 'instant',"
-                + "  value: '" + nowWithoutNanos.toString() + "'"
-                + "}");
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  name: 'variable',"
+                        + "  type: 'instant',"
+                        + "  value: '" + nowWithoutNanos.toString() + "'"
+                        + "}");
     }
 
     @Test
@@ -126,20 +134,21 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         runtimeService.setVariable(processInstance.getId(), "variable", now);
 
         CloseableHttpResponse response = executeRequest(
-            new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")),
-            HttpStatus.SC_OK);
+                new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")),
+                HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
 
         closeResponse(response);
         assertThat(responseNode).isNotNull();
         assertThatJson(responseNode)
-            .when(Option.IGNORING_EXTRA_FIELDS)
-            .isEqualTo("{"
-                + "  name: 'variable',"
-                + "  type: 'localDate',"
-                + "  value: '" + now.toString() + "'"
-                + "}");
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  name: 'variable',"
+                        + "  type: 'localDate',"
+                        + "  value: '" + now.toString() + "'"
+                        + "}");
     }
 
     @Test
@@ -152,20 +161,21 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         runtimeService.setVariable(processInstance.getId(), "variable", now);
 
         CloseableHttpResponse response = executeRequest(
-            new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")),
-            HttpStatus.SC_OK);
+                new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "variable")),
+                HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
 
         closeResponse(response);
         assertThat(responseNode).isNotNull();
         assertThatJson(responseNode)
-            .when(Option.IGNORING_EXTRA_FIELDS)
-            .isEqualTo("{"
-                + "  name: 'variable',"
-                + "  type: 'localDateTime',"
-                + "  value: '" + nowWithoutNanos.toString() + "'"
-                + "}");
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  name: 'variable',"
+                        + "  type: 'localDateTime',"
+                        + "  value: '" + nowWithoutNanos.toString() + "'"
+                        + "}");
     }
 
     /**
@@ -177,13 +187,14 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         runtimeService.setVariableLocal(processInstance.getId(), "var", "This is a binary piece of text".getBytes());
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "var")),
+        CloseableHttpResponse response = executeRequest(new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "var")),
                 HttpStatus.SC_OK);
 
         String actualResponseBytesAsText = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
         closeResponse(response);
-        assertEquals("This is a binary piece of text", actualResponseBytesAsText);
-        assertEquals("application/octet-stream", response.getEntity().getContentType().getValue());
+        assertThat(actualResponseBytesAsText).isEqualTo("This is a binary piece of text");
+        assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/octet-stream");
     }
 
     /**
@@ -199,16 +210,17 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         runtimeService.setVariableLocal(processInstance.getId(), "var", originalSerializable);
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "var")),
+        CloseableHttpResponse response = executeRequest(new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "var")),
                 HttpStatus.SC_OK);
 
         // Read the serializable from the stream
         ObjectInputStream stream = new ObjectInputStream(response.getEntity().getContent());
         Object readSerializable = stream.readObject();
-        assertNotNull(readSerializable);
-        assertTrue(readSerializable instanceof TestSerializableVariable);
-        assertEquals("This is some field", ((TestSerializableVariable) readSerializable).getSomeField());
-        assertEquals("application/x-java-serialized-object", response.getEntity().getContentType().getValue());
+        assertThat(readSerializable).isNotNull();
+        assertThat(readSerializable).isInstanceOf(TestSerializableVariable.class);
+        assertThat(((TestSerializableVariable) readSerializable).getSomeField()).isEqualTo("This is some field");
+        assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/x-java-serialized-object");
         closeResponse(response);
     }
 
@@ -223,45 +235,50 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         runtimeService.setVariableLocal(processInstance.getId(), "localTaskVariable", "this is a plain string variable");
 
         // Try getting data for non-binary variable
-        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "localTaskVariable")),
+        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "localTaskVariable")),
                 HttpStatus.SC_NOT_FOUND));
 
         // Try getting data for unexisting property
-        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "unexistingVariable")),
+        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "unexistingVariable")),
                 HttpStatus.SC_NOT_FOUND));
     }
 
     /**
      * Test deleting a single process variable in, including "not found" check.
-     * 
+     * <p>
      * DELETE runtime/process-instances/{processInstanceId}/variables/{variableName}
      */
     @Test
     @Deployment(resources = { "org/flowable/rest/service/api/runtime/ProcessInstanceVariableResourceTest.testProcess.bpmn20.xml" })
     public void testDeleteProcessVariable() throws Exception {
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("myVariable", (Object) "processValue"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("myVariable", (Object) "processValue"));
 
         // Delete variable
-        closeResponse(executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVariable")),
+        closeResponse(executeRequest(new HttpDelete(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVariable")),
                 HttpStatus.SC_NO_CONTENT));
 
-        assertFalse(runtimeService.hasVariable(processInstance.getId(), "myVariable"));
+        assertThat(runtimeService.hasVariable(processInstance.getId(), "myVariable")).isFalse();
 
-        // Run the same delete again, variable is not there so 404 should be
-        // returned
-        closeResponse(executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVariable")),
+        // Run the same delete again, variable is not there so 404 should be returned
+        closeResponse(executeRequest(new HttpDelete(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVariable")),
                 HttpStatus.SC_NOT_FOUND));
     }
 
     /**
      * Test updating a single process variable, including "not found" check.
-     * 
+     * <p>
      * PUT runtime/process-instances/{processInstanceId}/variables/{variableName}
      */
     @Test
     @Deployment(resources = { "org/flowable/rest/service/api/runtime/ProcessInstanceVariableResourceTest.testProcess.bpmn20.xml" })
     public void testUpdateProcessVariable() throws Exception {
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
         runtimeService.setVariable(processInstance.getId(), "myVar", "value");
 
         // Update variable
@@ -270,14 +287,19 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         requestNode.put("value", "updatedValue");
         requestNode.put("type", "string");
 
-        HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVar"));
+        HttpPut httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVar"));
         httpPut.setEntity(new StringEntity(requestNode.toString()));
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("updatedValue", responseNode.get("value").asText());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "value: 'updatedValue'"
+                        + "}");
 
         // Try updating with mismatch between URL and body variableName
         requestNode.put("name", "unexistingVariable");
@@ -286,7 +308,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
 
         // Try updating unexisting property
         requestNode.put("name", "unexistingVariable");
-        httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "unexistingVariable"));
+        httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "unexistingVariable"));
         httpPut.setEntity(new StringEntity(requestNode.toString()));
         closeResponse(executeRequest(httpPut, HttpStatus.SC_NOT_FOUND));
     }
@@ -297,7 +320,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         Instant initial = Instant.parse("2019-12-03T12:32:45.583345Z");
         Instant tenDaysLater = initial.plus(10, ChronoUnit.DAYS);
         Instant tenDaysLaterWithoutNanos = tenDaysLater.truncatedTo(ChronoUnit.MILLIS);
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
         runtimeService.setVariable(processInstance.getId(), "myVar", initial);
 
         // Update variable
@@ -306,7 +330,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         requestNode.put("value", "2019-12-13T12:32:45.583345Z");
         requestNode.put("type", "instant");
 
-        HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVar"));
+        HttpPut httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVar"));
         httpPut.setEntity(new StringEntity(requestNode.toString()));
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
 
@@ -316,10 +341,10 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         closeResponse(response);
         assertThat(responseNode).isNotNull();
         assertThatJson(responseNode)
-            .when(Option.IGNORING_EXTRA_FIELDS)
-            .isEqualTo("{"
-                + "  value: '2019-12-13T12:32:45.583345Z'"
-                + "}");
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  value: '2019-12-13T12:32:45.583345Z'"
+                        + "}");
     }
 
     @Test
@@ -327,7 +352,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
     public void testUpdateLocalDateProcessVariable() throws Exception {
         LocalDate initial = LocalDate.parse("2020-01-18");
         LocalDate tenDaysLater = initial.plusDays(10);
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
         runtimeService.setVariable(processInstance.getId(), "myVar", initial);
 
         // Update variable
@@ -336,7 +362,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         requestNode.put("value", "2020-01-28");
         requestNode.put("type", "localDate");
 
-        HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVar"));
+        HttpPut httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVar"));
         httpPut.setEntity(new StringEntity(requestNode.toString()));
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
 
@@ -346,10 +373,10 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         closeResponse(response);
         assertThat(responseNode).isNotNull();
         assertThatJson(responseNode)
-            .when(Option.IGNORING_EXTRA_FIELDS)
-            .isEqualTo("{"
-                + "  value: '2020-01-28'"
-                + "}");
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  value: '2020-01-28'"
+                        + "}");
     }
 
     @Test
@@ -357,7 +384,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
     public void testUpdateLocalDateTimeProcessVariable() throws Exception {
         LocalDateTime initial = LocalDateTime.parse("2020-01-18T12:32:45");
         LocalDateTime tenDaysLater = initial.plus(10, ChronoUnit.DAYS);
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
         runtimeService.setVariable(processInstance.getId(), "myVar", initial);
 
         // Update variable
@@ -366,7 +394,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         requestNode.put("value", "2020-01-28T12:32:45");
         requestNode.put("type", "localDateTime");
 
-        HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVar"));
+        HttpPut httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "myVar"));
         httpPut.setEntity(new StringEntity(requestNode.toString()));
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
 
@@ -376,10 +405,10 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         closeResponse(response);
         assertThat(responseNode).isNotNull();
         assertThatJson(responseNode)
-            .when(Option.IGNORING_EXTRA_FIELDS)
-            .isEqualTo("{"
-                + "  value: '2020-01-28T12:32:45'"
-                + "}");
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  value: '2020-01-28T12:32:45'"
+                        + "}");
     }
 
     /**
@@ -389,7 +418,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
     @Deployment(resources = { "org/flowable/rest/service/api/runtime/ProcessInstanceVariableResourceTest.testProcess.bpmn20.xml" })
     public void testUpdateBinaryProcessVariable() throws Exception {
 
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
         runtimeService.setVariable(processInstance.getId(), "binaryVariable", "Initial binary value".getBytes());
 
         InputStream binaryContent = new ByteArrayInputStream("This is binary content".getBytes());
@@ -399,22 +429,28 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         additionalFields.put("name", "binaryVariable");
         additionalFields.put("type", "binary");
 
-        HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "binaryVariable"));
+        HttpPut httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE, processInstance.getId(), "binaryVariable"));
         httpPut.setEntity(HttpMultipartHelper.getMultiPartEntity("value", "application/octet-stream", binaryContent, additionalFields));
         CloseableHttpResponse response = executeBinaryRequest(httpPut, HttpStatus.SC_OK);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("binaryVariable", responseNode.get("name").asText());
-        assertTrue(responseNode.get("value").isNull());
-        assertEquals("binary", responseNode.get("type").asText());
-        assertNotNull(responseNode.get("valueUrl"));
-        assertTrue(responseNode.get("valueUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "binaryVariable")));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "name: 'binaryVariable',"
+                        + "type : 'binary',"
+                        + "value : null,"
+                        + "valueUrl : '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_VARIABLE_DATA, processInstance.getId(), "binaryVariable") + "',"
+                        + "scope : 'local'"
+                        + "}");
 
         // Check actual value of variable in engine
         Object variableValue = runtimeService.getVariableLocal(processInstance.getId(), "binaryVariable");
-        assertNotNull(variableValue);
-        assertTrue(variableValue instanceof byte[]);
-        assertEquals("This is binary content", new String((byte[]) variableValue));
+        assertThat(variableValue).isNotNull();
+        assertThat(variableValue).isInstanceOf(byte[].class);
+        assertThat(new String((byte[]) variableValue)).isEqualTo("This is binary content");
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskAttachmentResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskAttachmentResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,11 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -42,6 +39,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * @author Frederik Heremans
  */
@@ -57,19 +56,23 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
 
             // Create URL-attachment
-            Attachment urlAttachment = taskService.createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
+            Attachment urlAttachment = taskService
+                    .createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
             taskService.saveAttachment(urlAttachment);
 
             // Create Binary-attachment
-            Attachment binaryAttachment = taskService.createAttachment("binaryType", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
-                    "This is binary content".getBytes()));
+            Attachment binaryAttachment = taskService
+                    .createAttachment("binaryType", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
+                            "This is binary content".getBytes()));
             taskService.saveAttachment(binaryAttachment);
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_COLLECTION, task.getId())), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_COLLECTION, task.getId())),
+                    HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertTrue(responseNode.isArray());
-            assertEquals(2, responseNode.size());
+            assertThat(responseNode.isArray()).isTrue();
+            assertThat(responseNode).hasSize(2);
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -85,7 +88,9 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
      */
     @Test
     public void testGetAttachmentsUnexistingTask() throws Exception {
-        closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_COLLECTION, "unexistingtask")), HttpStatus.SC_NOT_FOUND));
+        closeResponse(
+                executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_COLLECTION, "unexistingtask")),
+                        HttpStatus.SC_NOT_FOUND));
     }
 
     /**
@@ -98,47 +103,60 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
 
             // Create URL-attachment
-            Attachment urlAttachment = taskService.createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
+            Attachment urlAttachment = taskService
+                    .createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
             taskService.saveAttachment(urlAttachment);
 
             // Create Binary-attachment
-            Attachment binaryAttachment = taskService.createAttachment("binaryType", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
-                    "This is binary content".getBytes()));
+            Attachment binaryAttachment = taskService
+                    .createAttachment("binaryType", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
+                            "This is binary content".getBytes()));
             taskService.saveAttachment(binaryAttachment);
 
             // Get external url attachment
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId())),
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId())),
                     HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(urlAttachment.getId(), responseNode.get("id").textValue());
-            assertEquals("simpleType", responseNode.get("type").textValue());
-            assertEquals("Simple attachment", responseNode.get("name").textValue());
-            assertEquals("Simple attachment description", responseNode.get("description").textValue());
-            assertEquals("http://activiti.org", responseNode.get("externalUrl").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId())));
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId())));
-
-            assertTrue(responseNode.get("contentUrl").isNull());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
-            assertFalse(responseNode.get("time").isNull());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id : '" + urlAttachment.getId() + "',"
+                            + "type: 'simpleType',"
+                            + "name: 'Simple attachment',"
+                            + "description: 'Simple attachment description',"
+                            + "externalUrl: 'http://activiti.org',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId()) + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
+                            + "contentUrl: null,"
+                            + "processInstanceUrl: null"
+                            + "}");
+            assertThat(responseNode.get("time")).isNotNull();
 
             // Get binary attachment
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId())), HttpStatus.SC_OK);
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId())),
+                    HttpStatus.SC_OK);
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(binaryAttachment.getId(), responseNode.get("id").textValue());
-            assertEquals("binaryType", responseNode.get("type").textValue());
-            assertEquals("Binary attachment", responseNode.get("name").textValue());
-            assertEquals("Binary attachment description", responseNode.get("description").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId())));
-            assertTrue(responseNode.get("contentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId())));
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId())));
-
-            assertTrue(responseNode.get("externalUrl").isNull());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
-
-            assertFalse(responseNode.get("time").isNull());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id : '" + binaryAttachment.getId() + "',"
+                            + "type: 'binaryType',"
+                            + "name: 'Binary attachment',"
+                            + "description: 'Binary attachment description',"
+                            + "externalUrl: null,"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId()) + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
+                            + "contentUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId()) + "',"
+                            + "processInstanceUrl: null"
+                            + "}");
+            assertThat(responseNode.get("time").isNull()).isFalse();
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -159,14 +177,19 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
 
             // Create URL-attachment
-            Attachment urlAttachment = taskService.createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
+            Attachment urlAttachment = taskService
+                    .createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
             taskService.saveAttachment(urlAttachment);
 
             // Get attachment for unexisting task
-            closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, "unexistingtask", urlAttachment.getId())), HttpStatus.SC_NOT_FOUND));
+            closeResponse(executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, "unexistingtask", urlAttachment.getId())),
+                    HttpStatus.SC_NOT_FOUND));
 
             // Get attachment for task attachment
-            closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), "unexistingattachment")), HttpStatus.SC_NOT_FOUND));
+            closeResponse(executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), "unexistingattachment")),
+                    HttpStatus.SC_NOT_FOUND));
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -187,12 +210,14 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
 
             // Create Binary-attachment
-            Attachment binaryAttachment = taskService.createAttachment("binaryType", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
-                    "This is binary content".getBytes()));
+            Attachment binaryAttachment = taskService
+                    .createAttachment("binaryType", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
+                            "This is binary content".getBytes()));
             taskService.saveAttachment(binaryAttachment);
 
             // Get external url attachment
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId())),
+            CloseableHttpResponse response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId())),
                     HttpStatus.SC_OK);
 
             // Check response body
@@ -201,7 +226,7 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             }
 
             // Check response headers
-            assertEquals("application/octet-stream", response.getEntity().getContentType().getValue());
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/octet-stream");
             closeResponse(response);
 
         } finally {
@@ -223,16 +248,18 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
 
             // Create Binary-attachment
-            Attachment binaryAttachment = taskService.createAttachment("application/xml", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
-                    "<p>This is binary content</p>".getBytes()));
+            Attachment binaryAttachment = taskService
+                    .createAttachment("application/xml", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
+                            "<p>This is binary content</p>".getBytes()));
             taskService.saveAttachment(binaryAttachment);
 
             // Get external url attachment
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId())),
+            CloseableHttpResponse response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId())),
                     HttpStatus.SC_OK);
 
             // Check response headers
-            assertEquals("application/xml", response.getEntity().getContentType().getValue());
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/xml");
             closeResponse(response);
 
         } finally {
@@ -254,11 +281,14 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
 
             // Create URL-attachment
-            Attachment urlAttachment = taskService.createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
+            Attachment urlAttachment = taskService
+                    .createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
             taskService.saveAttachment(urlAttachment);
 
             // Get attachment content for non-binary attachment
-            closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), urlAttachment.getId())), HttpStatus.SC_NOT_FOUND));
+            closeResponse(executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), urlAttachment.getId())),
+                    HttpStatus.SC_NOT_FOUND));
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -290,23 +320,27 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
 
             // Check if attachment is created
             List<Attachment> attachments = taskService.getTaskAttachments(task.getId());
-            assertEquals(1, attachments.size());
+            assertThat(attachments).hasSize(1);
 
             Attachment urlAttachment = attachments.get(0);
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(urlAttachment.getId(), responseNode.get("id").textValue());
-            assertEquals("simpleType", responseNode.get("type").textValue());
-            assertEquals("Simple attachment", responseNode.get("name").textValue());
-            assertEquals("Simple attachment description", responseNode.get("description").textValue());
-            assertEquals("http://activiti.org", responseNode.get("externalUrl").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId())));
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId())));
-
-            assertTrue(responseNode.get("contentUrl").isNull());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
-            assertFalse(responseNode.get("time").isNull());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id : '" + urlAttachment.getId() + "',"
+                            + "type: 'simpleType',"
+                            + "name: 'Simple attachment',"
+                            + "description: 'Simple attachment description',"
+                            + "externalUrl: 'http://activiti.org',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId()) + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
+                            + "contentUrl: null,"
+                            + "processInstanceUrl: null"
+                            + "}");
+            assertThat(responseNode.get("time")).isNotNull();
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -341,7 +375,7 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
 
             // Check if attachment is created
             List<Attachment> attachments = taskService.getTaskAttachments(task.getId());
-            assertEquals(1, attachments.size());
+            assertThat(attachments).hasSize(1);
 
             Attachment binaryAttachment = attachments.get(0);
             try (InputStream contentStream = taskService.getAttachmentContent(binaryAttachment.getId())) {
@@ -350,17 +384,22 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(binaryAttachment.getId(), responseNode.get("id").textValue());
-            assertEquals("myType", responseNode.get("type").textValue());
-            assertEquals("An attachment", responseNode.get("name").textValue());
-            assertEquals("An attachment description", responseNode.get("description").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId())));
-            assertTrue(responseNode.get("contentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId())));
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId())));
-
-            assertTrue(responseNode.get("externalUrl").isNull());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
-            assertFalse(responseNode.get("time").isNull());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id : '" + binaryAttachment.getId() + "',"
+                            + "type: 'myType',"
+                            + "name: 'An attachment',"
+                            + "description: 'An attachment description',"
+                            + "externalUrl: null,"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId()) + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
+                            + "contentUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId()) + "',"
+                            + "processInstanceUrl: null"
+                            + "}");
+            assertThat(responseNode.get("time")).isNotNull();
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -410,15 +449,17 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
 
             // Create URL-attachment
-            Attachment urlAttachment = taskService.createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
+            Attachment urlAttachment = taskService
+                    .createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
             taskService.saveAttachment(urlAttachment);
 
             // Delete the attachment
-            HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId()));
+            HttpDelete httpDelete = new HttpDelete(
+                    SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId()));
             closeResponse(executeBinaryRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
             // Check if attachment is really deleted
-            assertNull(taskService.getAttachment(urlAttachment.getId()));
+            assertThat(taskService.getAttachment(urlAttachment.getId())).isNull();
 
             // Deleting again should result in 404
             closeResponse(executeBinaryRequest(httpDelete, HttpStatus.SC_NOT_FOUND));
@@ -442,48 +483,62 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
 
             // Create URL-attachment
-            Attachment urlAttachment = taskService.createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
+            Attachment urlAttachment = taskService
+                    .createAttachment("simpleType", task.getId(), null, "Simple attachment", "Simple attachment description", "http://activiti.org");
             taskService.saveAttachment(urlAttachment);
 
             // Create Binary-attachment
-            Attachment binaryAttachment = taskService.createAttachment("binaryType", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
-                    "This is binary content".getBytes()));
+            Attachment binaryAttachment = taskService
+                    .createAttachment("binaryType", task.getId(), null, "Binary attachment", "Binary attachment description", new ByteArrayInputStream(
+                            "This is binary content".getBytes()));
             taskService.saveAttachment(binaryAttachment);
 
             taskService.complete(task.getId());
 
             // Get external url attachment
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId())),
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId())),
                     HttpStatus.SC_OK);
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(urlAttachment.getId(), responseNode.get("id").textValue());
-            assertEquals("simpleType", responseNode.get("type").textValue());
-            assertEquals("Simple attachment", responseNode.get("name").textValue());
-            assertEquals("Simple attachment description", responseNode.get("description").textValue());
-            assertEquals("http://activiti.org", responseNode.get("externalUrl").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId())));
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId())));
-
-            assertTrue(responseNode.get("contentUrl").isNull());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
-            assertFalse(responseNode.get("time").isNull());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id : '" + urlAttachment.getId() + "',"
+                            + "type: 'simpleType',"
+                            + "name: 'Simple attachment',"
+                            + "description: 'Simple attachment description',"
+                            + "externalUrl: 'http://activiti.org',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId()) + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
+                            + "contentUrl: null,"
+                            + "processInstanceUrl: null"
+                            + "}");
+            assertThat(responseNode.get("time")).isNotNull();
 
             // Get binary attachment
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId())), HttpStatus.SC_OK);
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId())),
+                    HttpStatus.SC_OK);
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(binaryAttachment.getId(), responseNode.get("id").textValue());
-            assertEquals("binaryType", responseNode.get("type").textValue());
-            assertEquals("Binary attachment", responseNode.get("name").textValue());
-            assertEquals("Binary attachment description", responseNode.get("description").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId())));
-            assertTrue(responseNode.get("contentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId())));
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId())));
-
-            assertTrue(responseNode.get("externalUrl").isNull());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id : '" + binaryAttachment.getId() + "',"
+                            + "type: 'binaryType',"
+                            + "name: 'Binary attachment',"
+                            + "description: 'Binary attachment description',"
+                            + "externalUrl: null,"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), binaryAttachment.getId()) + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
+                            + "contentUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId()) + "',"
+                            + "processInstanceUrl: null"
+                            + "}");
 
         } finally {
             // Clean adhoc-tasks even if test fails

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,10 +15,7 @@ package org.flowable.rest.service.api.runtime;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Calendar;
 import java.util.List;
@@ -50,9 +47,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to a single Task resource.
- * 
+ *
  * @author Frederik Heremans
  */
 public class TaskResourceTest extends BaseSpringRestTestCase {
@@ -71,7 +70,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         taskService.setDueDate(task.getId(), now.getTime());
         taskService.setOwner(task.getId(), "owner");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         String url = buildUrl(RestUrls.URL_TASK, task.getId());
         CloseableHttpResponse response = executeRequest(new HttpGet(url), HttpStatus.SC_OK);
@@ -79,23 +78,26 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         // Check resulting task
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals(task.getId(), responseNode.get("id").asText());
-        assertEquals(task.getAssignee(), responseNode.get("assignee").asText());
-        assertEquals(task.getOwner(), responseNode.get("owner").asText());
-        assertEquals(task.getFormKey(), responseNode.get("formKey").asText());
-        assertEquals(task.getDescription(), responseNode.get("description").asText());
-        assertEquals(task.getName(), responseNode.get("name").asText());
-        assertEquals(task.getDueDate(), getDateFromISOString(responseNode.get("dueDate").asText()));
-        assertEquals(task.getCreateTime(), getDateFromISOString(responseNode.get("createTime").asText()));
-        assertEquals(task.getPriority(), responseNode.get("priority").asInt());
-        assertTrue(responseNode.get("parentTaskId").isNull());
-        assertTrue(responseNode.get("delegationState").isNull());
-        assertEquals("", responseNode.get("tenantId").textValue());
-
-        assertEquals(responseNode.get("executionUrl").asText(), buildUrl(RestUrls.URL_EXECUTION, task.getExecutionId()));
-        assertEquals(responseNode.get("processInstanceUrl").asText(), buildUrl(RestUrls.URL_PROCESS_INSTANCE, task.getProcessInstanceId()));
-        assertEquals(responseNode.get("processDefinitionUrl").asText(), buildUrl(RestUrls.URL_PROCESS_DEFINITION, task.getProcessDefinitionId()));
-        assertEquals(responseNode.get("url").asText(), url);
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id : '" + task.getId() + "',"
+                        + "assignee: '" + task.getAssignee() + "',"
+                        + "owner: '" + task.getOwner() + "',"
+                        + "formKey: '" + task.getFormKey() + "',"
+                        + "description: '" + task.getDescription() + "',"
+                        + "name: '" + task.getName() + "',"
+                        + "priority: " + task.getPriority() + ","
+                        + "parentTaskId: null,"
+                        + "delegationState: null,"
+                        + "tenantId: \"\","
+                        + "executionUrl: '" + buildUrl(RestUrls.URL_EXECUTION, task.getExecutionId()) + "',"
+                        + "processInstanceUrl: '" + buildUrl(RestUrls.URL_PROCESS_INSTANCE, task.getProcessInstanceId()) + "',"
+                        + "processDefinitionUrl: '" + buildUrl(RestUrls.URL_PROCESS_DEFINITION, task.getProcessDefinitionId()) + "',"
+                        + "url: '" + url + "'"
+                        + "}");
+        assertThat(getDateFromISOString(responseNode.get("dueDate").asText())).isEqualTo(task.getDueDate());
+        assertThat(getDateFromISOString(responseNode.get("createTime").asText())).isEqualTo(task.getCreateTime());
 
         // Set tenant on deployment
         managementService.executeCommand(new ChangeDeploymentTenantIdCmd(deploymentId, "myTenant"));
@@ -104,7 +106,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
 
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals("myTenant", responseNode.get("tenantId").asText());
+        assertThat(responseNode.get("tenantId").asText()).isEqualTo("myTenant");
     }
 
     /**
@@ -138,22 +140,24 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             // Check resulting task
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(task.getId(), responseNode.get("id").asText());
-            assertEquals(task.getAssignee(), responseNode.get("assignee").asText());
-            assertEquals(task.getOwner(), responseNode.get("owner").asText());
-            assertEquals(task.getDescription(), responseNode.get("description").asText());
-            assertEquals(task.getName(), responseNode.get("name").asText());
-            assertEquals(task.getDueDate(), getDateFromISOString(responseNode.get("dueDate").asText()));
-            assertEquals(task.getCreateTime(), getDateFromISOString(responseNode.get("createTime").asText()));
-            assertEquals(task.getPriority(), responseNode.get("priority").asInt());
-            assertEquals("resolved", responseNode.get("delegationState").asText());
-            assertTrue(responseNode.get("executionId").isNull());
-            assertTrue(responseNode.get("processInstanceId").isNull());
-            assertTrue(responseNode.get("processDefinitionId").isNull());
-            assertEquals("", responseNode.get("tenantId").textValue());
-
-            assertEquals(responseNode.get("parentTaskUrl").asText(), buildUrl(RestUrls.URL_TASK, parentTask.getId()));
-            assertEquals(responseNode.get("url").asText(), url);
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id : '" + task.getId() + "',"
+                            + "assignee: '" + task.getAssignee() + "',"
+                            + "owner: '" + task.getOwner() + "',"
+                            + "description: '" + task.getDescription() + "',"
+                            + "name: '" + task.getName() + "',"
+                            + "priority: " + task.getPriority() + ","
+                            + "delegationState: 'resolved',"
+                            + "executionId: null,"
+                            + "processInstanceId: null,"
+                            + "processDefinitionId: null,"
+                            + "url: '" + url + "',"
+                            + "parentTaskUrl: '" + buildUrl(RestUrls.URL_TASK, parentTask.getId()) + "'"
+                            + "}");
+            assertThat(getDateFromISOString(responseNode.get("dueDate").asText())).isEqualTo(task.getDueDate());
+            assertThat(getDateFromISOString(responseNode.get("createTime").asText())).isEqualTo(task.getCreateTime());
 
         } finally {
 
@@ -195,14 +199,14 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpPut, HttpStatus.SC_OK));
 
             task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-            assertEquals("Task name", task.getName());
-            assertEquals("Description", task.getDescription());
-            assertEquals("kermit", task.getAssignee());
-            assertEquals("owner", task.getOwner());
-            assertEquals(20, task.getPriority());
-            assertEquals(DelegationState.RESOLVED, task.getDelegationState());
-            assertEquals(now.getTime(), task.getDueDate());
-            assertEquals(parentTask.getId(), task.getParentTaskId());
+            assertThat(task.getName()).isEqualTo("Task name");
+            assertThat(task.getDescription()).isEqualTo("Description");
+            assertThat(task.getAssignee()).isEqualTo("kermit");
+            assertThat(task.getOwner()).isEqualTo("owner");
+            assertThat(task.getPriority()).isEqualTo(20);
+            assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
+            assertThat(task.getDueDate()).isEqualTo(now.getTime());
+            assertThat(task.getParentTaskId()).isEqualTo(parentTask.getId());
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -245,14 +249,14 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpPut, HttpStatus.SC_OK));
 
             task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-            assertEquals("New task name", task.getName());
-            assertEquals("New task description", task.getDescription());
-            assertEquals("assignee", task.getAssignee());
-            assertEquals("owner", task.getOwner());
-            assertEquals(20, task.getPriority());
-            assertEquals(DelegationState.RESOLVED, task.getDelegationState());
-            assertEquals(dateFormat.parse(dueDateString), task.getDueDate());
-            assertEquals(parentTask.getId(), task.getParentTaskId());
+            assertThat(task.getName()).isEqualTo("New task name");
+            assertThat(task.getDescription()).isEqualTo("New task description");
+            assertThat(task.getAssignee()).isEqualTo("assignee");
+            assertThat(task.getOwner()).isEqualTo("owner");
+            assertThat(task.getPriority()).isEqualTo(20);
+            assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
+            assertThat(task.getDueDate()).isEqualTo(dateFormat.parse(dueDateString));
+            assertThat(task.getParentTaskId()).isEqualTo(parentTask.getId());
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -293,11 +297,11 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
             task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
             if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
                 // Check that the historic task has not been deleted
-                assertNotNull(historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult());
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult()).isNotNull();
             }
 
             // 2. Cascade delete
@@ -310,11 +314,11 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
             task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
             if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
                 // Check that the historic task has been deleted
-                assertNull(historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult());
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult()).isNull();
             }
 
             // 3. Delete with reason
@@ -327,14 +331,14 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
             task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
             if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
                 // Check that the historic task has been deleted and
                 // delete-reason has been set
                 HistoricTaskInstance instance = historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult();
-                assertNotNull(instance);
-                assertEquals("fortestingpurposes", instance.getDeleteReason());
+                assertThat(instance).isNotNull();
+                assertThat(instance.getDeleteReason()).isEqualTo("fortestingpurposes");
             }
 
         } finally {
@@ -359,9 +363,9 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = "org/flowable/rest/service/api/oneTaskProcess.bpmn20.xml")
     public void testDeleteTaskLinkedWithAProcessInstance() throws Exception {
         String processInstanceId = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .start()
-            .getId();
+                .processDefinitionKey("oneTaskProcess")
+                .start()
+                .getId();
 
         // 1. Simple delete
         Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
@@ -375,10 +379,10 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         closeResponse(response);
 
         assertThatJson(responseNode)
-            .isEqualTo("{"
-                + "message: 'Forbidden',"
-                + "exception: 'Cannot delete a task that is part of a process instance.'"
-                + "}");
+                .isEqualTo("{"
+                        + "message: 'Forbidden',"
+                        + "exception: 'Cannot delete a task that is part of a process instance.'"
+                        + "}");
 
         assertThat(taskService.createTaskQuery().taskId(task.getId()).singleResult()).isNotNull();
 
@@ -395,10 +399,10 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         closeResponse(response);
 
         assertThatJson(responseNode)
-            .isEqualTo("{"
-                + "message: 'Forbidden',"
-                + "exception: 'Cannot delete a task that is part of a process instance.'"
-                + "}");
+                .isEqualTo("{"
+                        + "message: 'Forbidden',"
+                        + "exception: 'Cannot delete a task that is part of a process instance.'"
+                        + "}");
 
         assertThat(taskService.createTaskQuery().taskId(task.getId()).singleResult()).isNotNull();
 
@@ -415,10 +419,10 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         closeResponse(response);
 
         assertThatJson(responseNode)
-            .isEqualTo("{"
-                + "message: 'Forbidden',"
-                + "exception: 'Cannot delete a task that is part of a process instance.'"
-                + "}");
+                .isEqualTo("{"
+                        + "message: 'Forbidden',"
+                        + "exception: 'Cannot delete a task that is part of a process instance.'"
+                        + "}");
 
         assertThat(taskService.createTaskQuery().taskId(task.getId()).singleResult()).isNotNull();
 
@@ -446,7 +450,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
     public void testDeleteTaskInProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()));
         closeResponse(executeRequest(httpDelete, HttpStatus.SC_FORBIDDEN));
@@ -472,7 +476,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
 
             // Task should not exist anymore
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
             // Test completing with variables
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -498,29 +502,19 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
 
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNull(task);
+            assertThat(task).isNull();
 
             if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
                 HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult();
-                assertNotNull(historicTaskInstance);
+                assertThat(historicTaskInstance).isNotNull();
                 List<HistoricVariableInstance> updates = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-                assertNotNull(updates);
-                assertEquals(2, updates.size());
-                boolean foundFirst = false;
-                boolean foundSecond = false;
+                assertThat(updates).isNotNull();
 
-                for (HistoricVariableInstance var : updates) {
-                    if (var.getVariableName().equals("var1")) {
-                        assertEquals("First value", var.getValue());
-                        foundFirst = true;
-                    } else if (var.getVariableName().equals("var2")) {
-                        assertEquals("Second value", var.getValue());
-                        foundSecond = true;
-                    }
-                }
-
-                assertTrue(foundFirst);
-                assertTrue(foundSecond);
+                assertThat(updates)
+                        .extracting(HistoricVariableInstance::getVariableName, HistoricVariableInstance::getValue)
+                        .containsExactlyInAnyOrder(
+                                tuple("var1", "First value"),
+                                tuple("var2", "Second value"));
             }
 
         } finally {
@@ -537,30 +531,34 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             }
         }
     }
-    
+
     @Test
     @Deployment
     public void testCompleteTaskWithForm() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").singleResult();
         try {
             formRepositoryService.createDeployment().addClasspathResource("org/flowable/rest/service/api/runtime/simple.form").deploy();
-            
+
             FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-            assertNotNull(formDefinition);
-            
+            assertThat(formDefinition).isNotNull();
+
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             String taskId = task.getId();
-            
+
             String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_FORM, taskId);
             CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(formDefinition.getId(), responseNode.get("id").asText());
-            assertEquals(formDefinition.getKey(), responseNode.get("key").asText());
-            assertEquals(formDefinition.getName(), responseNode.get("name").asText());
-            assertEquals(2, responseNode.get("fields").size());
-            
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id : '" + formDefinition.getId() + "',"
+                            + "key: '" + formDefinition.getKey() + "',"
+                            + "name: '" + formDefinition.getName() + "'"
+                            + "}");
+            assertThat(responseNode.get("fields")).hasSize(2);
+
             ObjectNode requestNode = objectMapper.createObjectNode();
             ArrayNode variablesNode = objectMapper.createArrayNode();
             requestNode.put("action", "complete");
@@ -581,43 +579,34 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
 
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNull(task);
-            
+            assertThat(task).isNull();
+
             FormInstance formInstance = formEngineFormService.createFormInstanceQuery().taskId(taskId).singleResult();
-            assertNotNull(formInstance);
+            assertThat(formInstance).isNotNull();
             byte[] valuesBytes = formEngineFormService.getFormInstanceValues(formInstance.getId());
-            assertNotNull(valuesBytes);
+            assertThat(valuesBytes).isNotNull();
             JsonNode instanceNode = objectMapper.readTree(valuesBytes);
             JsonNode valuesNode = instanceNode.get("values");
-            assertEquals("First value", valuesNode.get("user").asText());
-            assertEquals(789, valuesNode.get("number").asInt());
+            assertThat(valuesNode.get("user").asText()).isEqualTo("First value");
+            assertThat(valuesNode.get("number").asInt()).isEqualTo(789);
 
             if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
                 HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult();
-                assertNotNull(historicTaskInstance);
-                List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-                assertNotNull(variables);
-                assertEquals(2, variables.size());
-                boolean foundFirst = false;
-                boolean foundSecond = false;
+                assertThat(historicTaskInstance).isNotNull();
+                List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId())
+                        .list();
+                assertThat(variables).isNotNull();
 
-                for (HistoricVariableInstance variable : variables) {
-                    if (variable.getVariableName().equals("user")) {
-                        assertEquals("First value", variable.getValue());
-                        foundFirst = true;
-                    } else if (variable.getVariableName().equals("number")) {
-                        assertEquals(789, variable.getValue());
-                        foundSecond = true;
-                    }
-                }
-
-                assertTrue(foundFirst);
-                assertTrue(foundSecond);
+                assertThat(variables)
+                        .extracting(HistoricVariableInstance::getVariableName, HistoricVariableInstance::getValue)
+                        .containsExactlyInAnyOrder(
+                                tuple("user", "First value"),
+                                tuple("number", 789));
             }
 
         } finally {
             formEngineFormService.deleteFormInstancesByProcessDefinition(processDefinition.getId());
-            
+
             List<FormDeployment> formDeployments = formRepositoryService.createDeploymentQuery().list();
             for (FormDeployment formDeployment : formDeployments) {
                 formRepositoryService.deleteDeployment(formDeployment.getId());
@@ -636,7 +625,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
             taskService.addCandidateUser(task.getId(), "newAssignee");
 
-            assertEquals(1L, taskService.createTaskQuery().taskCandidateUser("newAssignee").count());
+            assertThat(taskService.createTaskQuery().taskCandidateUser("newAssignee").count()).isEqualTo(1L);
             // Add candidate group
             String taskId = task.getId();
 
@@ -649,26 +638,26 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNotNull(task);
-            assertNull(task.getAssignee());
-            assertEquals(1L, taskService.createTaskQuery().taskCandidateUser("newAssignee").count());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isNull();
+            assertThat(taskService.createTaskQuery().taskCandidateUser("newAssignee").count()).isEqualTo(1L);
 
             // Claim the task and check result
             requestNode.put("assignee", "newAssignee");
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNotNull(task);
-            assertEquals("newAssignee", task.getAssignee());
-            assertEquals(0L, taskService.createTaskQuery().taskCandidateUser("newAssignee").count());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("newAssignee");
+            assertThat(taskService.createTaskQuery().taskCandidateUser("newAssignee").count()).isEqualTo(0L);
 
             // Claiming with the same user should not cause an exception
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNotNull(task);
-            assertEquals("newAssignee", task.getAssignee());
-            assertEquals(0L, taskService.createTaskQuery().taskCandidateUser("newAssignee").count());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("newAssignee");
+            assertThat(taskService.createTaskQuery().taskCandidateUser("newAssignee").count()).isEqualTo(0L);
 
             // Claiming with another user should cause exception
             requestNode.put("assignee", "anotherUser");
@@ -703,10 +692,11 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
         String taskId = ((ArrayNode) dataNode).get(0).get("id").asText();
-        assertNotNull(taskId);
+        assertThat(taskId).isNotNull();
+        System.out.println("******" + dataNode.toPrettyString());
 
         // Claim
-        assertEquals(0L, taskService.createTaskQuery().taskAssignee("kermit").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("kermit").count()).isZero();
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("action", "claim");
         requestNode.put("assignee", "kermit");
@@ -716,7 +706,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         httpPost.setEntity(new StringEntity(requestNode.toString()));
         closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
 
-        assertEquals(1L, taskService.createTaskQuery().taskAssignee("kermit").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("kermit").count()).isEqualTo(1L);
 
         // Unclaim
         requestNode = objectMapper.createObjectNode();
@@ -725,7 +715,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
                 RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, taskId));
         httpPost.setEntity(new StringEntity(requestNode.toString()));
         closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
-        assertEquals(0L, taskService.createTaskQuery().taskAssignee("kermit").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("kermit").count()).isZero();
 
         // Claim again
         requestNode = objectMapper.createObjectNode();
@@ -735,7 +725,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
                 RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, taskId));
         httpPost.setEntity(new StringEntity(requestNode.toString()));
         closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
-        assertEquals(1L, taskService.createTaskQuery().taskAssignee("kermit").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("kermit").count()).isEqualTo(1L);
     }
 
     /**
@@ -762,10 +752,10 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNotNull(task);
-            assertEquals("newAssignee", task.getAssignee());
-            assertEquals("initialAssignee", task.getOwner());
-            assertEquals(DelegationState.PENDING, task.getDelegationState());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("newAssignee");
+            assertThat(task.getOwner()).isEqualTo("initialAssignee");
+            assertThat(task.getDelegationState()).isEqualTo(DelegationState.PENDING);
 
             // Delegating again should not cause an exception and should delegate
             // to user without affecting initial delegator (owner)
@@ -773,10 +763,10 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNotNull(task);
-            assertEquals("anotherAssignee", task.getAssignee());
-            assertEquals("initialAssignee", task.getOwner());
-            assertEquals(DelegationState.PENDING, task.getDelegationState());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("anotherAssignee");
+            assertThat(task.getOwner()).isEqualTo("initialAssignee");
+            assertThat(task.getDelegationState()).isEqualTo(DelegationState.PENDING);
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -807,19 +797,19 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
 
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNotNull(task);
-            assertEquals("initialAssignee", task.getAssignee());
-            assertEquals("initialAssignee", task.getOwner());
-            assertEquals(DelegationState.RESOLVED, task.getDelegationState());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("initialAssignee");
+            assertThat(task.getOwner()).isEqualTo("initialAssignee");
+            assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
 
             // Resolving again should not cause an exception
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_OK));
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
-            assertNotNull(task);
-            assertEquals("initialAssignee", task.getAssignee());
-            assertEquals("initialAssignee", task.getOwner());
-            assertEquals(DelegationState.RESOLVED, task.getDelegationState());
+            assertThat(task).isNotNull();
+            assertThat(task.getAssignee()).isEqualTo("initialAssignee");
+            assertThat(task.getOwner()).isEqualTo("initialAssignee");
+            assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
 
         } finally {
             // Clean adhoc-tasks even if test fails

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskVariablesCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskVariablesCollectionResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,10 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -48,12 +46,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to Task variables.
- * 
+ *
  * @author Frederik Heremans
  * @author Filip Hrisafov
  */
@@ -104,89 +101,93 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
 
         // Request all variables (no scope provides) which include global an
         // local
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLES_COLLECTION, task.getId())), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLES_COLLECTION, task.getId())), HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        JsonAssertions.assertThatJson(responseNode)
-            .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_ARRAY_ORDER)
-            .isEqualTo("["
-                + "  { name: 'stringProcVar', type: 'string', value: 'This is a ProcVariable', scope: 'global' },"
-                + "  { name: 'intProcVar', type: 'integer', value: 123, scope: 'global' },"
-                + "  { name: 'longProcVar', type: 'long', value: 1234, scope: 'global' },"
-                + "  { name: 'shortProcVar', type: 'short', value: 123, scope: 'global' },"
-                + "  { name: 'doubleProcVar', type: 'double', value: 99.99, scope: 'global' },"
-                + "  { name: 'booleanProcVar', type: 'boolean', value: true, scope: 'global' },"
-                + "  { name: 'dateProcVar', type: 'date', value: '${json-unit.any-string}', scope: 'global' },"
-                + "  { name: 'instantProcVar', type: 'instant', value: '2019-12-13T12:32:45.583Z', scope: 'global' },"
-                + "  { name: 'localDateProcVar', type: 'localDate', value: '2020-01-18', scope: 'global' },"
-                + "  { name: 'localDateTimeProcVar', type: 'localDateTime', value: '2020-01-18T16:18:45', scope: 'global' },"
-                + "  { name: 'byteArrayProcVar', type: 'binary', value: null, scope: 'global' },"
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_ARRAY_ORDER)
+                .isEqualTo("["
+                        + "  { name: 'stringProcVar', type: 'string', value: 'This is a ProcVariable', scope: 'global' },"
+                        + "  { name: 'intProcVar', type: 'integer', value: 123, scope: 'global' },"
+                        + "  { name: 'longProcVar', type: 'long', value: 1234, scope: 'global' },"
+                        + "  { name: 'shortProcVar', type: 'short', value: 123, scope: 'global' },"
+                        + "  { name: 'doubleProcVar', type: 'double', value: 99.99, scope: 'global' },"
+                        + "  { name: 'booleanProcVar', type: 'boolean', value: true, scope: 'global' },"
+                        + "  { name: 'dateProcVar', type: 'date', value: '${json-unit.any-string}', scope: 'global' },"
+                        + "  { name: 'instantProcVar', type: 'instant', value: '2019-12-13T12:32:45.583Z', scope: 'global' },"
+                        + "  { name: 'localDateProcVar', type: 'localDate', value: '2020-01-18', scope: 'global' },"
+                        + "  { name: 'localDateTimeProcVar', type: 'localDateTime', value: '2020-01-18T16:18:45', scope: 'global' },"
+                        + "  { name: 'byteArrayProcVar', type: 'binary', value: null, scope: 'global' },"
 
-                + "  { name: 'stringTaskVar', type: 'string', value: 'This is a TaskVariable', scope: 'local' },"
-                + "  { name: 'intTaskVar', type: 'integer', value: 123, scope: 'local' },"
-                + "  { name: 'longTaskVar', type: 'long', value: 1234, scope: 'local' },"
-                + "  { name: 'shortTaskVar', type: 'short', value: 123, scope: 'local' },"
-                + "  { name: 'doubleTaskVar', type: 'double', value: 99.99, scope: 'local' },"
-                + "  { name: 'booleanTaskVar', type: 'boolean', value: true, scope: 'local' },"
-                + "  { name: 'dateTaskVar', type: 'date', value: '${json-unit.any-string}', scope: 'local' },"
-                + "  { name: 'instantTaskVar', type: 'instant', value: '2019-12-13T12:32:45.583Z', scope: 'local' },"
-                + "  { name: 'localDateTaskVar', type: 'localDate', value: '2020-01-18', scope: 'local' },"
-                + "  { name: 'localDateTimeTaskVar', type: 'localDateTime', value: '2020-01-18T16:18:45', scope: 'local' },"
-                + "  { name: 'byteArrayTaskVar', type: 'binary', value: null, scope: 'local' },"
-                + "  { name: 'overlappingVariable', type: 'string', value: 'task-value', scope: 'local' }"
-                + "]");
-        assertTrue(responseNode.isArray());
-        assertEquals(23, responseNode.size());
+                        + "  { name: 'stringTaskVar', type: 'string', value: 'This is a TaskVariable', scope: 'local' },"
+                        + "  { name: 'intTaskVar', type: 'integer', value: 123, scope: 'local' },"
+                        + "  { name: 'longTaskVar', type: 'long', value: 1234, scope: 'local' },"
+                        + "  { name: 'shortTaskVar', type: 'short', value: 123, scope: 'local' },"
+                        + "  { name: 'doubleTaskVar', type: 'double', value: 99.99, scope: 'local' },"
+                        + "  { name: 'booleanTaskVar', type: 'boolean', value: true, scope: 'local' },"
+                        + "  { name: 'dateTaskVar', type: 'date', value: '${json-unit.any-string}', scope: 'local' },"
+                        + "  { name: 'instantTaskVar', type: 'instant', value: '2019-12-13T12:32:45.583Z', scope: 'local' },"
+                        + "  { name: 'localDateTaskVar', type: 'localDate', value: '2020-01-18', scope: 'local' },"
+                        + "  { name: 'localDateTimeTaskVar', type: 'localDateTime', value: '2020-01-18T16:18:45', scope: 'local' },"
+                        + "  { name: 'byteArrayTaskVar', type: 'binary', value: null, scope: 'local' },"
+                        + "  { name: 'overlappingVariable', type: 'string', value: 'task-value', scope: 'local' }"
+                        + "]");
+        assertThat(responseNode.isArray()).isTrue();
+        assertThat(responseNode).hasSize(23);
 
-        // Overlapping variable should contain task-value AND be defined as
-        // "local"
+        // Overlapping variable should contain task-value AND be defined as "local"
         boolean foundOverlapping = false;
         for (int i = 0; i < responseNode.size(); i++) {
             JsonNode var = responseNode.get(i);
             if (var.get("name") != null && "overlappingVariable".equals(var.get("name").asText())) {
                 foundOverlapping = true;
-                assertEquals("task-value", var.get("value").asText());
-                assertEquals("local", var.get("scope").asText());
+                assertThat(var.get("value").asText()).isEqualTo("task-value");
+                assertThat(var.get("scope").asText()).isEqualTo("local");
                 break;
             }
         }
-        assertTrue(foundOverlapping);
+        assertThat(foundOverlapping).isTrue();
 
         // Check local variables filtering
-        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLES_COLLECTION, task.getId()) + "?scope=local"), HttpStatus.SC_OK);
+        response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLES_COLLECTION, task.getId()) + "?scope=local"),
+                HttpStatus.SC_OK);
 
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertTrue(responseNode.isArray());
-        assertEquals(12, responseNode.size());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.isArray()).isTrue();
+        assertThat(responseNode).hasSize(12);
 
         for (int i = 0; i < responseNode.size(); i++) {
             JsonNode var = responseNode.get(i);
-            assertEquals("local", var.get("scope").asText());
+            assertThat(var.get("scope").asText()).isEqualTo("local");
         }
 
         // Check global variables filtering
-        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLES_COLLECTION, task.getId()) + "?scope=global"), HttpStatus.SC_OK);
+        response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLES_COLLECTION, task.getId()) + "?scope=global"),
+                HttpStatus.SC_OK);
 
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertTrue(responseNode.isArray());
-        assertEquals(12, responseNode.size());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.isArray()).isTrue();
+        assertThat(responseNode).hasSize(12);
 
         foundOverlapping = false;
         for (int i = 0; i < responseNode.size(); i++) {
             JsonNode var = responseNode.get(i);
-            assertEquals("global", var.get("scope").asText());
+            assertThat(var.get("scope").asText()).isEqualTo("global");
             if ("overlappingVariable".equals(var.get("name").asText())) {
                 foundOverlapping = true;
-                assertEquals("process-value", var.get("value").asText());
+                assertThat(var.get("value").asText()).isEqualTo("process-value");
             }
         }
-        assertTrue(foundOverlapping);
+        assertThat(foundOverlapping).isTrue();
     }
 
     /**
@@ -212,15 +213,18 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent()).get(0);
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("myVariable", responseNode.get("name").asText());
-        assertEquals("simple string value", responseNode.get("value").asText());
-        assertEquals("local", responseNode.get("scope").asText());
-        assertEquals("string", responseNode.get("type").asText());
-        assertNull(responseNode.get("valueUrl"));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "name : 'myVariable',"
+                        + "value: 'simple string value',"
+                        + "scope: 'local',"
+                        + "type: 'string'"
+                        + "}");
 
-        assertTrue(taskService.hasVariableLocal(task.getId(), "myVariable"));
-        assertEquals("simple string value", taskService.getVariableLocal(task.getId(), "myVariable"));
+        assertThat(taskService.hasVariableLocal(task.getId(), "myVariable")).isTrue();
+        assertThat(taskService.getVariableLocal(task.getId(), "myVariable")).isEqualTo("simple string value");
 
         // Create a new global variable
         variableNode.put("name", "myVariable");
@@ -233,14 +237,17 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
         response = executeRequest(httpPost, HttpStatus.SC_CREATED);
         responseNode = objectMapper.readTree(response.getEntity().getContent()).get(0);
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("myVariable", responseNode.get("name").asText());
-        assertEquals("Another simple string value", responseNode.get("value").asText());
-        assertEquals("global", responseNode.get("scope").asText());
-        assertEquals("string", responseNode.get("type").asText());
-        assertNull(responseNode.get("valueUrl"));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "name : 'myVariable',"
+                        + "value: 'Another simple string value',"
+                        + "scope: 'global',"
+                        + "type: 'string'"
+                        + "}");
 
-        assertTrue(runtimeService.hasVariable(task.getExecutionId(), "myVariable"));
+        assertThat(runtimeService.hasVariable(task.getExecutionId(), "myVariable")).isTrue();
 
         // Create a new scope-less variable, which defaults to local variables
         variableNode.removeAll();
@@ -253,15 +260,18 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
         response = executeRequest(httpPost, HttpStatus.SC_CREATED);
         responseNode = objectMapper.readTree(response.getEntity().getContent()).get(0);
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("scopelessVariable", responseNode.get("name").asText());
-        assertEquals("simple string value", responseNode.get("value").asText());
-        assertEquals("local", responseNode.get("scope").asText());
-        assertEquals("string", responseNode.get("type").asText());
-        assertNull(responseNode.get("valueUrl"));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "name : 'scopelessVariable',"
+                        + "value: 'simple string value',"
+                        + "scope: 'local',"
+                        + "type: 'string'"
+                        + "}");
 
-        assertTrue(taskService.hasVariableLocal(task.getId(), "scopelessVariable"));
-        assertEquals("simple string value", taskService.getVariableLocal(task.getId(), "scopelessVariable"));
+        assertThat(taskService.hasVariableLocal(task.getId(), "scopelessVariable")).isTrue();
+        assertThat(taskService.getVariableLocal(task.getId(), "scopelessVariable")).isEqualTo("simple string value");
     }
 
     /**
@@ -286,19 +296,23 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
             CloseableHttpResponse response = executeBinaryRequest(httpPost, HttpStatus.SC_CREATED);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("binaryVariable", responseNode.get("name").asText());
-            assertTrue(responseNode.get("value").isNull());
-            assertEquals("local", responseNode.get("scope").asText());
-            assertEquals("binary", responseNode.get("type").asText());
-            assertNotNull(responseNode.get("valueUrl"));
-            assertTrue(responseNode.get("valueUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "binaryVariable")));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "name : 'binaryVariable',"
+                            + "value: null,"
+                            + "scope: 'local',"
+                            + "type: 'binary',"
+                            + "valueUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "binaryVariable") + "'"
+                            + "}");
 
             // Check actual value of variable in engine
             Object variableValue = taskService.getVariableLocal(task.getId(), "binaryVariable");
-            assertNotNull(variableValue);
-            assertTrue(variableValue instanceof byte[]);
-            assertEquals("This is binary content", new String((byte[]) variableValue));
+            assertThat(variableValue).isNotNull();
+            assertThat(variableValue).isInstanceOf(byte[].class);
+            assertThat(new String((byte[]) variableValue)).isEqualTo("This is binary content");
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -341,19 +355,23 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
             // Check "CREATED" status
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("serializableVariable", responseNode.get("name").asText());
-            assertTrue(responseNode.get("value").isNull());
-            assertEquals("local", responseNode.get("scope").asText());
-            assertEquals("serializable", responseNode.get("type").asText());
-            assertNotNull(responseNode.get("valueUrl"));
-            assertTrue(responseNode.get("valueUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "serializableVariable")));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "name : 'serializableVariable',"
+                            + "value: null,"
+                            + "scope: 'local',"
+                            + "type: 'serializable',"
+                            + "valueUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "serializableVariable") + "'"
+                            + "}");
 
             // Check actual value of variable in engine
             Object variableValue = taskService.getVariableLocal(task.getId(), "serializableVariable");
-            assertNotNull(variableValue);
-            assertTrue(variableValue instanceof TestSerializableVariable);
-            assertEquals("some value", ((TestSerializableVariable) variableValue).getSomeField());
+            assertThat(variableValue).isNotNull();
+            assertThat(variableValue).isInstanceOf(TestSerializableVariable.class);
+            assertThat(((TestSerializableVariable) variableValue).getSomeField()).isEqualTo("some value");
         } finally {
             // Clean adhoc-tasks even if test fails
             List<Task> tasks = taskService.createTaskQuery().list();
@@ -448,7 +466,7 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_CREATED));
 
-            assertEquals("String value", taskService.getVariable(task.getId(), "stringVar"));
+            assertThat(taskService.getVariable(task.getId(), "stringVar")).isEqualTo("String value");
 
             // Integer type detection
             varNode.put("name", "integerVar");
@@ -459,7 +477,7 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_CREATED));
 
-            assertEquals(123, taskService.getVariable(task.getId(), "integerVar"));
+            assertThat(taskService.getVariable(task.getId(), "integerVar")).isEqualTo(123);
 
             // Double type detection
             varNode.put("name", "doubleVar");
@@ -470,7 +488,7 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_CREATED));
 
-            assertEquals(123.456, taskService.getVariable(task.getId(), "doubleVar"));
+            assertThat(taskService.getVariable(task.getId(), "doubleVar")).isEqualTo(123.456);
 
             // Boolean type detection
             varNode.put("name", "booleanVar");
@@ -481,7 +499,7 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             closeResponse(executeRequest(httpPost, HttpStatus.SC_CREATED));
 
-            assertEquals(Boolean.TRUE, taskService.getVariable(task.getId(), "booleanVar"));
+            assertThat(taskService.getVariable(task.getId(), "booleanVar")).isEqualTo(Boolean.TRUE);
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -561,21 +579,21 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
             CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertTrue(responseNode.isArray());
-            assertEquals(7, responseNode.size());
+            assertThat(responseNode).isNotNull();
+            assertThat(responseNode.isArray()).isTrue();
+            assertThat(responseNode).hasSize(7);
 
             // Check if engine has correct variables set
             Map<String, Object> taskVariables = taskService.getVariablesLocal(task.getId());
-            assertEquals(7, taskVariables.size());
+            assertThat(taskVariables).hasSize(7);
 
-            assertEquals("simple string value", taskVariables.get("stringVariable"));
-            assertEquals(1234, taskVariables.get("integerVariable"));
-            assertEquals((short) 123, taskVariables.get("shortVariable"));
-            assertEquals(4567890L, taskVariables.get("longVariable"));
-            assertEquals(123.456, taskVariables.get("doubleVariable"));
-            assertEquals(Boolean.TRUE, taskVariables.get("booleanVariable"));
-            assertEquals(dateFormat.parse(isoString), taskVariables.get("dateVariable"));
+            assertThat(taskVariables.get("stringVariable")).isEqualTo("simple string value");
+            assertThat(taskVariables.get("integerVariable")).isEqualTo(1234);
+            assertThat(taskVariables.get("shortVariable")).isEqualTo((short) 123);
+            assertThat(taskVariables.get("longVariable")).isEqualTo(4567890L);
+            assertThat(taskVariables.get("doubleVariable")).isEqualTo(123.456);
+            assertThat(taskVariables.get("booleanVariable")).isEqualTo(Boolean.TRUE);
+            assertThat(taskVariables.get("dateVariable")).isEqualTo(dateFormat.parse(isoString));
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -603,13 +621,13 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
         taskVariables.put("var1", "This is a TaskVariable");
         taskVariables.put("var2", 123);
         taskService.setVariablesLocal(task.getId(), taskVariables);
-        assertEquals(2, taskService.getVariablesLocal(task.getId()).size());
+        assertThat(taskService.getVariablesLocal(task.getId())).hasSize(2);
 
         HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLES_COLLECTION, task.getId()));
         closeResponse(executeBinaryRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
         // Check if local variables are gone and global remain unchanged
-        assertEquals(0, taskService.getVariablesLocal(task.getId()).size());
-        assertEquals(1, taskService.getVariables(task.getId()).size());
+        assertThat(taskService.getVariablesLocal(task.getId())).isEmpty();
+        assertThat(taskService.getVariables(task.getId())).hasSize(1);
     }
 }


### PR DESCRIPTION
Various test files in the `org.flowable.rest.service.api` directory.

There were 10 files in the directory that had a mix of styles so I just updated those files in this PR.

