### PR TITLE
Integration of comments with history manager

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -252,6 +252,9 @@ import org.flowable.engine.impl.history.async.json.transformer.UpdateProcessDefi
 import org.flowable.engine.impl.history.async.json.transformer.VariableCreatedHistoryJsonTransformer;
 import org.flowable.engine.impl.history.async.json.transformer.VariableRemovedHistoryJsonTransformer;
 import org.flowable.engine.impl.history.async.json.transformer.VariableUpdatedHistoryJsonTransformer;
+import org.flowable.engine.impl.history.async.json.transformer.CommentCreatedHistoryJsonTransformer;
+import org.flowable.engine.impl.history.async.json.transformer.CommentUpdatedHistoryJsonTransformer;
+import org.flowable.engine.impl.history.async.json.transformer.CommentDeletedHistoryJsonTransformer;
 import org.flowable.engine.impl.interceptor.BpmnOverrideContextInterceptor;
 import org.flowable.engine.impl.interceptor.CommandInvoker;
 import org.flowable.engine.impl.interceptor.DefaultIdentityLinkInterceptor;
@@ -2128,6 +2131,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
         historyJsonTransformers.add(new HistoricUserTaskLogRecordJsonTransformer());
         historyJsonTransformers.add(new HistoricUserTaskLogDeleteJsonTransformer());
+
+        historyJsonTransformers.add(new CommentCreatedHistoryJsonTransformer());
+        historyJsonTransformers.add(new CommentUpdatedHistoryJsonTransformer());
+        historyJsonTransformers.add(new CommentDeletedHistoryJsonTransformer());
+
         return historyJsonTransformers;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AddCommentCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AddCommentCmd.java
@@ -111,7 +111,7 @@ public class AddCommentCmd implements Command<Comment> {
 
         comment.setFullMessage(message);
 
-        CommandContextUtil.getCommentEntityManager(commandContext).insert(comment);
+        CommandContextUtil.getHistoryManager().createComment(comment);
 
         return comment;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteCommentCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/DeleteCommentCmd.java
@@ -19,7 +19,6 @@ import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.compatibility.Flowable5CompatibilityHandler;
-import org.flowable.engine.impl.persistence.entity.CommentEntity;
 import org.flowable.engine.impl.persistence.entity.CommentEntityManager;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.util.CommandContextUtil;
@@ -71,7 +70,7 @@ public class DeleteCommentCmd implements Command<Void>, Serializable {
                 }
             }
 
-            commentManager.delete((CommentEntity) comment);
+            CommandContextUtil.getHistoryManager().deleteComment(commentId);
 
         } else {
             // Delete all comments on a task of process
@@ -100,7 +99,7 @@ public class DeleteCommentCmd implements Command<Void>, Serializable {
             }
 
             for (Comment comment : comments) {
-                commentManager.delete((CommentEntity) comment);
+                CommandContextUtil.getHistoryManager().deleteComment(comment.getId());
             }
         }
         return null;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SaveCommentCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SaveCommentCmd.java
