### PR TITLE
Support Task Queries by caseDefinitionKey

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnTaskQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnTaskQueryTest.java
@@ -14,6 +14,7 @@ package org.flowable.cmmn.test.task;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.flowable.cmmn.api.repository.CaseDefinition;
@@ -82,6 +83,34 @@ public class CmmnTaskQueryTest extends FlowableCmmnTestCase {
     }
 
     @Test
+    public void testQueryByCaseDefinitionKey() {
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
+        assertThat(caseDefinition).isNotNull();
+        assertThat(cmmnTaskService.createTaskQuery().caseDefinitionKey(caseDefinition.getKey()).list()).hasSize(NR_CASE_INSTANCES);
+    }
+
+    @Test
+    public void testQueryByCaseDefinitionKeyLike() {
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
+        assertThat(caseDefinition).isNotNull();
+        assertThat(cmmnTaskService.createTaskQuery().caseDefinitionKeyLike("oneTask%").list()).hasSize(NR_CASE_INSTANCES);
+    }
+
+    public void testQueryByCaseDefinitionKeyLikeIgnoreCase() {
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
+        assertThat(caseDefinition).isNotNull();
+        assertThat(cmmnTaskService.createTaskQuery().caseDefinitionKeyLikeIgnoreCase("onetask%").list()).hasSize(NR_CASE_INSTANCES);
+    }
+
+    @Test
+    public void testQueryByCaseDefinitionKeyIn() {
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
+        assertThat(caseDefinition).isNotNull();
+        assertThat(cmmnTaskService.createTaskQuery().caseDefinitionKeyIn(Arrays.asList(caseDefinition.getKey(),"dummyKey")).list())
+                .hasSize(NR_CASE_INSTANCES);
+    }
+
+    @Test
     public void testQueryByCmmnDeploymentId() {
         CmmnDeployment deployment = cmmnRepositoryService.createDeploymentQuery().singleResult();
         assertThat(deployment).isNotNull();
@@ -141,4 +170,31 @@ public class CmmnTaskQueryTest extends FlowableCmmnTestCase {
         }
     }
 
+    @Test
+    public void testHistoricTaskQueryByCaseDefinitionKey(){
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
+        assertThat(caseDefinition).isNotNull();
+        assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseDefinitionKey(caseDefinition.getKey()).list()).hasSize(NR_CASE_INSTANCES);
+    }
+
+    @Test
+    public void testHistoricTaskQueryByCaseDefinitionKeyLike() {
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
+        assertThat(caseDefinition).isNotNull();
+        assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseDefinitionKeyLike("oneTask%").list()).hasSize(NR_CASE_INSTANCES);
+    }
+
+    public void testHistoricTaskQueryByCaseDefinitionKeyLikeIgnoreCase() {
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
+        assertThat(caseDefinition).isNotNull();
+        assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseDefinitionKeyLikeIgnoreCase("onetask%").list()).hasSize(NR_CASE_INSTANCES);
+    }
+
+    @Test
+    public void testHistoricTaskQueryByCaseDefinitionKeyIn() {
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
+        assertThat(caseDefinition).isNotNull();
+        assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseDefinitionKeyIn(Arrays.asList(caseDefinition.getKey(),"dummyKey")).list())
+                .hasSize(NR_CASE_INSTANCES);
+    }
 }

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
@@ -217,7 +217,28 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
      * Only select tasks for the given case definition.
      */
     T caseDefinitionId(String caseDefinitionId);
