### PR TITLE
Use assertj fluent style in flowable-rest module.

### DIFF
--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupCollectionResourceTest.java
@@ -13,9 +13,8 @@
 
 package org.flowable.rest.service.api.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +31,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Frederik Heremans
@@ -59,10 +60,10 @@ public class GroupCollectionResourceTest extends BaseSpringRestTestCase {
             savedGroups.add(group2);
 
             Group group3 = identityService.createGroupQuery().groupId("admin").singleResult();
-            assertNotNull(group3);
+            assertThat(group3).isNotNull();
             
             Group group4 = identityService.createGroupQuery().groupId("sales").singleResult();
-            assertNotNull(group4);
+            assertThat(group4).isNotNull();
 
             // Test filter-less
             String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP_COLLECTION);
@@ -108,13 +109,17 @@ public class GroupCollectionResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertEquals("Test group", responseNode.get("name").textValue());
-            assertEquals("Test type", responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup")));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: 'Test group',"
+                            + " type: 'Test type',"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup") + "'"
+                            + "}");
 
-            assertNotNull(identityService.createGroupQuery().groupId("testgroup").singleResult());
+            assertThat(identityService.createGroupQuery().groupId("testgroup").singleResult()).isNotNull();
         } finally {
             try {
                 identityService.deleteGroup("testgroup");

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupResourceTest.java
@@ -13,10 +13,8 @@
 
 package org.flowable.rest.service.api.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -31,6 +29,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Frederik Heremans
@@ -48,20 +48,25 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
             testGroup.setType("Test type");
             identityService.saveGroup(testGroup);
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup")), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup")), HttpStatus.SC_OK);
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertEquals("Test group", responseNode.get("name").textValue());
-            assertEquals("Test type", responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: 'Test group',"
+                            + " type: 'Test type',"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId()) + "'"
+                            + "}");
 
             Group createdGroup = identityService.createGroupQuery().groupId("testgroup").singleResult();
