### PR TITLE
Use assertj fluent style in flowable-dmn-engine module.

### DIFF
--- a/modules/flowable-dmn-engine/pom.xml
+++ b/modules/flowable-dmn-engine/pom.xml
@@ -124,6 +124,11 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>com.zaxxer</groupId>

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/impl/el/util/CollectionUtilTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/impl/el/util/CollectionUtilTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.dmn.engine.impl.el.util;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
@@ -25,79 +24,88 @@ public class CollectionUtilTest {
 
     @Test
     public void noneOf() {
-        assertTrue(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), Arrays.asList("group3", "group4")));
-        assertFalse(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), Arrays.asList("group1", "group2")));
-        assertFalse(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), Arrays.asList("group2", "group3")));
+        assertThat(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), Arrays.asList("group3", "group4"))).isTrue();
+        assertThat(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), Arrays.asList("group1", "group2"))).isFalse();
+        assertThat(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), Arrays.asList("group2", "group3"))).isFalse();
 
-        assertTrue(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), "group3"));
-        assertFalse(CollectionUtil.noneOf(Arrays.asList("group1", "group2"),"group2"));
+        assertThat(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), "group3")).isTrue();
+        assertThat(CollectionUtil.noneOf(Arrays.asList("group1", "group2"), "group2")).isFalse();
 
-        assertTrue(CollectionUtil.noneOf("group1, group2", "group3, group4"));
-        assertFalse(CollectionUtil.noneOf("group1, group2", "group1, group2"));
-        assertFalse(CollectionUtil.noneOf("group1, group2", "group2, group3"));
+        assertThat(CollectionUtil.noneOf("group1, group2", "group3, group4")).isTrue();
+        assertThat(CollectionUtil.noneOf("group1, group2", "group1, group2")).isFalse();
+        assertThat(CollectionUtil.noneOf("group1, group2", "group2, group3")).isFalse();
 
         ObjectMapper mapper = new ObjectMapper();
-        assertTrue(CollectionUtil.noneOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group3", "group4"))));
-        assertFalse(CollectionUtil.noneOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group1", "group2"))));
-        assertFalse(CollectionUtil.noneOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group2", "group3"))));
+        assertThat(CollectionUtil.noneOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group3", "group4"))))
+                .isTrue();
+        assertThat(CollectionUtil.noneOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group1", "group2"))))
+                .isFalse();
+        assertThat(CollectionUtil.noneOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group2", "group3"))))
+                .isFalse();
     }
 
 
     @Test
     public void anyOf() {
-        assertFalse(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), Arrays.asList("group3", "group4")));
-        assertTrue(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), Arrays.asList("group1", "group2")));
-        assertTrue(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), Arrays.asList("group2", "group3")));
+        assertThat(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), Arrays.asList("group3", "group4"))).isFalse();
+        assertThat(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), Arrays.asList("group1", "group2"))).isTrue();
+        assertThat(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), Arrays.asList("group2", "group3"))).isTrue();
 
-        assertFalse(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), "group3"));
-        assertTrue(CollectionUtil.anyOf(Arrays.asList("group1", "group2"),"group2"));
+        assertThat(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), "group3")).isFalse();
+        assertThat(CollectionUtil.anyOf(Arrays.asList("group1", "group2"), "group2")).isTrue();
 
-        assertFalse(CollectionUtil.anyOf("group1, group2", "group3, group4"));
-        assertTrue(CollectionUtil.anyOf("group1, group2", "group1, group2"));
-        assertTrue(CollectionUtil.anyOf("group1, group2", "group2, group3"));
+        assertThat(CollectionUtil.anyOf("group1, group2", "group3, group4")).isFalse();
+        assertThat(CollectionUtil.anyOf("group1, group2", "group1, group2")).isTrue();
+        assertThat(CollectionUtil.anyOf("group1, group2", "group2, group3")).isTrue();
 
         ObjectMapper mapper = new ObjectMapper();
-        assertFalse(CollectionUtil.anyOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group3", "group4"))));
-        assertTrue(CollectionUtil.anyOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group1", "group2"))));
-        assertTrue(CollectionUtil.anyOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group2", "group3"))));
+        assertThat(CollectionUtil.anyOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group3", "group4"))))
+                .isFalse();
+        assertThat(CollectionUtil.anyOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group1", "group2")))).isTrue();
+        assertThat(CollectionUtil.anyOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group2", "group3")))).isTrue();
     }
 
     @Test
     public void notAllOf() {
-        assertTrue(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), Arrays.asList("group3", "group4")));
-        assertFalse(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), Arrays.asList("group1", "group2")));
-        assertTrue(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), Arrays.asList("group2", "group3")));
+        assertThat(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), Arrays.asList("group3", "group4"))).isTrue();
+        assertThat(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), Arrays.asList("group1", "group2"))).isFalse();
+        assertThat(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), Arrays.asList("group2", "group3"))).isTrue();
 
-        assertTrue(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), "group3"));
-        assertFalse(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"),"group2"));
+        assertThat(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), "group3")).isTrue();
+        assertThat(CollectionUtil.notAllOf(Arrays.asList("group1", "group2"), "group2")).isFalse();
 
-        assertTrue(CollectionUtil.notAllOf("group1, group2", "group3, group4"));
-        assertFalse(CollectionUtil.notAllOf("group1, group2", "group1, group2"));
-        assertTrue(CollectionUtil.notAllOf("group1, group2", "group2, group3"));
+        assertThat(CollectionUtil.notAllOf("group1, group2", "group3, group4")).isTrue();
+        assertThat(CollectionUtil.notAllOf("group1, group2", "group1, group2")).isFalse();
+        assertThat(CollectionUtil.notAllOf("group1, group2", "group2, group3")).isTrue();
 
         ObjectMapper mapper = new ObjectMapper();
-        assertTrue(CollectionUtil.notAllOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group3", "group4"))));
-        assertFalse(CollectionUtil.notAllOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group1", "group2"))));
-        assertTrue(CollectionUtil.notAllOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group2", "group3"))));
+        assertThat(CollectionUtil.notAllOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group3", "group4"))))
+                .isTrue();
+        assertThat(CollectionUtil.notAllOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group1", "group2"))))
+                .isFalse();
+        assertThat(CollectionUtil.notAllOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group2", "group3"))))
+                .isTrue();
     }
 
     @Test
     public void allOf() {
-        assertFalse(CollectionUtil.allOf(Arrays.asList("group1", "group2"), Arrays.asList("group3", "group4")));
-        assertTrue(CollectionUtil.allOf(Arrays.asList("group1", "group2"), Arrays.asList("group1", "group2")));
-        assertFalse(CollectionUtil.allOf(Arrays.asList("group1", "group2"), Arrays.asList("group2", "group3")));
+        assertThat(CollectionUtil.allOf(Arrays.asList("group1", "group2"), Arrays.asList("group3", "group4"))).isFalse();
+        assertThat(CollectionUtil.allOf(Arrays.asList("group1", "group2"), Arrays.asList("group1", "group2"))).isTrue();
+        assertThat(CollectionUtil.allOf(Arrays.asList("group1", "group2"), Arrays.asList("group2", "group3"))).isFalse();
 
-        assertFalse(CollectionUtil.allOf(Arrays.asList("group1", "group2"), "group3"));
-        assertTrue(CollectionUtil.allOf(Arrays.asList("group1", "group2"),"group2"));
+        assertThat(CollectionUtil.allOf(Arrays.asList("group1", "group2"), "group3")).isFalse();
+        assertThat(CollectionUtil.allOf(Arrays.asList("group1", "group2"), "group2")).isTrue();
 
-        assertFalse(CollectionUtil.allOf("group1, group2", "group3, group4"));
-        assertTrue(CollectionUtil.allOf("group1, group2", "group1, group2"));
-        assertFalse(CollectionUtil.allOf("group1, group2", "group2, group3"));
+        assertThat(CollectionUtil.allOf("group1, group2", "group3, group4")).isFalse();
+        assertThat(CollectionUtil.allOf("group1, group2", "group1, group2")).isTrue();
+        assertThat(CollectionUtil.allOf("group1, group2", "group2, group3")).isFalse();
 
         ObjectMapper mapper = new ObjectMapper();
-        assertFalse(CollectionUtil.allOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group3", "group4"))));
-        assertTrue(CollectionUtil.allOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group1", "group2"))));
-        assertFalse(CollectionUtil.allOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group2", "group3"))));
+        assertThat(CollectionUtil.allOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group3", "group4"))))
+                .isFalse();
+        assertThat(CollectionUtil.allOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group1", "group2")))).isTrue();
+        assertThat(CollectionUtil.allOf(mapper.valueToTree(Arrays.asList("group1", "group2")), mapper.valueToTree(Arrays.asList("group2", "group3"))))
+                .isFalse();
     }
 
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.dmn.engine.test.cfg;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
@@ -41,14 +40,14 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemDmnEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         // then
         // if the  engine is closed
         dmnEngine.close();
 
         // the idle connections are closed
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isZero();
 
     }
 
@@ -65,17 +64,17 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemDmnEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         // then
         // if the  engine is closed
         dmnEngine.close();
 
         // the idle connections are not closed
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isPositive();
 
         pooledDataSource.forceCloseAll();
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/deployment/DeploymentQueryTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/deployment/DeploymentQueryTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.dmn.engine.test.deployment;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.dmn.engine.test.AbstractFlowableDmnTest;
 import org.junit.After;
@@ -63,93 +61,93 @@ public class DeploymentQueryTest extends AbstractFlowableDmnTest {
     
     @Test
     public void testQueryById() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentId(deploymentId1).list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentId(deploymentId1).count());
-        
-        assertNull(repositoryService.createDeploymentQuery().deploymentId("invalid").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentId("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentId("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).count()).isEqualTo(1);
+
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByName() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentName("test2.dmn").singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentName("test2.dmn").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentName("test2.dmn").count());
-        
-        assertNull(repositoryService.createDeploymentQuery().deploymentName("invalid").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentName("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentName("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.dmn").singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.dmn").list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.dmn").count()).isEqualTo(1);
+
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByNameLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentNameLike("test%").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentNameLike("test%").count());
-        
-        assertNull(repositoryService.createDeploymentQuery().deploymentNameLike("inva%").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentNameLike("inva").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentNameLike("inva").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("test%").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("test%").count()).isEqualTo(3);
+
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva%").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").count()).isZero();
     }
     
     @Test
     public void testQueryByCategory() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").count());
-        
-        assertNull(repositoryService.createDeploymentQuery().deploymentCategory("inva%").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentCategory("inva%").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentCategory("inva%").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").count()).isEqualTo(1);
+
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").count()).isZero();
     }
     
     @Test
     public void testQueryByCategoryNotEquals() {
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").list().size());
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").count());
-        
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").list()).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").count()).isEqualTo(2);
+
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").count()).isEqualTo(3);
     }
     
     @Test
     public void testQueryByTenantId() {
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").list().size());
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").count());
-        
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantId("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantId("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").list()).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").count()).isEqualTo(2);
+
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByTenantIdLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").count());
-        
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").count()).isEqualTo(3);
+
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByDecisionTableKey() {
-        assertEquals(1, repositoryService.createDeploymentQuery().decisionTableKey("anotherDecision").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().decisionTableKey("anotherDecision").count());
-        
-        assertEquals(0, repositoryService.createDeploymentQuery().decisionTableKey("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().decisionTableKey("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKey("anotherDecision").list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKey("anotherDecision").count()).isEqualTo(1);
+
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKey("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKey("invalid").count()).isZero();
     }
     
     @Test
     public void testQueryByDecisionTableKeyLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").count());
-        assertEquals(1, repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").listPage(0, 1).size());
-        assertEquals(2, repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").listPage(0, 2).size());
-        assertEquals(2, repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").listPage(1, 2).size());
-        
-        assertEquals(0, repositoryService.createDeploymentQuery().decisionTableKeyLike("inva%").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().decisionTableKeyLike("inva%").count());
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").count()).isEqualTo(3);
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").listPage(0, 1)).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").listPage(0, 2)).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKeyLike("%sion").listPage(1, 2)).hasSize(2);
+
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKeyLike("inva%").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().decisionTableKeyLike("inva%").count()).isZero();
     }
     
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/deployment/DeploymentTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/deployment/DeploymentTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.dmn.engine.test.deployment;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -36,19 +33,19 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .latestVersion()
                 .decisionTableKey("decision")
                 .singleResult();
-        assertNotNull(decision);
-        assertEquals("decision", decision.getKey());
+        assertThat(decision).isNotNull();
+        assertThat(decision.getKey()).isEqualTo("decision");
     }
 
     @Test
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/deployment/multiple_conclusions_DMN12.dmn")
     public void deploySingleDecisionDMN12() {
         DmnDecisionTable decision = repositoryService.createDecisionTableQuery()
-            .latestVersion()
-            .decisionTableKey("decision")
-            .singleResult();
-        assertNotNull(decision);
-        assertEquals("decision", decision.getKey());
+                .latestVersion()
+                .decisionTableKey("decision")
+                .singleResult();
+        assertThat(decision).isNotNull();
+        assertThat(decision.getKey()).isEqualTo("decision");
     }
 
     @Test
@@ -58,16 +55,16 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .latestVersion()
                 .decisionTableKey("decision")
                 .singleResult();
-        assertNotNull(decision);
-        assertEquals("decision", decision.getKey());
+        assertThat(decision).isNotNull();
+        assertThat(decision.getKey()).isEqualTo("decision");
 
-        assertTrue(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId()));
+        assertThat(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId())).isTrue();
         dmnEngineConfiguration.getDeploymentManager().getDecisionCache().clear();
