### PR TITLE
Use assertj fluent style in flowable-event-registry-rest module.

### DIFF
--- a/modules/flowable-event-registry-rest/pom.xml
+++ b/modules/flowable-event-registry-rest/pom.xml
@@ -187,6 +187,11 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/ChannelDefinitionResourceTest.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/ChannelDefinitionResourceTest.java
@@ -12,7 +12,9 @@
  */
 package org.flowable.eventregistry.rest.service.api.repository;
 
-import java.net.URLDecoder;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
@@ -25,6 +27,8 @@ import org.flowable.eventregistry.rest.service.api.EventRestUrls;
 import org.flowable.eventregistry.test.ChannelDeploymentAnnotation;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to single a Channel Definition resource.
@@ -41,24 +45,26 @@ public class ChannelDefinitionResourceTest extends BaseSpringRestTestCase {
 
         ChannelDefinition channelDefinition = repositoryService.createChannelDefinitionQuery().singleResult();
 
-        HttpGet httpGet = new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_CHANNEL_DEFINITION, channelDefinition.getId()));
+        HttpGet httpGet = new HttpGet(
+                SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_CHANNEL_DEFINITION, channelDefinition.getId()));
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals(channelDefinition.getId(), responseNode.get("id").textValue());
-        assertEquals(channelDefinition.getKey(), responseNode.get("key").textValue());
-        assertEquals(channelDefinition.getCategory(), responseNode.get("category").textValue());
-        assertEquals(channelDefinition.getVersion(), responseNode.get("version").intValue());
-        assertEquals(channelDefinition.getDescription(), responseNode.get("description").textValue());
-        assertEquals(channelDefinition.getName(), responseNode.get("name").textValue());
-        assertNotNull(responseNode.get("createTime").textValue());
-
-        // Check URL's
-        assertEquals(httpGet.getURI().toString(), responseNode.get("url").asText());
-        assertEquals(channelDefinition.getDeploymentId(), responseNode.get("deploymentId").textValue());
-        assertTrue(responseNode.get("deploymentUrl").textValue().endsWith(EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT, channelDefinition.getDeploymentId())));
-        assertTrue(URLDecoder.decode(responseNode.get("resource").textValue(), "UTF-8").endsWith(
-                EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_RESOURCE, channelDefinition.getDeploymentId(), channelDefinition.getResourceName())));
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + channelDefinition.getId() + "',"
+                        + "url: '" + httpGet.getURI().toString() + "',"
+                        + "key: '" + channelDefinition.getKey() + "',"
+                        + "version: " + channelDefinition.getVersion() + ","
+                        + "name: '" + channelDefinition.getName() + "',"
+                        + "description: '" + channelDefinition.getDescription() + "',"
+                        + "deploymentId: '" + channelDefinition.getDeploymentId() + "',"
+                        + "deploymentUrl: '" + SERVER_URL_PREFIX + EventRestUrls
+                        .createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT, channelDefinition.getDeploymentId()) + "',"
+                        + "resourceName: '" + channelDefinition.getResourceName() + "',"
+                        + "category: '" + channelDefinition.getCategory() + "'"
+                        + "}");
     }
 
     /**
@@ -74,32 +80,48 @@ public class ChannelDefinitionResourceTest extends BaseSpringRestTestCase {
     public void testGetChannelDefinitionResourceData() throws Exception {
         ChannelDefinition channelDefinition = repositoryService.createChannelDefinitionQuery().singleResult();
 
-        HttpGet httpGet = new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_CHANNEL_DEFINITION_RESOURCE_CONTENT, channelDefinition.getId()));
+        HttpGet httpGet = new HttpGet(
+                SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_CHANNEL_DEFINITION_RESOURCE_CONTENT, channelDefinition.getId()));
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
 
         // Check "OK" status
         String content = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
         closeResponse(response);
-        assertNotNull(content);
+        assertThat(content).isNotNull();
         JsonNode eventNode = objectMapper.readTree(content);
-        assertEquals("myChannel", eventNode.get("key").asText());
-        assertEquals("myEvent", eventNode.get("channelEventKeyDetection").get("fixedValue").asText());
+        assertThatJson(eventNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "key: 'myChannel',"
+                        + "channelEventKeyDetection:"
+                        + " {"
+                        + "   fixedValue: 'myEvent'"
+                        + " }"
+                        + "}");
     }
     
     @ChannelDeploymentAnnotation(resources = { "simpleChannel.channel" })
     public void testGetChannelDefinitionModel() throws Exception {
         ChannelDefinition channelDefinition = repositoryService.createChannelDefinitionQuery().singleResult();
 
-        HttpGet httpGet = new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_CHANNEL_DEFINITION_MODEL, channelDefinition.getId()));
+        HttpGet httpGet = new HttpGet(
+                SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_CHANNEL_DEFINITION_MODEL, channelDefinition.getId()));
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
 
         // Check "OK" status
         String content = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
         closeResponse(response);
-        assertNotNull(content);
+        assertThat(content).isNotNull();
         JsonNode eventNode = objectMapper.readTree(content);
-        assertEquals("myChannel", eventNode.get("key").asText());
-        assertEquals("myEvent", eventNode.get("channelEventKeyDetection").get("fixedValue").asText());
+        assertThatJson(eventNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "key: 'myChannel',"
+                        + "channelEventKeyDetection:"
+                        + " {"
+                        + "   fixedValue: 'myEvent'"
+                        + " }"
+                        + "}");
     }
 
     /**

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/DeploymentCollectionResourceTest.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/DeploymentCollectionResourceTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.eventregistry.rest.service.api.repository;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
 import java.util.Calendar;
 import java.util.List;
 
@@ -23,6 +25,8 @@ import org.flowable.eventregistry.rest.service.BaseSpringRestTestCase;
 import org.flowable.eventregistry.rest.service.api.EventRestUrls;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to the Deployment collection.
@@ -86,40 +90,69 @@ public class DeploymentCollectionResourceTest extends BaseSpringRestTestCase {
             assertResultsPresentInDataResponse(url, firstDeployment.getId());
 
             // Check ordering by name
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=name&order=asc"),
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=name&order=asc"),
                     HttpStatus.SC_OK);
             JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
-            assertEquals(2L, dataNode.size());
-            assertEquals(firstDeployment.getId(), dataNode.get(0).get("id").textValue());
-            assertEquals(secondDeployment.getId(), dataNode.get(1).get("id").textValue());
+            assertThatJson(dataNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("[{"
+                            + "     id: '" + firstDeployment.getId() + "'"
+                            + "},"
+                            + "{"
+                            + "     id: '" + secondDeployment.getId() + "'"
+                            + "}]");
 
             // Check ordering by deploy time
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=deployTime&order=asc"), HttpStatus.SC_OK);
+            response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=deployTime&order=asc"),
+                    HttpStatus.SC_OK);
             dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
-            assertEquals(2L, dataNode.size());
-            assertEquals(firstDeployment.getId(), dataNode.get(0).get("id").textValue());
-            assertEquals(secondDeployment.getId(), dataNode.get(1).get("id").textValue());
+            assertThatJson(dataNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("[{"
+                            + "     id: '" + firstDeployment.getId() + "'"
+                            + "},"
+                            + "{"
+                            + "     id: '" + secondDeployment.getId() + "'"
+                            + "}]");
 
             // Check ordering by tenantId
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=tenantId&order=desc"), HttpStatus.SC_OK);
+            response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=tenantId&order=desc"),
+                    HttpStatus.SC_OK);
             dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
-            assertEquals(2L, dataNode.size());
-            assertEquals(secondDeployment.getId(), dataNode.get(0).get("id").textValue());
-            assertEquals(firstDeployment.getId(), dataNode.get(1).get("id").textValue());
+            assertThatJson(dataNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("[{"
+                            + "     id: '" + secondDeployment.getId() + "'"
+                            + "},"
+                            + "{"
+                            + "     id: '" + firstDeployment.getId() + "'"
+                            + "}]");
 
             // Check paging
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=deployTime&order=asc&start=1&size=1"), HttpStatus.SC_OK);
+            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT_COLLECTION)
+                    + "?sort=deployTime&order=asc&start=1&size=1"), HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
             dataNode = responseNode.get("data");
-            assertEquals(1L, dataNode.size());
-            assertEquals(secondDeployment.getId(), dataNode.get(0).get("id").textValue());
-            assertEquals(2L, responseNode.get("total").longValue());
-            assertEquals(1L, responseNode.get("start").longValue());
-            assertEquals(1L, responseNode.get("size").longValue());
+            assertThatJson(dataNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("["
+                            + "{"
+                            + "     id: '" + secondDeployment.getId() + "'"
+                            + "}]");
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "     total: 2,"
+                            + "     start: 1,"
+                            + "     size: 1"
+                            + "}");
 
         } finally {
             // Always cleanup any created deployments, even if the test failed

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/DeploymentResourceTest.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/DeploymentResourceTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.eventregistry.rest.service.api.repository;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.apache.http.HttpStatus;
@@ -27,6 +30,8 @@ import org.flowable.eventregistry.rest.service.api.EventRestUrls;
 import org.flowable.eventregistry.test.EventDeploymentAnnotation;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to a single Deployment resource.
@@ -50,32 +55,22 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
             closeResponse(response);
 
             String newDeploymentId = responseNode.get("id").textValue();
-            String name = responseNode.get("name").textValue();
-            String category = responseNode.get("category").textValue();
-            String deployTime = responseNode.get("deploymentTime").textValue();
-            String url = responseNode.get("url").textValue();
-            String tenantId = responseNode.get("tenantId").textValue();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "url: '" + SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT, newDeploymentId) + "',"
+                            + "name: 'simpleEvent',"
+                            + "tenantId: \"\","
+                            + "category: null"
+                            + "}");
 
-            assertEquals("", tenantId);
-
-            assertNotNull(newDeploymentId);
-            assertEquals(1L, repositoryService.createDeploymentQuery().deploymentId(newDeploymentId).count());
-
-            assertNotNull(name);
-            assertEquals("simpleEvent", name);
-
-            assertNotNull(url);
-            assertTrue(url.endsWith(EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT, newDeploymentId)));
-
-            // No deployment-category should have been set
-            assertNull(category);
-            assertNotNull(deployTime);
+            assertThat(repositoryService.createDeploymentQuery().deploymentId(newDeploymentId).count()).isEqualTo(1L);
 
             // Check if process is actually deployed in the deployment
             List<String> resources = repositoryService.getDeploymentResourceNames(newDeploymentId);
-            assertEquals(1L, resources.size());
-            assertEquals("simpleEvent.event", resources.get(0));
-            assertEquals(1L, repositoryService.createEventDefinitionQuery().deploymentId(newDeploymentId).count());
+            assertThat(resources.size()).isEqualTo(1L);
+            assertThat(resources.get(0)).isEqualTo("simpleEvent.event");
+            assertThat(repositoryService.createEventDefinitionQuery().deploymentId(newDeploymentId).count()).isEqualTo(1L);
 
         } finally {
             // Always cleanup any created deployments, even if the test failed
@@ -107,29 +102,18 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
-        
+
         closeResponse(response);
 
-        String deploymentId = responseNode.get("id").textValue();
-        String name = responseNode.get("name").textValue();
-        String category = responseNode.get("category").textValue();
-        String deployTime = responseNode.get("deploymentTime").textValue();
-        String url = responseNode.get("url").textValue();
-        String tenantId = responseNode.get("tenantId").textValue();
-
-        assertEquals("", tenantId);
-        assertNotNull(deploymentId);
-        assertEquals(existingDeployment.getId(), deploymentId);
-
-        assertNotNull(name);
-        assertEquals(existingDeployment.getName(), name);
-
-        assertEquals(existingDeployment.getCategory(), category);
-
-        assertNotNull(deployTime);
-
-        assertNotNull(url);
-        assertTrue(url.endsWith(EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT, deploymentId)));
+        String deploymentId = existingDeployment.getId();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "url: '" + SERVER_URL_PREFIX + EventRestUrls.createRelativeResourceUrl(EventRestUrls.URL_DEPLOYMENT, deploymentId) + "',"
+                        + "name: '" + existingDeployment.getName() + "',"
+                        + "tenantId: \"\","
+                        + "category: " + existingDeployment.getCategory()
+                        + "}");
     }
 
     /**
@@ -155,7 +139,7 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
         closeResponse(response);
 
         existingDeployment = repositoryService.createDeploymentQuery().deploymentId(existingDeployment.getId()).singleResult();
-        assertNull(existingDeployment);
+        assertThat(existingDeployment).isNull();
     }
 
     /**

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/runtime/EventInstanceCollectionResourceTest.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/runtime/EventInstanceCollectionResourceTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.eventregistry.rest.service.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 
 import org.apache.http.HttpStatus;
@@ -37,7 +39,7 @@ public class EventInstanceCollectionResourceTest extends BaseSpringRestTestCase 
     public void testSendEvent() throws Exception {
         ProcessInstance processInstance = processRuntimeService.startProcessInstanceByKey("process", Collections.singletonMap("customerIdVar", "123"));
         Task task = processTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
         
         ObjectNode requestNode = objectMapper.createObjectNode();
         
@@ -54,7 +56,7 @@ public class EventInstanceCollectionResourceTest extends BaseSpringRestTestCase 
         closeResponse(response);
         
         task = processTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("task", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
 
         // now send event with matching correlation value
         requestNode.put("eventDefinitionKey", "myEvent");
@@ -68,6 +70,6 @@ public class EventInstanceCollectionResourceTest extends BaseSpringRestTestCase 
         closeResponse(response);
         
         task = processTaskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfterBoundary", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterBoundary");
     }
 }


### PR DESCRIPTION
The module had a mix of assertion styles.
Added `net.javacrumbs.json-unit` dependency so `assertThatJson` was available.
