### PR TITLE
Use assertj fluent style in flowable-cmmn-converter module.

### DIFF
--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseCustomExtensionElementXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseCustomExtensionElementXmlConverterTest.java
@@ -50,8 +50,6 @@ public class CaseCustomExtensionElementXmlConverterTest extends AbstractConverte
         assertThat(primaryCase.getExtensionElements()).containsOnlyKeys("customElement");
 
         List<ExtensionElement> customElements = primaryCase.getExtensionElements().get("customElement");
-        assertThat(customElements).hasSize(1);
-
         assertThat(customElements)
                 .extracting(ExtensionElement::getElementText, ExtensionElement::getNamespacePrefix, ExtensionElement::getNamespace)
                 .containsExactly(tuple("Element text", "flowable", "http://flowable.org/cmmn"));

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CasePageTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CasePageTaskCmmnXmlConverterTest.java
@@ -67,41 +67,43 @@ public class CasePageTaskCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(planItems).hasSize(2);
 
         PlanItem planItemTaskA = cmmnModel.findPlanItem("planItemTaskA");
-        PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
         assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
-        assertThat(planItemDefinition).isInstanceOf(CasePageTask.class);
-
-        CasePageTask taskA = (CasePageTask) planItemDefinition;
-        assertThat(taskA.getType()).isEqualTo(CasePageTask.TYPE);
-        assertThat(taskA.getName()).isEqualTo("A");
-        assertThat(taskA.getFormKey()).isEqualTo("testKey");
-        assertThat(taskA.getLabel()).isEqualTo("Label 1");
-        assertThat(taskA.getIcon()).isEqualTo("Icon 1");
-        assertThat(taskA.getAssignee()).isEqualTo("johndoe");
-        assertThat(taskA.getOwner()).isEqualTo("janedoe");
-        assertThat(taskA.getCandidateUsers()).containsExactly("johndoe", "janedoe");
-        assertThat(taskA.getCandidateGroups()).containsExactly("sales", "management");
         assertThat(planItemTaskA.getItemControl()).isNotNull();
         assertThat(planItemTaskA.getItemControl().getParentCompletionRule()).isNotNull();
         assertThat(planItemTaskA.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE);
 
+        PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(CasePageTask.class, taskA -> {
+                    assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
+                    assertThat(taskA.getType()).isEqualTo(CasePageTask.TYPE);
+                    assertThat(taskA.getName()).isEqualTo("A");
+                    assertThat(taskA.getFormKey()).isEqualTo("testKey");
+                    assertThat(taskA.getLabel()).isEqualTo("Label 1");
+                    assertThat(taskA.getIcon()).isEqualTo("Icon 1");
+                    assertThat(taskA.getAssignee()).isEqualTo("johndoe");
+                    assertThat(taskA.getOwner()).isEqualTo("janedoe");
+                    assertThat(taskA.getCandidateUsers()).containsExactly("johndoe", "janedoe");
+                    assertThat(taskA.getCandidateGroups()).containsExactly("sales", "management");
+                });
+
         PlanItem planItemTaskB = cmmnModel.findPlanItem("planItemTaskB");
         planItemDefinition = planItemTaskB.getPlanItemDefinition();
         assertThat(planItemTaskB.getEntryCriteria()).hasSize(1);
-        assertThat(planItemDefinition).isInstanceOf(CasePageTask.class);
-        CasePageTask taskB = (CasePageTask) planItemDefinition;
-        assertThat(taskB.getType()).isEqualTo(CasePageTask.TYPE);
-        assertThat(taskB.getName()).isEqualTo("B");
         assertThat(planItemTaskB.getItemControl()).isNotNull();
         assertThat(planItemTaskB.getItemControl().getParentCompletionRule()).isNotNull();
         assertThat(planItemTaskB.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE);