-        assertFalse(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId()));
+        assertThat(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId())).isFalse();
 
         decision = repositoryService.getDecisionTable(decision.getId());
-        assertNotNull(decision);
-        assertEquals("decision", decision.getKey());
+        assertThat(decision).isNotNull();
+        assertThat(decision.getKey()).isEqualTo("decision");
     }
 
     @Test
@@ -78,7 +75,7 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .decisionTableKey("decision")
                 .singleResult();
 
-        assertEquals(1, decision.getVersion());
+        assertThat(decision.getVersion()).isEqualTo(1);
 
         repositoryService.createDeployment().name("secondDeployment")
                 .addClasspathResource("org/flowable/dmn/engine/test/deployment/multiple_conclusions.dmn")
@@ -89,7 +86,7 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .decisionTableKey("decision")
                 .singleResult();
 
-        assertEquals(2, decision.getVersion());
+        assertThat(decision.getVersion()).isEqualTo(2);
     }
 
     @Test
@@ -104,18 +101,18 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .decisionTableKey("decision")
                 .decisionTableTenantId("testTenant")
                 .singleResult();
-        assertNotNull(decision);
-        assertEquals("decision", decision.getKey());
-        assertEquals("testTenant", decision.getTenantId());
-        assertEquals(1, decision.getVersion());
+        assertThat(decision).isNotNull();
+        assertThat(decision.getKey()).isEqualTo("decision");
+        assertThat(decision.getTenantId()).isEqualTo("testTenant");
+        assertThat(decision.getVersion()).isEqualTo(1);
 
-        assertTrue(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId()));
+        assertThat(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId())).isTrue();
         dmnEngineConfiguration.getDeploymentManager().getDecisionCache().clear();
-        assertFalse(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId()));
+        assertThat(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId())).isFalse();
 
         decision = repositoryService.getDecisionTable(decision.getId());
-        assertNotNull(decision);
-        assertEquals("decision", decision.getKey());
+        assertThat(decision).isNotNull();
+        assertThat(decision.getKey()).isEqualTo("decision");
 
         deleteDeployments();
     }
@@ -133,7 +130,7 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .decisionTableTenantId("testTenant")
                 .singleResult();
 
-        assertEquals(1, decision.getVersion());
+        assertThat(decision.getVersion()).isEqualTo(1);
 
         repositoryService.createDeployment().name("secondDeployment")
                 .addClasspathResource("org/flowable/dmn/engine/test/deployment/multiple_conclusions.dmn")
@@ -146,7 +143,7 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .decisionTableTenantId("testTenant")
                 .singleResult();
 
-        assertEquals(2, decision.getVersion());
+        assertThat(decision.getVersion()).isEqualTo(2);
 
         deleteDeployments();
     }
@@ -159,31 +156,31 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .latestVersion()
                 .decisionTableKey("decision")
                 .singleResult();
-        assertNotNull(decision);
-        assertEquals("decision", decision.getKey());
+        assertThat(decision).isNotNull();
+        assertThat(decision.getKey()).isEqualTo("decision");
 
-        assertTrue(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId()));
+        assertThat(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId())).isTrue();
         dmnEngineConfiguration.getDeploymentManager().getDecisionCache().clear();
-        assertFalse(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId()));
+        assertThat(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision.getId())).isFalse();
 
         decision = repositoryService.getDecisionTable(decision.getId());
-        assertNotNull(decision);
-        assertEquals("decision", decision.getKey());
+        assertThat(decision).isNotNull();
+        assertThat(decision.getKey()).isEqualTo("decision");
 
         DmnDecisionTable decision2 = repositoryService.createDecisionTableQuery()
                 .latestVersion()
                 .decisionTableKey("decision2")
                 .singleResult();
-        assertNotNull(decision2);
-        assertEquals("decision2", decision2.getKey());
+        assertThat(decision2).isNotNull();
+        assertThat(decision2.getKey()).isEqualTo("decision2");
 
-        assertTrue(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision2.getId()));
+        assertThat(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision2.getId())).isTrue();
         dmnEngineConfiguration.getDeploymentManager().getDecisionCache().clear();
-        assertFalse(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision2.getId()));
+        assertThat(dmnEngineConfiguration.getDeploymentManager().getDecisionCache().contains(decision2.getId())).isFalse();
 
         decision2 = repositoryService.getDecisionTable(decision2.getId());
-        assertNotNull(decision2);
-        assertEquals("decision2", decision2.getKey());
+        assertThat(decision2).isNotNull();
+        assertThat(decision2.getKey()).isEqualTo("decision2");
     }
 
     @Test
@@ -196,15 +193,15 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .deploy();
 
         org.flowable.dmn.api.DmnDeployment deployment = repositoryService.createDeploymentQuery().deploymentCategory("TEST_DEPLOYMENT_CATEGORY").singleResult();
-        assertNotNull(deployment);
+        assertThat(deployment).isNotNull();
 
         DmnDecisionTable decisionTable = repositoryService.createDecisionTableQuery().decisionTableKey("decision").singleResult();
-        assertNotNull(decisionTable);
+        assertThat(decisionTable).isNotNull();
 
         repositoryService.setDecisionTableCategory(decisionTable.getId(), "TEST_DECISION_TABLE_CATEGORY");
 
         DmnDecisionTable decisionTableWithCategory = repositoryService.createDecisionTableQuery().decisionTableCategory("TEST_DECISION_TABLE_CATEGORY").singleResult();
-        assertNotNull(decisionTableWithCategory);
+        assertThat(decisionTableWithCategory).isNotNull();
 
         deleteDeployments();
     }