-            assertNotNull(createdGroup);
-            assertEquals("Test group", createdGroup.getName());
-            assertEquals("Test type", createdGroup.getType());
+            assertThat(createdGroup).isNotNull();
+            assertThat(createdGroup.getName()).isEqualTo("Test group");
+            assertThat(createdGroup.getType()).isEqualTo("Test type");
 
         } finally {
             try {
@@ -94,7 +99,7 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
 
             closeResponse(executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup")), HttpStatus.SC_NO_CONTENT));
 
-            assertNull(identityService.createGroupQuery().groupId("testgroup").singleResult());
+            assertThat(identityService.createGroupQuery().groupId("testgroup").singleResult()).isNull();
 
         } finally {
             try {
@@ -135,16 +140,20 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertEquals("Updated group", responseNode.get("name").textValue());
-            assertEquals("Updated type", responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: 'Updated group',"
+                            + " type: 'Updated type',"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId()) + "'"
+                            + "}");
 
             Group createdGroup = identityService.createGroupQuery().groupId("testgroup").singleResult();
-            assertNotNull(createdGroup);
-            assertEquals("Updated group", createdGroup.getName());
-            assertEquals("Updated type", createdGroup.getType());
+            assertThat(createdGroup).isNotNull();
+            assertThat(createdGroup.getName()).isEqualTo("Updated group");
+            assertThat(createdGroup.getType()).isEqualTo("Updated type");
 
         } finally {
             try {
@@ -175,16 +184,20 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertEquals("Test group", responseNode.get("name").textValue());
-            assertEquals("Test type", responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: 'Test group',"
+                            + " type: 'Test type',"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId()) + "'"
+                            + "}");
 
             Group createdGroup = identityService.createGroupQuery().groupId("testgroup").singleResult();
-            assertNotNull(createdGroup);
-            assertEquals("Test group", createdGroup.getName());
-            assertEquals("Test type", createdGroup.getType());
+            assertThat(createdGroup).isNotNull();
+            assertThat(createdGroup.getName()).isEqualTo("Test group");
+            assertThat(createdGroup.getType()).isEqualTo("Test type");
 
         } finally {
             try {
@@ -216,16 +229,20 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertNull(responseNode.get("name").textValue());
-            assertNull(responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: null,"
+                            + " type: null,"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId()) + "'"
+                            + "}");
 
             Group createdGroup = identityService.createGroupQuery().groupId("testgroup").singleResult();
-            assertNotNull(createdGroup);
-            assertNull(createdGroup.getName());
-            assertNull(createdGroup.getType());
+            assertThat(createdGroup).isNotNull();
+            assertThat(createdGroup.getName()).isNull();
+            assertThat(createdGroup.getType()).isNull();
 
         } finally {
             try {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserCollectionResourceTest.java
@@ -51,14 +51,14 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             user1.setFirstName("Fred");
             user1.setLastName("McDonald");
             user1.setDisplayName("Fred McDonald");
-            user1.setEmail("no-reply@activiti.org");
+            user1.setEmail("no-reply@flowable.org");
             identityService.saveUser(user1);
             savedUsers.add(user1);
 
             User user2 = identityService.newUser("anotherUser");
             user2.setFirstName("Tijs");
             user2.setLastName("Barrez");
-            user2.setEmail("no-reply@alfresco.org");
+            user2.setEmail("no-reply@flowable.com");
             identityService.saveUser(user2);
             savedUsers.add(user2);
 
@@ -89,7 +89,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             assertResultsPresentInDataResponse(url, user1.getId());
 
             // Test based on email
-            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION) + "?email=no-reply@activiti.org";
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION) + "?email=no-reply@flowable.org";
             assertResultsPresentInDataResponse(url, user1.getId());
 
             // Test based on firstNameLike
@@ -105,7 +105,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             assertResultsPresentInDataResponse(url, user1.getId());
 
             // Test based on emailLike
-            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION) + "?emailLike=" + encode("no-reply@activiti.org%");
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION) + "?emailLike=" + encode("no-reply@flowable.org%");
             assertResultsPresentInDataResponse(url, user1.getId());
 
             // Test based on memberOfGroup
@@ -132,7 +132,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             requestNode.put("lastName", "Heremans");
             requestNode.put("displayName", "Frederik Heremans");
             requestNode.put("password", "test");
-            requestNode.put("email", "no-reply@activiti.org");
+            requestNode.put("email", "no-reply@flowable.org");
 
             HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION, "testuser"));
             httpPost.setEntity(new StringEntity(requestNode.toString()));
@@ -147,7 +147,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
                             + "firstName: 'Frederik',"
                             + "lastName: 'Heremans',"
                             + "displayName: 'Frederik Heremans',"
-                            + "email: 'no-reply@activiti.org',"
+                            + "email: 'no-reply@flowable.org',"
                             + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER, "testuser") + "'"
                             + "}");
 
@@ -157,7 +157,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             assertThat(createdUser.getLastName()).isEqualTo("Heremans");
             assertThat(createdUser.getDisplayName()).isEqualTo("Frederik Heremans");
             assertThat(createdUser.getPassword()).isEqualTo("test");
-            assertThat(createdUser.getEmail()).isEqualTo("no-reply@activiti.org");
+            assertThat(createdUser.getEmail()).isEqualTo("no-reply@flowable.org");
         } finally {
             try {
                 identityService.deleteUser("testuser");
@@ -173,7 +173,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("firstName", "Frederik");
         requestNode.put("lastName", "Heremans");
-        requestNode.put("email", "no-reply@activiti.org");
+        requestNode.put("email", "no-reply@flowable.org");
 
         HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION, "unexisting"));
         httpPost.setEntity(new StringEntity(requestNode.toString()));
@@ -185,7 +185,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
         requestNode.put("id", "kermit");
         requestNode.put("firstName", "Frederik");
         requestNode.put("lastName", "Heremans");