-
-        assertThat(taskB.getExtensionElements()).hasSize(1);
-        List<ExtensionElement> extensionElements = taskB.getExtensionElements().get("index");
-        assertThat(extensionElements).hasSize(1);
-        assertThat(extensionElements)
-                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-                .containsExactly(tuple("index", "0"));
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(CasePageTask.class, taskB -> {
+                    assertThat(taskB.getType()).isEqualTo(CasePageTask.TYPE);
+                    assertThat(taskB.getName()).isEqualTo("B");
+                    assertThat(taskB.getExtensionElements()).hasSize(1);
+                    List<ExtensionElement> extensionElements = taskB.getExtensionElements().get("index");
+                    assertThat(extensionElements).hasSize(1);
+                    assertThat(extensionElements)
+                            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                            .containsExactly(tuple("index", "0"));
+                });
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseTaskCmmnXmlConverterTest.java
@@ -60,16 +60,17 @@ public class CaseTaskCmmnXmlConverterTest extends AbstractConverterTest {
 
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem1");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
-        assertThat(planItemDefinition).isInstanceOf(CaseTask.class);
-        CaseTask task1 = (CaseTask) planItemDefinition;
-        assertThat(task1.getCaseRefExpression()).isEqualTo("caseDefinitionKey");
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(CaseTask.class, task1 -> {
+                    assertThat(task1.getCaseRefExpression()).isEqualTo("caseDefinitionKey");
+                    assertThat(task1.getFallbackToDefaultTenant()).isTrue();
+                    assertThat(task1.isSameDeployment()).isTrue();
 
-        assertThat(task1.getFallbackToDefaultTenant()).isTrue();
-        assertThat(task1.isSameDeployment()).isTrue();
+                    assertThat(task1.getInParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget)
+                            .containsExactly(tuple("testSource", "testTarget"));
 
-        assertThat(task1.getInParameters())
-                .extracting(IOParameter::getSource, IOParameter::getTarget)
-                .containsExactly(tuple("testSource", "testTarget"));
+                });
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/HumanTaskSameDeploymentCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/HumanTaskSameDeploymentCmmnXmlConverterTest.java
@@ -48,8 +48,8 @@ public class HumanTaskSameDeploymentCmmnXmlConverterTest extends AbstractConvert
                 .isInstanceOfSatisfying(HumanTask.class, task -> {
                     assertThat(task.getFormKey()).isEqualTo("taskForm");
                     assertThat(task.isSameDeployment()).isTrue();
+                    assertThat(task.getAttributes()).isEmpty();
                 });
-        assertThat(itemDefinition.getAttributes()).isEmpty();
 
         itemDefinition = cmmnModel.findPlanItemDefinition("humanTaskSameDeploymentFalse");
 
@@ -57,8 +57,8 @@ public class HumanTaskSameDeploymentCmmnXmlConverterTest extends AbstractConvert
                 .isInstanceOfSatisfying(HumanTask.class, task -> {
                     assertThat(task.getFormKey()).isEqualTo("taskForm2");
                     assertThat(task.isSameDeployment()).isFalse();
+                    assertThat(task.getAttributes()).isEmpty();
                 });
-        assertThat(itemDefinition.getAttributes()).isEmpty();
 
         itemDefinition = cmmnModel.findPlanItemDefinition("humanTaskSameDeploymentGlobal");
 
@@ -66,8 +66,8 @@ public class HumanTaskSameDeploymentCmmnXmlConverterTest extends AbstractConvert
                 .isInstanceOfSatisfying(HumanTask.class, task -> {
                     assertThat(task.getFormKey()).isEqualTo("taskForm3");
                     assertThat(task.isSameDeployment()).isTrue();
+                    assertThat(task.getAttributes()).isEmpty();
                 });
-        assertThat(itemDefinition.getAttributes()).isEmpty();
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/JavaTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/JavaTaskCmmnXmlConverterTest.java
@@ -74,51 +74,55 @@ public class JavaTaskCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(planItems).hasSize(3);
 
         PlanItem planItemTaskA = cmmnModel.findPlanItem("planItemTaskA");
-        PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
         assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
-        assertThat(planItemDefinition).isInstanceOf(ServiceTask.class);
-        ServiceTask taskA = (ServiceTask) planItemDefinition;
-        assertThat(taskA.getType()).isEqualTo(ServiceTask.JAVA_TASK);
-        assertThat(taskA.getImplementationType()).isEqualTo(ImplementationType.IMPLEMENTATION_TYPE_CLASS);
-        assertThat(taskA.getImplementation()).isEqualTo("org.flowable.TestJavaDelegate");
-        assertThat(taskA.getResultVariableName()).isEqualTo("result");
-        assertThat(taskA.isAsync()).isFalse();
-        assertThat(taskA.isExclusive()).isFalse();
-        assertThat(taskA.isStoreResultVariableAsTransient()).isFalse();
+        PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ServiceTask.class, taskA -> {
+                    assertThat(taskA.getType()).isEqualTo(ServiceTask.JAVA_TASK);
+                    assertThat(taskA.getImplementationType()).isEqualTo(ImplementationType.IMPLEMENTATION_TYPE_CLASS);
+                    assertThat(taskA.getImplementation()).isEqualTo("org.flowable.TestJavaDelegate");
+                    assertThat(taskA.getResultVariableName()).isEqualTo("result");
+                    assertThat(taskA.isAsync()).isFalse();
+                    assertThat(taskA.isExclusive()).isFalse();
+                    assertThat(taskA.isStoreResultVariableAsTransient()).isFalse();
+                });
 
         PlanItem planItemTaskB = cmmnModel.findPlanItem("planItemTaskB");