@@ -222,27 +219,27 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
         
         try {
             DmnDecisionTable decision = repositoryService.createDecisionTableQuery().deploymentId(deployment.getId()).singleResult();
-            assertNotNull(decision);
-            assertEquals("decision", decision.getKey());
-            assertEquals(1, decision.getVersion());
-            
+            assertThat(decision).isNotNull();
+            assertThat(decision.getKey()).isEqualTo("decision");
+            assertThat(decision.getVersion()).isEqualTo(1);
+
             DmnDecisionTable newDecision = repositoryService.createDecisionTableQuery().deploymentId(newDeployment.getId()).singleResult();
-            assertNotNull(newDecision);
-            assertEquals("decision", newDecision.getKey());
-            assertEquals(2, newDecision.getVersion());
-            
+            assertThat(newDecision).isNotNull();
+            assertThat(newDecision.getKey()).isEqualTo("decision");
+            assertThat(newDecision.getVersion()).isEqualTo(2);
+
             DecisionExecutionAuditContainer auditContainer = ruleService.createExecuteDecisionBuilder()
-                            .decisionKey("decision")
-                            .parentDeploymentId("someDeploymentId")
-                            .executeWithAuditTrail();
-            assertEquals("decision", auditContainer.getDecisionKey());
-            assertEquals(1, auditContainer.getDecisionVersion());
-            
+                    .decisionKey("decision")
+                    .parentDeploymentId("someDeploymentId")
+                    .executeWithAuditTrail();
+            assertThat(auditContainer.getDecisionKey()).isEqualTo("decision");
+            assertThat(auditContainer.getDecisionVersion()).isEqualTo(1);
+
             dmnEngineConfiguration.setAlwaysLookupLatestDefinitionVersion(true);
             auditContainer = ruleService.createExecuteDecisionBuilder().decisionKey("decision").executeWithAuditTrail();
-            assertEquals("decision", auditContainer.getDecisionKey());
-            assertEquals(2, auditContainer.getDecisionVersion());
-        
+            assertThat(auditContainer.getDecisionKey()).isEqualTo("decision");
+            assertThat(auditContainer.getDecisionVersion()).isEqualTo(2);
+
         } finally {
             dmnEngineConfiguration.setAlwaysLookupLatestDefinitionVersion(false);
             repositoryService.deleteDeployment(deployment.getId());
@@ -254,7 +251,7 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
     @DmnDeployment
     public void testNativeQuery() {
         org.flowable.dmn.api.DmnDeployment deployment = repositoryService.createDeploymentQuery().singleResult();
-        assertNotNull(deployment);
+        assertThat(deployment).isNotNull();
 
         long count = repositoryService.createNativeDeploymentQuery()
                 .sql("SELECT count(*) FROM " + managementService.getTableName(DmnDeploymentEntity.class) + " D1, "
@@ -264,13 +261,13 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
                 .parameter("deploymentId", deployment.getId())
                 .count();
 
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
     }
     
     @Test
     @DmnDeployment
     public void testDeployWithXmlSuffix() {
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
     }
 
     protected void deleteDeployments() {

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/history/HistoryNoneTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/history/HistoryNoneTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.engine.test.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.dmn.engine.impl.test.ResourceFlowableDmnTestCase;
 import org.flowable.dmn.engine.test.DmnDeployment;
 
@@ -30,7 +32,7 @@ public class HistoryNoneTest extends ResourceFlowableDmnTestCase {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 11)
                 .executeWithSingleResult();
-        
-        assertEquals(0, historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").list().size());
+
+        assertThat(historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").list()).isEmpty();
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/history/HistoryTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/history/HistoryTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.dmn.engine.test.history;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 import java.util.List;
 
@@ -20,6 +23,8 @@ import org.flowable.dmn.engine.impl.test.PluggableFlowableDmnTestCase;
 import org.flowable.dmn.engine.test.DmnDeployment;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Tijs Rademakers
@@ -32,52 +37,60 @@ public class HistoryTest extends PluggableFlowableDmnTestCase {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 11)
                 .executeWithSingleResult();
-        
+
         DmnHistoricDecisionExecution decisionExecution = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").singleResult();
-        assertNotNull(decisionExecution.getDecisionDefinitionId());
-        assertNotNull(decisionExecution.getDeploymentId());
-        assertFalse(decisionExecution.isFailed());
-        assertNotNull(decisionExecution.getStartTime());
-        assertNotNull(decisionExecution.getEndTime());
-        assertNotNull(decisionExecution.getExecutionJson());
-        
+        assertThat(decisionExecution.getDecisionDefinitionId()).isNotNull();
+        assertThat(decisionExecution.getDeploymentId()).isNotNull();
+        assertThat(decisionExecution.isFailed()).isFalse();
+        assertThat(decisionExecution.getStartTime()).isNotNull();
+        assertThat(decisionExecution.getEndTime()).isNotNull();
+        assertThat(decisionExecution.getExecutionJson()).isNotNull();
+
         JsonNode executionNode = dmnEngineConfiguration.getObjectMapper().readTree(decisionExecution.getExecutionJson());
-        assertEquals("decision1", executionNode.get("decisionKey").asText());
-        assertEquals("Full Decision", executionNode.get("decisionName").asText());
-        assertEquals("FIRST", executionNode.get("hitPolicy").asText());
-        
+        assertThat(executionNode.get("decisionKey").asText()).isEqualTo("decision1");
+        assertThat(executionNode.get("decisionName").asText()).isEqualTo("Full Decision");
+        assertThat(executionNode.get("hitPolicy").asText()).isEqualTo("FIRST");
+
         JsonNode inputVariables = executionNode.get("inputVariables");
-        assertTrue(inputVariables.isObject());
-        assertTrue(inputVariables.has("inputVariable1"));
-        assertEquals(11, inputVariables.get("inputVariable1").asLong());
-        
+        assertThat(inputVariables.isObject()).isTrue();
+        assertThat(inputVariables.has("inputVariable1")).isTrue();
+        assertThat(inputVariables.get("inputVariable1").asLong()).isEqualTo(11);
+
         JsonNode inputVariableTypes = executionNode.get("inputVariableTypes");
-        assertTrue(inputVariableTypes.isObject());
-        assertTrue(inputVariableTypes.has("inputVariable1"));
-        assertEquals("number", inputVariableTypes.get("inputVariable1").asText());
-        
+        assertThat(inputVariableTypes.isObject()).isTrue();
+        assertThat(inputVariableTypes.has("inputVariable1")).isTrue();
+        assertThat(inputVariableTypes.get("inputVariable1").asText()).isEqualTo("number");
+
         JsonNode decisionResultArray = executionNode.get("decisionResult");
-        assertTrue(decisionResultArray.isArray());
-        assertEquals(1, decisionResultArray.size());
-        JsonNode decisionResultNode = decisionResultArray.get(0);
-        assertTrue(decisionResultNode.has("outputVariable1"));
-        assertTrue(decisionResultNode.has("outputVariable2"));
-        assertEquals("gt 10", decisionResultNode.get("outputVariable1").asText());
-        assertEquals("result2", decisionResultNode.get("outputVariable2").asText());
-        
+        assertThat(decisionResultArray.isArray()).isTrue();
+        assertThatJson(decisionResultArray)
+                .isEqualTo("["
+                        + "  {"
+                        + "    outputVariable1: 'gt 10',"
+                        + "    outputVariable2: 'result2'"
+                        + "  }"
+                        + "]");
+
         JsonNode decisionResultTypes = executionNode.get("decisionResultTypes");
-        assertTrue(decisionResultTypes.isObject());
-        assertTrue(decisionResultTypes.has("outputVariable1"));
-        assertEquals("string", decisionResultTypes.get("outputVariable1").asText());
-        assertTrue(decisionResultTypes.has("outputVariable2"));
-        assertEquals("string", decisionResultTypes.get("outputVariable2").asText());
-        
+        assertThat(decisionResultTypes.isObject()).isTrue();
+        assertThatJson(decisionResultTypes)
+                .isEqualTo("{"
+                        + "    outputVariable1: 'string',"
+                        + "    outputVariable2: 'string'"
+                        + "}");
+
         JsonNode ruleExecutions = executionNode.get("ruleExecutions");
-        assertTrue(ruleExecutions.isObject());
-        assertTrue(ruleExecutions.has("1"));
-        assertFalse(ruleExecutions.get("1").get("valid").asBoolean());
-        assertTrue(ruleExecutions.has("2"));
-        assertTrue(ruleExecutions.get("2").get("valid").asBoolean());
+        assertThat(ruleExecutions.isObject()).isTrue();
+        assertThatJson(ruleExecutions)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "    1: {"
+                        + "         valid: false"
+                        + "        },"
+                        + "    2: {"
+                        + "         valid: true"
+                        + "       }"
+                        + "}");
     }
     
     @DmnDeployment
@@ -86,59 +99,75 @@ public class HistoryTest extends PluggableFlowableDmnTestCase {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 5)
                 .execute();
-        
+
         DmnHistoricDecisionExecution decisionExecution = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").singleResult();
-        assertNotNull(decisionExecution.getDecisionDefinitionId());
-        assertNotNull(decisionExecution.getDeploymentId());
-        assertFalse(decisionExecution.isFailed());
-        assertNotNull(decisionExecution.getStartTime());
-        assertNotNull(decisionExecution.getEndTime());
-        assertNotNull(decisionExecution.getExecutionJson());
-        
+        assertThat(decisionExecution.getDecisionDefinitionId()).isNotNull();
+        assertThat(decisionExecution.getDeploymentId()).isNotNull();
+        assertThat(decisionExecution.isFailed()).isFalse();
+        assertThat(decisionExecution.getStartTime()).isNotNull();
+        assertThat(decisionExecution.getEndTime()).isNotNull();
+        assertThat(decisionExecution.getExecutionJson()).isNotNull();
+
         JsonNode executionNode = dmnEngineConfiguration.getObjectMapper().readTree(decisionExecution.getExecutionJson());
-        assertEquals("decision1", executionNode.get("decisionKey").asText());
-        assertEquals("Full Decision", executionNode.get("decisionName").asText());
-        assertEquals("OUTPUT ORDER", executionNode.get("hitPolicy").asText());
-        
+        assertThatJson(executionNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "    decisionKey: 'decision1',"
+                        + "    decisionName: 'Full Decision',"
+                        + "    hitPolicy: 'OUTPUT ORDER'"
+                        + "}");
+
         JsonNode inputVariables = executionNode.get("inputVariables");
-        assertTrue(inputVariables.isObject());
-        assertTrue(inputVariables.has("inputVariable1"));
-        assertEquals(5, inputVariables.get("inputVariable1").asLong());
-        
+        assertThat(inputVariables.isObject()).isTrue();
+        assertThatJson(inputVariables)
+                .isEqualTo("{"
+                        + "    inputVariable1: 5"
+                        + "}");
+
         JsonNode inputVariableTypes = executionNode.get("inputVariableTypes");
-        assertTrue(inputVariableTypes.isObject());
-        assertTrue(inputVariableTypes.has("inputVariable1"));
-        assertEquals("number", inputVariableTypes.get("inputVariable1").asText());
-        
+        assertThat(inputVariableTypes.isObject()).isTrue();
+        assertThatJson(inputVariableTypes)
+                .isEqualTo("{"
+                        + "    inputVariable1: 'number'"
+                        + "}");
+
         JsonNode decisionResultArray = executionNode.get("decisionResult");
-        assertTrue(decisionResultArray.isArray());
-        assertEquals(3, decisionResultArray.size());
-        JsonNode decisionResultNode = decisionResultArray.get(0);
-        assertTrue(decisionResultNode.has("outputVariable1"));
-        assertEquals("OUTPUT2", decisionResultNode.get("outputVariable1").asText());
-        
-        decisionResultNode = decisionResultArray.get(1);
-        assertTrue(decisionResultNode.has("outputVariable1"));
-        assertEquals("OUTPUT3", decisionResultNode.get("outputVariable1").asText());
-        
-        decisionResultNode = decisionResultArray.get(2);
-        assertTrue(decisionResultNode.has("outputVariable1"));
-        assertEquals("OUTPUT1", decisionResultNode.get("outputVariable1").asText());
-        
-        
+        assertThat(decisionResultArray.isArray()).isTrue();
+        assertThatJson(decisionResultArray)
+                .isEqualTo("["
+                        + "  {"
+                        + "    outputVariable1: 'OUTPUT2'"
+                        + "  },"
+                        + "  {"
+                        + "    outputVariable1: 'OUTPUT3'"
+                        + "  },"
+                        + "  {"
+                        + "    outputVariable1: 'OUTPUT1'"
+                        + "  }"
+                        + "]");
+
         JsonNode decisionResultTypes = executionNode.get("decisionResultTypes");
-        assertTrue(decisionResultTypes.isObject());
-        assertTrue(decisionResultTypes.has("outputVariable1"));
-        assertEquals("string", decisionResultTypes.get("outputVariable1").asText());
-        
+        assertThat(decisionResultTypes.isObject()).isTrue();
+        assertThatJson(decisionResultTypes)
+                .isEqualTo("{"
+                        + "    outputVariable1: 'string'"
+                        + "}");
+
         JsonNode ruleExecutions = executionNode.get("ruleExecutions");
-        assertTrue(ruleExecutions.isObject());
-        assertTrue(ruleExecutions.has("1"));
-        assertTrue(ruleExecutions.get("1").get("valid").asBoolean());
-        assertTrue(ruleExecutions.has("2"));
-        assertTrue(ruleExecutions.get("2").get("valid").asBoolean());
-        assertTrue(ruleExecutions.has("3"));
-        assertTrue(ruleExecutions.get("3").get("valid").asBoolean());
+        assertThat(ruleExecutions.isObject()).isTrue();
+        assertThatJson(ruleExecutions)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "    1: {"
+                        + "         valid: true"
+                        + "        },"
+                        + "    2: {"
+                        + "         valid: true"
+                        + "       },"
+                        + "    3: {"
+                        + "         valid: true"
+                        + "       }"
+                        + "}");
     }
     
     @DmnDeployment
@@ -150,61 +179,80 @@ public class HistoryTest extends PluggableFlowableDmnTestCase {
                 .activityId("myActivityId")
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
-        
-        assertEquals(1, historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").list().size());
-        assertEquals(1, historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").instanceId("myInstanceId").list().size());
-        assertEquals(0, historyService.createHistoricDecisionExecutionQuery().executionId("myInstanceId2").list().size());
-        assertEquals(1, historyService.createHistoricDecisionExecutionQuery().executionId("myExecutionId").list().size());
-        assertEquals(0, historyService.createHistoricDecisionExecutionQuery().executionId("myExecutionId2").list().size());
-        assertEquals(1, historyService.createHistoricDecisionExecutionQuery().activityId("myActivityId").list().size());
-        assertEquals(0, historyService.createHistoricDecisionExecutionQuery().activityId("myActivityId2").list().size());
-        
+
+        assertThat(historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").list()).hasSize(1);
+        assertThat(historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").instanceId("myInstanceId").list()).hasSize(1);
+        assertThat(historyService.createHistoricDecisionExecutionQuery().executionId("myInstanceId2").list()).isEmpty();
+        assertThat(historyService.createHistoricDecisionExecutionQuery().executionId("myExecutionId").list()).hasSize(1);
+        assertThat(historyService.createHistoricDecisionExecutionQuery().executionId("myExecutionId2").list()).isEmpty();
+        assertThat(historyService.createHistoricDecisionExecutionQuery().activityId("myActivityId").list()).hasSize(1);
+        assertThat(historyService.createHistoricDecisionExecutionQuery().activityId("myActivityId2").list()).isEmpty();
+
         DmnHistoricDecisionExecution decisionExecution = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").singleResult();
-        assertNotNull(decisionExecution.getDecisionDefinitionId());
-        assertNotNull(decisionExecution.getDeploymentId());
-        assertEquals("myInstanceId", decisionExecution.getInstanceId());
-        assertEquals("myExecutionId", decisionExecution.getExecutionId());
-        assertEquals("myActivityId", decisionExecution.getActivityId());
-        assertFalse(decisionExecution.isFailed());
-        assertNotNull(decisionExecution.getStartTime());
-        assertNotNull(decisionExecution.getEndTime());
-        assertNotNull(decisionExecution.getExecutionJson());
-        
+        assertThat(decisionExecution.getDecisionDefinitionId()).isNotNull();
+        assertThat(decisionExecution.getDeploymentId()).isNotNull();
+        assertThat(decisionExecution.getInstanceId()).isEqualTo("myInstanceId");
+        assertThat(decisionExecution.getExecutionId()).isEqualTo("myExecutionId");
+        assertThat(decisionExecution.getActivityId()).isEqualTo("myActivityId");
+        assertThat(decisionExecution.isFailed()).isFalse();
+        assertThat(decisionExecution.getStartTime()).isNotNull();
+        assertThat(decisionExecution.getEndTime()).isNotNull();
+        assertThat(decisionExecution.getExecutionJson()).isNotNull();
+
         JsonNode executionNode = dmnEngineConfiguration.getObjectMapper().readTree(decisionExecution.getExecutionJson());
-        assertEquals("decision1", executionNode.get("decisionKey").asText());
-        assertEquals("Full Decision", executionNode.get("decisionName").asText());
-        assertEquals("PRIORITY", executionNode.get("hitPolicy").asText());
-        
+        assertThatJson(executionNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "    decisionKey: 'decision1',"
+                        + "    decisionName: 'Full Decision',"
+                        + "    hitPolicy: 'PRIORITY'"
+                        + "}");
+
         JsonNode inputVariables = executionNode.get("inputVariables");
-        assertTrue(inputVariables.isObject());
-        assertTrue(inputVariables.has("inputVariable1"));
-        assertEquals(5, inputVariables.get("inputVariable1").asLong());
-        
+        assertThat(inputVariables.isObject()).isTrue();
+        assertThatJson(inputVariables)
+                .isEqualTo("{"
+                        + "    inputVariable1: 5"
+                        + "}");
+
         JsonNode inputVariableTypes = executionNode.get("inputVariableTypes");
-        assertTrue(inputVariableTypes.isObject());
-        assertTrue(inputVariableTypes.has("inputVariable1"));
-        assertEquals("number", inputVariableTypes.get("inputVariable1").asText());
-        
+        assertThat(inputVariableTypes.isObject()).isTrue();
+        assertThatJson(inputVariableTypes)
+                .isEqualTo("{"
+                        + "    inputVariable1: 'number'"
+                        + "}");
+
         JsonNode decisionResultArray = executionNode.get("decisionResult");
-        assertTrue(decisionResultArray.isArray());
-        assertEquals(1, decisionResultArray.size());
-        JsonNode decisionResultNode = decisionResultArray.get(0);
-        assertTrue(decisionResultNode.has("outputVariable1"));
-        assertEquals("OUTPUT2", decisionResultNode.get("outputVariable1").asText());
-        
+        assertThat(decisionResultArray.isArray()).isTrue();
+        assertThatJson(decisionResultArray)
+                .isEqualTo("["
+                        + "  {"
+                        + "    outputVariable1: 'OUTPUT2'"
+                        + "  }"
+                        + "]");
+
         JsonNode decisionResultTypes = executionNode.get("decisionResultTypes");
-        assertTrue(decisionResultTypes.isObject());
-        assertTrue(decisionResultTypes.has("outputVariable1"));
-        assertEquals("string", decisionResultTypes.get("outputVariable1").asText());
-        
+        assertThat(decisionResultTypes.isObject()).isTrue();
+        assertThatJson(decisionResultTypes)
+                .isEqualTo("{"
+                        + "    outputVariable1: 'string'"
+                        + "}");
+
         JsonNode ruleExecutions = executionNode.get("ruleExecutions");
-        assertTrue(ruleExecutions.isObject());
-        assertTrue(ruleExecutions.has("1"));
-        assertTrue(ruleExecutions.get("1").get("valid").asBoolean());
-        assertTrue(ruleExecutions.has("2"));
-        assertTrue(ruleExecutions.get("2").get("valid").asBoolean());
-        assertTrue(ruleExecutions.has("3"));
-        assertTrue(ruleExecutions.get("3").get("valid").asBoolean());
+        assertThat(ruleExecutions.isObject()).isTrue();
+        assertThatJson(ruleExecutions)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "    1: {"
+                        + "         valid: true"
+                        + "        },"
+                        + "    2: {"
+                        + "         valid: true"
+                        + "       },"
+                        + "    3: {"
+                        + "         valid: true"
+                        + "       }"
+                        + "}");
     }
     
     @DmnDeployment
@@ -213,37 +261,38 @@ public class HistoryTest extends PluggableFlowableDmnTestCase {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 11)
                 .executeWithSingleResult();
-        
+
         DmnHistoricDecisionExecution decisionExecution = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").singleResult();
         String firstDecisionExecutionId = decisionExecution.getId();
 
         dmnEngineConfiguration.getClock().setCurrentTime(new Date(new Date().getTime() + 2000L));
 
         ruleService.createExecuteDecisionBuilder()
-            .decisionKey("decision1")
-            .variable("inputVariable1", 11)
-            .executeWithSingleResult();
-        
+                .decisionKey("decision1")
+                .variable("inputVariable1", 11)
+                .executeWithSingleResult();
+
         List<DmnHistoricDecisionExecution> historicExecutions = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").list();
-        assertEquals(2, historicExecutions.size());
-        
+        assertThat(historicExecutions).hasSize(2);
+
         String secondDecisionExcecutionId = null;
         for (DmnHistoricDecisionExecution historicDecisionExecution : historicExecutions) {
             if (!historicDecisionExecution.getId().equals(firstDecisionExecutionId)) {
                 secondDecisionExcecutionId = historicDecisionExecution.getId();
             }
         }
-        
-        assertNotNull(secondDecisionExcecutionId);
-        
+
+        assertThat(secondDecisionExcecutionId).isNotNull();
+
         historicExecutions = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").orderByStartTime().asc().list();
-        assertEquals(2, historicExecutions.size());
-        assertEquals(firstDecisionExecutionId, historicExecutions.get(0).getId());
-        assertEquals(secondDecisionExcecutionId, historicExecutions.get(1).getId());
-        
+        assertThat(historicExecutions)
+                .extracting(DmnHistoricDecisionExecution::getId)
+                .containsExactly(firstDecisionExecutionId, secondDecisionExcecutionId);
+
         historicExecutions = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").orderByStartTime().desc().list();
-        assertEquals(secondDecisionExcecutionId, historicExecutions.get(0).getId());
-        assertEquals(firstDecisionExecutionId, historicExecutions.get(1).getId());
+        assertThat(historicExecutions)
+                .extracting(DmnHistoricDecisionExecution::getId)
+                .containsExactly(secondDecisionExcecutionId, firstDecisionExecutionId);
     }
     
     @DmnDeployment
@@ -252,36 +301,37 @@ public class HistoryTest extends PluggableFlowableDmnTestCase {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 11)
                 .executeWithSingleResult();
-        
+
         DmnHistoricDecisionExecution decisionExecution = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").singleResult();
         String firstDecisionExecutionId = decisionExecution.getId();
 
         dmnEngineConfiguration.getClock().setCurrentTime(new Date(new Date().getTime() + 2000L));
-        
+
         ruleService.createExecuteDecisionBuilder()
-            .decisionKey("decision1")
-            .variable("inputVariable1", 11)
-            .executeWithSingleResult();
-        
+                .decisionKey("decision1")
+                .variable("inputVariable1", 11)
+                .executeWithSingleResult();
+
         List<DmnHistoricDecisionExecution> historicExecutions = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").list();
-        assertEquals(2, historicExecutions.size());
-        
+        assertThat(historicExecutions).hasSize(2);
+
         String secondDecisionExcecutionId = null;
         for (DmnHistoricDecisionExecution historicDecisionExecution : historicExecutions) {
             if (!historicDecisionExecution.getId().equals(firstDecisionExecutionId)) {
                 secondDecisionExcecutionId = historicDecisionExecution.getId();
             }
         }
-        
-        assertNotNull(secondDecisionExcecutionId);
-        
+
+        assertThat(secondDecisionExcecutionId).isNotNull();
+
         historicExecutions = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").orderByStartTime().asc().listPage(0, 10);
-        assertEquals(2, historicExecutions.size());
-        assertEquals(firstDecisionExecutionId, historicExecutions.get(0).getId());
-        assertEquals(secondDecisionExcecutionId, historicExecutions.get(1).getId());
-        
+        assertThat(historicExecutions)
+                .extracting(DmnHistoricDecisionExecution::getId)
+                .containsExactly(firstDecisionExecutionId, secondDecisionExcecutionId);
+
         historicExecutions = historyService.createHistoricDecisionExecutionQuery().decisionKey("decision1").orderByStartTime().desc().listPage(0, 10);
-        assertEquals(secondDecisionExcecutionId, historicExecutions.get(0).getId());
-        assertEquals(firstDecisionExecutionId, historicExecutions.get(1).getId());
+        assertThat(historicExecutions)
+                .extracting(DmnHistoricDecisionExecution::getId)
+                .containsExactly(secondDecisionExcecutionId, firstDecisionExecutionId);
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/history/HistoryTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/history/HistoryTest.java
@@ -47,19 +47,27 @@ public class HistoryTest extends PluggableFlowableDmnTestCase {
         assertThat(decisionExecution.getExecutionJson()).isNotNull();
 
         JsonNode executionNode = dmnEngineConfiguration.getObjectMapper().readTree(decisionExecution.getExecutionJson());
-        assertThat(executionNode.get("decisionKey").asText()).isEqualTo("decision1");
-        assertThat(executionNode.get("decisionName").asText()).isEqualTo("Full Decision");
-        assertThat(executionNode.get("hitPolicy").asText()).isEqualTo("FIRST");
+        assertThatJson(executionNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "    decisionKey: 'decision1',"
+                        + "    decisionName: 'Full Decision',"
+                        + "    hitPolicy: 'FIRST'"
+                        + "}");
 
         JsonNode inputVariables = executionNode.get("inputVariables");
         assertThat(inputVariables.isObject()).isTrue();
-        assertThat(inputVariables.has("inputVariable1")).isTrue();
-        assertThat(inputVariables.get("inputVariable1").asLong()).isEqualTo(11);
+        assertThatJson(inputVariables)
+                .isEqualTo("{"
+                        + "    inputVariable1: 11"
+                        + "}");
 
         JsonNode inputVariableTypes = executionNode.get("inputVariableTypes");
         assertThat(inputVariableTypes.isObject()).isTrue();
-        assertThat(inputVariableTypes.has("inputVariable1")).isTrue();
-        assertThat(inputVariableTypes.get("inputVariable1").asText()).isEqualTo("number");
+        assertThatJson(inputVariableTypes)
+                .isEqualTo("{"
+                        + "    inputVariable1: 'number'"
+                        + "}");
 
         JsonNode decisionResultArray = executionNode.get("decisionResult");
         assertThat(decisionResultArray.isArray()).isTrue();

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CalculationsTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CalculationsTest.java
@@ -12,17 +12,18 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.api.DmnRuleService;
 import org.flowable.dmn.engine.DmnEngine;
 import org.flowable.dmn.engine.test.DmnDeployment;
 import org.flowable.dmn.engine.test.FlowableDmnRule;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author Yvo Swillens
@@ -45,13 +46,13 @@ public class CalculationsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("dmnWithExpressionAndDecimals")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("dmnWithExpressionAndDecimals")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertEquals(2, result.getRuleExecutions().size());
-        Assert.assertTrue(result.getRuleExecutions().get(2).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions()).hasSize(2);
+        assertThat(result.getRuleExecutions().get(2).isValid()).isTrue();
     }
 
     @Test
@@ -67,13 +68,13 @@ public class CalculationsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("dmnWithExpressionAndDecimals")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("dmnWithExpressionAndDecimals")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertEquals(2, result.getRuleExecutions().size());
-        Assert.assertTrue(result.getRuleExecutions().get(2).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions()).hasSize(2);
+        assertThat(result.getRuleExecutions().get(2).isValid()).isTrue();
     }
 
 
@@ -96,15 +97,15 @@ public class CalculationsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertEquals(1D, result.getRuleExecutions().get(1).getConclusionResults().get(0).getResult());
-        Assert.assertEquals(1D, result.getRuleExecutions().get(1).getConclusionResults().get(1).getResult());
-        Assert.assertEquals(inputDouble2, result.getRuleExecutions().get(2).getConclusionResults().get(0).getResult());
-        Assert.assertEquals(10L, result.getRuleExecutions().get(2).getConclusionResults().get(1).getResult());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(1).getConclusionResults().get(0).getResult()).isEqualTo(1D);
+        assertThat(result.getRuleExecutions().get(1).getConclusionResults().get(1).getResult()).isEqualTo(1D);
+        assertThat(result.getRuleExecutions().get(2).getConclusionResults().get(0).getResult()).isEqualTo(inputDouble2);
+        assertThat(result.getRuleExecutions().get(2).getConclusionResults().get(1).getResult()).isEqualTo(10L);
     }
 
     @Test