-    
+
+    /**
+     * Only select tasks which are part of a case instance which has the given case definition key.
+     */
+    T caseDefinitionKey(String caseDefinitionKey);
+
+    /**
+     * Only select tasks which are part of a case instance which has a case definition key like the given value. The syntax that should be used is the same as in SQL, eg. %test%.
+     */
+    T caseDefinitionKeyLike(String caseDefinitionKeyLike);
+
+    /**
+     * Only select tasks which are part of a case instance which has a case definition key like the given value. The syntax that should be used is the same as in SQL, eg. %test%.
+     *
+     * This method, unlike the {@link #caseDefinitionKeyLike(String)} method will not take in account the upper/lower case: both the input parameter as the column value are lowercased when the
+     * query is executed.
+     */
+    T caseDefinitionKeyLikeIgnoreCase(String caseDefinitionKeyLikeIgnoreCase);
+
+    /** Only select tasks that have a case definition for which the key is present in the given list **/
+    T caseDefinitionKeyIn(Collection<String> caseDefinitionKeys);
+
     /**
      * Only select tasks for the given plan item instance. 
      */

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
@@ -43,7 +43,7 @@ import org.flowable.variable.service.impl.persistence.entity.HistoricVariableIns
  * @author Tom Baeyens
  * @author Joram Barrez
  */
-public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<HistoricTaskInstanceQuery, HistoricTaskInstance> 
+public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<HistoricTaskInstanceQuery, HistoricTaskInstance>
         implements HistoricTaskInstanceQuery, CacheAwareQuery<HistoricTaskInstanceEntity> {
 
     private static final long serialVersionUID = 1L;
@@ -74,6 +74,10 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     protected String propagatedStageInstanceId;
     protected String processInstanceIdWithChildren;
     protected String caseInstanceIdWithChildren;
+    protected String caseDefinitionKey;
+    protected String caseDefinitionKeyLike;
+    protected String caseDefinitionKeyLikeIgnoreCase;
+    protected Collection<String> caseDefinitionKeys;
     protected String taskId;
     protected String taskName;
     protected String taskNameLike;
@@ -325,6 +329,46 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
         } else {
             this.scopeDefinitionId(caseDefinitionId);
             this.scopeType(ScopeTypes.CMMN);
+        }
+        return this;
+    }
+
+    @Override
+    public HistoricTaskInstanceQueryImpl caseDefinitionKey(String caseDefinitionKey) {
+        if (inOrStatement) {
+            currentOrQueryObject.caseDefinitionKey = caseDefinitionKey;
+        } else {
+            this.caseDefinitionKey = caseDefinitionKey;
+        }
+        return this;
+    }
+
+    @Override
+    public HistoricTaskInstanceQueryImpl caseDefinitionKeyLike(String caseDefinitionKeyLike) {
+        if (inOrStatement) {
+            currentOrQueryObject.caseDefinitionKeyLike = caseDefinitionKeyLike;
+        } else {
+            this.caseDefinitionKeyLike = caseDefinitionKeyLike;
+        }
+        return this;
+    }
+
+    @Override
+    public HistoricTaskInstanceQueryImpl caseDefinitionKeyLikeIgnoreCase(String caseDefinitionKeyLikeIgnoreCase) {
+        if (inOrStatement) {
+            currentOrQueryObject.caseDefinitionKeyLikeIgnoreCase = caseDefinitionKeyLikeIgnoreCase;
+        } else {
+            this.caseDefinitionKeyLikeIgnoreCase = caseDefinitionKeyLikeIgnoreCase;
+        }
+        return this;
+    }
+
+    @Override
+    public HistoricTaskInstanceQueryImpl caseDefinitionKeyIn(Collection<String> caseDefinitionKeys) {
+        if (inOrStatement) {
+            currentOrQueryObject.caseDefinitionKeys = caseDefinitionKeys;
+        } else {
+            this.caseDefinitionKeys = caseDefinitionKeys;
         }
         return this;
     }
@@ -1994,7 +2038,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     public String getTaskId() {
         return taskId;
     }
