### PR TITLE
Use assertj fluent style in flowable-content-rest module.

### DIFF
--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -190,6 +190,11 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>

--- a/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
@@ -12,12 +12,6 @@
  */
 package org.flowable.content.rest.service.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -59,12 +53,19 @@ import org.flowable.content.rest.ContentRestUrlBuilder;
 import org.flowable.content.rest.conf.ApplicationConfiguration;
 import org.flowable.content.rest.util.TestServerUtil;
 import org.flowable.content.rest.util.TestServerUtil.TestServer;
+import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 public abstract class BaseSpringContentRestTestCase extends AbstractContentTestCase {
 
@@ -353,5 +354,12 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
         contentItem.setLastModifiedBy(lastModifiedBy);
 
         return contentItem;
+    }
+
+    protected String getISODateStringWithTZ(Date date) {
+        if (date == null) {
+            return null;
+        }
+        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 }

--- a/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/content/ContentItemCollectionResourceTest.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/content/ContentItemCollectionResourceTest.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.content.rest.service.api.content;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -32,6 +33,9 @@ import org.flowable.content.rest.service.api.HttpMultipartHelper;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Tijs Rademakers
@@ -58,26 +62,30 @@ public class ContentItemCollectionResourceTest extends BaseSpringContentRestTest
 
             // Check if content item is created
             List<ContentItem> contentItems = contentService.createContentItemQuery().list();