@@ -119,11 +120,11 @@ public class CalculationsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertEquals(10D, result.getRuleExecutions().get(1).getConclusionResults().get(0).getResult());
-        Assert.assertEquals(20D, result.getRuleExecutions().get(2).getConclusionResults().get(0).getResult());
+        assertThat(result.getRuleExecutions().get(1).getConclusionResults().get(0).getResult()).isEqualTo(10D);
+        assertThat(result.getRuleExecutions().get(2).getConclusionResults().get(0).getResult()).isEqualTo(20D);
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsContainsAnyTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsContainsAnyTest.java
@@ -12,19 +12,20 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import org.flowable.dmn.api.DecisionExecutionAuditContainer;
-import org.flowable.dmn.api.DmnRuleService;
-import org.flowable.dmn.engine.DmnEngine;
-import org.flowable.dmn.engine.test.DmnDeployment;
-import org.flowable.dmn.engine.test.FlowableDmnRule;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.flowable.dmn.api.DecisionExecutionAuditContainer;
+import org.flowable.dmn.api.DmnRuleService;
+import org.flowable.dmn.engine.DmnEngine;
+import org.flowable.dmn.engine.test.DmnDeployment;
+import org.flowable.dmn.engine.test.FlowableDmnRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * @author Yvo Swillens
@@ -54,16 +55,16 @@ public class CollectionsContainsAnyTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertTrue(result.getRuleExecutions().get(1).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(2).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(5).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(6).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(8).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(1).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(2).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(5).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(6).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(8).isValid()).isTrue();
     }
 
     @Test