-        requestNode.put("email", "no-reply@activiti.org");
+        requestNode.put("email", "no-reply@flowable.org");
 
         httpPost.setEntity(new StringEntity(requestNode.toString()));
         closeResponse(executeRequest(httpPost, HttpStatus.SC_CONFLICT));

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserInfoResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserInfoResourceTest.java
@@ -13,10 +13,8 @@
 
 package org.flowable.rest.service.api.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -48,38 +46,29 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
             identityService.setUserInfo(newUser.getId(), "key1", "Value 1");
             identityService.setUserInfo(newUser.getId(), "key2", "Value 2");
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO_COLLECTION, newUser.getId())), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO_COLLECTION, newUser.getId())), HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertTrue(responseNode.isArray());
-            assertEquals(2, responseNode.size());
-
-            boolean foundFirst = false;
-            boolean foundSecond = false;
-
-            for (int i = 0; i < responseNode.size(); i++) {
-                ObjectNode info = (ObjectNode) responseNode.get(i);
-                assertNotNull(info.get("key").textValue());
-                assertNotNull(info.get("url").textValue());
-
-                if (info.get("key").textValue().equals("key1")) {
-                    foundFirst = true;
-                    assertTrue(info.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")));
-                } else if (info.get("key").textValue().equals("key2")) {
-                    assertTrue(info.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key2")));
-                    foundSecond = true;
-                }
-            }
-            assertTrue(foundFirst);
-            assertTrue(foundSecond);
+            assertThat(responseNode).isNotNull();
+            assertThat(responseNode.isArray()).isTrue();
+            assertThatJson(responseNode)
+                    .isEqualTo("[ {"
+                            + "  key: 'key1',"
+                            + "  url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1") + "'"
+                            + "},"
+                            + "{"
+                            + "  key: 'key2',"
+                            + "  url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key2") + "'"
+                            + "}"
+                            + "]");
 
         } finally {
 
@@ -100,19 +89,22 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
             identityService.setUserInfo(newUser.getId(), "key1", "Value 1");
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")), HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals("key1", responseNode.get("key").textValue());
-            assertEquals("Value 1", responseNode.get("value").textValue());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")));
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "key: 'key1',"
+                            + "value: 'Value 1',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1") + "'"
+                            + "}");
 
         } finally {
 
@@ -141,7 +133,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -166,7 +158,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -175,7 +167,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")), HttpStatus.SC_NO_CONTENT));
 
             // Check if info is actually deleted
-            assertNull(identityService.getUserInfo(newUser.getId(), "key1"));
+            assertThat(identityService.getUserInfo(newUser.getId(), "key1")).isNull();
         } finally {
 
             // Delete user after test passes or fails
@@ -195,7 +187,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -209,13 +201,15 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals("key1", responseNode.get("key").textValue());
-            assertEquals("Updated value", responseNode.get("value").textValue());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")));
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "key: 'key1',"
+                            + "value: 'Updated value',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1") + "'"
+                            + "}");
 
             // Check if info is actually updated
-            assertEquals("Updated value", identityService.getUserInfo(newUser.getId(), "key1"));
+            assertThat(identityService.getUserInfo(newUser.getId(), "key1")).isEqualTo("Updated value");
 
         } finally {
 
@@ -249,7 +243,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -287,7 +281,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -309,7 +303,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -322,10 +316,12 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals("key1", responseNode.get("key").textValue());
-            assertEquals("Value 1", responseNode.get("value").textValue());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")));
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "key: 'key1',"
+                            + "value: 'Value 1',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1") + "'"
+                            + "}");
 
         } finally {
 
@@ -343,7 +339,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/JobCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/JobCollectionResourceTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -50,7 +49,7 @@ public class JobCollectionResourceTest extends BaseSpringRestTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerProcess", Collections.singletonMap("error", (Object) Boolean.TRUE));
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).timers().singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION);
         assertResultsPresentInDataResponse(url, timerJob.getId());