-    
+
     @Override
     public String getId() {
         return taskId;

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
@@ -118,6 +118,10 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     protected String processInstanceBusinessKey;
     protected String processInstanceBusinessKeyLike;
     protected String processInstanceBusinessKeyLikeIgnoreCase;
+    protected String caseDefinitionKey;
+    protected String caseDefinitionKeyLike;
+    protected String caseDefinitionKeyLikeIgnoreCase;
+    protected Collection<String> caseDefinitionKeys;
     protected Date dueDate;
     protected Date dueBefore;
     protected Date dueAfter;
@@ -749,6 +753,46 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
         } else {
             this.scopeDefinitionId(caseDefinitionId);
             this.scopeType(ScopeTypes.CMMN);
+        }
+        return this;
+    }
+
+    @Override
+    public TaskQuery caseDefinitionKey(String caseDefinitionKey) {
+        if (orActive) {
+            currentOrQueryObject.caseDefinitionKey = caseDefinitionKey;
+        } else {
+            this.caseDefinitionKey = caseDefinitionKey;
+        }
+        return this;
+    }
+
+    @Override
+    public TaskQuery caseDefinitionKeyLike(String caseDefinitionKeyLike) {
+        if (orActive) {
+            currentOrQueryObject.caseDefinitionKeyLike = caseDefinitionKeyLike;
+        } else {
+            this.caseDefinitionKeyLike = caseDefinitionKeyLike;
+        }
+        return this;
+    }
+
+    @Override
+    public TaskQuery caseDefinitionKeyLikeIgnoreCase(String caseDefinitionKeyLikeIgnoreCase) {
+        if (orActive) {
+            currentOrQueryObject.caseDefinitionKeyLikeIgnoreCase = caseDefinitionKeyLikeIgnoreCase;
+        } else {
+            this.caseDefinitionKeyLikeIgnoreCase = caseDefinitionKeyLikeIgnoreCase;
+        }
+        return this;
+    }
+
+    @Override
+    public TaskQuery caseDefinitionKeyIn(Collection<String> caseDefinitionKeys) {
+        if (orActive) {
+            currentOrQueryObject.caseDefinitionKeys = caseDefinitionKeys;
+        } else {
+            this.caseDefinitionKeys = caseDefinitionKeys;
         }
         return this;
     }
@@ -1825,7 +1869,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     public String getTaskId() {
         return taskId;
     }
-    
+
     @Override
     public String getId() {
         return taskId;

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
@@ -580,6 +580,9 @@
     <if test="cmmnDeploymentId != null || (cmmnDeploymentIds != null &amp;&amp; cmmnDeploymentIds.size() &gt; 0)">
       left outer join ${prefix}ACT_CMMN_CASEDEF DEPLOY_C ON RES.SCOPE_DEFINITION_ID_ = DEPLOY_C.ID_
     </if>
+    <if test="caseDefinitionKey != null || caseDefinitionKeyLike != null ||  caseDefinitionKeyLikeIgnoreCase != null || (caseDefinitionKeys != null &amp;&amp; caseDefinitionKeys.size() &gt; 0)">
+      inner join ${prefix}ACT_CMMN_CASEDEF CD on RES.SCOPE_DEFINITION_ID_ = CD.ID_
+    </if>
     <foreach collection="queryVariableValues" index="index" item="var">
       <if test="!var.operator.equals('EXISTS') &amp;&amp; !var.operator.equals('NOT_EXISTS')">
           <choose>
@@ -604,6 +607,9 @@
       </if>
       <if test="orQueryObject.cmmnDeploymentId != null || (orQueryObject.cmmnDeploymentIds != null &amp;&amp; orQueryObject.cmmnDeploymentIds.size() &gt; 0)">
         left outer join ${prefix}ACT_CMMN_CASEDEF DEPLOY_C_OR${orIndex} ON RES.SCOPE_DEFINITION_ID_ = DEPLOY_C_OR${orIndex}.ID_
+      </if>
+      <if test="orQueryObject.caseDefinitionKey != null || orQueryObject.caseDefinitionKeyLike != null || orQueryObject.caseDefinitionKeyLikeIgnoreCase != null || (orQueryObject.caseDefinitionKeys != null &amp;&amp; orQueryObject.caseDefinitionKeys.size() &gt; 0)">
+        left outer join ${prefix}ACT_CMMN_CASEDEF CD_OR${orIndex} on RES.SCOPE_DEFINITION_ID_ = CD_OR${orIndex}.ID_
       </if>
       <if test="orQueryObject.queryVariableValues.size() &gt; 0">
         <if test="orQueryObject.hasValueComparisonQueryVariables()">
@@ -690,6 +696,21 @@
                 #{cmmnDeployment}
             </foreach>
         )