@@ -85,14 +86,14 @@ public class CollectionsContainsAnyTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertFalse(result.getRuleExecutions().get(3).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(4).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(7).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(9).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(3).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(4).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(7).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(9).isValid()).isFalse();
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsContainsReversedTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsContainsReversedTest.java
@@ -12,17 +12,18 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.api.DmnRuleService;
 import org.flowable.dmn.engine.DmnEngine;
 import org.flowable.dmn.engine.test.DmnDeployment;
 import org.flowable.dmn.engine.test.FlowableDmnRule;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author Yvo Swillens
@@ -47,15 +48,15 @@ public class CollectionsContainsReversedTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertTrue(result.getRuleExecutions().get(1).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(2).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(3).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(4).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(1).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(2).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(3).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(4).isValid()).isTrue();
     }
 
     @Test
@@ -73,15 +74,15 @@ public class CollectionsContainsReversedTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertFalse(result.getRuleExecutions().get(1).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(2).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(3).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(4).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(1).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(2).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(3).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(4).isValid()).isFalse();
     }
 
     class Person {

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsContainsTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsContainsTest.java
@@ -12,9 +12,15 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.api.DmnRuleService;
 import org.flowable.dmn.engine.DmnEngine;
@@ -23,16 +29,12 @@ import org.flowable.dmn.engine.test.FlowableDmnRule;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Yvo Swillens
@@ -85,34 +87,34 @@ public class CollectionsContainsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertTrue(result.getRuleExecutions().get(1).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(2).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(3).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(4).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(7).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(8).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(11).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(13).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(14).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(15).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(16).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(17).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(18).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(19).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(20).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(21).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(22).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(24).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(25).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(26).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(27).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(28).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(29).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(1).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(2).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(3).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(4).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(7).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(8).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(11).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(13).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(14).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(15).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(16).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(17).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(18).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(19).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(20).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(21).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(22).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(24).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(25).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(26).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(27).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(28).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(29).isValid()).isTrue();
     }
 
     @Test
@@ -156,16 +158,16 @@ public class CollectionsContainsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertFalse(result.getRuleExecutions().get(5).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(6).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(9).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(10).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(12).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(5).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(6).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(9).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(10).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(12).isValid()).isFalse();
     }
 
     @Test
@@ -199,28 +201,28 @@ public class CollectionsContainsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
+        assertThat(result.isFailed()).isFalse();
 
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(0).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(1).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(2).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(3).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(4).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(5).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(6).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(7).getResult());
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(0).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(1).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(2).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(3).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(4).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(5).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(6).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(7).getResult()).isEqualTo(true);
 
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(0).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(1).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(2).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(3).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(4).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(5).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(6).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(7).getResult());
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(0).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(1).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(2).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(3).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(4).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(5).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(6).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(7).getResult()).isEqualTo(true);
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsNotContainsAnyTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsNotContainsAnyTest.java
@@ -12,19 +12,20 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import org.flowable.dmn.api.DecisionExecutionAuditContainer;
-import org.flowable.dmn.api.DmnRuleService;
-import org.flowable.dmn.engine.DmnEngine;
-import org.flowable.dmn.engine.test.DmnDeployment;
-import org.flowable.dmn.engine.test.FlowableDmnRule;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.flowable.dmn.api.DecisionExecutionAuditContainer;
+import org.flowable.dmn.api.DmnRuleService;
+import org.flowable.dmn.engine.DmnEngine;
+import org.flowable.dmn.engine.test.DmnDeployment;
+import org.flowable.dmn.engine.test.FlowableDmnRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * @author Yvo Swillens
@@ -53,19 +54,19 @@ public class CollectionsNotContainsAnyTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertTrue(result.getRuleExecutions().get(1).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(2).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(5).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(6).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(7).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(8).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(9).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(10).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(1).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(2).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(5).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(6).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(7).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(8).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(9).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(10).isValid()).isTrue();
     }
 
     @Test
@@ -87,12 +88,12 @@ public class CollectionsNotContainsAnyTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertFalse(result.getRuleExecutions().get(3).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(4).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(3).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(4).isValid()).isFalse();
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsNotContainsTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsNotContainsTest.java
@@ -12,19 +12,20 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import org.flowable.dmn.api.DecisionExecutionAuditContainer;
-import org.flowable.dmn.api.DmnRuleService;
-import org.flowable.dmn.engine.DmnEngine;
-import org.flowable.dmn.engine.test.DmnDeployment;
-import org.flowable.dmn.engine.test.FlowableDmnRule;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.flowable.dmn.api.DecisionExecutionAuditContainer;
+import org.flowable.dmn.api.DmnRuleService;
+import org.flowable.dmn.engine.DmnEngine;
+import org.flowable.dmn.engine.test.DmnDeployment;
+import org.flowable.dmn.engine.test.FlowableDmnRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * @author Yvo Swillens
@@ -54,14 +55,14 @@ public class CollectionsNotContainsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertTrue(result.getRuleExecutions().get(1).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(2).isValid());
-        Assert.assertTrue(result.getRuleExecutions().get(6).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(1).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(2).isValid()).isTrue();
+        assertThat(result.getRuleExecutions().get(6).isValid()).isTrue();
     }
 
     @Test
@@ -83,17 +84,17 @@ public class CollectionsNotContainsTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         DecisionExecutionAuditContainer result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .executeWithAuditTrail();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .executeWithAuditTrail();
 
-        Assert.assertFalse(result.isFailed());
-        Assert.assertFalse(result.getRuleExecutions().get(3).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(4).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(5).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(7).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(8).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(9).isValid());
-        Assert.assertFalse(result.getRuleExecutions().get(10).isValid());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getRuleExecutions().get(3).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(4).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(5).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(7).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(8).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(9).isValid()).isFalse();
+        assertThat(result.getRuleExecutions().get(10).isValid()).isFalse();
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomConfigRuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomConfigRuntimeTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -58,9 +57,9 @@ public class CustomConfigRuntimeTest {
                 .decisionKey("decision")
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
-        
-        assertSame(String.class, result.get("output1").getClass());
-        assertEquals("test2", result.get("output1"));
+
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -77,8 +76,8 @@ public class CustomConfigRuntimeTest {
                 .decisionKey("decision")
                 .variable("input1", localDate.toDate())
                 .executeWithAuditTrail();
-        
-        assertEquals(0, result.getDecisionResult().size());
-        assertEquals(true, result.isFailed());
+
+        assertThat(result.getDecisionResult()).isEmpty();
+        assertThat(result.isFailed()).isTrue();
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomConfigRuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomConfigRuntimeTest.java
@@ -58,7 +58,6 @@ public class CustomConfigRuntimeTest {
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
 
-        assertThat(result.get("output1").getClass()).isSameAs(String.class);
         assertThat(result.get("output1")).isEqualTo("test2");
     }
 

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomHitPoliciesEngineConfigTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomHitPoliciesEngineConfigTest.java
@@ -12,11 +12,12 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.dmn.engine.DmnEngine;
 import org.flowable.dmn.engine.DmnEngineConfiguration;
 import org.flowable.dmn.engine.impl.hitpolicy.AbstractHitPolicy;
 import org.flowable.dmn.engine.test.FlowableDmnRule;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -43,7 +44,7 @@ public class CustomHitPoliciesEngineConfigTest {
         DmnEngine dmnEngine = flowableDmnRule1.getDmnEngine();
         DmnEngineConfiguration dmnEngineConfiguration = dmnEngine.getDmnEngineConfiguration();
 
-        Assert.assertEquals(1, dmnEngineConfiguration.getHitPolicyBehaviors().size());
+        assertThat(dmnEngineConfiguration.getHitPolicyBehaviors()).hasSize(1);
     }
 
     @Test
@@ -51,9 +52,9 @@ public class CustomHitPoliciesEngineConfigTest {
         DmnEngine dmnEngine = flowableDmnRule2.getDmnEngine();
         DmnEngineConfiguration dmnEngineConfiguration = dmnEngine.getDmnEngineConfiguration();
 
-        Assert.assertEquals(7, dmnEngineConfiguration.getHitPolicyBehaviors().size());
+        assertThat(dmnEngineConfiguration.getHitPolicyBehaviors()).hasSize(7);
         AbstractHitPolicy overwrittenHitPolicyBehavior = dmnEngineConfiguration.getHitPolicyBehaviors().get("FIRST");
-        Assert.assertEquals("CUSTOM_HIT_POLICY", overwrittenHitPolicyBehavior.getHitPolicyName());
+        assertThat(overwrittenHitPolicyBehavior.getHitPolicyName()).isEqualTo("CUSTOM_HIT_POLICY");
     }
 
     @Test
@@ -61,8 +62,8 @@ public class CustomHitPoliciesEngineConfigTest {
         DmnEngine dmnEngine = flowableDmnRule3.getDmnEngine();
         DmnEngineConfiguration dmnEngineConfiguration = dmnEngine.getDmnEngineConfiguration();
 
-        Assert.assertEquals(8, dmnEngineConfiguration.getHitPolicyBehaviors().size());
-        Assert.assertTrue(dmnEngineConfiguration.getHitPolicyBehaviors().containsKey("CUSTOM_HIT_POLICY"));
+        assertThat(dmnEngineConfiguration.getHitPolicyBehaviors()).hasSize(8);
+        assertThat(dmnEngineConfiguration.getHitPolicyBehaviors()).containsKey("CUSTOM_HIT_POLICY");
     }
 
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/DecisionTableExecutionFallBackTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/DecisionTableExecutionFallBackTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,7 +22,6 @@ import org.flowable.dmn.api.DmnDeployment;
 import org.flowable.dmn.engine.DmnEngine;
 import org.flowable.dmn.engine.test.AbstractFlowableDmnTest;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,7 +59,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
     @Test
     public void decisionKeyDeploymentIdTenantId() {
         Map<String, Object> result = executeDecision(TEST_TENANT_ID, TEST_PARENT_DEPLOYMENT_ID);
-        Assert.assertEquals("result2", result.get("outputVariable1"));
+        assertThat(result.get("outputVariable1")).isEqualTo("result2");
     }
 
 
@@ -66,7 +67,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
     public void fallBackDecisionKeyDeploymentIdTenantIdWrongDeploymentId() {
         Map<String, Object> result = executeDecision(TEST_TENANT_ID, "WRONG_PARENT_DEPLOYMENT_ID");
 
-        Assert.assertEquals("result2", result.get("outputVariable1"));
+        assertThat(result.get("outputVariable1")).isEqualTo("result2");
     }
 
     @Test
@@ -97,7 +98,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
         try {
             Map<String, Object> result = executeDecision(null, TEST_PARENT_DEPLOYMENT_ID);
 
-            Assert.assertEquals("result2", result.get("outputVariable1"));
+            assertThat(result.get("outputVariable1")).isEqualTo("result2");
         } finally {
             dmnEngine.getDmnRepositoryService().deleteDeployment(localDeployment.getId());
         }
@@ -106,7 +107,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
     @Test
     public void decisionKeyTenantId() {
         Map<String, Object> result = executeDecision(TEST_TENANT_ID, null);
-        Assert.assertEquals("result2", result.get("outputVariable1"));
+        assertThat(result.get("outputVariable1")).isEqualTo("result2");
     }
 
 
@@ -121,7 +122,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
         try {
             Map<String, Object> result = executeDecision(null, "WRONG_PARENT_DEPLOYMENT_ID");
 
-            Assert.assertEquals("result2", result.get("outputVariable1"));
+            assertThat(result.get("outputVariable1")).isEqualTo("result2");
         } finally {
             dmnEngine.getDmnRepositoryService().deleteDeployment(localDeployment.getId());
         }
@@ -148,7 +149,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
                 .fallbackToDefaultTenant()
                 .executeWithSingleResult();
 
-            Assert.assertEquals("result2", result.get("outputVariable1"));
+            assertThat(result.get("outputVariable1")).isEqualTo("result2");
         } finally {
             dmnEngine.getDmnRepositoryService().deleteDeployment(localDeployment.getId());
         }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyAnyTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyAnyTest.java
@@ -12,11 +12,7 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,8 +47,8 @@ public class HitPolicyAnyTest {
                 .variables(inputVariables)
                 .executeWithSingleResult();
 
-        assertEquals(10D, result.get("outputVariable1"));
-        assertEquals("result1", result.get("outputVariable2"));
+        assertThat(result.get("outputVariable1")).isEqualTo(10D);
+        assertThat(result.get("outputVariable2")).isEqualTo("result1");
     }
 
     @Test
@@ -69,10 +65,10 @@ public class HitPolicyAnyTest {
                 .variables(inputVariables)
                 .executeWithAuditTrail();
 
-        assertEquals(0, result.getDecisionResult().size());
-        assertTrue(result.isFailed());
-        assertNull(result.getValidationMessage());
-        assertNotNull(result.getExceptionMessage());
+        assertThat(result.getDecisionResult()).isEmpty();
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getValidationMessage()).isNull();
+        assertThat(result.getExceptionMessage()).isNotNull();
     }
 
     @Test
