### PR TITLE
Use assertj fluent style in flowable-rest module.

### DIFF
--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryResourceTest.java
@@ -13,7 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import java.util.HashMap;
 
@@ -32,6 +32,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for REST-operation related to the historic process instance query resource.
@@ -173,14 +175,19 @@ public class HistoricProcessInstanceQueryResourceTest extends BaseSpringRestTest
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertThat(dataNode).hasSize(2);
-        JsonNode valueNode = dataNode.get(0);
-        assertThat(valueNode.get("id").asText()).isEqualTo(processInstance.getId());
-        assertThat(dataNode.get(1).get("id").asText()).isEqualTo(processInstance2.getId());
-
-        assertThat(valueNode.get("processDefinitionName").asText()).isEqualTo("The One Task Process");
-        assertThat(valueNode.get("processDefinitionDescription").asText()).isEqualTo("One task process description");
-        assertThat(valueNode.has("startTime")).as("has startTime").isTrue();
-        assertThat(valueNode.get("startUserId").textValue()).as("startUserId").isEqualTo(processInstance.getStartUserId());
+        assertThatJson(dataNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("["
+                        + "{"
+                        + "    id: '" + processInstance.getId() + "',"
+                        + "    processDefinitionName: 'The One Task Process',"
+                        + "    processDefinitionDescription: 'One task process description',"
+                        + "    startTime: '${json-unit.any-string}',"
+                        + "    startUserId: '" + processInstance.getStartUserId() + "'"
+                        + "},"
+                        + "{"
+                        + "    id: '" + processInstance2.getId() + "'"
+                        + "}"
+                        + "]");
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceResourceTest.java
@@ -13,8 +13,8 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -29,9 +29,11 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for REST-operation related to get and delete a historic process instance.
- * 
+ *
  * @author Tijs Rademakers
  * @author Joram Barrez
  */
@@ -44,35 +46,42 @@ public class HistoricProcessInstanceResourceTest extends BaseSpringRestTestCase 
     @Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml" })
     public void testGetProcessInstance() throws Exception {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .businessKey("myBusinessKey")
-            .callbackId("testCallbackId")
-            .callbackType("testCallbackType")
-            .referenceId("testReferenceId")
-            .referenceType("testReferenceType")
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .businessKey("myBusinessKey")
+                .callbackId("testCallbackId")
+                .callbackType("testCallbackType")
+                .referenceId("testReferenceId")
+                .referenceType("testReferenceType")
+                .start();
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, processInstance.getId())),
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, processInstance.getId())),
                 HttpStatus.SC_OK);
 
-        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("id").textValue());
-        assertEquals("myBusinessKey", responseNode.get("businessKey").textValue());
-        assertEquals("testCallbackId", responseNode.get("callbackId").textValue());
-        assertEquals("testCallbackType", responseNode.get("callbackType").textValue());
-        assertEquals("testReferenceId", responseNode.get("referenceId").textValue());
-        assertEquals("testReferenceType", responseNode.get("referenceType").textValue());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processInstance.getId() + "',"
+                        + "businessKey: 'myBusinessKey',"
+                        + "callbackId: 'testCallbackId',"
+                        + "callbackType: 'testCallbackType',"
+                        + "referenceId: 'testReferenceId',"
+                        + "referenceType: 'testReferenceType'"
+                        + "}");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
-        response = executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, processInstance.getId())), HttpStatus.SC_NO_CONTENT);
-        assertEquals(HttpStatus.SC_NO_CONTENT, response.getStatusLine().getStatusCode());
+        response = executeRequest(
+                new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, processInstance.getId())),
+                HttpStatus.SC_NO_CONTENT);
+        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         closeResponse(response);
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceCollectionResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -178,7 +177,7 @@ public class HistoricTaskInstanceCollectionResourceTest extends BaseSpringRestTe
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         if (expectedTaskIds != null) {
@@ -188,7 +187,7 @@ public class HistoricTaskInstanceCollectionResourceTest extends BaseSpringRestTe
                 String id = it.next().get("id").textValue();
                 toBeFound.remove(id);
             }