-        planItemDefinition = planItemTaskB.getPlanItemDefinition();
         assertThat(planItemTaskB.getEntryCriteria()).hasSize(1);
-        assertThat(planItemDefinition).isInstanceOf(ServiceTask.class);
-        ServiceTask taskB = (ServiceTask) planItemDefinition;
-        assertThat(taskB.getType()).isEqualTo(ServiceTask.JAVA_TASK);
-        assertThat(taskB.getImplementationType()).isEqualTo(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION);
-        assertThat(taskB.getImplementation()).isEqualTo("${testJavaDelegate}");
-        assertThat(taskB.getResultVariableName()).isNull();
-        assertThat(taskB.isAsync()).isTrue();
-        assertThat(taskB.isExclusive()).isTrue();
-        assertThat(taskB.isStoreResultVariableAsTransient()).isFalse();
+        planItemDefinition = planItemTaskB.getPlanItemDefinition();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ServiceTask.class, taskB -> {
+                    assertThat(taskB.getType()).isEqualTo(ServiceTask.JAVA_TASK);
+                    assertThat(taskB.getImplementationType()).isEqualTo(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION);
+                    assertThat(taskB.getImplementation()).isEqualTo("${testJavaDelegate}");
+                    assertThat(taskB.getResultVariableName()).isNull();
+                    assertThat(taskB.isAsync()).isTrue();
+                    assertThat(taskB.isExclusive()).isTrue();
+                    assertThat(taskB.isStoreResultVariableAsTransient()).isFalse();
 
-        assertThat(taskB.getFieldExtensions())
-                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue, FieldExtension::getExpression)
-                .containsExactly(tuple("fieldA", "test", null), tuple("fieldB", null, "test"), tuple("fieldC", "test", null), tuple("fieldD", null, "test"));
+                    assertThat(taskB.getFieldExtensions())
+                            .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue, FieldExtension::getExpression)
+                            .containsExactly(tuple("fieldA", "test", null), tuple("fieldB", null, "test"), tuple("fieldC", "test", null),
+                                    tuple("fieldD", null, "test"));
 
-        assertThat(taskB.getExtensionElements()).hasSize(1);
-        List<ExtensionElement> extensionElements = taskB.getExtensionElements().get("taskTest");
-        assertThat(extensionElements)
-                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
-                .containsExactly(tuple("taskTest", "hello"));
+                    assertThat(taskB.getExtensionElements()).hasSize(1);
+                    List<ExtensionElement> extensionElements = taskB.getExtensionElements().get("taskTest");
+                    assertThat(extensionElements)
+                            .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                            .containsExactly(tuple("taskTest", "hello"));
+                });
 
         PlanItem planItemTaskC = cmmnModel.findPlanItem("planItemTaskC");
-        planItemDefinition = planItemTaskC.getPlanItemDefinition();
         assertThat(planItemTaskC.getEntryCriteria()).isEmpty();