@@ -89,16 +85,16 @@ public class HitPolicyAnyTest {
                 .variables(inputVariables)
                 .executeWithAuditTrail();
 
-        assertEquals(0, result.getDecisionResult().size());
-        assertTrue(result.isFailed());
+        assertThat(result.getDecisionResult()).isEmpty();
+        assertThat(result.isFailed()).isTrue();
 
-        assertNotNull(result.getExceptionMessage());
-        assertNotNull(result.getRuleExecutions().get(1).getExceptionMessage());
-        assertNotNull(result.getRuleExecutions().get(3).getExceptionMessage());
+        assertThat(result.getExceptionMessage()).isNotNull();
+        assertThat(result.getRuleExecutions().get(1).getExceptionMessage()).isNotNull();
+        assertThat(result.getRuleExecutions().get(3).getExceptionMessage()).isNotNull();
 
-        assertNull(result.getValidationMessage());
-        assertNull(result.getRuleExecutions().get(1).getValidationMessage());
-        assertNull(result.getRuleExecutions().get(3).getValidationMessage());
+        assertThat(result.getValidationMessage()).isNull();
+        assertThat(result.getRuleExecutions().get(1).getValidationMessage()).isNull();
+        assertThat(result.getRuleExecutions().get(3).getValidationMessage()).isNull();
     }
 
     @Test
@@ -118,18 +114,18 @@ public class HitPolicyAnyTest {
                 .executeWithAuditTrail();
 
         Map<String, Object> outputMap = result.getDecisionResult().iterator().next();
-        assertEquals(2, outputMap.keySet().size());
-        assertEquals(10D, outputMap.get("outputVariable1"));
-        assertEquals("result2", outputMap.get("outputVariable2"));
-        assertFalse(result.isFailed());
+        assertThat(outputMap.keySet()).hasSize(2);
+        assertThat(outputMap.get("outputVariable1")).isEqualTo(10D);
+        assertThat(outputMap.get("outputVariable2")).isEqualTo("result2");
+        assertThat(result.isFailed()).isFalse();
 
-        assertNull(result.getExceptionMessage());
-        assertNull(result.getRuleExecutions().get(1).getExceptionMessage());
-        assertNull(result.getRuleExecutions().get(3).getExceptionMessage());
+        assertThat(result.getExceptionMessage()).isNull();
+        assertThat(result.getRuleExecutions().get(1).getExceptionMessage()).isNull();
+        assertThat(result.getRuleExecutions().get(3).getExceptionMessage()).isNull();
 
-        assertNotNull(result.getValidationMessage());
-        assertNotNull(result.getRuleExecutions().get(1).getValidationMessage());
-        assertNotNull(result.getRuleExecutions().get(3).getValidationMessage());
+        assertThat(result.getValidationMessage()).isNotNull();
+        assertThat(result.getRuleExecutions().get(1).getValidationMessage()).isNotNull();
+        assertThat(result.getRuleExecutions().get(3).getValidationMessage()).isNotNull();
 
         // re enable strict mode
         dmnEngine.getDmnEngineConfiguration().setStrictMode(true);

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyCollectTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyCollectTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -48,10 +45,9 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .execute();
 
-        assertEquals(3, result.size());
-        assertEquals("OUTPUT1", result.get(0).get("outputVariable1"));
-        assertEquals("OUTPUT2", result.get(1).get("outputVariable1"));
-        assertEquals("OUTPUT3", result.get(2).get("outputVariable1"));
+        assertThat(result)
+                .extracting("outputVariable1")
+                .containsExactly("OUTPUT1", "OUTPUT2", "OUTPUT3");
     }
 
     @Test
@@ -66,16 +62,16 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .execute();
 
-        assertEquals(3, result.size());
-        assertEquals(2, result.get(0).keySet().size());
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).keySet()).hasSize(2);
 
-        assertEquals("OUTPUT1", result.get(0).get("outputVariable1"));
-        assertEquals("OUTPUT2", result.get(1).get("outputVariable1"));
-        assertEquals("OUTPUT3", result.get(2).get("outputVariable1"));
+        assertThat(result)
+                .extracting("outputVariable1")
+                .containsExactly("OUTPUT1", "OUTPUT2", "OUTPUT3");
 
-        assertEquals(1D, result.get(0).get("outputVariable2"));
-        assertEquals(2D, result.get(1).get("outputVariable2"));
-        assertEquals(3D, result.get(2).get("outputVariable2"));
+        assertThat(result)
+                .extracting("outputVariable2")
+                .containsExactly(1D, 2D, 3D);
     }
 
     @Test
@@ -90,9 +86,9 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithAuditTrail();
 
-        assertEquals(0, result.getDecisionResult().size());
-        assertTrue(result.isFailed());
-        assertNotNull(result.getExceptionMessage());
+        assertThat(result.getDecisionResult()).isEmpty();
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getExceptionMessage()).isNotNull();
     }
 
     @Test
@@ -107,9 +103,9 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithAuditTrail();
 
-        assertEquals(0, result.getDecisionResult().size());
-        assertTrue(result.isFailed());
-        assertNotNull(result.getExceptionMessage());
+        assertThat(result.getDecisionResult()).isEmpty();
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getExceptionMessage()).isNotNull();
     }
 
     @Test
@@ -124,8 +120,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertEquals(1, result.keySet().size());
-        assertEquals(90D, result.get("outputVariable1"));
+        assertThat(result.keySet()).hasSize(1);
+        assertThat(result.get("outputVariable1")).isEqualTo(90D);
     }
 
     @Test
@@ -136,12 +132,12 @@ public class HitPolicyCollectTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         Map<String, Object> result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision1")
-            .variable("inputVariable1", 5)
-            .executeWithSingleResult();
+                .decisionKey("decision1")
+                .variable("inputVariable1", 5)
+                .executeWithSingleResult();
 
-        assertEquals(1, result.keySet().size());
-        assertEquals(60D, result.get("outputVariable1"));
+        assertThat(result.keySet()).hasSize(1);
+        assertThat(result.get("outputVariable1")).isEqualTo(60D);
     }
 
     @Test
@@ -156,8 +152,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertEquals(1, result.keySet().size());
-        assertEquals(10D, result.get("outputVariable1"));
+        assertThat(result.keySet()).hasSize(1);
+        assertThat(result.get("outputVariable1")).isEqualTo(10D);
     }
 
     @Test
@@ -172,8 +168,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertEquals(1, result.keySet().size());
-        assertEquals(30D, result.get("outputVariable1"));
+        assertThat(result.keySet()).hasSize(1);
+        assertThat(result.get("outputVariable1")).isEqualTo(30D);
     }
 
     @Test
@@ -188,8 +184,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertEquals(1, result.keySet().size());
-        assertEquals(4D, result.get("outputVariable1"));
+        assertThat(result.keySet()).hasSize(1);
+        assertThat(result.get("outputVariable1")).isEqualTo(4D);
     }
 
     @Test
@@ -200,12 +196,12 @@ public class HitPolicyCollectTest {
         DmnRuleService dmnRuleService = dmnEngine.getDmnRuleService();
 
         Map<String, Object> result = dmnRuleService.createExecuteDecisionBuilder()
-            .decisionKey("decision1")
-            .variable("inputVariable1", 5)
-            .executeWithSingleResult();
+                .decisionKey("decision1")
+                .variable("inputVariable1", 5)
+                .executeWithSingleResult();
 
-        assertEquals(1, result.keySet().size());
-        assertEquals(3D, result.get("outputVariable1"));
+        assertThat(result.keySet()).hasSize(1);
+        assertThat(result.get("outputVariable1")).isEqualTo(3D);
     }
 
     @Test
@@ -220,6 +216,6 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 50)
                 .executeWithSingleResult();
 
-        assertNull(result);
+        assertThat(result).isNull();
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyFirstTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyFirstTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -42,8 +42,8 @@ public class HitPolicyFirstTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 11)
                 .executeWithSingleResult();
-        
-        assertEquals("gt 10", result.get("outputVariable1"));
-        assertEquals("result2", result.get("outputVariable2"));
+
+        assertThat(result.get("outputVariable1")).isEqualTo("gt 10");
+        assertThat(result.get("outputVariable2")).isEqualTo("result2");
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyOutputOrderTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyOutputOrderTest.java
@@ -12,11 +12,7 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -48,11 +44,10 @@ public class HitPolicyOutputOrderTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 5)
                 .execute();
-        
-        assertEquals(3, result.size());
-        assertEquals("OUTPUT2", result.get(0).get("outputVariable1"));
-        assertEquals("OUTPUT3", result.get(1).get("outputVariable1"));
-        assertEquals("OUTPUT1", result.get(2).get("outputVariable1"));
+
+        assertThat(result)
+                .extracting("outputVariable1")
+                .containsExactly("OUTPUT2", "OUTPUT3", "OUTPUT1");
     }
 
     @Test
@@ -67,15 +62,14 @@ public class HitPolicyOutputOrderTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 5)
                 .executeWithAuditTrail();
-        
-        assertEquals(3, result.getDecisionResult().size());
-        assertEquals("OUTPUT1", result.getDecisionResult().get(0).get("outputVariable1"));
-        assertEquals("OUTPUT2", result.getDecisionResult().get(1).get("outputVariable1"));
-        assertEquals("OUTPUT3", result.getDecisionResult().get(2).get("outputVariable1"));
 
-        assertFalse(result.isFailed());
-        assertNull(result.getExceptionMessage());
-        assertNotNull(result.getValidationMessage());
+        assertThat(result.getDecisionResult())
+                .extracting("outputVariable1")
+                .containsExactly("OUTPUT1", "OUTPUT2", "OUTPUT3");
+
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getExceptionMessage()).isNull();
+        assertThat(result.getValidationMessage()).isNotNull();
 
         dmnEngine.getDmnEngineConfiguration().setStrictMode(true);
     }
@@ -92,11 +86,11 @@ public class HitPolicyOutputOrderTest {
                 .variable("inputVariable1", 5)
                 .executeWithAuditTrail();
 
-        assertEquals(0, result.getDecisionResult().size());
+        assertThat(result.getDecisionResult()).isEmpty();
 
-        assertTrue(result.isFailed());
-        assertNotNull(result.getExceptionMessage());
-        assertNull(result.getValidationMessage());
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getExceptionMessage()).isNotNull();
+        assertThat(result.getValidationMessage()).isNull();
     }
 
     @Test