-            assertTrue("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+            assertThat(toBeFound).as("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", ")).isEmpty();
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceIdentityLinkCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceIdentityLinkCollectionResourceTest.java
@@ -13,12 +13,9 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -33,9 +30,11 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for REST-operation related to the historic task instance identity links resource.
- * 
+ *
  * @author Tijs Rademakers
  */
 public class HistoricTaskInstanceIdentityLinkCollectionResourceTest extends BaseSpringRestTestCase {
@@ -67,27 +66,25 @@ public class HistoricTaskInstanceIdentityLinkCollectionResourceTest extends Base
         // Check status and size
         JsonNode linksArray = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals(2, linksArray.size());
-        Map<String, JsonNode> linksMap = new HashMap<>();
-        for (JsonNode linkNode : linksArray) {
-            linksMap.put(linkNode.get("type").asText(), linkNode);
-        }
-        JsonNode assigneeNode = linksMap.get("assignee");
-        assertNotNull(assigneeNode);
-        assertEquals("fozzie", assigneeNode.get("userId").asText());
-        assertTrue(assigneeNode.get("groupId").isNull());
-        assertEquals(task.getId(), assigneeNode.get("taskId").asText());
-        assertNotNull(assigneeNode.get("taskUrl").asText());
-        assertTrue(assigneeNode.get("processInstanceId").isNull());
-        assertTrue(assigneeNode.get("processInstanceUrl").isNull());
-
-        JsonNode ownerNode = linksMap.get("owner");
-        assertNotNull(ownerNode);
-        assertEquals("test", ownerNode.get("userId").asText());
-        assertTrue(ownerNode.get("groupId").isNull());
-        assertEquals(task.getId(), ownerNode.get("taskId").asText());
-        assertNotNull(ownerNode.get("taskUrl").asText());
-        assertTrue(ownerNode.get("processInstanceId").isNull());
-        assertTrue(ownerNode.get("processInstanceUrl").isNull());
+        assertThatJson(linksArray)
+                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_ARRAY_ORDER)
+                .isEqualTo("["
+                        + "{"
+                        + "  userId: 'fozzie',"
+                        + "  groupId: null,"
+                        + "  taskId: '" + task.getId() + "',"
+                        + "  taskUrl: '${json-unit.any-string}',"
+                        + "  processInstanceId: null,"
+                        + "  processInstanceUrl: null"
+                        + "},"
+                        + "{"
+                        + "  userId: 'test',"
+                        + "  groupId: null,"
+                        + "  taskId: '" + task.getId() + "',"
+                        + "  taskUrl: '${json-unit.any-string}',"
+                        + "  processInstanceId: null,"
+                        + "  processInstanceUrl: null"
+                        + "}"
+                        + "]");
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -283,7 +282,7 @@ public class HistoricTaskInstanceQueryResourceTest extends BaseSpringRestTestCas
         CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_OK);
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         if (expectedTaskIds != null) {
@@ -293,7 +292,7 @@ public class HistoricTaskInstanceQueryResourceTest extends BaseSpringRestTestCas
                 String id = it.next().get("id").textValue();
                 toBeFound.remove(id);
             }
-            assertTrue("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+            assertThat(toBeFound).as("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", ")).isEmpty();
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceResourceTest.java
@@ -13,10 +13,8 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.HashMap;
@@ -42,6 +40,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to a single Historic task instance resource.
  */
@@ -56,37 +56,38 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
             Calendar now = Calendar.getInstance();
             processEngineConfiguration.getClock().setCurrentTime(now.getTime());
-    
+
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             taskService.setDueDate(task.getId(), now.getTime());
             taskService.setOwner(task.getId(), "owner");
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
-    
+            assertThat(task).isNotNull();
+
             String url = buildUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE, task.getId());
             CloseableHttpResponse response = executeRequest(new HttpGet(url), HttpStatus.SC_OK);
-    
+
             // Check resulting task
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(task.getId(), responseNode.get("id").asText());
-            assertEquals(task.getAssignee(), responseNode.get("assignee").asText());
-            assertEquals(task.getOwner(), responseNode.get("owner").asText());
-            assertEquals(task.getFormKey(), responseNode.get("formKey").asText());
-            assertEquals(task.getExecutionId(), responseNode.get("executionId").asText());
-            assertEquals(task.getDescription(), responseNode.get("description").asText());
-            assertEquals(task.getName(), responseNode.get("name").asText());
-            assertEquals(task.getDueDate(), getDateFromISOString(responseNode.get("dueDate").asText()));
-            assertEquals(task.getCreateTime(), getDateFromISOString(responseNode.get("startTime").asText()));
-            assertEquals(task.getPriority(), responseNode.get("priority").asInt());
-            assertTrue(responseNode.get("endTime").isNull());
-            assertTrue(responseNode.get("parentTaskId").isNull());
-            assertEquals("", responseNode.get("tenantId").textValue());
-    
-            assertEquals(buildUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, task.getProcessInstanceId()), responseNode.get("processInstanceUrl").asText());
-            assertEquals(buildUrl(RestUrls.URL_PROCESS_DEFINITION, task.getProcessDefinitionId()), responseNode.get("processDefinitionUrl").asText());
-            assertEquals(responseNode.get("url").asText(), url);
+            assertThat(responseNode.get("id").asText()).isEqualTo(task.getId());
+            assertThat(responseNode.get("assignee").asText()).isEqualTo(task.getAssignee());
+            assertThat(responseNode.get("owner").asText()).isEqualTo(task.getOwner());
+            assertThat(responseNode.get("formKey").asText()).isEqualTo(task.getFormKey());
+            assertThat(responseNode.get("executionId").asText()).isEqualTo(task.getExecutionId());
+            assertThat(responseNode.get("description").asText()).isEqualTo(task.getDescription());
+            assertThat(responseNode.get("name").asText()).isEqualTo(task.getName());
+            assertThat(getDateFromISOString(responseNode.get("dueDate").asText())).isEqualTo(task.getDueDate());
+            assertThat(getDateFromISOString(responseNode.get("startTime").asText())).isEqualTo(task.getCreateTime());
+            assertThat(responseNode.get("priority").asInt()).isEqualTo(task.getPriority());
+            assertThat(responseNode.get("endTime").isNull()).isTrue();
+            assertThat(responseNode.get("parentTaskId").isNull()).isTrue();
+            assertThat(responseNode.get("tenantId").textValue()).isEqualTo("");
+
+            assertThat(responseNode.get("processInstanceUrl").asText())
+                    .isEqualTo(buildUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, task.getProcessInstanceId()));
+            assertThat(responseNode.get("processDefinitionUrl").asText()).isEqualTo(buildUrl(RestUrls.URL_PROCESS_DEFINITION, task.getProcessDefinitionId()));
+            assertThat(url).isEqualTo(responseNode.get("url").asText());
         }
     }
 