-        assertThat(planItemDefinition).isInstanceOf(ServiceTask.class);
-        ServiceTask taskC = (ServiceTask) planItemDefinition;
-        assertThat(taskC.getType()).isEqualTo(ServiceTask.JAVA_TASK);
-        assertThat(taskC.getImplementationType()).isEqualTo(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION);
-        assertThat(taskC.getImplementation()).isEqualTo("${'test'}");
-        assertThat(taskC.getResultVariableName()).isEqualTo("transientResult");
-        assertThat(taskC.isStoreResultVariableAsTransient()).isTrue();
+        planItemDefinition = planItemTaskC.getPlanItemDefinition();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ServiceTask.class, taskC -> {
+                    assertThat(taskC.getType()).isEqualTo(ServiceTask.JAVA_TASK);
+                    assertThat(taskC.getImplementationType()).isEqualTo(ImplementationType.IMPLEMENTATION_TYPE_EXPRESSION);
+                    assertThat(taskC.getImplementation()).isEqualTo("${'test'}");
+                    assertThat(taskC.getResultVariableName()).isEqualTo("transientResult");
+                    assertThat(taskC.isStoreResultVariableAsTransient()).isTrue();
+                });
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTask2CmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTask2CmmnXmlConverterTest.java
@@ -59,24 +59,26 @@ public class ProcessTask2CmmnXmlConverterTest extends AbstractConverterTest {
 
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem2");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
-        assertThat(planItemDefinition).isInstanceOf(ProcessTask.class);
-        ProcessTask task1 = (ProcessTask) planItemDefinition;
-        assertThat(task1.getProcessRefExpression()).isEqualTo("myTestProcess");
-        assertThat((task1.isSameDeployment())).isTrue();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ProcessTask.class, task1 -> {
+                    assertThat(task1.getProcessRefExpression()).isEqualTo("myTestProcess");
+                    assertThat((task1.isSameDeployment())).isTrue();
 
-        assertThat(task1.getInParameters()).isEmpty();
-        assertThat(task1.getOutParameters()).isEmpty();
+                    assertThat(task1.getInParameters()).isEmpty();
+                    assertThat(task1.getOutParameters()).isEmpty();
+                });
         PlanItemDefinition taskDefinition = cmmnModel.findPlanItemDefinition("onehumantask1");
-        assertThat(taskDefinition).isInstanceOf(HumanTask.class);
-        HumanTask humanTask = (HumanTask) taskDefinition;
-        assertThat(humanTask.getName()).isEqualTo("Human task");
-        assertThat(humanTask.getAssignee()).isEqualTo("admin");
-        assertThat(humanTask.getOwner()).isEqualTo("admin");
-        assertThat(humanTask.getFormKey()).isEqualTo("aHumanTaskForm");
-        assertThat(humanTask.getPriority()).isEqualTo("50");
-        assertThat(humanTask.getDueDate()).isEqualTo("2019-01-01");
-        assertThat(humanTask.getCategory()).isEqualTo("testCategory");
-        assertThat(humanTask.getValidateFormFields()).isEqualTo("validateFormFieldsValue");
+        assertThat(taskDefinition)
+                .isInstanceOfSatisfying(HumanTask.class, humanTask -> {
+                    assertThat(humanTask.getName()).isEqualTo("Human task");
+                    assertThat(humanTask.getAssignee()).isEqualTo("admin");
+                    assertThat(humanTask.getOwner()).isEqualTo("admin");
+                    assertThat(humanTask.getFormKey()).isEqualTo("aHumanTaskForm");
+                    assertThat(humanTask.getPriority()).isEqualTo("50");
+                    assertThat(humanTask.getDueDate()).isEqualTo("2019-01-01");
+                    assertThat(humanTask.getCategory()).isEqualTo("testCategory");
+                    assertThat(humanTask.getValidateFormFields()).isEqualTo("validateFormFieldsValue");
+                });
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
@@ -13,7 +13,6 @@
 package org.flowable.test.cmmn.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Map;
@@ -76,13 +75,9 @@ public class RepetitionRuleExtendedAttributesConverterTest extends AbstractConve
             .filter(caseElement -> caseElement instanceof PlanItem && planItemName.equals(caseElement.getName()))
             .collect(Collectors.toList());
 
-        if (planItems.size() == 0) {
-            fail("No plan item found with name " + planItemName);
-        }
+        assertThat(planItems).as("No plan item found with name " + planItemName).isNotEmpty();
 
-        if (planItems.size() > 1) {
-            fail("More than one plan item found with name " + planItemName + ", make sure it is unique for testing purposes");
-        }
+        assertThat(planItems).as("More than one plan item found with name " + planItemName + ", make sure it is unique for testing purposes").hasSize(1);
 
         RepetitionRule repetitionRule = ((PlanItem) planItems.get(0)).getItemControl().getRepetitionRule();
         assertThat(repetitionRule).as("no repetition rule found for plan item with name '" + planItemName + "'").isNotNull();

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ScriptServiceTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ScriptServiceTaskCmmnXmlConverterTest.java
@@ -71,29 +71,31 @@ public class ScriptServiceTaskCmmnXmlConverterTest extends AbstractConverterTest
         assertThat(planItems).hasSize(2);
 
         PlanItem planItemTaskA = cmmnModel.findPlanItem("planItemTaskA");
