### PR TITLE
Use assertj fluent style in flowable-dmn-engine-configurator module.

### DIFF
--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/history/HistoryTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/history/HistoryTest.java
@@ -12,10 +12,7 @@
  */
 package org.flowable.dmn.test.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,19 +44,20 @@ public class HistoryTest extends AbstractFlowableDmnEngineConfiguratorTest {
     public void deployNestedProcessAndDecisionTable() {
         try {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivityProcess", Collections.singletonMap("inputVariable1", 10));
-    
+
             DmnHistoryService dmnHistoryService = DmnEngines.getDefaultDmnEngine().getDmnHistoryService();
-            DmnHistoricDecisionExecution decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery().processInstanceIdWithChildren(processInstance.getId()).singleResult();
-            assertEquals("decision1", decisionExecution.getDecisionKey());
+            DmnHistoricDecisionExecution decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery()
+                    .processInstanceIdWithChildren(processInstance.getId()).singleResult();
+            assertThat(decisionExecution.getDecisionKey()).isEqualTo("decision1");
             String subProcessInstanceId = decisionExecution.getInstanceId();
-            assertNotEquals(subProcessInstanceId, processInstance.getId());
-            
+            assertThat(processInstance.getId()).isNotEqualTo(subProcessInstanceId);
+
             decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery().instanceId(processInstance.getId()).singleResult();
-            assertNull(decisionExecution);
-            
+            assertThat(decisionExecution).isNull();
+
             decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery().instanceId(subProcessInstanceId).singleResult();
-            assertEquals("decision1", decisionExecution.getDecisionKey());
-            
+            assertThat(decisionExecution.getDecisionKey()).isEqualTo("decision1");
+
         } finally {
             deleteAllDmnDeployments();
         }
@@ -81,37 +79,38 @@ public class HistoryTest extends AbstractFlowableDmnEngineConfiguratorTest {
             
             DmnHistoryService dmnHistoryService = DmnEngines.getDefaultDmnEngine().getDmnHistoryService();
             List<DmnHistoricDecisionExecution> decisionExecutions = dmnHistoryService.createHistoricDecisionExecutionQuery().caseInstanceIdWithChildren(caseInstance.getId()).list();
-            assertEquals(1, decisionExecutions.size());
+            assertThat(decisionExecutions).hasSize(1);
             
             PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                             .caseInstanceId(caseInstance.getId())
                             .planItemDefinitionId("task")
                             .singleResult();
             cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-            
+
             decisionExecutions = dmnHistoryService.createHistoricDecisionExecutionQuery().caseInstanceIdWithChildren(caseInstance.getId()).list();
-            assertEquals(2, decisionExecutions.size());
-            
+            assertThat(decisionExecutions).hasSize(2);
+
             String caseInstanceId = null;
             String processInstanceId = null;
             for (DmnHistoricDecisionExecution dmnExecution : decisionExecutions) {
-                assertEquals("decision1", dmnExecution.getDecisionKey());
+                assertThat(dmnExecution.getDecisionKey()).isEqualTo("decision1");
                 if (caseInstance.getId().equals(dmnExecution.getInstanceId())) {
                     caseInstanceId = dmnExecution.getInstanceId();
                 } else {
                     processInstanceId = dmnExecution.getInstanceId();
                 }
             }
-            
-            assertNotNull(caseInstanceId);
-            assertNotNull(processInstanceId);
-            
-            DmnHistoricDecisionExecution decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery().instanceId(processInstanceId).singleResult();
-            assertEquals("decision1", decisionExecution.getDecisionKey());
-            
+
+            assertThat(caseInstanceId).isNotNull();
+            assertThat(processInstanceId).isNotNull();
+
+            DmnHistoricDecisionExecution decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery().instanceId(processInstanceId)
+                    .singleResult();
+            assertThat(decisionExecution.getDecisionKey()).isEqualTo("decision1");
+
             decisionExecution = dmnHistoryService.createHistoricDecisionExecutionQuery().processInstanceIdWithChildren(processInstanceId).singleResult();
-            assertEquals("decision1", decisionExecution.getDecisionKey());
-            
+            assertThat(decisionExecution.getDecisionKey()).isEqualTo("decision1");
+
         } finally {
             deleteAllDmnDeployments();
         }

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
@@ -13,15 +13,10 @@
 package org.flowable.dmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.flowable.cmmn.api.CmmnRuntimeService;
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
@@ -36,10 +31,13 @@ import org.flowable.dmn.api.DmnHistoricDecisionExecution;
 import org.flowable.dmn.engine.DmnEngineConfiguration;
 import org.flowable.dmn.engine.DmnEngines;
 import org.flowable.task.api.Task;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author martin.grofcik
@@ -269,15 +267,15 @@ public class DecisionTaskTest {
     )
     public void testUseDmnOutputInEntryCriteria() {
         CaseInstance caseInstance = cmmnRule.getCmmnRuntimeService().createCaseInstanceBuilder()
-            .caseDefinitionKey("testRules")
-            .variable("first", "11")
-            .variable("second", "11")
-            .start();
+                .caseDefinitionKey("testRules")
+                .variable("first", "11")
+                .variable("second", "11")
+                .start();
 
         // The entry sentry on the first stage uses the output of the DMN table
         List<Task> tasks = cmmnRule.getCmmnTaskService().createTaskQuery().caseInstanceId(caseInstance.getId()).orderByTaskName().asc().list();
-        assertEquals("Human task", tasks.get(0).getName());
-        assertEquals("Task One", tasks.get(1).getName());
+        assertThat(tasks.get(0).getName()).isEqualTo("Human task");
+        assertThat(tasks.get(1).getName()).isEqualTo("Task One");
     }
 
     @Test
@@ -577,10 +575,10 @@ public class DecisionTaskTest {
         Object resultObject = caseVariables.get("DecisionTable");
         assertThat(resultObject).isInstanceOf(ArrayNode.class);
         ArrayNode result = (ArrayNode) resultObject;
-        assertThat(result).hasSize(0);
+        assertThat(result).isEmpty();
     }
 
-    // Helper methodes
+    // Helper methods
 
     protected void deployDmnTableAssertCaseStarted() {
         org.flowable.cmmn.api.repository.CmmnDeployment cmmnDeployment = cmmnRule.getCmmnRepositoryService().createDeployment().
@@ -590,25 +588,25 @@ public class DecisionTaskTest {
 
         try {
             CaseInstance caseInstance = cmmnRule.getCmmnRuntimeService().createCaseInstanceBuilder()
-                .caseDefinitionKey("myCase")
-                .variable("testVar", "test2")
-                .tenantId("flowable")
-                .start();
+                    .caseDefinitionKey("myCase")
+                    .variable("testVar", "test2")
+                    .tenantId("flowable")
+                    .start();
 
             assertResultVariable(caseInstance);
-            
+
             CmmnEngineConfiguration cmmnEngineConfiguration = cmmnRule.getCmmnEngineConfiguration();
             DmnEngineConfiguration dmnEngineConfiguration = (DmnEngineConfiguration) cmmnEngineConfiguration.getEngineConfigurations().get(
-                            EngineConfigurationConstants.KEY_DMN_ENGINE_CONFIG);
-            
+                    EngineConfigurationConstants.KEY_DMN_ENGINE_CONFIG);
+
             DmnHistoricDecisionExecution decisionExecution = dmnEngineConfiguration.getDmnHistoryService()
-                            .createHistoricDecisionExecutionQuery()
-                            .instanceId(caseInstance.getId())
-                            .singleResult();
-            
-            assertNotNull(decisionExecution);
-            assertEquals("flowable", decisionExecution.getTenantId());
-            
+                    .createHistoricDecisionExecutionQuery()
+                    .instanceId(caseInstance.getId())
+                    .singleResult();
+
+            assertThat(decisionExecution).isNotNull();
+            assertThat(decisionExecution.getTenantId()).isEqualTo("flowable");
+
         } finally {
             cmmnRule.getCmmnRepositoryService().deleteDeployment(cmmnDeployment.getId(), true);
         }
@@ -630,21 +628,21 @@ public class DecisionTaskTest {
 
         try {
             CaseInstance caseInstance = cmmnRule.getCmmnRuntimeService().createCaseInstanceBuilder()
-                .caseDefinitionKey("myCase")
-                .variable("testVar", "test2")
-                .tenantId("flowable")
-                .start();
+                    .caseDefinitionKey("myCase")
+                    .variable("testVar", "test2")
+                    .tenantId("flowable")
+                    .start();
 
             assertResultVariable(caseInstance);
-            
+
             DmnHistoricDecisionExecution decisionExecution = dmnEngineConfiguration.getDmnHistoryService()
-                            .createHistoricDecisionExecutionQuery()
-                            .instanceId(caseInstance.getId())
-                            .singleResult();
-            
-            assertNotNull(decisionExecution);
-            assertEquals("flowable", decisionExecution.getTenantId());
-            
+                    .createHistoricDecisionExecutionQuery()
+                    .instanceId(caseInstance.getId())
+                    .singleResult();
+
+            assertThat(decisionExecution).isNotNull();
+            assertThat(decisionExecution.getTenantId()).isEqualTo("flowable");
+
         } finally {
             dmnEngineConfiguration.setFallbackToDefaultTenant(false);
             dmnEngineConfiguration.setDefaultTenantProvider(originalDefaultTenantProvider);
@@ -653,40 +651,40 @@ public class DecisionTaskTest {
     }
 
     protected void assertResultVariable(CaseInstance caseInstance) {
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         PlanItemInstance planItemInstance = cmmnRule.getCmmnRuntimeService().createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
+        assertThat(planItemInstance).isNotNull();
 
-        Assert.assertEquals("executed", cmmnRule.getCmmnRuntimeService().getVariable(caseInstance.getId(), "resultVar"));
+        assertThat(cmmnRule.getCmmnRuntimeService().getVariable(caseInstance.getId(), "resultVar")).isEqualTo("executed");
 
         // Triggering the task should end the case instance
         cmmnRule.getCmmnRuntimeService().triggerPlanItemInstance(planItemInstance.getId());
-        Assert.assertEquals(0, cmmnRule.getCmmnRuntimeService().createCaseInstanceQuery().count());
+        assertThat(cmmnRule.getCmmnRuntimeService().createCaseInstanceQuery().count()).isEqualTo(0);
 
-        Assert.assertEquals("executed", cmmnRule.getCmmnHistoryService().createHistoricVariableInstanceQuery()
+        assertThat(cmmnRule.getCmmnHistoryService().createHistoricVariableInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .variableName("resultVar")
-                .singleResult().getValue());
+                .singleResult().getValue()).isEqualTo("executed");
     }
 
     protected void assertNoResultVariable(CaseInstance caseInstance) {
-        assertNotNull(caseInstance);
+        assertThat(caseInstance).isNotNull();
 
         PlanItemInstance planItemInstance = cmmnRule.getCmmnRuntimeService().createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
-        assertNotNull(planItemInstance);
+        assertThat(planItemInstance).isNotNull();
 
-        Assert.assertNull(cmmnRule.getCmmnRuntimeService().getVariable(caseInstance.getId(), "resultVar"));
+        assertThat(cmmnRule.getCmmnRuntimeService().getVariable(caseInstance.getId(), "resultVar")).isNull();
 
         // Triggering the task should end the case instance
         cmmnRule.getCmmnRuntimeService().triggerPlanItemInstance(planItemInstance.getId());
-        Assert.assertEquals(0, cmmnRule.getCmmnRuntimeService().createCaseInstanceQuery().count());
+        assertThat(cmmnRule.getCmmnRuntimeService().createCaseInstanceQuery().count()).isEqualTo(0);
     }
 
     protected void deleteAllDmnDeployments() {

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DmnTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DmnTaskTest.java
@@ -16,9 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.RuntimeService;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -27,6 +24,10 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.FlowableTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Valentin Zickner
@@ -126,7 +127,7 @@ public class DmnTaskTest {
         Object resultObject = processVariables.get("DecisionTable");
         assertThat(resultObject).isInstanceOf(ArrayNode.class);
         ArrayNode result = (ArrayNode) resultObject;
-        assertThat(result).hasSize(0);
+        assertThat(result).isEmpty();
     }
 
 }


### PR DESCRIPTION
The module had a mix of assertion styles.

