### PR TITLE
fixing case exit sentry with completion semantics

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/ExitPlanItemInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/ExitPlanItemInstanceOperation.java
@@ -100,6 +100,8 @@ public class ExitPlanItemInstanceOperation extends AbstractMovePlanItemInstanceT
         if (isStage()) {
             if (EXIT_EVENT_TYPE_COMPLETE.equals(exitEventType)) {
                 // if the stage should exit with a complete event instead of exit, we need to make sure it is completable
+                // we don't use the completion flag directly on the entity as it gets evaluated only at the end of an evaluation cycle which we didn't hit yet
+                // at this point, so we need a proper evaluation of the completion
                 if (!PlanItemInstanceContainerUtil.shouldPlanItemContainerComplete(commandContext, planItemInstanceEntity, true).isCompletable()) {
                     // we can't complete the stage as it is currently not completable, so we need to throw an exception
                     throw new FlowableIllegalArgumentException(

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/TerminateCaseInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/TerminateCaseInstanceOperation.java
@@ -16,8 +16,10 @@ import static org.flowable.cmmn.model.Criterion.EXIT_EVENT_TYPE_COMPLETE;
 import static org.flowable.cmmn.model.Criterion.EXIT_EVENT_TYPE_FORCE_COMPLETE;
 
 import org.flowable.cmmn.api.runtime.CaseInstanceState;
+import org.flowable.cmmn.engine.impl.persistence.entity.CaseInstanceEntity;
 import org.flowable.cmmn.engine.impl.persistence.entity.PlanItemInstanceEntity;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.cmmn.engine.impl.util.PlanItemInstanceContainerUtil;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 
@@ -56,8 +58,13 @@ public class TerminateCaseInstanceOperation extends AbstractDeleteCaseInstanceOp
      * Checks, if the case is completable and if not, raises an exception.
      */
     protected void checkCaseToBeCompletable() {
+        CaseInstanceEntity caseInstance = getCaseInstanceEntity();
+        boolean isAutoComplete = getPlanModel(caseInstance).isAutoComplete();
+
         // if the case should exit with a complete event instead of exit, we need to make sure it is completable
-        if (!getCaseInstanceEntity().isCompletable()) {
+        // we don't use the completion flag directly on the entity as it gets evaluated only at the end of an evaluation cycle which we didn't hit yet
+        // at this point, so we need a proper evaluation of the completion
+        if (!PlanItemInstanceContainerUtil.shouldPlanItemContainerComplete(commandContext, caseInstance, isAutoComplete).isCompletable()) {
             // we can't complete the case as it is currently not completable, so we need to throw an exception
             throw new FlowableIllegalArgumentException(
                 "Cannot exit case with 'complete' event type as the case '" + getCaseInstanceId() + "' is not yet completable.");

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.java
@@ -1,0 +1,38 @@
+package org.flowable.cmmn.test.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
+
+import java.util.List;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.junit.Test;
+
+/**
+ * Testing a milestone triggering an exit sentry on the case level with completion semantics.
+ *
+ * @author Micha Kiener
+ */
+public class CompleteWithExitSentryByMilestoneTest extends FlowableCmmnTestCase {
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.testExitSentryCompletion.cmmn")
+    public void testExitSentryCompletion() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("exitSentryTriggeredByMilestoneTestCase")
+            .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+
+        assertThat(planItemInstances).hasSize(3);
+        assertPlanItemInstanceState(planItemInstances, "Task", ACTIVE);
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task"));
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
+    }
+}

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.testExitSentryCompletion.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.testExitSentryCompletion.cmmn
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+  <case id="exitSentryTriggeredByMilestoneTestCase" name="Exit Sentry Triggered By Milestone Test Case" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItem1" name="Milestone" definitionRef="milestone1">
+        <entryCriterion id="entryCriterion2" sentryRef="sentry1"></entryCriterion>
+      </planItem>
+      <planItem id="planItem3" name="Stage" definitionRef="expandedStage1"></planItem>
+      <sentry id="sentry2">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExitCriterion]]></design:stencilid>
+        </extensionElements>
+        <planItemOnPart id="sentryOnPart1" sourceRef="planItem1">
+          <standardEvent>occur</standardEvent>
+        </planItemOnPart>
+      </sentry>
+      <sentry id="sentry1">
+        <extensionElements>
+          <design:stencilid><![CDATA[EntryCriterion]]></design:stencilid>
+        </extensionElements>
+        <planItemOnPart id="sentryOnPart2" sourceRef="planItem3">
+          <standardEvent>complete</standardEvent>
+        </planItemOnPart>
+      </sentry>
+      <milestone id="milestone1" name="Milestone" flowable:milestoneVariable="Milestone">
+        <extensionElements>
+          <design:stencilid><![CDATA[Milestone]]></design:stencilid>
+        </extensionElements>
+      </milestone>
+      <stage id="expandedStage1" name="Stage" flowable:includeInStageOverview="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItem2" name="Task" definitionRef="humanTask1"></planItem>
+        <humanTask id="humanTask1" name="Task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+      </stage>
+      <exitCriterion id="exitCriterion2" sentryRef="sentry2" flowable:exitEventType="complete"></exitCriterion>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_exitSentryTriggeredByMilestoneTestCase">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="330.0" width="600.0" x="30.0" y="45.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_exitCriterion2" cmmnElementRef="exitCriterion2">
+        <dc:Bounds height="28.0" width="18.0" x="621.0" y="206.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+        <dc:Bounds height="54.0" width="146.0" x="375.0" y="193.5"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_entryCriterion2" cmmnElementRef="entryCriterion2">
+        <dc:Bounds height="28.0" width="18.0" x="366.0" y="206.5"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+        <dc:Bounds height="165.0" width="225.0" x="90.0" y="138.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+        <dc:Bounds height="80.0" width="100.0" x="135.0" y="183.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="CMMNEdge_connector3" cmmnElementRef="planItem3" targetCMMNElementRef="entryCriterion2">
+        <di:waypoint x="314.94999999995747" y="220.5"></di:waypoint>
+        <di:waypoint x="345.0" y="220.5"></di:waypoint>
+        <di:waypoint x="345.0" y="220.5"></di:waypoint>
+        <di:waypoint x="366.0" y="220.5"></di:waypoint>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNEdge>
+      <cmmndi:CMMNEdge id="CMMNEdge_connector4" cmmnElementRef="planItem1" targetCMMNElementRef="exitCriterion2">
+        <di:waypoint x="520.9499999999048" y="212.43506493506493"></di:waypoint>
+        <di:waypoint x="571.0" y="212.43506493506493"></di:waypoint>
+        <di:waypoint x="571.0" y="220.0"></di:waypoint>
+        <di:waypoint x="621.0" y="220.0"></di:waypoint>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>


### PR DESCRIPTION
Fixing case exit sentry with completion semantics, triggered by a milestone to run a completion evaluation on the spot and not relying on the completion flag

#### Check List:
* Unit tests: YES
* Documentation: NA