-        PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
-
         assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
-        assertThat(planItemDefinition).isInstanceOf(ScriptServiceTask.class);
-        ScriptServiceTask scriptTask = (ScriptServiceTask) planItemDefinition;
-        assertThat(scriptTask.getType()).isEqualTo(ScriptServiceTask.SCRIPT_TASK);
-        assertThat(scriptTask.getScriptFormat()).isEqualTo("javascript");
-        assertThat(scriptTask.getResultVariableName()).isEqualTo("scriptResult");
-        assertThat(scriptTask.isAutoStoreVariables()).isFalse();
-        assertThat(scriptTask.isBlocking()).isTrue();
-        assertThat(scriptTask.isAsync()).isFalse();
 
-        assertThat(scriptTask.getFieldExtensions())
-                .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
-                .containsExactly(tuple("script", "var a = 5;"));
+        PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ScriptServiceTask.class, scriptTask -> {
+                    assertThat(scriptTask.getType()).isEqualTo(ScriptServiceTask.SCRIPT_TASK);
+                    assertThat(scriptTask.getScriptFormat()).isEqualTo("javascript");
+                    assertThat(scriptTask.getResultVariableName()).isEqualTo("scriptResult");
+                    assertThat(scriptTask.isAutoStoreVariables()).isFalse();
+                    assertThat(scriptTask.isBlocking()).isTrue();
+                    assertThat(scriptTask.isAsync()).isFalse();
+
+                    assertThat(scriptTask.getFieldExtensions())
+                            .extracting(FieldExtension::getFieldName, FieldExtension::getStringValue)
+                            .containsExactly(tuple("script", "var a = 5;"));
+                });
 
         PlanItem planItemTaskB = cmmnModel.findPlanItem("planItemTaskB");
         planItemDefinition = planItemTaskB.getPlanItemDefinition();
-        assertThat(planItemDefinition).isInstanceOfSatisfying(ScriptServiceTask.class, scriptServiceTask -> {
-            assertThat(scriptServiceTask.getScriptFormat()).isEqualTo("groovy");
-            assertThat(scriptServiceTask.getScript()).isEqualTo("var b = 5;");
-            assertThat(scriptServiceTask.isAutoStoreVariables()).isTrue();
-        });
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ScriptServiceTask.class, scriptServiceTask -> {
+                    assertThat(scriptServiceTask.getScriptFormat()).isEqualTo("groovy");
+                    assertThat(scriptServiceTask.getScript()).isEqualTo("var b = 5;");
+                    assertThat(scriptServiceTask.isAutoStoreVariables()).isTrue();
+                });
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SendEventTaskXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SendEventTaskXmlConverterTest.java
@@ -38,13 +38,12 @@ public class SendEventTaskXmlConverterTest extends AbstractConverterTest {
         CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
         validateModel(parsedModel);
     }
-    
+
     public void validateModel(CmmnModel cmmnModel) {
         PlanItemDefinition planItemDefinition = cmmnModel.findPlanItemDefinition("sendEventTask1");
-        assertThat(planItemDefinition).isInstanceOf(SendEventServiceTask.class);
-
-        SendEventServiceTask sendEventServiceTask = (SendEventServiceTask) planItemDefinition;
-        assertThat(sendEventServiceTask.getEventType()).isEqualTo("testEvent");
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(SendEventServiceTask.class, sendEventServiceTask -> {
+                    assertThat(sendEventServiceTask.getEventType()).isEqualTo("testEvent");
+                });
     }
-
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/TaskBlockingExpressionCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/TaskBlockingExpressionCmmnXmlConverterTest.java
@@ -58,10 +58,11 @@ public class TaskBlockingExpressionCmmnXmlConverterTest extends AbstractConverte
 
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem1");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
-        assertThat(planItemDefinition).isInstanceOfSatisfying(Task.class, task -> {
-            assertThat(task.getBlockingExpression()).isEqualTo("${false}");
-            assertThat(task.isBlocking()).isTrue();
-        });
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(Task.class, task -> {
+                    assertThat(task.getBlockingExpression()).isEqualTo("${false}");
+                    assertThat(task.isBlocking()).isTrue();
+                });
     }
 
 }


### PR DESCRIPTION
Small improvements for more idiomatic assertj style.