@@ -74,28 +73,28 @@ public class JobCollectionResourceTest extends BaseSpringRestTestCase {
         
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION) + "?elementId=unknown";
         assertEmptyResultsPresentInDataResponse(url);
-        
+
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION) + "?elementName=Escalation";
         assertResultsPresentInDataResponse(url, timerJob.getId());
-        
+
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION) + "?elementName=unknown";
         assertEmptyResultsPresentInDataResponse(url);
 
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION) + "?withoutTenantId=true";
         assertResultsPresentInDataResponse(url, timerJob.getId());
 
-        for (int i = 0; i < timerJob.getRetries(); i++) {
+        Job timerJob2 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).timers().singleResult();
+        for (int i = 0; i < timerJob2.getRetries(); i++) {
             // Force execution of job until retries are exhausted
-            try {
-                managementService.moveTimerToExecutableJob(timerJob.getId());
-                managementService.executeJob(timerJob.getId());
-                fail();
-            } catch (FlowableException expected) {
-                // Ignore, we expect the exception
-            }
+            assertThatThrownBy(() -> {
+                managementService.moveTimerToExecutableJob(timerJob2.getId());
+                managementService.executeJob(timerJob2.getId());
+            })
+                    .isExactlyInstanceOf(FlowableException.class);
         }
+
         timerJob = managementService.createDeadLetterJobQuery().processInstanceId(processInstance.getId()).timers().singleResult();
-        assertEquals(0, timerJob.getRetries());
+        assertThat(timerJob.getRetries()).isZero();
 
         // Fetch the async-job (which has retries left)
         Job asyncJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/PropertiesCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/PropertiesCollectionResourceTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -28,8 +27,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * Test for all REST-operations related to the Job collection and a single job resource.
- * 
+ * Test for all REST-operations related to Properties
+ *
  * @author Frederik Heremans
  */
 public class PropertiesCollectionResourceTest extends BaseSpringRestTestCase {
@@ -39,22 +38,23 @@ public class PropertiesCollectionResourceTest extends BaseSpringRestTestCase {
      */
     @Test
     public void testGetProperties() throws Exception {
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROPERTIES_COLLECTION)), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROPERTIES_COLLECTION)),
+                HttpStatus.SC_OK);
 
         Map<String, String> properties = managementService.getProperties();
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(properties.size(), responseNode.size());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode).hasSize(properties.size());
 
         Iterator<Map.Entry<String, JsonNode>> nodes = responseNode.fields();
         Map.Entry<String, JsonNode> node = null;
         while (nodes.hasNext()) {
             node = nodes.next();
             String propValue = properties.get(node.getKey());
-            assertNotNull(propValue);
-            assertEquals(propValue, node.getValue().textValue());
+            assertThat(propValue).isNotNull();
+            assertThat(node.getValue().textValue()).isEqualTo(propValue);
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableColumnsResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableColumnsResourceTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -42,25 +41,26 @@ public class TableColumnsResourceTest extends BaseSpringRestTestCase {
 
         TableMetaData metaData = managementService.getTableMetaData(tableName);
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_COLUMNS, tableName)), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_COLUMNS, tableName)), HttpStatus.SC_OK);
 
         // Check table
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(tableName, responseNode.get("tableName").textValue());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.get("tableName").textValue()).isEqualTo(tableName);
 
         ArrayNode names = (ArrayNode) responseNode.get("columnNames");
         ArrayNode types = (ArrayNode) responseNode.get("columnTypes");
-        assertNotNull(names);
-        assertNotNull(types);
+        assertThat(names).isNotNull();
+        assertThat(types).isNotNull();
 