+      </if>
+      <if test="caseDefinitionKey != null">
+        and CD.KEY_ = #{caseDefinitionKey}
+      </if>
+      <if test="caseDefinitionKeyLike != null">
+        and CD.KEY_ like #{caseDefinitionKeyLike}${wildcardEscapeClause}
+      </if>
+      <if test="caseDefinitionKeyLikeIgnoreCase != null">
+        and lower(CD.KEY_) like #{caseDefinitionKeyLikeIgnoreCase}${wildcardEscapeClause}
+      </if>
+      <if test="caseDefinitionKeys != null &amp;&amp; caseDefinitionKeys.size() &gt; 0">
+        and CD.KEY_ in
+        <foreach item="item" index="index" collection="caseDefinitionKeys" open="(" separator="," close=")">
+          #{item}
+        </foreach>
       </if>
       <if test="processFinished">
         and HPI.END_TIME_ is not null
@@ -855,6 +876,21 @@
             <foreach item="deployment" index="index" collection="orQueryObject.cmmnDeploymentIds"
                      open="(" separator="," close=")">
               #{deployment}
+            </foreach>
+          </if>
+          <if test="orQueryObject.caseDefinitionKey != null">
+            or CD_OR${orIndex}.KEY_ = #{orQueryObject.caseDefinitionKey}
+          </if>
+          <if test="orQueryObject.caseDefinitionKeyLike != null">
+            or CD_OR${orIndex}.KEY_ like #{orQueryObject.caseDefinitionKeyLike}${wildcardEscapeClause}
+          </if>
+          <if test="orQueryObject.caseDefinitionKeyLikeIgnoreCase != null">
+            or lower(CD_OR${orIndex}.KEY_) like #{orQueryObject.caseDefinitionKeyLikeIgnoreCase}${wildcardEscapeClause}
+          </if>
+          <if test="orQueryObject.caseDefinitionKeys != null &amp;&amp; orQueryObject.caseDefinitionKeys.size() &gt; 0">
+            or CD_OR${orIndex}.KEY_ in
+            <foreach item="item" index="index" collection="orQueryObject.caseDefinitionKeys" open="(" separator="," close=")">
+              #{item}
             </foreach>
           </if>
           <if test="orQueryObject.processInstanceBusinessKey != null">

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -570,10 +570,16 @@
       <if test="orQueryObject.cmmnDeploymentId != null || (orQueryObject.cmmnDeploymentIds != null &amp;&amp; orQueryObject.cmmnDeploymentIds.size() &gt; 0)">
         left outer join ${prefix}ACT_CMMN_CASEDEF DEPLOY_C_OR${orIndex} ON RES.SCOPE_DEFINITION_ID_ = DEPLOY_C_OR${orIndex}.ID_
       </if>
+      <if test="orQueryObject.caseDefinitionKey != null || orQueryObject.caseDefinitionKeyLike != null || orQueryObject.caseDefinitionKeyLikeIgnoreCase != null || (orQueryObject.caseDefinitionKeys != null &amp;&amp; orQueryObject.caseDefinitionKeys.size() &gt; 0)">
+            left outer join ${prefix}ACT_CMMN_CASEDEF CD_OR${orIndex} on RES.SCOPE_DEFINITION_ID_ = CD_OR${orIndex}.ID_
+      </if>
     </foreach>
 
     <if test="processDefinitionKey != null || processDefinitionKeyLike != null ||  processDefinitionKeyLikeIgnoreCase != null || processDefinitionName != null || processDefinitionNameLike != null || (processCategoryInList != null &amp;&amp; processCategoryInList.size() &gt; 0) || (processCategoryNotInList != null &amp;&amp; processCategoryNotInList.size() &gt; 0) || (processDefinitionKeys != null &amp;&amp; processDefinitionKeys.size() &gt; 0)">
       inner join ${prefix}ACT_RE_PROCDEF D on RES.PROC_DEF_ID_ = D.ID_