@@ -111,16 +105,13 @@ public class HitPolicyOutputOrderTest {
                 .variable("inputVariable1", 5)
                 .execute();
 
-        assertEquals(4, result.size());
-        assertEquals("DECLINE", result.get(0).get("outputVariable1"));
-        assertEquals("REFER", result.get(1).get("outputVariable1"));
-        assertEquals("REFER", result.get(2).get("outputVariable1"));
-        assertEquals("ACCEPT", result.get(3).get("outputVariable1"));
+        assertThat(result)
+                .extracting("outputVariable1")
+                .containsExactly("DECLINE", "REFER", "REFER", "ACCEPT");
 
-        assertEquals("NONE", result.get(0).get("outputVariable2"));
-        assertEquals("LEVEL 2", result.get(1).get("outputVariable2"));
-        assertEquals("LEVEL 1", result.get(2).get("outputVariable2"));
-        assertEquals("NONE", result.get(3).get("outputVariable2"));
+        assertThat(result)
+                .extracting("outputVariable2")
+                .containsExactly("NONE", "LEVEL 2", "LEVEL 1", "NONE");
     }
 
     @Test
@@ -135,16 +126,13 @@ public class HitPolicyOutputOrderTest {
                 .variable("inputVariable1", 5)
                 .execute();
 
-        assertEquals(4, result.size());
-        assertEquals("DECLINE", result.get(0).get("outputVariable1"));
-        assertEquals("REFER", result.get(1).get("outputVariable1"));
-        assertEquals("REFER", result.get(2).get("outputVariable1"));
-        assertEquals("ACCEPT", result.get(3).get("outputVariable1"));
+        assertThat(result)
+                .extracting("outputVariable1")
+                .containsExactly("DECLINE", "REFER", "REFER", "ACCEPT");
 
-        assertEquals(10D, result.get(0).get("outputVariable2"));
-        assertEquals(30D, result.get(1).get("outputVariable2"));
-        assertEquals(20D, result.get(2).get("outputVariable2"));
-        assertEquals(10D, result.get(3).get("outputVariable2"));
+        assertThat(result)
+                .extracting("outputVariable2")
+                .containsExactly(10D, 30D, 20D, 10D);
     }
 
     @Test
@@ -159,16 +147,13 @@ public class HitPolicyOutputOrderTest {
                 .variable("inputVariable1", 5)
                 .execute();
 
-        assertEquals(4, result.size());
-        assertEquals("DECLINE", result.get(0).get("outputVariable1"));
-        assertEquals("REFER", result.get(1).get("outputVariable1"));
-        assertEquals("REFER", result.get(2).get("outputVariable1"));
-        assertEquals("ACCEPT", result.get(3).get("outputVariable1"));
+        assertThat(result)
+                .extracting("outputVariable1")
+                .containsExactly("DECLINE", "REFER", "REFER", "ACCEPT");
 
-        assertEquals("NONE", result.get(0).get("outputVariable2"));
-        assertEquals("LEVEL 1", result.get(1).get("outputVariable2"));
-        assertEquals("LEVEL 2", result.get(2).get("outputVariable2"));
-        assertEquals("NONE", result.get(3).get("outputVariable2"));
+        assertThat(result)
+                .extracting("outputVariable2")
+                .containsExactly("NONE", "LEVEL 1", "LEVEL 2", "NONE");
     }
 
     @Test
@@ -183,15 +168,12 @@ public class HitPolicyOutputOrderTest {
                 .variable("inputVariable1", 5)
                 .execute();
 
-        assertEquals(4, result.size());
-        assertEquals("REFER", result.get(0).get("outputVariable1"));
-        assertEquals("REFER", result.get(1).get("outputVariable1"));
-        assertEquals("ACCEPT", result.get(2).get("outputVariable1"));
-        assertEquals("DECLINE", result.get(3).get("outputVariable1"));
+        assertThat(result)
+                .extracting("outputVariable1")
+                .containsExactly("REFER", "REFER", "ACCEPT", "DECLINE");
 
-        assertEquals("LEVEL 2", result.get(0).get("outputVariable2"));
-        assertEquals("LEVEL 1", result.get(1).get("outputVariable2"));
-        assertEquals("NONE", result.get(2).get("outputVariable2"));
-        assertEquals("NONE", result.get(3).get("outputVariable2"));
+        assertThat(result)
+                .extracting("outputVariable2")
+                .containsExactly("LEVEL 2", "LEVEL 1", "NONE", "NONE");
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyPriorityTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyPriorityTest.java
@@ -12,11 +12,7 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -47,9 +43,9 @@ public class HitPolicyPriorityTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
-        
-        assertEquals(1, result.keySet().size());
-        assertEquals("OUTPUT2", result.get("outputVariable1"));
+
+        assertThat(result.keySet()).hasSize(1);
+        assertThat(result.get("outputVariable1")).isEqualTo("OUTPUT2");
     }
 
     @Test
@@ -63,10 +59,10 @@ public class HitPolicyPriorityTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
-        
-        assertEquals(2, result.keySet().size());
-        assertEquals("REFER", result.get("outputVariable1"));
-        assertEquals("LEVEL 2", result.get("outputVariable2"));
+
+        assertThat(result.keySet()).hasSize(2);
+        assertThat(result.get("outputVariable1")).isEqualTo("REFER");
+        assertThat(result.get("outputVariable2")).isEqualTo("LEVEL 2");
     }
 
     @Test
@@ -80,10 +76,10 @@ public class HitPolicyPriorityTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
-        
-        assertEquals(2, result.keySet().size());
-        assertEquals("REFER", result.get("outputVariable1"));
-        assertEquals("LEVEL 1", result.get("outputVariable2"));
+
+        assertThat(result.keySet()).hasSize(2);
+        assertThat(result.get("outputVariable1")).isEqualTo("REFER");
+        assertThat(result.get("outputVariable2")).isEqualTo("LEVEL 1");
     }
 
     @Test
@@ -98,9 +94,9 @@ public class HitPolicyPriorityTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertEquals(2, result.keySet().size());
-        assertEquals("REFER", result.get("outputVariable1"));
-        assertEquals("LEVEL 2", result.get("outputVariable2"));
+        assertThat(result.keySet()).hasSize(2);
+        assertThat(result.get("outputVariable1")).isEqualTo("REFER");
+        assertThat(result.get("outputVariable2")).isEqualTo("LEVEL 2");
     }
 
     @Test
@@ -114,11 +110,11 @@ public class HitPolicyPriorityTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 5)
                 .executeWithAuditTrail();
-        
-        assertEquals(0, result.getDecisionResult().size());
-        assertTrue(result.isFailed());
-        assertNotNull(result.getExceptionMessage());
-        assertNull(result.getValidationMessage());
+
+        assertThat(result.getDecisionResult()).isEmpty();
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getExceptionMessage()).isNotNull();
+        assertThat(result.getValidationMessage()).isNull();
     }
 
     @Test
@@ -134,15 +130,15 @@ public class HitPolicyPriorityTest {
                 .variable("inputVariable1", 5)
                 .executeWithAuditTrail();
 
-        assertEquals(1, result.getDecisionResult().size());
+        assertThat(result.getDecisionResult()).hasSize(1);
         Map<String, Object> outputMap = result.getDecisionResult().iterator().next();
-        assertEquals(2, outputMap.keySet().size());
-        assertEquals("ACCEPT", outputMap.get("outputVariable1"));
-        assertEquals("NONE", outputMap.get("outputVariable2"));
+        assertThat(outputMap.keySet()).hasSize(2);
+        assertThat(outputMap.get("outputVariable1")).isEqualTo("ACCEPT");
+        assertThat(outputMap.get("outputVariable2")).isEqualTo("NONE");
 
-        assertFalse(result.isFailed());
-        assertNull(result.getExceptionMessage());
-        assertNotNull(result.getValidationMessage());
+        assertThat(result.isFailed()).isFalse();
+        assertThat(result.getExceptionMessage()).isNull();
+        assertThat(result.getValidationMessage()).isNotNull();
 
         dmnEngine.getDmnEngineConfiguration().setStrictMode(true);
     }
@@ -159,8 +155,8 @@ public class HitPolicyPriorityTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
-        
-        assertEquals(1, result.keySet().size());
-        assertEquals(20D, result.get("outputVariable1"));
+
+        assertThat(result.keySet()).hasSize(1);
+        assertThat(result.get("outputVariable1")).isEqualTo(20D);
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyRuleOrderTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyRuleOrderTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -43,9 +43,9 @@ public class HitPolicyRuleOrderTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 13)
                 .execute();
-        
-        assertEquals(2, result.size());
-        assertEquals("result2", result.get(0).get("outputVariable1"));
-        assertEquals("result4", result.get(1).get("outputVariable1"));
+
+        assertThat(result)
+                .extracting("outputVariable1")
+                .containsExactly("result2", "result4");
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyUniqueTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyUniqueTest.java
@@ -12,11 +12,7 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -47,7 +43,7 @@ public class HitPolicyUniqueTest {
                 .variable("inputVariable1", 10)
                 .executeWithSingleResult();
 
-        assertEquals("eq 10", result.get("outputVariable1"));
+        assertThat(result.get("outputVariable1")).isEqualTo("eq 10");
     }
 
     @Test
@@ -60,17 +56,17 @@ public class HitPolicyUniqueTest {
                 .decisionKey("decision1")
                 .variable("inputVariable1", 9)
                 .executeWithAuditTrail();
-        
-        assertEquals(0, result.getDecisionResult().size());
-        assertTrue(result.isFailed());
 
-        assertNotNull(result.getExceptionMessage());
-        assertNotNull(result.getRuleExecutions().get(1).getExceptionMessage());
-        assertNotNull(result.getRuleExecutions().get(3).getExceptionMessage());
+        assertThat(result.getDecisionResult()).isEmpty();
+        assertThat(result.isFailed()).isTrue();
 
-        assertNull(result.getValidationMessage());
-        assertNull(result.getRuleExecutions().get(1).getValidationMessage());
-        assertNull(result.getRuleExecutions().get(3).getValidationMessage());
+        assertThat(result.getExceptionMessage()).isNotNull();
+        assertThat(result.getRuleExecutions().get(1).getExceptionMessage()).isNotNull();
+        assertThat(result.getRuleExecutions().get(3).getExceptionMessage()).isNotNull();
+
+        assertThat(result.getValidationMessage()).isNull();
+        assertThat(result.getRuleExecutions().get(1).getValidationMessage()).isNull();
+        assertThat(result.getRuleExecutions().get(3).getValidationMessage()).isNull();
     }
 
     @Test
@@ -86,21 +82,21 @@ public class HitPolicyUniqueTest {
                 .variable("inputVariable1", 9)
                 .executeWithAuditTrail();
 
-        assertEquals(1, result.getDecisionResult().size());
-        
+        assertThat(result.getDecisionResult()).hasSize(1);
+
         Map<String, Object> outputMap = result.getDecisionResult().iterator().next();
-        
-        assertEquals("lt 20", outputMap.get("outputVariable1"));
-        assertEquals(10D, outputMap.get("outputVariable2"));
-        assertFalse(result.isFailed());
 
-        assertNull(result.getExceptionMessage());
-        assertNull(result.getRuleExecutions().get(1).getExceptionMessage());
-        assertNull(result.getRuleExecutions().get(3).getExceptionMessage());
+        assertThat(outputMap.get("outputVariable1")).isEqualTo("lt 20");
+        assertThat(outputMap.get("outputVariable2")).isEqualTo(10D);
+        assertThat(result.isFailed()).isFalse();
 
-        assertNotNull(result.getValidationMessage());
-        assertNotNull(result.getRuleExecutions().get(1).getValidationMessage());
-        assertNotNull(result.getRuleExecutions().get(3).getValidationMessage());
+        assertThat(result.getExceptionMessage()).isNull();
+        assertThat(result.getRuleExecutions().get(1).getExceptionMessage()).isNull();
+        assertThat(result.getRuleExecutions().get(3).getExceptionMessage()).isNull();
+
+        assertThat(result.getValidationMessage()).isNotNull();
+        assertThat(result.getRuleExecutions().get(1).getValidationMessage()).isNotNull();
+        assertThat(result.getRuleExecutions().get(3).getValidationMessage()).isNotNull();
 
         // re enable strict mode
         dmnEngine.getDmnEngineConfiguration().setStrictMode(true);

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
@@ -278,7 +278,6 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", null)
                 .executeWithSingleResult();
-        assertThat(result.get("output1").getClass()).isSameAs(String.class);
         assertThat(result.get("output1")).isEqualTo("test2");
     }
 
