### PR TITLE
Use assertj fluent style in flowable-event-registry module.

### DIFF
--- a/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/deployment/DeploymentQueryTest.java
+++ b/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/deployment/DeploymentQueryTest.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.eventregistry.test.deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -83,114 +84,114 @@ public class DeploymentQueryTest extends AbstractFlowableEventTest {
     
     @Test
     public void testQueryById() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentId(deploymentId1).list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentId(deploymentId1).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId1).count()).isEqualTo(1);
         
-        assertNull(repositoryService.createDeploymentQuery().deploymentId("invalid").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentId("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentId("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentId("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByName() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentName("test2.event").singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentName("test2.event").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentName("test2.event").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.event").singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.event").list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("test2.event").count()).isEqualTo(1);
         
-        assertNull(repositoryService.createDeploymentQuery().deploymentName("invalid").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentName("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentName("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentName("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByNameLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentNameLike("test%").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentNameLike("test%").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("test%").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("test%").count()).isEqualTo(3);
         
-        assertNull(repositoryService.createDeploymentQuery().deploymentNameLike("inva%").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentNameLike("inva").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentNameLike("inva").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva%").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentNameLike("inva").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByCategory() {
-        assertNotNull(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").singleResult());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").singleResult()).isNotNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("testCategoryC").count()).isEqualTo(1);
         
-        assertNull(repositoryService.createDeploymentQuery().deploymentCategory("inva%").singleResult());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentCategory("inva%").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentCategory("inva%").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").singleResult()).isNull();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategory("inva%").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByCategoryNotEquals() {
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").list().size());
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").list()).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("testCategoryC").count()).isEqualTo(2);
         
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentCategoryNotEquals("invalid").count()).isEqualTo(3);
     }
     
     @Test
     public void testQueryByTenantId() {
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").list().size());
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").list()).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("tenantA").count()).isEqualTo(2);
         
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantId("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantId("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByTenantIdLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("tenant%").count()).isEqualTo(3);
         
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantIdLike("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByEventDefinitionKey() {
-        assertEquals(1, repositoryService.createDeploymentQuery().eventDefinitionKey("event2").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().eventDefinitionKey("event2").count());
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKey("event2").list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKey("event2").count()).isEqualTo(1);
         
-        assertEquals(0, repositoryService.createDeploymentQuery().eventDefinitionKey("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().eventDefinitionKey("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKey("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKey("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByEventDefinitionKeyLike() {
-        assertEquals(3, repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").list().size());
-        assertEquals(3, repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").count());
-        assertEquals(1, repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").listPage(0, 1).size());
-        assertEquals(2, repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").listPage(0, 2).size());
-        assertEquals(2, repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").listPage(1, 2).size());
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").list()).hasSize(3);
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").count()).isEqualTo(3);
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").listPage(0, 1)).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").listPage(0, 2)).hasSize(2);
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKeyLike("event%").listPage(1, 2)).hasSize(2);
         
-        assertEquals(0, repositoryService.createDeploymentQuery().eventDefinitionKeyLike("inva%").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().eventDefinitionKeyLike("inva%").count());
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKeyLike("inva%").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().eventDefinitionKeyLike("inva%").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByChannelDefinitionKey() {
-        assertEquals(1, repositoryService.createDeploymentQuery().channelDefinitionKey("channel1").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().channelDefinitionKey("channel1").count());
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKey("channel1").list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKey("channel1").count()).isEqualTo(1);
         
-        assertEquals(0, repositoryService.createDeploymentQuery().channelDefinitionKey("invalid").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().channelDefinitionKey("invalid").count());
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKey("invalid").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKey("invalid").count()).isEqualTo(0);
     }
     
     @Test
     public void testQueryByChannelDefinitionKeyLike() {
-        assertEquals(1, repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").list().size());
-        assertEquals(1, repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").count());
-        assertEquals(1, repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").listPage(0, 1).size());
-        assertEquals(1, repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").listPage(0, 2).size());
-        assertEquals(0, repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").listPage(1, 2).size());
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").list()).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").count()).isEqualTo(1);
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").listPage(0, 1)).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").listPage(0, 2)).hasSize(1);
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKeyLike("channel%").listPage(1, 2)).isEmpty();
         
-        assertEquals(0, repositoryService.createDeploymentQuery().channelDefinitionKeyLike("inva%").list().size());
-        assertEquals(0, repositoryService.createDeploymentQuery().channelDefinitionKeyLike("inva%").count());
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKeyLike("inva%").list()).isEmpty();
+        assertThat(repositoryService.createDeploymentQuery().channelDefinitionKeyLike("inva%").count()).isEqualTo(0);
     }
     
 }

--- a/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/deployment/DeploymentTest.java
+++ b/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/deployment/DeploymentTest.java
@@ -13,10 +13,8 @@
 package org.flowable.eventregistry.test.deployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.tuple;
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.flowable.common.engine.impl.persistence.deploy.DeploymentCache;
@@ -47,9 +45,9 @@ public class DeploymentTest extends AbstractFlowableEventTest {
                 .eventDefinitionKey("myEvent")
                 .latestVersion()
                 .singleResult();
-        assertNotNull(eventDefinition);
-        assertEquals("myEvent", eventDefinition.getKey());
-        assertEquals(1, eventDefinition.getVersion());
+        assertThat(eventDefinition).isNotNull();
+        assertThat(eventDefinition.getKey()).isEqualTo("myEvent");
+        assertThat(eventDefinition.getVersion()).isEqualTo(1);
     }
 
     @Test
@@ -59,9 +57,9 @@ public class DeploymentTest extends AbstractFlowableEventTest {
                 .channelDefinitionKey("myChannel")
                 .latestVersion()
                 .singleResult();
-        assertNotNull(channelDefinition);
-        assertEquals("myChannel", channelDefinition.getKey());
-        assertEquals(1, channelDefinition.getVersion());
+        assertThat(channelDefinition).isNotNull();
+        assertThat(channelDefinition.getKey()).isEqualTo("myChannel");
+        assertThat(channelDefinition.getVersion()).isEqualTo(1);
     }
 
     @Test
@@ -96,17 +94,17 @@ public class DeploymentTest extends AbstractFlowableEventTest {
                 .eventDefinitionKey("myEvent")
                 .latestVersion()
                 .singleResult();
-        assertNotNull(eventDefinition);
-        assertEquals("myEvent", eventDefinition.getKey());
-        assertEquals(1, eventDefinition.getVersion());
-        
+        assertThat(eventDefinition).isNotNull();
+        assertThat(eventDefinition.getKey()).isEqualTo("myEvent");
+        assertThat(eventDefinition.getVersion()).isEqualTo(1);
+
         ChannelDefinition channelDefinition = repositoryService.createChannelDefinitionQuery()
                 .channelDefinitionKey("myChannel")
                 .latestVersion()
                 .singleResult();
-        assertNotNull(channelDefinition);
-        assertEquals("myChannel", channelDefinition.getKey());
-        assertEquals(1, channelDefinition.getVersion());
+        assertThat(channelDefinition).isNotNull();
+        assertThat(channelDefinition.getKey()).isEqualTo("myChannel");
+        assertThat(channelDefinition.getVersion()).isEqualTo(1);
     }
 
     @Test
@@ -116,31 +114,24 @@ public class DeploymentTest extends AbstractFlowableEventTest {
                 .eventDefinitionKey("myEvent")
                 .latestVersion()
                 .singleResult();
-        assertNotNull(eventDefinition);
-        assertEquals("myEvent", eventDefinition.getKey());
-        assertEquals(1, eventDefinition.getVersion());
+        assertThat(eventDefinition).isNotNull();
+        assertThat(eventDefinition.getKey()).isEqualTo("myEvent");
+        assertThat(eventDefinition.getVersion()).isEqualTo(1);
 
         EventModel eventModel = repositoryService.getEventModelById(eventDefinition.getId());
-        assertEquals("myEvent", eventModel.getKey());
-        
-        assertEquals(1, eventModel.getCorrelationParameters().size());
-        EventPayload correlationParameter = eventModel.getCorrelationParameters().iterator().next();
-        assertEquals("customerId", correlationParameter.getName());
-        assertEquals("string", correlationParameter.getType());
-        
-        assertEquals(3, eventModel.getPayload().size());
-        Iterator<EventPayload> itPayload = eventModel.getPayload().iterator();
-        EventPayload payloadDefinition = itPayload.next();
-        assertEquals("payload1", payloadDefinition.getName());
-        assertEquals("string", payloadDefinition.getType());
-        
-        payloadDefinition = itPayload.next();
-        assertEquals("payload2", payloadDefinition.getName());
-        assertEquals("integer", payloadDefinition.getType());
+        assertThat(eventModel.getKey()).isEqualTo("myEvent");
 
-        payloadDefinition = itPayload.next();
-        assertEquals("customerId", payloadDefinition.getName());
-        assertEquals("string", payloadDefinition.getType());
+        assertThat(eventModel.getCorrelationParameters())
+                .extracting(EventPayload::getName, EventPayload::getType)
+                .containsExactly(tuple("customerId", "string"));
+
+        assertThat(eventModel.getPayload())
+                .extracting(EventPayload::getName, EventPayload::getType)
+                .containsExactly(
+                        tuple("payload1", "string"),
+                        tuple("payload2", "integer"),
+                        tuple("customerId", "string")
+                );
 
         EventDeployment redeployment = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/eventregistry/test/deployment/simpleEvent2.event")
@@ -150,31 +141,24 @@ public class DeploymentTest extends AbstractFlowableEventTest {
                 .eventDefinitionKey("myEvent")
                 .latestVersion()
                 .singleResult();
-        assertNotNull(eventDefinition);
-        assertEquals("myEvent", eventDefinition.getKey());
-        assertEquals(2, eventDefinition.getVersion());
+        assertThat(eventDefinition).isNotNull();
+        assertThat(eventDefinition.getKey()).isEqualTo("myEvent");
+        assertThat(eventDefinition.getVersion()).isEqualTo(2);
 
         eventModel = repositoryService.getEventModelById(eventDefinition.getId());
-        assertEquals("myEvent", eventModel.getKey());
-        
-        assertEquals(1, eventModel.getCorrelationParameters().size());
-        correlationParameter = eventModel.getCorrelationParameters().iterator().next();
-        assertEquals("customerId2", correlationParameter.getName());
-        assertEquals("string", correlationParameter.getType());
-        
-        assertEquals(3, eventModel.getPayload().size());
-        itPayload = eventModel.getPayload().iterator();
-        payloadDefinition = itPayload.next();
-        assertEquals("payload3", payloadDefinition.getName());
-        assertEquals("string", payloadDefinition.getType());
-        
-        payloadDefinition = itPayload.next();
-        assertEquals("payload4", payloadDefinition.getName());
-        assertEquals("integer", payloadDefinition.getType());
+        assertThat(eventModel.getKey()).isEqualTo("myEvent");
 
-        payloadDefinition = itPayload.next();
-        assertEquals("customerId2", payloadDefinition.getName());
-        assertEquals("string", payloadDefinition.getType());
+        assertThat(eventModel.getCorrelationParameters())
+                .extracting(EventPayload::getName, EventPayload::getType)
+                .containsExactly(tuple("customerId2", "string"));
+
+        assertThat(eventModel.getPayload())
+                .extracting(EventPayload::getName, EventPayload::getType)
+                .containsExactly(
+                        tuple("payload3", "string"),
+                        tuple("payload4", "integer"),
+                        tuple("customerId2", "string")
+                );
 
         repositoryService.deleteDeployment(redeployment.getId());
     }
@@ -186,21 +170,21 @@ public class DeploymentTest extends AbstractFlowableEventTest {
                 .channelDefinitionKey("myChannel")
                 .latestVersion()
                 .singleResult();
-        assertNotNull(channelDefinition);
-        assertEquals("myChannel", channelDefinition.getKey());
-        assertEquals(1, channelDefinition.getVersion());
+        assertThat(channelDefinition).isNotNull();
+        assertThat(channelDefinition.getKey()).isEqualTo("myChannel");
+        assertThat(channelDefinition.getVersion()).isEqualTo(1);
 
         ChannelModel channelModel = repositoryService.getChannelModelById(channelDefinition.getId());
         assertThat(channelModel)
-            .isInstanceOfSatisfying(JmsInboundChannelModel.class, channel -> {
-                assertThat(channel.getKey()).isEqualTo("myChannel");
-                assertThat(channel.getChannelType()).isEqualTo("inbound");
-                assertThat(channel.getType()).isEqualTo("jms");
+                .isInstanceOfSatisfying(JmsInboundChannelModel.class, channel -> {
+                    assertThat(channel.getKey()).isEqualTo("myChannel");
+                    assertThat(channel.getChannelType()).isEqualTo("inbound");
+                    assertThat(channel.getType()).isEqualTo("jms");
 
-                assertThat(channel.getDestination()).isEqualTo("testQueue");
-                assertThat(channel.getDeserializerType()).isEqualTo("json");
+                    assertThat(channel.getDestination()).isEqualTo("testQueue");
+                    assertThat(channel.getDeserializerType()).isEqualTo("json");
                 assertThat(channel.getChannelEventKeyDetection().getFixedValue()).isEqualTo("myEvent");
-            });
+                });
 
         EventDeployment redeployment = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/eventregistry/test/deployment/simpleChannel2.channel")
@@ -210,19 +194,19 @@ public class DeploymentTest extends AbstractFlowableEventTest {
                 .channelDefinitionKey("myChannel")
                 .latestVersion()
                 .singleResult();
-        assertNotNull(channelDefinition);
-        assertEquals("myChannel", channelDefinition.getKey());
-        assertEquals(2, channelDefinition.getVersion());
+        assertThat(channelDefinition).isNotNull();
+        assertThat(channelDefinition.getKey()).isEqualTo("myChannel");
+        assertThat(channelDefinition.getVersion()).isEqualTo(2);
 
         channelModel = repositoryService.getChannelModelById(channelDefinition.getId());
         assertThat(channelModel)
-            .isInstanceOfSatisfying(JmsInboundChannelModel.class, channel -> {
-                assertThat(channel.getChannelType()).isEqualTo("inbound");
-                assertThat(channel.getType()).isEqualTo("jms");
-                assertThat(channel.getDestination()).isEqualTo("testQueue2");
+                .isInstanceOfSatisfying(JmsInboundChannelModel.class, channel -> {
+                    assertThat(channel.getChannelType()).isEqualTo("inbound");
+                    assertThat(channel.getType()).isEqualTo("jms");
+                    assertThat(channel.getDestination()).isEqualTo("testQueue2");
 
-                assertThat(channel.getDeserializerType()).isEqualTo("json");
-                assertThat(channel.getChannelEventKeyDetection().getFixedValue()).isEqualTo("myEvent2");
+                    assertThat(channel.getDeserializerType()).isEqualTo("json");
+                    assertThat(channel.getChannelEventKeyDetection().getFixedValue()).isEqualTo("myEvent2");
             });
 
         repositoryService.deleteDeployment(redeployment.getId());
@@ -233,10 +217,9 @@ public class DeploymentTest extends AbstractFlowableEventTest {
             "org/flowable/eventregistry/test/deployment/orderEvent.event" })
     public void deploy2EventDefinitions() {
         List<EventDefinition> eventDefinitions = repositoryService.createEventDefinitionQuery().orderByEventDefinitionName().asc().list();
-        assertEquals(2, eventDefinitions.size());
-
-        assertEquals("My event", eventDefinitions.get(0).getName());
-        assertEquals("My order event", eventDefinitions.get(1).getName());
+        assertThat(eventDefinitions)
+                .extracting(EventDefinition::getName)
+                .containsExactly("My event", "My order event");
     }
     
     @Test
@@ -244,10 +227,9 @@ public class DeploymentTest extends AbstractFlowableEventTest {
             "org/flowable/eventregistry/test/deployment/orderChannel.channel" })
     public void deploy2ChannelDefinitions() {
         List<ChannelDefinition> channelDefinitions = repositoryService.createChannelDefinitionQuery().orderByChannelDefinitionName().asc().list();
-        assertEquals(2, channelDefinitions.size());
-
-        assertEquals("My channel", channelDefinitions.get(0).getName());
-        assertEquals("Order channel", channelDefinitions.get(1).getName());
+        assertThat(channelDefinitions)
+                .extracting(ChannelDefinition::getName)
+                .containsExactly("My channel", "Order channel");
     }
 
     @Test
@@ -256,7 +238,7 @@ public class DeploymentTest extends AbstractFlowableEventTest {
 
         repositoryService.createDeployment().addClasspathResource("org/flowable/eventregistry/test/deployment/simpleChannel.channel").deploy();
         ChannelDefinition channelDefinition1 = repositoryService.createChannelDefinitionQuery().channelDefinitionKey("myChannel").latestVersion().singleResult();
-        assertEquals("My channel", channelDefinition1.getName());
+        assertThat(channelDefinition1.getName()).isEqualTo("My channel");
 
         assertThat(channelDefinitionCache.size()).isEqualTo(1);
         assertThat(channelDefinitionCache.get(channelDefinition1.getId())).isNotNull();
@@ -264,7 +246,7 @@ public class DeploymentTest extends AbstractFlowableEventTest {
         repositoryService.createDeployment().addClasspathResource("org/flowable/eventregistry/test/deployment/simpleChannel2.channel").deploy();
 
         ChannelDefinition channelDefinition2 = repositoryService.createChannelDefinitionQuery().channelDefinitionKey("myChannel").latestVersion().singleResult();
-        assertEquals("My channel2", channelDefinition2.getName());
+        assertThat(channelDefinition2.getName()).isEqualTo("My channel2");
 
         assertThat(channelDefinitionCache.size()).isEqualTo(1);
         assertThat(channelDefinitionCache.get(channelDefinition1.getId())).isNull();
@@ -284,24 +266,24 @@ public class DeploymentTest extends AbstractFlowableEventTest {
         
         try {
             EventDefinition definition = repositoryService.createEventDefinitionQuery().deploymentId(deployment.getId()).singleResult();
-            assertNotNull(definition);
-            assertEquals("myEvent", definition.getKey());
-            assertEquals(1, definition.getVersion());
-            
+            assertThat(definition).isNotNull();
+            assertThat(definition.getKey()).isEqualTo("myEvent");
+            assertThat(definition.getVersion()).isEqualTo(1);
+
             EventDefinition newDefinition = repositoryService.createEventDefinitionQuery().deploymentId(newDeployment.getId()).singleResult();
-            assertNotNull(newDefinition);
-            assertEquals("myEvent", newDefinition.getKey());
-            assertEquals(2, newDefinition.getVersion());
-            
+            assertThat(newDefinition).isNotNull();
+            assertThat(newDefinition.getKey()).isEqualTo("myEvent");
+            assertThat(newDefinition.getVersion()).isEqualTo(2);
+
             EventModel eventModel = repositoryService.getEventModelByKeyAndParentDeploymentId("myEvent", "someDeploymentId");
-            assertEquals("myEvent", eventModel.getKey());
-            assertEquals("My event", eventModel.getName());
-            
+            assertThat(eventModel.getKey()).isEqualTo("myEvent");
+            assertThat(eventModel.getName()).isEqualTo("My event");
+
             eventEngineConfiguration.setAlwaysLookupLatestDefinitionVersion(true);
             eventModel = repositoryService.getEventModelByKeyAndParentDeploymentId("myEvent", "someDeploymentId");
-            assertEquals("myEvent", eventModel.getKey());
-            assertEquals("My event2", eventModel.getName());
-        
+            assertThat(eventModel.getKey()).isEqualTo("myEvent");
+            assertThat(eventModel.getName()).isEqualTo("My event2");
+
         } finally {
             eventEngineConfiguration.setAlwaysLookupLatestDefinitionVersion(false);
             repositoryService.deleteDeployment(deployment.getId());
@@ -322,24 +304,24 @@ public class DeploymentTest extends AbstractFlowableEventTest {
         
         try {
             ChannelDefinition definition = repositoryService.createChannelDefinitionQuery().deploymentId(deployment.getId()).singleResult();
-            assertNotNull(definition);
-            assertEquals("myChannel", definition.getKey());
-            assertEquals(1, definition.getVersion());
-            
+            assertThat(definition).isNotNull();
+            assertThat(definition.getKey()).isEqualTo("myChannel");
+            assertThat(definition.getVersion()).isEqualTo(1);
+
             ChannelDefinition newDefinition = repositoryService.createChannelDefinitionQuery().deploymentId(newDeployment.getId()).singleResult();
-            assertNotNull(newDefinition);
-            assertEquals("myChannel", newDefinition.getKey());
-            assertEquals(2, newDefinition.getVersion());
-            
+            assertThat(newDefinition).isNotNull();
+            assertThat(newDefinition.getKey()).isEqualTo("myChannel");
+            assertThat(newDefinition.getVersion()).isEqualTo(2);
+
             ChannelModel channelModel = repositoryService.getChannelModelByKeyAndParentDeploymentId("myChannel", "someDeploymentId");
-            assertEquals("myChannel", channelModel.getKey());
-            assertEquals("My channel", channelModel.getName());
-            
+            assertThat(channelModel.getKey()).isEqualTo("myChannel");
+            assertThat(channelModel.getName()).isEqualTo("My channel");
+
             eventEngineConfiguration.setAlwaysLookupLatestDefinitionVersion(true);
             channelModel = repositoryService.getChannelModelByKeyAndParentDeploymentId("myChannel", "someDeploymentId");
-            assertEquals("myChannel", channelModel.getKey());
-            assertEquals("My channel2", channelModel.getName());
-        
+            assertThat(channelModel.getKey()).isEqualTo("myChannel");
+            assertThat(channelModel.getName()).isEqualTo("My channel2");
+
         } finally {
             eventEngineConfiguration.setAlwaysLookupLatestDefinitionVersion(false);
             repositoryService.deleteDeployment(deployment.getId());
@@ -358,6 +340,6 @@ public class DeploymentTest extends AbstractFlowableEventTest {
             .eventDefinitionKey("myOrderEvent")
             .latestVersion()
             .singleResult();
-        assertNotNull(eventDefinition);
+        assertThat(eventDefinition).isNotNull();
     }
 }


### PR DESCRIPTION
The module had a mix of assertion styles even in the same file.