-        assertEquals(metaData.getColumnNames().size(), names.size());
-        assertEquals(metaData.getColumnTypes().size(), types.size());
+        assertThat(names).hasSize(metaData.getColumnNames().size());
+        assertThat(types).hasSize(metaData.getColumnTypes().size());
 
         for (int i = 0; i < names.size(); i++) {
-            assertEquals(names.get(i).textValue(), metaData.getColumnNames().get(i));
-            assertEquals(types.get(i).textValue(), metaData.getColumnTypes().get(i));
+            assertThat(metaData.getColumnNames().get(i)).isEqualTo(names.get(i).textValue());
+            assertThat(metaData.getColumnTypes().get(i)).isEqualTo(types.get(i).textValue());
         }
     }
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableDataResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableDataResourceTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -28,7 +27,8 @@ import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEnt
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to the Table columns.
@@ -53,72 +53,121 @@ public class TableDataResourceTest extends BaseSpringRestTestCase {
             // We use variable-table as a reference
             String tableName = managementService.getTableName(VariableInstanceEntity.class);
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName)), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName)), HttpStatus.SC_OK);
 
             // Check paging result
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(3, responseNode.get("total").intValue());
-            assertEquals(3, responseNode.get("size").intValue());
-            assertEquals(0, responseNode.get("start").intValue());
-            assertTrue(responseNode.get("order").isNull());
-            assertTrue(responseNode.get("sort").isNull());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "total: 3,"
+                            + "size: 3,"
+                            + "start: 0,"
+                            + "order: null,"
+                            + "sort: null"
+                            + "}");
 
             // Check variables are actually returned