-            assertEquals(1, contentItems.size());
+            assertThat(contentItems).hasSize(1);
 
             urlContentItem = contentItems.get(0);
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(urlContentItem.getId(), responseNode.get("id").asText());
-            assertEquals("Simple content item", responseNode.get("name").asText());
-            assertEquals("application/pdf", responseNode.get("mimeType").asText());
-            assertEquals("12345", responseNode.get("taskId").asText());
-            assertEquals("123456", responseNode.get("processInstanceId").asText());
-            assertEquals("id", responseNode.get("contentStoreId").asText());
-            assertEquals("testStore", responseNode.get("contentStoreName").asText());
-            assertFalse(responseNode.get("contentAvailable").asBoolean());
-            assertEquals("testa", responseNode.get("createdBy").asText());
-            assertEquals("testb", responseNode.get("lastModifiedBy").asText());
-            assertEquals(urlContentItem.getCreated(), getDateFromISOString(responseNode.get("created").asText()));
-            assertEquals(urlContentItem.getLastModified(), getDateFromISOString(responseNode.get("lastModified").asText()));
-            assertTrue(responseNode.get("url").textValue().endsWith(ContentRestUrls.createRelativeResourceUrl(
-                    ContentRestUrls.URL_CONTENT_ITEM, urlContentItem.getId())));
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "  id: '" + urlContentItem.getId() + "',"
+                            + "  name: 'Simple content item',"
+                            + "  mimeType: 'application/pdf',"
+                            + "  taskId: '12345',"
+                            + "  processInstanceId: '123456',"
+                            + "  contentStoreId: 'id',"
+                            + "  contentStoreName: 'testStore',"
+                            + "  contentAvailable: false,"
+                            + "  created: " + new TextNode(getISODateStringWithTZ(urlContentItem.getCreated())) + ","
+                            + "  createdBy: 'testa',"
+                            + "  lastModified: " + new TextNode(getISODateStringWithTZ(urlContentItem.getLastModified())) + ","
+                            + "  lastModifiedBy: 'testb',"
+                            + "  url: '" + SERVER_URL_PREFIX + ContentRestUrls.createRelativeResourceUrl(
+                            ContentRestUrls.URL_CONTENT_ITEM, urlContentItem.getId()) + "'"
+                            + "}");
 
         } finally {
             if (urlContentItem != null) {
@@ -107,7 +115,7 @@ public class ContentItemCollectionResourceTest extends BaseSpringContentRestTest
 
             // Check if content item is created
             List<ContentItem> contentItems = contentService.createContentItemQuery().list();
-            assertEquals(1, contentItems.size());
+            assertThat(contentItems).hasSize(1);
 
             urlContentItem = contentItems.get(0);
 
@@ -117,20 +125,24 @@ public class ContentItemCollectionResourceTest extends BaseSpringContentRestTest
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(urlContentItem.getId(), responseNode.get("id").asText());
-            assertEquals("Simple content item", responseNode.get("name").asText());
-            assertEquals("application/pdf", responseNode.get("mimeType").asText());
-            assertEquals("12345", responseNode.get("taskId").asText());
-            assertEquals("123456", responseNode.get("processInstanceId").asText());
-            assertEquals(urlContentItem.getContentStoreId(), responseNode.get("contentStoreId").asText());
-            assertEquals("file", responseNode.get("contentStoreName").asText());
-            assertTrue(responseNode.get("contentAvailable").asBoolean());
-            assertEquals("testa", responseNode.get("createdBy").asText());
-            assertEquals("testb", responseNode.get("lastModifiedBy").asText());
-            assertEquals(urlContentItem.getCreated(), getDateFromISOString(responseNode.get("created").asText()));
-            assertEquals(urlContentItem.getLastModified(), getDateFromISOString(responseNode.get("lastModified").asText()));
-            assertTrue(responseNode.get("url").textValue().endsWith(ContentRestUrls.createRelativeResourceUrl(
-                    ContentRestUrls.URL_CONTENT_ITEM, urlContentItem.getId())));
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "  id: '" + urlContentItem.getId() + "',"
+                            + "  name: 'Simple content item',"
+                            + "  mimeType: 'application/pdf',"
+                            + "  taskId: '12345',"
+                            + "  processInstanceId: '123456',"
+                            + "  contentStoreId: '" + urlContentItem.getContentStoreId() + "',"
+                            + "  contentStoreName: 'file',"
+                            + "  contentAvailable: true,"
+                            + "  created: " + new TextNode(getISODateStringWithTZ(urlContentItem.getCreated())) + ","
+                            + "  createdBy: 'testa',"
+                            + "  lastModified: " + new TextNode(getISODateStringWithTZ(urlContentItem.getLastModified())) + ","
+                            + "  lastModifiedBy: 'testb',"
+                            + "  url: '" + SERVER_URL_PREFIX + ContentRestUrls.createRelativeResourceUrl(
+                            ContentRestUrls.URL_CONTENT_ITEM, urlContentItem.getId()) + "'"
+                            + "}");
 
         } finally {
             if (urlContentItem != null) {

--- a/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/content/ContentItemResourceTest.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/content/ContentItemResourceTest.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.content.rest.service.api.content;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -31,6 +32,9 @@ import org.flowable.content.rest.service.api.HttpMultipartHelper;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Tijs Rademakers
@@ -50,19 +54,21 @@ public class ContentItemResourceTest extends BaseSpringContentRestTestCase {
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
 
-            assertEquals(contentItem.getId(), responseNode.get("id").asText());
-            assertEquals(contentItem.getName(), responseNode.get("name").asText());
-            assertEquals(contentItem.getMimeType(), responseNode.get("mimeType").asText());
-            assertTrue(responseNode.get("taskId").isNull());
-            assertEquals(contentItem.getProcessInstanceId(), responseNode.get("processInstanceId").asText());
-            assertEquals("", responseNode.get("tenantId").asText());
-            assertEquals(contentItem.getCreatedBy(), responseNode.get("createdBy").asText());
-            assertEquals(contentItem.getLastModifiedBy(), responseNode.get("lastModifiedBy").asText());
-            assertEquals(contentItem.getCreated(), getDateFromISOString(responseNode.get("created").asText()));
-            assertEquals(contentItem.getLastModified(), getDateFromISOString(responseNode.get("lastModified").asText()));
-
-            // Check URL's
-            assertEquals(httpGet.getURI().toString(), responseNode.get("url").asText());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "  id: '" + contentItem.getId() + "',"
+                            + "  name: '" + contentItem.getName() + "',"
+                            + "  mimeType: '" + contentItem.getMimeType() + "',"
+                            + "  taskId: null,"
+                            + "  tenantId: '',"
+                            + "  processInstanceId: '" + contentItem.getProcessInstanceId() + "',"
+                            + "  created: " + new TextNode(getISODateStringWithTZ(contentItem.getCreated())) + ","
+                            + "  createdBy: '" + contentItem.getCreatedBy() + "',"
+                            + "  lastModified: " + new TextNode(getISODateStringWithTZ(contentItem.getLastModified())) + ","
+                            + "  lastModifiedBy: '" + contentItem.getLastModifiedBy() + "',"
+                            + "  url: '" + httpGet.getURI().toString() + "'"
+                            + "}");
 
         } finally {
             contentService.deleteContentItem(contentItemId);
@@ -87,7 +93,7 @@ public class ContentItemResourceTest extends BaseSpringContentRestTestCase {
                     ContentRestUrls.URL_CONTENT_ITEM_DATA, contentItemId)), HttpStatus.SC_OK);
 
             // Check response headers