@@ -292,7 +291,6 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("date", localDate.toDate())
                 .executeWithSingleResult();
-        assertThat(result.get("output1").getClass()).isSameAs(String.class);
         assertThat(result.get("output1")).isEqualTo("test2");
     }
 

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
@@ -12,20 +12,23 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.engine.test.AbstractFlowableDmnTest;
 import org.flowable.dmn.engine.test.DmnDeployment;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import org.junit.Assert;
 import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Yvo Swillens
@@ -41,10 +44,10 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", 10)
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test3", result.get("output1"));
-        Assert.assertSame(Double.class, result.get("output2").getClass());
-        Assert.assertEquals(3D, result.get("output2"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test3");
+        assertThat(result.get("output2").getClass()).isSameAs(Double.class);
+        assertThat(result.get("output2")).isEqualTo(3D);
     }
 
     @Test
@@ -57,8 +60,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test2", result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -71,8 +74,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test2", result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -85,8 +88,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test2", result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -99,8 +102,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test2", result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -113,8 +116,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", localDate)
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test2", result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -124,9 +127,9 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", "testString")
                 .executeWithSingleResult();
-        Assert.assertNotNull(result);
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test1", result.get("output1"));
+        assertThat(result).isNotNull();
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test1");
     }
 
     @Test
@@ -141,8 +144,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variables(processVariablesInput)
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test2", result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -157,7 +160,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
             .variables(processVariablesInput)
             .executeWithSingleResult();
 
-        Assert.assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
@@ -168,17 +171,17 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("input1", 11D);
 
         List<Map<String, Object>> result = ruleService.createExecuteDecisionBuilder()
-            .decisionKey("decision")
-            .variables(processVariablesInput)
-            .execute();
+                .decisionKey("decision")
+                .variables(processVariablesInput)
+                .execute();
 
-        Assert.assertEquals(3, result.size());
-        Assert.assertEquals(1, result.get(0).size());
-        Assert.assertEquals(11d, result.get(0).get("output1"));
-        Assert.assertEquals(1, result.get(1).size());
-        Assert.assertEquals(11d, result.get(1).get("output2"));
-        Assert.assertEquals(1, result.get(2).size());
-        Assert.assertEquals(11d, result.get(2).get("output3"));
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0)).hasSize(1);
+        assertThat(result.get(0).get("output1")).isEqualTo(11d);
+        assertThat(result.get(1)).hasSize(1);
+        assertThat(result.get(1).get("output2")).isEqualTo(11d);
+        assertThat(result.get(2)).hasSize(1);
+        assertThat(result.get(2).get("output3")).isEqualTo(11d);
     }
 
     @Test
@@ -188,8 +191,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", "blablatest")
                 .executeWithSingleResult();
-        Assert.assertSame(Double.class, result.get("output1").getClass());
-        Assert.assertEquals(5D, result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(Double.class);
+        assertThat(result.get("output1")).isEqualTo(5D);
     }
 
     @Test
@@ -199,7 +202,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", "blablatest")
                 .executeWithAuditTrail();
-        Assert.assertNotNull(result.getRuleExecutions().get(2).getConclusionResults().iterator().next().getException());
+        assertThat(result.getRuleExecutions().get(2).getConclusionResults().iterator().next().getException()).isNotNull();
     }
 
     @Test
@@ -208,7 +211,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         DecisionExecutionAuditContainer result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
                 .executeWithAuditTrail();
-        Assert.assertEquals(true, result.isFailed());
+        assertThat(result.isFailed()).isTrue();
     }
 
     @Test
@@ -218,7 +221,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variables(new HashMap<>())
                 .executeWithAuditTrail();
-        Assert.assertEquals(false, result.isFailed());
+        assertThat(result.isFailed()).isFalse();
     }
 
     @Test
@@ -228,7 +231,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", "blablatest")
                 .executeWithAuditTrail();
-        Assert.assertEquals(true, result.isFailed());
+        assertThat(result.isFailed()).isTrue();
     }
 
     @Test
@@ -239,13 +242,13 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("input1", "blablatest");
         processVariablesInput.put("referenceVar1", 10D);
         processVariablesInput.put("referenceVar2", 20D);
-        
+
         Map<String, Object> result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
                 .variables(processVariablesInput)
                 .executeWithSingleResult();
-        
-        Assert.assertEquals(200D, result.get("output1"));
+
+        assertThat(result.get("output1")).isEqualTo(200D);
     }
 
     @Test
@@ -255,7 +258,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", "blablatest")
                 .executeWithAuditTrail();
-        Assert.assertEquals(true, result.isFailed());
+        assertThat(result.isFailed()).isTrue();
     }
 
     @Test
@@ -265,7 +268,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", "testblabla")
                 .executeWithAuditTrail();
-        Assert.assertEquals(false, result.isFailed());
+        assertThat(result.isFailed()).isFalse();
     }
 
     @Test
@@ -275,8 +278,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", null)
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test2", result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -289,8 +292,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("date", localDate.toDate())
                 .executeWithSingleResult();
-        Assert.assertSame(String.class, result.get("output1").getClass());
-        Assert.assertEquals("test2", result.get("output1"));
+        assertThat(result.get("output1").getClass()).isSameAs(String.class);
+        assertThat(result.get("output1")).isEqualTo("test2");
     }
 
     @Test
@@ -299,16 +302,15 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         Map<String, Object> processVariablesInput = new HashMap<>();
         processVariablesInput.put("input1", "AAA");
         processVariablesInput.put("input2", "BBB");
-        
+
         List<Map<String, Object>> result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
                 .variables(processVariablesInput)
                 .execute();
 
-        Assert.assertEquals(3, result.size());
-        Assert.assertEquals("THIRD", result.get(0).get("output1"));
-        Assert.assertEquals("FIRST", result.get(1).get("output1"));
-        Assert.assertEquals("SECOND", result.get(2).get("output1"));
+        assertThat(result)
+                .extracting("output1")
+                .containsExactly("THIRD", "FIRST", "SECOND");
     }
 
     @Test
@@ -323,27 +325,15 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("RiskRatingDecisionTable")
                 .variables(processVariablesInput)
                 .execute();
-        
-        Map<String, Object> ruleResult1 = result.get(0);
-        Map<String, Object> ruleResult2 = result.get(1);
-        Map<String, Object> ruleResult3 = result.get(2);
-        Map<String, Object> ruleResult4 = result.get(3);
 
-        Assert.assertEquals("DECLINE", ruleResult1.get("routing"));
-        Assert.assertEquals("Applicant too young", ruleResult1.get("reason"));
-        Assert.assertEquals("NONE", ruleResult1.get("reviewlevel"));
-
-        Assert.assertEquals("REFER", ruleResult2.get("routing"));
-        Assert.assertEquals("Applicant under debt review", ruleResult2.get("reason"));
-        Assert.assertEquals("LEVEL 2", ruleResult2.get("reviewlevel"));
-
-        Assert.assertEquals("REFER", ruleResult3.get("routing"));
-        Assert.assertEquals("High risk application", ruleResult3.get("reason"));
-        Assert.assertEquals("LEVEL 1", ruleResult3.get("reviewlevel"));
-
-        Assert.assertEquals("ACCEPT", ruleResult4.get("routing"));
-        Assert.assertEquals("Acceptable", ruleResult4.get("reason"));
-        Assert.assertEquals("NONE", ruleResult4.get("reviewlevel"));
+        assertThat(result)
+                .extracting("routing", "reason", "reviewlevel")
+                .containsExactly(
+                        tuple("DECLINE", "Applicant too young", "NONE"),
+                        tuple("REFER", "Applicant under debt review", "LEVEL 2"),
+                        tuple("REFER", "High risk application", "LEVEL 1"),
+                        tuple("ACCEPT", "Acceptable", "NONE")
+                );
     }
 
     @Test
@@ -355,30 +345,18 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
         processVariablesInput.put("debtreview", true);
 
         List<Map<String, Object>> result = ruleService.createExecuteDecisionBuilder()
-            .decisionKey("RiskRatingDecisionTable")
-            .variables(processVariablesInput)
-            .execute();
+                .decisionKey("RiskRatingDecisionTable")
+                .variables(processVariablesInput)
+                .execute();
 
-        Map<String, Object> ruleResult1 = result.get(0);
-        Map<String, Object> ruleResult2 = result.get(1);
-        Map<String, Object> ruleResult3 = result.get(2);
-        Map<String, Object> ruleResult4 = result.get(3);
-
-        Assert.assertEquals("DECLINE", ruleResult1.get("routing"));
-        Assert.assertEquals("Applicant too young", ruleResult1.get("reason"));
-        Assert.assertEquals("NONE", ruleResult1.get("reviewlevel"));
-
-        Assert.assertEquals("REFER", ruleResult2.get("routing"));
-        Assert.assertEquals("Applicant under debt review", ruleResult2.get("reason"));
-        Assert.assertEquals("LEVEL 2", ruleResult2.get("reviewlevel"));
-
-        Assert.assertEquals("REFER", ruleResult3.get("routing"));
-        Assert.assertEquals("High risk application", ruleResult3.get("reason"));
-        Assert.assertEquals("LEVEL 1", ruleResult3.get("reviewlevel"));
-
-        Assert.assertEquals("ACCEPT", ruleResult4.get("routing"));
-        Assert.assertEquals("Acceptable", ruleResult4.get("reason"));
-        Assert.assertEquals("NONE", ruleResult4.get("reviewlevel"));
+        assertThat(result)
+                .extracting("routing", "reason", "reviewlevel")
+                .containsExactly(
+                        tuple("DECLINE", "Applicant too young", "NONE"),
+                        tuple("REFER", "Applicant under debt review", "LEVEL 2"),
+                        tuple("REFER", "High risk application", "LEVEL 1"),
+                        tuple("ACCEPT", "Acceptable", "NONE")
+                );
     }
 
     @Test
@@ -394,8 +372,8 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variables(processVariablesInput)
                 .executeWithSingleResult();
 
-        Assert.assertEquals(500D, result.get("total"));
-        Assert.assertEquals(0D, result.get("discount"));
+        assertThat(result.get("total")).isEqualTo(500D);
+        assertThat(result.get("discount")).isEqualTo(0D);
     }
 
     @Test
@@ -410,10 +388,10 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variables(processVariablesInput)
                 .executeWithAuditTrail();
 
-        Assert.assertNotNull(result);
-        Assert.assertEquals(true, result.getRuleExecutions().get(1).getConditionResults().get(0).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(2).getConditionResults().get(0).getResult());
-        Assert.assertEquals(true, result.getRuleExecutions().get(3).getConditionResults().get(0).getResult());
+        assertThat(result).isNotNull();
+        assertThat(result.getRuleExecutions().get(1).getConditionResults().get(0).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(2).getConditionResults().get(0).getResult()).isEqualTo(true);
+        assertThat(result.getRuleExecutions().get(3).getConditionResults().get(0).getResult()).isEqualTo(true);
     }
 
 
@@ -431,6 +409,6 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variables(processVariablesInput)
                 .executeWithSingleResult();
 
-        Assert.assertEquals("result2", result.get("outputVariable1"));
+        assertThat(result.get("outputVariable1")).isEqualTo("result2");
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/StandaloneRuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/StandaloneRuntimeTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.engine.test.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,7 +21,6 @@ import org.flowable.dmn.api.DmnRuleService;
 import org.flowable.dmn.engine.DmnEngine;
 import org.flowable.dmn.engine.test.DmnDeployment;
 import org.flowable.dmn.engine.test.FlowableDmnRule;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -45,7 +46,7 @@ public class StandaloneRuntimeTest {
                 .decisionKey("decision1")
                 .variables(inputVariables)
                 .executeWithSingleResult();
-        
-        Assert.assertEquals("result2", result.get("outputVariable1"));
+
+        assertThat(result.get("outputVariable1")).isEqualTo("result2");
     }
 }


### PR DESCRIPTION
Added `net.javacrumbs.json-unit` dependency so `assertThatJson` was available.