-            ArrayNode rows = (ArrayNode) responseNode.get("data");
-            assertNotNull(rows);
-            assertEquals(3, rows.size());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + "data: [ {"
+                            + "      },"
+                            + "      {"
+                            + "      },"
+                            + "      {"
+                            + "      }"
+                            + "]"
+                            + "}");
 
             // Check sorting, ascending
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderAscendingColumn=LONG_"), HttpStatus.SC_OK);
-            responseNode = objectMapper.readTree(response.getEntity().getContent());
-            closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(3, responseNode.get("total").intValue());
-            assertEquals(3, responseNode.get("size").intValue());
-            assertEquals(0, responseNode.get("start").intValue());
-            assertEquals("asc", responseNode.get("order").textValue());
-            assertEquals("LONG_", responseNode.get("sort").textValue());
-            rows = (ArrayNode) responseNode.get("data");
-            assertNotNull(rows);
-            assertEquals(3, rows.size());
-
-            assertEquals("var1", rows.get(0).get("NAME_").textValue());
-            assertEquals("var2", rows.get(1).get("NAME_").textValue());
-            assertEquals("var3", rows.get(2).get("NAME_").textValue());
-
-            // Check sorting, descending
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderDescendingColumn=LONG_"), HttpStatus.SC_OK);
-            responseNode = objectMapper.readTree(response.getEntity().getContent());
-            closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(3, responseNode.get("total").intValue());
-            assertEquals(3, responseNode.get("size").intValue());
-            assertEquals(0, responseNode.get("start").intValue());
-            assertEquals("desc", responseNode.get("order").textValue());
-            assertEquals("LONG_", responseNode.get("sort").textValue());
-            rows = (ArrayNode) responseNode.get("data");
-            assertNotNull(rows);
-            assertEquals(3, rows.size());
-
-            assertEquals("var3", rows.get(0).get("NAME_").textValue());
-            assertEquals("var2", rows.get(1).get("NAME_").textValue());
-            assertEquals("var1", rows.get(2).get("NAME_").textValue());
-
-            // Finally, check result limiting
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderAscendingColumn=LONG_&start=1&size=1"),
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderAscendingColumn=LONG_"),
                     HttpStatus.SC_OK);
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(3, responseNode.get("total").intValue());
-            assertEquals(1, responseNode.get("size").intValue());
-            assertEquals(1, responseNode.get("start").intValue());
-            rows = (ArrayNode) responseNode.get("data");
-            assertNotNull(rows);
-            assertEquals(1, rows.size());
-            assertEquals("var2", rows.get(0).get("NAME_").textValue());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "total: 3,"
+                            + "size: 3,"
+                            + "start: 0,"
+                            + "order: 'asc',"
+                            + "sort: 'LONG_'"
+                            + "}");
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + "data: [ {"
+                            + "            NAME_: 'var1'"
+                            + "      },"
+                            + "      {"
+                            + "            NAME_: 'var2'"
+                            + "      },"
+                            + "      {"
+                            + "            NAME_: 'var3'"
+                            + "      }"
+                            + "]"
+                            + "}");
+
+            // Check sorting, descending
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderDescendingColumn=LONG_"),
+                    HttpStatus.SC_OK);
+            responseNode = objectMapper.readTree(response.getEntity().getContent());
+            closeResponse(response);
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "total: 3,"
+                            + "size: 3,"
+                            + "start: 0,"
+                            + "order: 'desc',"
+                            + "sort: 'LONG_'"
+                            + "}");
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + "data: [ {"
+                            + "            NAME_: 'var3'"
+                            + "      },"
+                            + "      {"
+                            + "            NAME_: 'var2'"
+                            + "      },"
+                            + "      {"
+                            + "            NAME_: 'var1'"
+                            + "      }"
+                            + "]"
+                            + "}");
+
+            // Finally, check result limiting
+            response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderAscendingColumn=LONG_&start=1&size=1"),
+                    HttpStatus.SC_OK);
+            responseNode = objectMapper.readTree(response.getEntity().getContent());
+            closeResponse(response);
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "total: 3,"
+                            + "size: 1,"
+                            + "start: 1,"
+                            + "order: 'asc',"
+                            + "sort: 'LONG_'"
+                            + "}");
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + "data: [ {"
+                            + "            NAME_: 'var2'"
+                            + "      } ]"
+                            + "}");
 
         } finally {
             // Clean adhoc-tasks even if test fails

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableResourceTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -42,22 +41,22 @@ public class TableResourceTest extends BaseSpringRestTestCase {
     public void testGetTables() throws Exception {
         Map<String, Long> tableCounts = managementService.getTableCount();
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLES_COLLECTION)), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLES_COLLECTION)),
+                HttpStatus.SC_OK);
 
         // Check table array
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertTrue(responseNode.isArray());
-        assertEquals(tableCounts.size(), responseNode.size());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.isArray()).isTrue();
+        assertThat(responseNode).hasSize(tableCounts.size());
 
         for (int i = 0; i < responseNode.size(); i++) {
             ObjectNode table = (ObjectNode) responseNode.get(i);
-            assertNotNull(table.get("name").textValue());
-            assertNotNull(table.get("count").longValue());
-            assertTrue(table.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, table.get("name").textValue())));
-
-            assertEquals(tableCounts.get(table.get("name").textValue()).longValue(), table.get("count").longValue());
+            assertThat(table.get("name").textValue()).isNotNull();
+            assertThat(table.get("count").longValue()).isNotNull();
+            assertThat(table.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, table.get("name").textValue()))).isTrue();
+            assertThat(table.get("count").longValue()).isEqualTo(tableCounts.get(table.get("name").textValue()).longValue());
         }
     }
 
@@ -70,15 +69,19 @@ public class TableResourceTest extends BaseSpringRestTestCase {
 
         String tableNameToGet = tableCounts.keySet().iterator().next();
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, tableNameToGet)), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, tableNameToGet)),
+                HttpStatus.SC_OK);
 
         // Check table
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(tableNameToGet, responseNode.get("name").textValue());
-        assertEquals(tableCounts.get(responseNode.get("name").textValue()).longValue(), responseNode.get("count").longValue());
-        assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, tableNameToGet)));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .isEqualTo("{"
+                        + "name: '" + tableNameToGet + "',"
+                        + "count: " + tableCounts.get(tableNameToGet) + ","
+                        + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, tableNameToGet) + "'"
+                        + "}");
     }
 
     @Test


### PR DESCRIPTION
The module had a mix of assertion styles.  This is part 3 for this module.
This finishes off the `org.flowable.rest.service.api.identity` and `org.flowable.rest.service.api.management` packages.