@@ -19,7 +19,6 @@ import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.persistence.entity.CommentEntity;
-import org.flowable.engine.impl.persistence.entity.CommentEntityManager;
 import org.flowable.engine.impl.util.CommandContextUtil;
 
 /**
@@ -42,16 +41,14 @@ public class SaveCommentCmd implements Command<Void>, Serializable {
         if (comment.getId() == null) {
             throw new FlowableIllegalArgumentException("comment id is null");
         } 
-        
-        CommentEntityManager commentEntityManager = CommandContextUtil.getCommentEntityManager(commandContext);
-        
+
         String eventMessage = comment.getFullMessage().replaceAll("\\s+", " ");
         if (eventMessage.length() > 163) {
             eventMessage = eventMessage.substring(0, 160) + "...";
         }
         comment.setMessage(eventMessage);
 
-        commentEntityManager.update(comment);
+        CommandContextUtil.getHistoryManager().updateComment(comment);
 
         return null;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/CompositeHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/CompositeHistoryManager.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.persistence.entity.HistoricActivityInstanceEntity;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntity;
@@ -347,6 +348,27 @@ public class CompositeHistoryManager implements HistoryManager {
     public void deleteHistoryUserTaskLog(long logNumber) {
         for (HistoryManager historyManager : historyManagers) {
             historyManager.deleteHistoryUserTaskLog(logNumber);
+        }
+    }
+
+    @Override
+    public void createComment(CommentEntity commentEntity) {
+        for (HistoryManager historyManager : historyManagers) {
+            historyManager.createComment(commentEntity);
+        }
+    }
+
+    @Override
+    public void updateComment(CommentEntity commentEntity) {
+        for (HistoryManager historyManager : historyManagers) {
+            historyManager.updateComment(commentEntity);
+        }
+    }
+
+    @Override
+    public void deleteComment(String commentId) {
+        for (HistoryManager historyManager : historyManagers) {
+            historyManager.deleteComment(commentId);
         }
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
@@ -33,6 +33,7 @@ import org.flowable.engine.impl.persistence.entity.HistoricActivityInstanceEntit
 import org.flowable.engine.impl.persistence.entity.HistoricDetailVariableInstanceUpdateEntity;
 import org.flowable.engine.impl.persistence.entity.HistoricProcessInstanceEntity;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
 import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.impl.util.TaskHelper;
 import org.flowable.engine.runtime.ActivityInstance;
@@ -518,6 +519,22 @@ public class DefaultHistoryManager extends AbstractHistoryManager {
         if (isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, activityInstance.getProcessDefinitionId())) {
             createNewHistoricActivityInstance(activityInstance);
         }
+    }
+
+    // Related to comments
+    @Override
+    public void createComment(CommentEntity commentEntity) {
+        CommandContextUtil.getCommentEntityManager().insert(commentEntity);
+    }
+
+    @Override
+    public void updateComment(CommentEntity commentEntity) {
+        CommandContextUtil.getCommentEntityManager().update(commentEntity);
+    }
+
+    @Override
+    public void deleteComment(String commentId) {
+        CommandContextUtil.getCommentEntityManager().delete(commentId);
     }
 
     protected HistoricActivityInstanceEntity createNewHistoricActivityInstance(ActivityInstance activityInstance) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/HistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/HistoryManager.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.persistence.entity.HistoricActivityInstanceEntity;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntity;
@@ -248,4 +249,22 @@ public interface HistoryManager {
      * @param logNumber log identifier
      */
     void deleteHistoryUserTaskLog(long logNumber);
+
+    /**
+     * Create new comment
+     * @param commentEntity comment to be created
+     */
+    void createComment(CommentEntity commentEntity);
+
+    /**
+     * Update comment
+     * @param commentEntity comment to be updated
+     */
+    void updateComment(CommentEntity commentEntity);
+
+    /**
+     * Delete comment
+     * @param commentId comment to be deleted
+     */
+    void deleteComment(String commentId);
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/AbstractAsyncHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/AbstractAsyncHistoryManager.java
@@ -18,6 +18,7 @@ import static org.flowable.job.service.impl.history.async.util.AsyncHistoryJsonU
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.history.AbstractHistoryManager;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ActivityInstance;
@@ -190,5 +191,17 @@ public abstract class AbstractAsyncHistoryManager extends AbstractHistoryManager
         putIfNotNull(data, HistoryJsonConstants.SUB_SCOPE_ID, taskLogEntryBuilder.getSubScopeId());
         putIfNotNull(data, HistoryJsonConstants.SCOPE_TYPE, taskLogEntryBuilder.getScopeType());
         putIfNotNull(data, HistoryJsonConstants.SCOPE_DEFINITION_ID, taskLogEntryBuilder.getScopeDefinitionId());