+    </if>
+    <if test="caseDefinitionKey != null || caseDefinitionKeyLike != null ||  caseDefinitionKeyLikeIgnoreCase != null || (caseDefinitionKeys != null &amp;&amp; caseDefinitionKeys.size() &gt; 0)">
+          inner join ${prefix}ACT_CMMN_CASEDEF CD on RES.SCOPE_DEFINITION_ID_ = CD.ID_
     </if>
     <if test="processInstanceBusinessKey != null || processInstanceBusinessKeyLike != null  || processInstanceBusinessKeyLikeIgnoreCase != null">
       inner join ${prefix}ACT_RU_EXECUTION E on RES.PROC_INST_ID_ = E.ID_
@@ -770,6 +776,21 @@
         <foreach item="processCategory" index="index" collection="processCategoryNotInList"
                  open="(" separator="," close=")">
           #{processCategory}
+        </foreach>
+      </if>
+      <if test="caseDefinitionKey != null">
+        and CD.KEY_ = #{caseDefinitionKey}
+      </if>
+      <if test="caseDefinitionKeyLike != null">
+        and CD.KEY_ like #{caseDefinitionKeyLike}${wildcardEscapeClause}
+      </if>
+      <if test="caseDefinitionKeyLikeIgnoreCase != null">
+        and lower(CD.KEY_) like #{caseDefinitionKeyLikeIgnoreCase}${wildcardEscapeClause}
+      </if>
+      <if test="caseDefinitionKeys != null &amp;&amp; caseDefinitionKeys.size() &gt; 0">
+        and CD.KEY_ in
+        <foreach item="item" index="index" collection="caseDefinitionKeys" open="(" separator="," close=")">
+            #{item}
         </foreach>
       </if>
       <if test="deploymentId != null &amp;&amp; cmmnDeploymentId == null">
@@ -1210,6 +1231,21 @@
                        open="(" separator="," close=")">
                 #{processCategory}
               </foreach>
+            </if>
+            <if test="orQueryObject.caseDefinitionKey != null">
+                or CD_OR${orIndex}.KEY_ = #{orQueryObject.caseDefinitionKey}
+            </if>
+            <if test="orQueryObject.caseDefinitionKeyLike != null">
+                or CD_OR${orIndex}.KEY_ like #{orQueryObject.caseDefinitionKeyLike}${wildcardEscapeClause}
+            </if>
+            <if test="orQueryObject.caseDefinitionKeyLikeIgnoreCase != null">
+                or lower(CD_OR${orIndex}.KEY_) like #{orQueryObject.caseDefinitionKeyLikeIgnoreCase}${wildcardEscapeClause}
+            </if>
+            <if test="orQueryObject.caseDefinitionKeys != null &amp;&amp; orQueryObject.caseDefinitionKeys.size() &gt; 0">
+                or CD_OR${orIndex}.KEY_ in
+                <foreach item="item" index="index" collection="orQueryObject.caseDefinitionKeys" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
             </if>
             <if test="orQueryObject.deploymentId != null">
               or DEPLOY_P_OR${orIndex}.DEPLOYMENT_ID_ = #{orQueryObject.deploymentId}


### PR DESCRIPTION
Add support to filter Tasks by caseDefinitionKey for both: TaskQuery and HistoricTaskInstanceQuery
#### Check List:
* Unit tests: YES
* Documentation: NA