@@ -115,29 +116,29 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
                 task.setOwner("owner");
                 task.setPriority(20);
                 taskService.saveTask(task);
-    
+
                 String url = buildUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE, task.getId());
                 CloseableHttpResponse response = executeRequest(new HttpGet(url), HttpStatus.SC_OK);
-    
+
                 // Check resulting task
                 JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
                 closeResponse(response);
-                assertEquals(task.getId(), responseNode.get("id").asText());
-                assertEquals(task.getAssignee(), responseNode.get("assignee").asText());
-                assertEquals(task.getOwner(), responseNode.get("owner").asText());
-                assertEquals(task.getDescription(), responseNode.get("description").asText());
-                assertEquals(task.getName(), responseNode.get("name").asText());
-                assertEquals(task.getDueDate(), getDateFromISOString(responseNode.get("dueDate").asText()));
-                assertEquals(task.getCreateTime(), getDateFromISOString(responseNode.get("startTime").asText()));
-                assertEquals(task.getPriority(), responseNode.get("priority").asInt());
-                assertEquals(task.getParentTaskId(), responseNode.get("parentTaskId").asText());
-                assertTrue(responseNode.get("executionId").isNull());
-                assertTrue(responseNode.get("processInstanceId").isNull());
-                assertTrue(responseNode.get("processDefinitionId").isNull());
-                assertEquals("", responseNode.get("tenantId").textValue());
-    
-                assertEquals(responseNode.get("url").asText(), url);
-    
+                assertThat(responseNode.get("id").asText()).isEqualTo(task.getId());
+                assertThat(responseNode.get("assignee").asText()).isEqualTo(task.getAssignee());
+                assertThat(responseNode.get("owner").asText()).isEqualTo(task.getOwner());
+                assertThat(responseNode.get("description").asText()).isEqualTo(task.getDescription());
+                assertThat(responseNode.get("name").asText()).isEqualTo(task.getName());
+                assertThat(getDateFromISOString(responseNode.get("dueDate").asText())).isEqualTo(task.getDueDate());
+                assertThat(getDateFromISOString(responseNode.get("startTime").asText())).isEqualTo(task.getCreateTime());
+                assertThat(responseNode.get("priority").asInt()).isEqualTo(task.getPriority());
+                assertThat(responseNode.get("parentTaskId").asText()).isEqualTo(task.getParentTaskId());
+                assertThat(responseNode.get("executionId").isNull()).isTrue();
+                assertThat(responseNode.get("processInstanceId").isNull()).isTrue();
+                assertThat(responseNode.get("processDefinitionId").isNull()).isTrue();
+                assertThat(responseNode.get("tenantId").textValue()).isEqualTo("");
+
+                assertThat(url).isEqualTo(responseNode.get("url").asText());
+
             } finally {
     
                 // Clean adhoc-tasks even if test fails
@@ -160,13 +161,13 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
                 Task task = taskService.newTask();
                 taskService.saveTask(task);
                 String taskId = task.getId();
-    
+
                 // Execute the request
                 HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE, taskId));
                 closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
-    
-                assertNull(historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult());
-    
+
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult()).isNull();
+
             } finally {
                 // Clean adhoc-tasks even if test fails
                 List<Task> tasks = taskService.createTaskQuery().list();
@@ -192,12 +193,12 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
-    
+            assertThat(task).isNotNull();
+
             HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE, task.getId()));
             closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