-            assertEquals("application/pdf", response.getEntity().getContentType().getValue());
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/pdf");
             try (InputStream contentStream = response.getEntity().getContent()) {
                 assertThat(contentStream).hasContent("This is binary content");
             }
@@ -118,16 +124,20 @@ public class ContentItemResourceTest extends BaseSpringContentRestTestCase {
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
 
-            assertEquals(contentItem.getId(), responseNode.get("id").asText());
-            assertEquals("test2.txt", responseNode.get("name").asText());
-            assertEquals("application/txt", responseNode.get("mimeType").asText());
-            assertTrue(responseNode.get("taskId").isNull());
-            assertEquals(contentItem.getProcessInstanceId(), responseNode.get("processInstanceId").asText());
-            assertEquals("", responseNode.get("tenantId").asText());
-            assertEquals("testb", responseNode.get("createdBy").asText());
-            assertEquals("testc", responseNode.get("lastModifiedBy").asText());
-            assertEquals(contentItem.getCreated(), getDateFromISOString(responseNode.get("created").asText()));
-            assertEquals(contentItem.getLastModified(), getDateFromISOString(responseNode.get("lastModified").asText()));
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "  id: '" + contentItem.getId() + "',"
+                            + "  name: 'test2.txt',"
+                            + "  mimeType: 'application/txt',"
+                            + "  taskId: null,"
+                            + "  tenantId: '',"
+                            + "  processInstanceId: '" + contentItem.getProcessInstanceId() + "',"
+                            + "  created: " + new TextNode(getISODateStringWithTZ(contentItem.getCreated())) + ","
+                            + "  createdBy: 'testb',"
+                            + "  lastModified: " + new TextNode(getISODateStringWithTZ(contentItem.getLastModified())) + ","
+                            + "  lastModifiedBy: 'testc'"
+                            + "}");
 
         } finally {
             contentService.deleteContentItem(contentItemId);
@@ -150,7 +160,7 @@ public class ContentItemResourceTest extends BaseSpringContentRestTestCase {
 
     protected void executePostAndAssert(String contentItemId) throws IOException {
         ContentItem origContentItem = contentService.createContentItemQuery().id(contentItemId).singleResult();
-        assertNotNull(origContentItem);
+        assertThat(origContentItem).isNotNull();
 
         try (InputStream binaryContent = new ByteArrayInputStream("This is binary content".getBytes())) {
 
@@ -165,14 +175,14 @@ public class ContentItemResourceTest extends BaseSpringContentRestTestCase {
                 ContentRestUrls.URL_CONTENT_ITEM_DATA, contentItemId)), HttpStatus.SC_OK);
 
             // Check response headers
-            assertEquals("application/pdf", response.getEntity().getContentType().getValue());
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/pdf");
             try (InputStream contentStream = response.getEntity().getContent()) {
                 assertThat(contentStream).hasContent("This is binary content");
             }
             closeResponse(response);
 
             ContentItem changedContentItem = contentService.createContentItemQuery().id(contentItemId).singleResult();
-            assertTrue(origContentItem.getLastModified().getTime() < changedContentItem.getLastModified().getTime());
+            assertThat(origContentItem.getLastModified().getTime() < changedContentItem.getLastModified().getTime()).isTrue();
 
         } finally {
             contentService.deleteContentItem(contentItemId);


### PR DESCRIPTION
Added `net.javacrumbs.json-unit` dependency so `assertThatJson` was available.