+    }
+
+    protected void addCommonCommentFields(CommentEntity commentEntity, ObjectNode data) {
+        putIfNotNull(data, HistoryJsonConstants.ID, commentEntity.getId());
+        putIfNotNull(data, HistoryJsonConstants.TYPE, commentEntity.getType());
+        putIfNotNull(data, HistoryJsonConstants.TIME, commentEntity.getTime());
+        putIfNotNull(data, HistoryJsonConstants.USER_ID, commentEntity.getUserId());
+        putIfNotNull(data, HistoryJsonConstants.TASK_ID, commentEntity.getTaskId());
+        putIfNotNull(data, HistoryJsonConstants.PROCESS_INSTANCE_ID, commentEntity.getProcessInstanceId());
+        putIfNotNull(data, HistoryJsonConstants.ACTION, commentEntity.getAction());
+        putIfNotNull(data, HistoryJsonConstants.MESSAGE, commentEntity.getMessage());
+        putIfNotNull(data, HistoryJsonConstants.FULL_MESSAGE, commentEntity.getFullMessage());
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/AsyncHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/AsyncHistoryManager.java
@@ -25,10 +25,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.history.async.json.transformer.ProcessInstancePropertyChangedHistoryJsonTransformer;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.runtime.ActivityInstance;
+import org.flowable.engine.task.Comment;
 import org.flowable.entitylink.service.impl.persistence.entity.EntityLinkEntity;
 import org.flowable.identitylink.service.impl.persistence.entity.IdentityLinkEntity;
 import org.flowable.job.service.JobServiceConfiguration;
@@ -514,6 +516,33 @@ public class AsyncHistoryManager extends AbstractAsyncHistoryManager {
             putIfNotNull(data, HistoryJsonConstants.LOG_ENTRY_LOGNUMBER, logNumber);
 
             getAsyncHistorySession().addHistoricData(getJobServiceConfiguration(), HistoryJsonConstants.TYPE_HISTORIC_TASK_LOG_DELETE, data);
+        }
+    }
+
+    @Override
+    public void createComment(CommentEntity comment) {
+        ObjectNode data = processEngineConfiguration.getObjectMapper().createObjectNode();
+        addCommonCommentFields(comment, data);
+
+        getAsyncHistorySession().addHistoricData(getJobServiceConfiguration(), HistoryJsonConstants.TYPE_COMMENT_CREATED, data);
+    }
+
+    @Override
+    public void updateComment(CommentEntity comment) {
+        ObjectNode data = processEngineConfiguration.getObjectMapper().createObjectNode();
+        addCommonCommentFields(comment, data);
+
+        getAsyncHistorySession().addHistoricData(getJobServiceConfiguration(), HistoryJsonConstants.TYPE_COMMENT_UPDATED, data);
+    }
+
+    @Override
+    public void deleteComment(String commentId) {
+        ObjectNode data = processEngineConfiguration.getObjectMapper().createObjectNode();
+        Comment comment = CommandContextUtil.getCommentEntityManager().findComment(commentId);
+        if(comment != null) {
+            addCommonCommentFields((CommentEntity) comment, data);
+
+            getAsyncHistorySession().addHistoricData(getJobServiceConfiguration(), HistoryJsonConstants.TYPE_COMMENT_DELETED, data);
         }
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/HistoryJsonConstants.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/HistoryJsonConstants.java
@@ -76,7 +76,9 @@ public interface HistoryJsonConstants {
     String TYPE_UPDATE_HISTORIC_ACTIVITY_INSTANCE = "activity-update";
     String TYPE_HISTORIC_TASK_LOG_RECORD = "historic-user-task-log-record";
     String TYPE_HISTORIC_TASK_LOG_DELETE = "historic-user-task-log-delete";
-
+    String TYPE_COMMENT_CREATED = "comment-created";
+    String TYPE_COMMENT_UPDATED = "comment-updated";
+    String TYPE_COMMENT_DELETED = "comment-deleted";
 
     String DATA = "data";
 
@@ -229,4 +231,12 @@ public interface HistoryJsonConstants {
     String LOG_ENTRY_DATA = "logEntryData";
 
     String LOG_ENTRY_LOGNUMBER = "logNumber";
+
+    String TIME = "time";
+
+    String ACTION = "action";
+
+    String MESSAGE = "message";
+
+    String FULL_MESSAGE = "fullMessage";
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/CommentCreatedHistoryJsonTransformer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/CommentCreatedHistoryJsonTransformer.java
@@ -1,0 +1,59 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.history.async.json.transformer;
+
+import static org.flowable.job.service.impl.history.async.util.AsyncHistoryJsonUtil.getDateFromJson;
+import static org.flowable.job.service.impl.history.async.util.AsyncHistoryJsonUtil.getStringFromJson;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.engine.impl.history.async.HistoryJsonConstants;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
+import org.flowable.engine.impl.persistence.entity.CommentEntityImpl;
+import org.flowable.engine.impl.persistence.entity.CommentEntityManager;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.job.service.impl.persistence.entity.HistoryJobEntity;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class CommentCreatedHistoryJsonTransformer extends AbstractHistoryJsonTransformer {
+    @Override
+    public List<String> getTypes() {
+        return Collections.singletonList(HistoryJsonConstants.TYPE_COMMENT_CREATED);
+    }
+
+    @Override
+    public boolean isApplicable(ObjectNode historicalData, CommandContext commandContext) {
+        return true;
+    }
+
+    @Override
+    public void transformJson(HistoryJobEntity job, ObjectNode historicalData, CommandContext commandContext) {
+        CommentEntityManager commentEntityManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getCommentEntityManager();
+
+        CommentEntity commentEntity = new CommentEntityImpl();
+        commentEntity.setId(getStringFromJson(historicalData, HistoryJsonConstants.ID));
+        commentEntity.setProcessInstanceId(getStringFromJson(historicalData, HistoryJsonConstants.TYPE));
+        commentEntity.setTime(getDateFromJson(historicalData, HistoryJsonConstants.TIME));
+        commentEntity.setUserId(getStringFromJson(historicalData, HistoryJsonConstants.USER_ID));
+        commentEntity.setTaskId(getStringFromJson(historicalData, HistoryJsonConstants.TASK_ID));
+        commentEntity.setProcessInstanceId(getStringFromJson(historicalData, HistoryJsonConstants.PROCESS_INSTANCE_ID));
+        commentEntity.setAction(getStringFromJson(historicalData, HistoryJsonConstants.ACTION));
+        commentEntity.setMessage(getStringFromJson(historicalData, HistoryJsonConstants.MESSAGE));
+        commentEntity.setFullMessage(getStringFromJson(historicalData, HistoryJsonConstants.FULL_MESSAGE));
+
+        commentEntityManager.insert(commentEntity);
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/CommentDeletedHistoryJsonTransformer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/CommentDeletedHistoryJsonTransformer.java
@@ -1,0 +1,47 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.history.async.json.transformer;
+
+import static org.flowable.job.service.impl.history.async.util.AsyncHistoryJsonUtil.getStringFromJson;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.engine.impl.history.async.HistoryJsonConstants;
+import org.flowable.engine.impl.persistence.entity.CommentEntityManager;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.job.service.impl.persistence.entity.HistoryJobEntity;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class CommentDeletedHistoryJsonTransformer extends AbstractHistoryJsonTransformer {
+    @Override
+    public List<String> getTypes() {
+        return Collections.singletonList(HistoryJsonConstants.TYPE_COMMENT_DELETED);
+    }
+
+    @Override
+    public boolean isApplicable(ObjectNode historicalData, CommandContext commandContext) {
+        return true;
+    }
+
+    @Override
+    public void transformJson(HistoryJobEntity job, ObjectNode historicalData, CommandContext commandContext) {
+        CommentEntityManager commentEntityManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getCommentEntityManager();
+
+        String commentId = getStringFromJson(historicalData, HistoryJsonConstants.ID);
+
+        commentEntityManager.delete(commentId);
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/CommentUpdatedHistoryJsonTransformer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/async/json/transformer/CommentUpdatedHistoryJsonTransformer.java
@@ -1,0 +1,59 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.history.async.json.transformer;
+
+import static org.flowable.job.service.impl.history.async.util.AsyncHistoryJsonUtil.getDateFromJson;
+import static org.flowable.job.service.impl.history.async.util.AsyncHistoryJsonUtil.getStringFromJson;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.engine.impl.history.async.HistoryJsonConstants;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
+import org.flowable.engine.impl.persistence.entity.CommentEntityImpl;
+import org.flowable.engine.impl.persistence.entity.CommentEntityManager;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.job.service.impl.persistence.entity.HistoryJobEntity;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class CommentUpdatedHistoryJsonTransformer extends AbstractHistoryJsonTransformer {
+    @Override
+    public List<String> getTypes() {
+        return Collections.singletonList(HistoryJsonConstants.TYPE_COMMENT_UPDATED);
+    }
+
+    @Override
+    public boolean isApplicable(ObjectNode historicalData, CommandContext commandContext) {
+        return true;
+    }
+
+    @Override
+    public void transformJson(HistoryJobEntity job, ObjectNode historicalData, CommandContext commandContext) {
+        CommentEntityManager commentEntityManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getCommentEntityManager();
+
+        CommentEntity commentEntity = new CommentEntityImpl();
+        commentEntity.setId(getStringFromJson(historicalData, HistoryJsonConstants.ID));
+        commentEntity.setProcessInstanceId(getStringFromJson(historicalData, HistoryJsonConstants.TYPE));
+        commentEntity.setTime(getDateFromJson(historicalData, HistoryJsonConstants.TIME));
+        commentEntity.setUserId(getStringFromJson(historicalData, HistoryJsonConstants.USER_ID));
+        commentEntity.setTaskId(getStringFromJson(historicalData, HistoryJsonConstants.TASK_ID));
+        commentEntity.setProcessInstanceId(getStringFromJson(historicalData, HistoryJsonConstants.PROCESS_INSTANCE_ID));
+        commentEntity.setAction(getStringFromJson(historicalData, HistoryJsonConstants.ACTION));
+        commentEntity.setMessage(getStringFromJson(historicalData, HistoryJsonConstants.MESSAGE));
+        commentEntity.setFullMessage(getStringFromJson(historicalData, HistoryJsonConstants.FULL_MESSAGE));
+
+        commentEntityManager.update(commentEntity);
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/CompositeHistoryManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/CompositeHistoryManagerTest.java
@@ -38,6 +38,8 @@ import org.flowable.engine.impl.persistence.entity.HistoricActivityInstanceEntit
 import org.flowable.engine.impl.persistence.entity.HistoricActivityInstanceEntityImpl;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.flowable.engine.impl.persistence.entity.ProcessDefinitionEntityImpl;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
+import org.flowable.engine.impl.persistence.entity.CommentEntityImpl;
 import org.flowable.engine.runtime.ActivityInstance;
 import org.flowable.entitylink.service.impl.persistence.entity.EntityLinkEntity;
 import org.flowable.entitylink.service.impl.persistence.entity.EntityLinkEntityImpl;
@@ -489,5 +491,31 @@ class CompositeHistoryManagerTest {
 
         verify(historyManager1).deleteHistoryUserTaskLog(10L);
         verify(historyManager2).deleteHistoryUserTaskLog(10L);
+    }
+
+    @Test
+    void createComment() {
+        CommentEntity commentEntity = new CommentEntityImpl();
+        compositeHistoryManager.createComment(commentEntity);
+
+        verify(historyManager1).createComment(commentEntity);
+        verify(historyManager2).createComment(commentEntity);
+    }
+
+    @Test
+    void updateComment() {
+        CommentEntity commentEntity = new CommentEntityImpl();
+        compositeHistoryManager.updateComment(commentEntity);
+
+        verify(historyManager1).updateComment(commentEntity);
+        verify(historyManager2).updateComment(commentEntity);
+    }
+
+    @Test
+    void deleteComment() {
+        compositeHistoryManager.deleteComment("comment-id");
+
+        verify(historyManager1).deleteComment("comment-id");
+        verify(historyManager2).deleteComment("comment-id");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/async/AsyncHistoryManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/async/AsyncHistoryManagerTest.java
@@ -1,0 +1,106 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.test.history.async;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.doReturn;
+
+import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.flowable.engine.impl.history.async.AsyncHistoryManager;
+import org.flowable.engine.impl.history.async.HistoryJsonConstants;
+import org.flowable.engine.impl.persistence.entity.CommentEntity;
+import org.flowable.engine.impl.persistence.entity.CommentEntityImpl;
+import org.flowable.engine.test.impl.CustomConfigurationFlowableTestCase;
+import org.flowable.job.service.impl.history.async.AsyncHistorySession;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+class AsyncHistoryManagerTest extends CustomConfigurationFlowableTestCase {
+
+    private AsyncHistoryManager spiedAsyncHistoryManager;
+    private AsyncHistorySession mockedAsyncHistorySession;
+    private ArgumentCaptor<ObjectNode> dataCaptor = ArgumentCaptor.forClass(ObjectNode.class);
+
+    public AsyncHistoryManagerTest() {
+        super(AsyncHistoryManagerTest.class.getName());
+    }
+
+    @Override
+    protected void configureConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {
+        spiedAsyncHistoryManager = new AsyncHistoryManager(processEngineConfiguration, HistoryLevel.ACTIVITY, false);
+        spiedAsyncHistoryManager = Mockito.spy(spiedAsyncHistoryManager);
+        processEngineConfiguration.setAsyncHistoryEnabled(true);
+        processEngineConfiguration.setAsyncHistoryExecutorActivate(true);
+        processEngineConfiguration.setHistoryManager(spiedAsyncHistoryManager);
+
+        mockedAsyncHistorySession = Mockito.mock(AsyncHistorySession.class);
+        doReturn(mockedAsyncHistorySession).when(spiedAsyncHistoryManager).getAsyncHistorySession();
+    }
+
+    @Test
+    void createComment() {
+        CommentEntity commentEntity = getCommentInstance(null);
+
+        spiedAsyncHistoryManager.createComment(commentEntity);
+
+        verify(mockedAsyncHistorySession, times(1))
+                .addHistoricData(any(), eq(HistoryJsonConstants.TYPE_COMMENT_CREATED), dataCaptor.capture());
+
+        checkResult(dataCaptor.getValue(), commentEntity);
+    }
+
+    @Test
+    void updateComment() {
+        CommentEntity commentEntity = getCommentInstance("id");
+
+        spiedAsyncHistoryManager.updateComment(commentEntity);
+
+        verify(mockedAsyncHistorySession, times(1))
+                .addHistoricData(any(), eq(HistoryJsonConstants.TYPE_COMMENT_UPDATED), dataCaptor.capture());
+
+        checkResult(dataCaptor.getValue(), commentEntity);
+    }
+
+    private CommentEntity getCommentInstance(String id) {
+        CommentEntity commentEntity = new CommentEntityImpl();
+        commentEntity.setId(id);
+        commentEntity.setProcessInstanceId("processInstanceId");
+        commentEntity.setTaskId("taskId");
+        commentEntity.setType("type");
+        commentEntity.setAction("action");
+        commentEntity.setUserId("userId");
+        commentEntity.setMessage("message");
+        commentEntity.setFullMessage("fullMessage");
+        return commentEntity;
+
+    }
+    private void checkResult(ObjectNode result, CommentEntity expected) {
+        if(expected.getId() != null) {
+            assertEquals(result.get(HistoryJsonConstants.ID).textValue(), expected.getId());
+        }
+        assertEquals(result.get(HistoryJsonConstants.PROCESS_INSTANCE_ID).textValue(), expected.getProcessInstanceId());
+        assertEquals(result.get(HistoryJsonConstants.TASK_ID).textValue(), expected.getTaskId());
+        assertEquals(result.get(HistoryJsonConstants.TYPE).textValue(), expected.getType());
+        assertEquals(result.get(HistoryJsonConstants.ACTION).textValue(), expected.getAction());
+        assertEquals(result.get(HistoryJsonConstants.USER_ID).textValue(), expected.getUserId());
+        assertEquals(result.get(HistoryJsonConstants.MESSAGE).textValue(), expected.getMessage());
+        assertEquals(result.get(HistoryJsonConstants.FULL_MESSAGE).textValue(), expected.getFullMessage());
+    }
+}


### PR DESCRIPTION
With this pull request, my intention is to make comments available in the history manager. It is not currently possible to integrate comments with an external resource when we have a composite history manager.
My use case makes use of the synchronous history manager, however I also implemented it for asynchronous history,

#### Check List:
* Unit tests: YES
* Documentation: NA