-            
-            assertNull(historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult());
+
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult()).isNull();
         }
     }
 
@@ -208,47 +209,56 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
             ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").singleResult();
             try {
                 formRepositoryService.createDeployment().addClasspathResource("org/flowable/rest/service/api/runtime/simple.form").deploy();
-                
+
                 FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-                assertNotNull(formDefinition);
-                
+                assertThat(formDefinition).isNotNull();
+
                 ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
                 Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
                 String taskId = task.getId();
-                
+
                 String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE_FORM, taskId);
                 CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
                 JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
                 closeResponse(response);
-                assertEquals(formDefinition.getId(), responseNode.get("id").asText());
-                assertEquals(formDefinition.getKey(), responseNode.get("key").asText());
-                assertEquals(formDefinition.getName(), responseNode.get("name").asText());
-                assertEquals(2, responseNode.get("fields").size());
-                
+                assertThatJson(responseNode)
+                        .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                        .isEqualTo("{"
+                                + "id: '" + formDefinition.getId() + "',"
+                                + "name: '" + formDefinition.getName() + "',"
+                                + "key: '" + formDefinition.getKey() + "',"
+                                + "fields: [ {  },"
+                                + "          {  }"
+                                + "        ]"
+                                + "}");
+
                 Map<String, Object> variables = new HashMap<>();
                 variables.put("user", "First value");
                 variables.put("number", 789);
                 taskService.completeTaskWithForm(taskId, formDefinition.getId(), null, variables);
-                
-                assertNull(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
-    
+
+                assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult()).isNull();
+
                 response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
                 responseNode = objectMapper.readTree(response.getEntity().getContent());
                 closeResponse(response);
-                assertEquals(formDefinition.getId(), responseNode.get("id").asText());
-                assertEquals(formDefinition.getKey(), responseNode.get("key").asText());
-                assertEquals(formDefinition.getName(), responseNode.get("name").asText());
-                assertEquals(2, responseNode.get("fields").size());
-                
-                JsonNode fieldNode = responseNode.get("fields").get(0);
-                assertEquals("user", fieldNode.get("id").asText());
-                assertEquals("First value", fieldNode.get("value").asText());
-                
-                fieldNode = responseNode.get("fields").get(1);
-                assertEquals("number", fieldNode.get("id").asText());
-                assertEquals(789, fieldNode.get("value").asInt());
-                
-    
+                assertThatJson(responseNode)
+                        .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                        .isEqualTo("{"
+                                + "id: '" + formDefinition.getId() + "',"
+                                + "name: '" + formDefinition.getName() + "',"
+                                + "key: '" + formDefinition.getKey() + "',"
+                                + "fields: [ { "
+                                + "            id: 'user',"
+                                + "            value: 'First value'"
+                                + "          },"
+                                + "          { "
+                                + "            id: 'number',"
+                                + "            value: '789'"
+                                + "          }"
+                                + "        ]"
+                                + "}");
+
             } finally {
                 formEngineFormService.deleteFormInstancesByProcessDefinition(processDefinition.getId());
                 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceCollectionResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -90,7 +89,7 @@ public class HistoricVariableInstanceCollectionResourceTest extends BaseSpringRe
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         if (variableName != null) {
@@ -103,15 +102,15 @@ public class HistoricVariableInstanceCollectionResourceTest extends BaseSpringRe
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
+                        assertThat((boolean) (Boolean) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asBoolean());
                     } else if (variableValue instanceof Integer) {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
+                        assertThat((int) (Integer) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asInt());
                     } else {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asText(), (String) variableValue);
+                        assertThat((String) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asText());
                     }
                 }
             }
-            assertTrue("Variable " + variableName + " is missing", variableFound);
+            assertThat(variableFound).as("Variable " + variableName + " is missing").isTrue();
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -141,7 +140,7 @@ public class HistoricVariableInstanceQueryResourceTest extends BaseSpringRestTes
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         if (variableName != null) {
@@ -154,15 +153,15 @@ public class HistoricVariableInstanceQueryResourceTest extends BaseSpringRestTes
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
+                        assertThat((boolean) (Boolean) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asBoolean());
                     } else if (variableValue instanceof Integer) {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
+                        assertThat((int) (Integer) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asInt());
                     } else {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asText(), (String) variableValue);
+                        assertThat((String) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asText());
                     }
                 }
             }
-            assertTrue("Variable " + variableName + " is missing", variableFound);
+            assertThat(variableFound).as("Variable " + variableName + " is missing").isTrue();
         }
     }
 }


### PR DESCRIPTION
The module had a mix of assertion styles.  This is part 2 for this module.
This finishes off the `org.flowable.rest.service.api.history` package.

