### PR TITLE
Use assertj fluent style in flowable-rest module.

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ModelCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/ModelCollectionResource.java
@@ -173,4 +173,5 @@ public class ModelCollectionResource extends BaseModelResource {
         response.setStatus(HttpStatus.CREATED.value());
         return restResponseFactory.createModelResponse(model);
     }
+
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/BaseSpringRestTestCase.java
@@ -79,6 +79,7 @@ import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
 import org.flowable.rest.conf.ApplicationConfiguration;
 import org.flowable.rest.util.TestServerUtil;
 import org.flowable.rest.util.TestServerUtil.TestServer;
+import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.After;
@@ -634,6 +635,13 @@ public class BaseSpringRestTestCase {
 
     protected String getISODateString(Date time) {
         return dateFormat.format(time);
+    }
+
+    protected String getISODateStringWithTZ(Date date) {
+        if (date == null) {
+            return null;
+        }
+        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 
     protected String buildUrl(String[] fragments, Object... arguments) {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceQueryResourceTest.java
@@ -13,7 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import java.util.HashMap;
 
@@ -32,6 +32,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for REST-operation related to the historic process instance query resource.
@@ -173,14 +175,19 @@ public class HistoricProcessInstanceQueryResourceTest extends BaseSpringRestTest
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertThat(dataNode).hasSize(2);
-        JsonNode valueNode = dataNode.get(0);
-        assertThat(valueNode.get("id").asText()).isEqualTo(processInstance.getId());
-        assertThat(dataNode.get(1).get("id").asText()).isEqualTo(processInstance2.getId());
-
-        assertThat(valueNode.get("processDefinitionName").asText()).isEqualTo("The One Task Process");
-        assertThat(valueNode.get("processDefinitionDescription").asText()).isEqualTo("One task process description");
-        assertThat(valueNode.has("startTime")).as("has startTime").isTrue();
-        assertThat(valueNode.get("startUserId").textValue()).as("startUserId").isEqualTo(processInstance.getStartUserId());
+        assertThatJson(dataNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("["
+                        + "{"
+                        + "    id: '" + processInstance.getId() + "',"
+                        + "    processDefinitionName: 'The One Task Process',"
+                        + "    processDefinitionDescription: 'One task process description',"
+                        + "    startTime: '${json-unit.any-string}',"
+                        + "    startUserId: '" + processInstance.getStartUserId() + "'"
+                        + "},"
+                        + "{"
+                        + "    id: '" + processInstance2.getId() + "'"
+                        + "}"
+                        + "]");
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricProcessInstanceResourceTest.java
@@ -13,8 +13,8 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -29,9 +29,11 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for REST-operation related to get and delete a historic process instance.
- * 
+ *
  * @author Tijs Rademakers
  * @author Joram Barrez
  */
@@ -44,35 +46,42 @@ public class HistoricProcessInstanceResourceTest extends BaseSpringRestTestCase 
     @Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml" })
     public void testGetProcessInstance() throws Exception {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("oneTaskProcess")
-            .businessKey("myBusinessKey")
-            .callbackId("testCallbackId")
-            .callbackType("testCallbackType")
-            .referenceId("testReferenceId")
-            .referenceType("testReferenceType")
-            .start();
+                .processDefinitionKey("oneTaskProcess")
+                .businessKey("myBusinessKey")
+                .callbackId("testCallbackId")
+                .callbackType("testCallbackType")
+                .referenceId("testReferenceId")
+                .referenceType("testReferenceType")
+                .start();
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, processInstance.getId())),
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, processInstance.getId())),
                 HttpStatus.SC_OK);
 
-        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("id").textValue());
-        assertEquals("myBusinessKey", responseNode.get("businessKey").textValue());
-        assertEquals("testCallbackId", responseNode.get("callbackId").textValue());
-        assertEquals("testCallbackType", responseNode.get("callbackType").textValue());
-        assertEquals("testReferenceId", responseNode.get("referenceId").textValue());
-        assertEquals("testReferenceType", responseNode.get("referenceType").textValue());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processInstance.getId() + "',"
+                        + "businessKey: 'myBusinessKey',"
+                        + "callbackId: 'testCallbackId',"
+                        + "callbackType: 'testCallbackType',"
+                        + "referenceId: 'testReferenceId',"
+                        + "referenceType: 'testReferenceType'"
+                        + "}");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
-        response = executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, processInstance.getId())), HttpStatus.SC_NO_CONTENT);
-        assertEquals(HttpStatus.SC_NO_CONTENT, response.getStatusLine().getStatusCode());
+        response = executeRequest(
+                new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, processInstance.getId())),
+                HttpStatus.SC_NO_CONTENT);
+        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
         closeResponse(response);
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceCollectionResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -178,7 +177,7 @@ public class HistoricTaskInstanceCollectionResourceTest extends BaseSpringRestTe
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         if (expectedTaskIds != null) {
@@ -188,7 +187,7 @@ public class HistoricTaskInstanceCollectionResourceTest extends BaseSpringRestTe
                 String id = it.next().get("id").textValue();
                 toBeFound.remove(id);
             }
-            assertTrue("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+            assertThat(toBeFound).as("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", ")).isEmpty();
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceIdentityLinkCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceIdentityLinkCollectionResourceTest.java
@@ -13,12 +13,9 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -33,9 +30,11 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for REST-operation related to the historic task instance identity links resource.
- * 
+ *
  * @author Tijs Rademakers
  */
 public class HistoricTaskInstanceIdentityLinkCollectionResourceTest extends BaseSpringRestTestCase {
@@ -67,27 +66,25 @@ public class HistoricTaskInstanceIdentityLinkCollectionResourceTest extends Base
         // Check status and size
         JsonNode linksArray = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals(2, linksArray.size());
-        Map<String, JsonNode> linksMap = new HashMap<>();
-        for (JsonNode linkNode : linksArray) {
-            linksMap.put(linkNode.get("type").asText(), linkNode);
-        }
-        JsonNode assigneeNode = linksMap.get("assignee");
-        assertNotNull(assigneeNode);
-        assertEquals("fozzie", assigneeNode.get("userId").asText());
-        assertTrue(assigneeNode.get("groupId").isNull());
-        assertEquals(task.getId(), assigneeNode.get("taskId").asText());
-        assertNotNull(assigneeNode.get("taskUrl").asText());
-        assertTrue(assigneeNode.get("processInstanceId").isNull());
-        assertTrue(assigneeNode.get("processInstanceUrl").isNull());
-
-        JsonNode ownerNode = linksMap.get("owner");
-        assertNotNull(ownerNode);
-        assertEquals("test", ownerNode.get("userId").asText());
-        assertTrue(ownerNode.get("groupId").isNull());
-        assertEquals(task.getId(), ownerNode.get("taskId").asText());
-        assertNotNull(ownerNode.get("taskUrl").asText());
-        assertTrue(ownerNode.get("processInstanceId").isNull());
-        assertTrue(ownerNode.get("processInstanceUrl").isNull());
+        assertThatJson(linksArray)
+                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_ARRAY_ORDER)
+                .isEqualTo("["
+                        + "{"
+                        + "  userId: 'fozzie',"
+                        + "  groupId: null,"
+                        + "  taskId: '" + task.getId() + "',"
+                        + "  taskUrl: '${json-unit.any-string}',"
+                        + "  processInstanceId: null,"
+                        + "  processInstanceUrl: null"
+                        + "},"
+                        + "{"
+                        + "  userId: 'test',"
+                        + "  groupId: null,"
+                        + "  taskId: '" + task.getId() + "',"
+                        + "  taskUrl: '${json-unit.any-string}',"
+                        + "  processInstanceId: null,"
+                        + "  processInstanceUrl: null"
+                        + "}"
+                        + "]");
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -283,7 +282,7 @@ public class HistoricTaskInstanceQueryResourceTest extends BaseSpringRestTestCas
         CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_OK);
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         if (expectedTaskIds != null) {
@@ -293,7 +292,7 @@ public class HistoricTaskInstanceQueryResourceTest extends BaseSpringRestTestCas
                 String id = it.next().get("id").textValue();
                 toBeFound.remove(id);
             }
-            assertTrue("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+            assertThat(toBeFound).as("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", ")).isEmpty();
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceResourceTest.java
@@ -17,7 +17,6 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,8 +36,6 @@ import org.flowable.rest.service.api.RestUrls;
 import org.flowable.task.api.DelegationState;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -277,12 +274,5 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
                 }
             }
         }
-    }
-
-    protected String getISODateStringWithTZ(Date date) {
-        if (date == null) {
-            return null;
-        }
-        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricTaskInstanceResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,12 +13,11 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,9 +37,14 @@ import org.flowable.rest.service.api.RestUrls;
 import org.flowable.task.api.DelegationState;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to a single Historic task instance resource.
@@ -56,37 +60,40 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
             Calendar now = Calendar.getInstance();
             processEngineConfiguration.getClock().setCurrentTime(now.getTime());
-    
+
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             taskService.setDueDate(task.getId(), now.getTime());
             taskService.setOwner(task.getId(), "owner");
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
-    
+            assertThat(task).isNotNull();
+
             String url = buildUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE, task.getId());
             CloseableHttpResponse response = executeRequest(new HttpGet(url), HttpStatus.SC_OK);
-    
+
             // Check resulting task
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(task.getId(), responseNode.get("id").asText());
-            assertEquals(task.getAssignee(), responseNode.get("assignee").asText());
-            assertEquals(task.getOwner(), responseNode.get("owner").asText());
-            assertEquals(task.getFormKey(), responseNode.get("formKey").asText());
-            assertEquals(task.getExecutionId(), responseNode.get("executionId").asText());
-            assertEquals(task.getDescription(), responseNode.get("description").asText());
-            assertEquals(task.getName(), responseNode.get("name").asText());
-            assertEquals(task.getDueDate(), getDateFromISOString(responseNode.get("dueDate").asText()));
-            assertEquals(task.getCreateTime(), getDateFromISOString(responseNode.get("startTime").asText()));
-            assertEquals(task.getPriority(), responseNode.get("priority").asInt());
-            assertTrue(responseNode.get("endTime").isNull());
-            assertTrue(responseNode.get("parentTaskId").isNull());
-            assertEquals("", responseNode.get("tenantId").textValue());
-    
-            assertEquals(buildUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, task.getProcessInstanceId()), responseNode.get("processInstanceUrl").asText());
-            assertEquals(buildUrl(RestUrls.URL_PROCESS_DEFINITION, task.getProcessDefinitionId()), responseNode.get("processDefinitionUrl").asText());
-            assertEquals(responseNode.get("url").asText(), url);
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: '" + task.getId() + "',"
+                            + " assignee: '" + task.getAssignee() + "',"
+                            + " owner: '" + task.getOwner() + "',"
+                            + " formKey: '" + task.getFormKey() + "',"
+                            + " executionId: '" + task.getExecutionId() + "',"
+                            + " description: '" + task.getDescription() + "',"
+                            + " name: '" + task.getName() + "',"
+                            + " dueDate: " + new TextNode(getISODateStringWithTZ(task.getDueDate())) + ","
+                            + " startTime: " + new TextNode(getISODateStringWithTZ(task.getCreateTime())) + ","
+                            + " priority: " + task.getPriority() + ","
+                            + " endTime: null,"
+                            + " parentTaskId: null,"
+                            + " tenantId: \"\","
+                            + " processInstanceUrl: '" + buildUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE, task.getProcessInstanceId()) + "',"
+                            + " processDefinitionUrl: '" + buildUrl(RestUrls.URL_PROCESS_DEFINITION, task.getProcessDefinitionId()) + "',"
+                            + " url: '" + url + "'"
+                            + "}");
         }
     }
 
@@ -97,13 +104,13 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
     public void testGetProcessAdhoc() throws Exception {
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
             try {
-    
+
                 Calendar now = Calendar.getInstance();
                 processEngineConfiguration.getClock().setCurrentTime(now.getTime());
-    
+
                 Task parentTask = taskService.newTask();
                 taskService.saveTask(parentTask);
-    
+
                 Task task = taskService.newTask();
                 task.setParentTaskId(parentTask.getId());
                 task.setName("Task name");
@@ -115,31 +122,34 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
                 task.setOwner("owner");
                 task.setPriority(20);
                 taskService.saveTask(task);
-    
+
                 String url = buildUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE, task.getId());
                 CloseableHttpResponse response = executeRequest(new HttpGet(url), HttpStatus.SC_OK);
-    
+
                 // Check resulting task
                 JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
                 closeResponse(response);
-                assertEquals(task.getId(), responseNode.get("id").asText());
-                assertEquals(task.getAssignee(), responseNode.get("assignee").asText());
-                assertEquals(task.getOwner(), responseNode.get("owner").asText());
-                assertEquals(task.getDescription(), responseNode.get("description").asText());
-                assertEquals(task.getName(), responseNode.get("name").asText());
-                assertEquals(task.getDueDate(), getDateFromISOString(responseNode.get("dueDate").asText()));
-                assertEquals(task.getCreateTime(), getDateFromISOString(responseNode.get("startTime").asText()));
-                assertEquals(task.getPriority(), responseNode.get("priority").asInt());
-                assertEquals(task.getParentTaskId(), responseNode.get("parentTaskId").asText());
-                assertTrue(responseNode.get("executionId").isNull());
-                assertTrue(responseNode.get("processInstanceId").isNull());
-                assertTrue(responseNode.get("processDefinitionId").isNull());
-                assertEquals("", responseNode.get("tenantId").textValue());
-    
-                assertEquals(responseNode.get("url").asText(), url);
-    
+                assertThatJson(responseNode)
+                        .when(Option.IGNORING_EXTRA_FIELDS)
+                        .isEqualTo("{"
+                                + " id: '" + task.getId() + "',"
+                                + " assignee: '" + task.getAssignee() + "',"
+                                + " owner: '" + task.getOwner() + "',"
+                                + " description: '" + task.getDescription() + "',"
+                                + " name: '" + task.getName() + "',"
+                                + " dueDate: " + new TextNode(getISODateStringWithTZ(task.getDueDate())) + ","
+                                + " startTime: " + new TextNode(getISODateStringWithTZ(task.getCreateTime())) + ","
+                                + " priority: " + task.getPriority() + ","
+                                + " parentTaskId: '" + task.getParentTaskId() + "',"
+                                + " executionId: null,"
+                                + " processInstanceId: null,"
+                                + " processDefinitionId: null,"
+                                + " tenantId: \"\","
+                                + " url: '" + url + "'"
+                                + "}");
+
             } finally {
-    
+
                 // Clean adhoc-tasks even if test fails
                 List<Task> tasks = taskService.createTaskQuery().list();
                 for (Task task : tasks) {
@@ -160,20 +170,20 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
                 Task task = taskService.newTask();
                 taskService.saveTask(task);
                 String taskId = task.getId();
-    
+
                 // Execute the request
                 HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE, taskId));
                 closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
-    
-                assertNull(historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult());
-    
+
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskId(taskId).singleResult()).isNull();
+
             } finally {
                 // Clean adhoc-tasks even if test fails
                 List<Task> tasks = taskService.createTaskQuery().list();
                 for (Task task : tasks) {
                     taskService.deleteTask(task.getId(), true);
                 }
-    
+
                 // Clean historic tasks with no runtime-counterpart
                 List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery().list();
                 for (HistoricTaskInstance task : historicTasks) {
@@ -192,12 +202,12 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
-    
+            assertThat(task).isNotNull();
+
             HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE, task.getId()));
             closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
-            
-            assertNull(historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult());
+
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult()).isNull();
         }
     }
 
@@ -208,55 +218,71 @@ public class HistoricTaskInstanceResourceTest extends BaseSpringRestTestCase {
             ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").singleResult();
             try {
                 formRepositoryService.createDeployment().addClasspathResource("org/flowable/rest/service/api/runtime/simple.form").deploy();
-                
+
                 FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-                assertNotNull(formDefinition);
-                
+                assertThat(formDefinition).isNotNull();
+
                 ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
                 Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
                 String taskId = task.getId();
-                
+
                 String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_TASK_INSTANCE_FORM, taskId);
                 CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
                 JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
                 closeResponse(response);
-                assertEquals(formDefinition.getId(), responseNode.get("id").asText());
-                assertEquals(formDefinition.getKey(), responseNode.get("key").asText());
-                assertEquals(formDefinition.getName(), responseNode.get("name").asText());
-                assertEquals(2, responseNode.get("fields").size());
-                
+                assertThatJson(responseNode)
+                        .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                        .isEqualTo("{"
+                                + "id: '" + formDefinition.getId() + "',"
+                                + "name: '" + formDefinition.getName() + "',"
+                                + "key: '" + formDefinition.getKey() + "',"
+                                + "fields: [ {  },"
+                                + "          {  }"
+                                + "        ]"
+                                + "}");
+
                 Map<String, Object> variables = new HashMap<>();
                 variables.put("user", "First value");
                 variables.put("number", 789);
                 taskService.completeTaskWithForm(taskId, formDefinition.getId(), null, variables);
-                
-                assertNull(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
-    
+
+                assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult()).isNull();
+
                 response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
                 responseNode = objectMapper.readTree(response.getEntity().getContent());
                 closeResponse(response);
-                assertEquals(formDefinition.getId(), responseNode.get("id").asText());
-                assertEquals(formDefinition.getKey(), responseNode.get("key").asText());
-                assertEquals(formDefinition.getName(), responseNode.get("name").asText());
-                assertEquals(2, responseNode.get("fields").size());
-                
-                JsonNode fieldNode = responseNode.get("fields").get(0);
-                assertEquals("user", fieldNode.get("id").asText());
-                assertEquals("First value", fieldNode.get("value").asText());
-                
-                fieldNode = responseNode.get("fields").get(1);
-                assertEquals("number", fieldNode.get("id").asText());
-                assertEquals(789, fieldNode.get("value").asInt());
-                
-    
+                assertThatJson(responseNode)
+                        .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                        .isEqualTo("{"
+                                + "id: '" + formDefinition.getId() + "',"
+                                + "name: '" + formDefinition.getName() + "',"
+                                + "key: '" + formDefinition.getKey() + "',"
+                                + "fields: [ { "
+                                + "            id: 'user',"
+                                + "            value: 'First value'"
+                                + "          },"
+                                + "          { "
+                                + "            id: 'number',"
+                                + "            value: '789'"
+                                + "          }"
+                                + "        ]"
+                                + "}");
+
             } finally {
                 formEngineFormService.deleteFormInstancesByProcessDefinition(processDefinition.getId());
-                
+
                 List<FormDeployment> formDeployments = formRepositoryService.createDeploymentQuery().list();
                 for (FormDeployment formDeployment : formDeployments) {
                     formRepositoryService.deleteDeployment(formDeployment.getId());
                 }
             }
         }
+    }
+
+    protected String getISODateStringWithTZ(Date date) {
+        if (date == null) {
+            return null;
+        }
+        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceCollectionResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -90,7 +89,7 @@ public class HistoricVariableInstanceCollectionResourceTest extends BaseSpringRe
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         if (variableName != null) {
@@ -103,15 +102,15 @@ public class HistoricVariableInstanceCollectionResourceTest extends BaseSpringRe
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
+                        assertThat((boolean) (Boolean) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asBoolean());
                     } else if (variableValue instanceof Integer) {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
+                        assertThat((int) (Integer) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asInt());
                     } else {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asText(), (String) variableValue);
+                        assertThat((String) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asText());
                     }
                 }
             }
-            assertTrue("Variable " + variableName + " is missing", variableFound);
+            assertThat(variableFound).as("Variable " + variableName + " is missing").isTrue();
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/history/HistoricVariableInstanceQueryResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.history;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -141,7 +140,7 @@ public class HistoricVariableInstanceQueryResourceTest extends BaseSpringRestTes
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         if (variableName != null) {
@@ -154,15 +153,15 @@ public class HistoricVariableInstanceQueryResourceTest extends BaseSpringRestTes
                 if (variableName.equals(name)) {
                     variableFound = true;
                     if (variableValue instanceof Boolean) {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asBoolean(), (boolean) (Boolean) variableValue);
+                        assertThat((boolean) (Boolean) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asBoolean());
                     } else if (variableValue instanceof Integer) {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asInt(), (int) (Integer) variableValue);
+                        assertThat((int) (Integer) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asInt());
                     } else {
-                        assertEquals("Variable value is not equal", variableNode.get("value").asText(), (String) variableValue);
+                        assertThat((String) variableValue).as("Variable value is not equal").isEqualTo(variableNode.get("value").asText());
                     }
                 }
             }
-            assertTrue("Variable " + variableName + " is missing", variableFound);
+            assertThat(variableFound).as("Variable " + variableName + " is missing").isTrue();
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupCollectionResourceTest.java
@@ -13,9 +13,8 @@
 
 package org.flowable.rest.service.api.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +31,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Frederik Heremans
@@ -59,10 +60,10 @@ public class GroupCollectionResourceTest extends BaseSpringRestTestCase {
             savedGroups.add(group2);
 
             Group group3 = identityService.createGroupQuery().groupId("admin").singleResult();
-            assertNotNull(group3);
+            assertThat(group3).isNotNull();
             
             Group group4 = identityService.createGroupQuery().groupId("sales").singleResult();
-            assertNotNull(group4);
+            assertThat(group4).isNotNull();
 
             // Test filter-less
             String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP_COLLECTION);
@@ -108,13 +109,17 @@ public class GroupCollectionResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertEquals("Test group", responseNode.get("name").textValue());
-            assertEquals("Test type", responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup")));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: 'Test group',"
+                            + " type: 'Test type',"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup") + "'"
+                            + "}");
 
-            assertNotNull(identityService.createGroupQuery().groupId("testgroup").singleResult());
+            assertThat(identityService.createGroupQuery().groupId("testgroup").singleResult()).isNotNull();
         } finally {
             try {
                 identityService.deleteGroup("testgroup");

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/GroupResourceTest.java
@@ -13,10 +13,8 @@
 
 package org.flowable.rest.service.api.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -31,6 +29,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Frederik Heremans
@@ -48,20 +48,25 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
             testGroup.setType("Test type");
             identityService.saveGroup(testGroup);
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup")), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup")), HttpStatus.SC_OK);
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertEquals("Test group", responseNode.get("name").textValue());
-            assertEquals("Test type", responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: 'Test group',"
+                            + " type: 'Test type',"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId()) + "'"
+                            + "}");
 
             Group createdGroup = identityService.createGroupQuery().groupId("testgroup").singleResult();
-            assertNotNull(createdGroup);
-            assertEquals("Test group", createdGroup.getName());
-            assertEquals("Test type", createdGroup.getType());
+            assertThat(createdGroup).isNotNull();
+            assertThat(createdGroup.getName()).isEqualTo("Test group");
+            assertThat(createdGroup.getType()).isEqualTo("Test type");
 
         } finally {
             try {
@@ -94,7 +99,7 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
 
             closeResponse(executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, "testgroup")), HttpStatus.SC_NO_CONTENT));
 
-            assertNull(identityService.createGroupQuery().groupId("testgroup").singleResult());
+            assertThat(identityService.createGroupQuery().groupId("testgroup").singleResult()).isNull();
 
         } finally {
             try {
@@ -135,16 +140,20 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertEquals("Updated group", responseNode.get("name").textValue());
-            assertEquals("Updated type", responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: 'Updated group',"
+                            + " type: 'Updated type',"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId()) + "'"
+                            + "}");
 
             Group createdGroup = identityService.createGroupQuery().groupId("testgroup").singleResult();
-            assertNotNull(createdGroup);
-            assertEquals("Updated group", createdGroup.getName());
-            assertEquals("Updated type", createdGroup.getType());
+            assertThat(createdGroup).isNotNull();
+            assertThat(createdGroup.getName()).isEqualTo("Updated group");
+            assertThat(createdGroup.getType()).isEqualTo("Updated type");
 
         } finally {
             try {
@@ -175,16 +184,20 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertEquals("Test group", responseNode.get("name").textValue());
-            assertEquals("Test type", responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: 'Test group',"
+                            + " type: 'Test type',"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId()) + "'"
+                            + "}");
 
             Group createdGroup = identityService.createGroupQuery().groupId("testgroup").singleResult();
-            assertNotNull(createdGroup);
-            assertEquals("Test group", createdGroup.getName());
-            assertEquals("Test type", createdGroup.getType());
+            assertThat(createdGroup).isNotNull();
+            assertThat(createdGroup.getName()).isEqualTo("Test group");
+            assertThat(createdGroup.getType()).isEqualTo("Test type");
 
         } finally {
             try {
@@ -216,16 +229,20 @@ public class GroupResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("testgroup", responseNode.get("id").textValue());
-            assertNull(responseNode.get("name").textValue());
-            assertNull(responseNode.get("type").textValue());
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + " id: 'testgroup',"
+                            + " name: null,"
+                            + " type: null,"
+                            + " url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_GROUP, testGroup.getId()) + "'"
+                            + "}");
 
             Group createdGroup = identityService.createGroupQuery().groupId("testgroup").singleResult();
-            assertNotNull(createdGroup);
-            assertNull(createdGroup.getName());
-            assertNull(createdGroup.getType());
+            assertThat(createdGroup).isNotNull();
+            assertThat(createdGroup.getName()).isNull();
+            assertThat(createdGroup.getType()).isNull();
 
         } finally {
             try {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserCollectionResourceTest.java
@@ -51,14 +51,14 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             user1.setFirstName("Fred");
             user1.setLastName("McDonald");
             user1.setDisplayName("Fred McDonald");
-            user1.setEmail("no-reply@activiti.org");
+            user1.setEmail("no-reply@flowable.org");
             identityService.saveUser(user1);
             savedUsers.add(user1);
 
             User user2 = identityService.newUser("anotherUser");
             user2.setFirstName("Tijs");
             user2.setLastName("Barrez");
-            user2.setEmail("no-reply@alfresco.org");
+            user2.setEmail("no-reply@flowable.com");
             identityService.saveUser(user2);
             savedUsers.add(user2);
 
@@ -89,7 +89,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             assertResultsPresentInDataResponse(url, user1.getId());
 
             // Test based on email
-            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION) + "?email=no-reply@activiti.org";
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION) + "?email=no-reply@flowable.org";
             assertResultsPresentInDataResponse(url, user1.getId());
 
             // Test based on firstNameLike
@@ -105,7 +105,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             assertResultsPresentInDataResponse(url, user1.getId());
 
             // Test based on emailLike
-            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION) + "?emailLike=" + encode("no-reply@activiti.org%");
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION) + "?emailLike=" + encode("no-reply@flowable.org%");
             assertResultsPresentInDataResponse(url, user1.getId());
 
             // Test based on memberOfGroup
@@ -132,7 +132,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             requestNode.put("lastName", "Heremans");
             requestNode.put("displayName", "Frederik Heremans");
             requestNode.put("password", "test");
-            requestNode.put("email", "no-reply@activiti.org");
+            requestNode.put("email", "no-reply@flowable.org");
 
             HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION, "testuser"));
             httpPost.setEntity(new StringEntity(requestNode.toString()));
@@ -147,7 +147,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
                             + "firstName: 'Frederik',"
                             + "lastName: 'Heremans',"
                             + "displayName: 'Frederik Heremans',"
-                            + "email: 'no-reply@activiti.org',"
+                            + "email: 'no-reply@flowable.org',"
                             + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER, "testuser") + "'"
                             + "}");
 
@@ -157,7 +157,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
             assertThat(createdUser.getLastName()).isEqualTo("Heremans");
             assertThat(createdUser.getDisplayName()).isEqualTo("Frederik Heremans");
             assertThat(createdUser.getPassword()).isEqualTo("test");
-            assertThat(createdUser.getEmail()).isEqualTo("no-reply@activiti.org");
+            assertThat(createdUser.getEmail()).isEqualTo("no-reply@flowable.org");
         } finally {
             try {
                 identityService.deleteUser("testuser");
@@ -173,7 +173,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("firstName", "Frederik");
         requestNode.put("lastName", "Heremans");
-        requestNode.put("email", "no-reply@activiti.org");
+        requestNode.put("email", "no-reply@flowable.org");
 
         HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_COLLECTION, "unexisting"));
         httpPost.setEntity(new StringEntity(requestNode.toString()));
@@ -185,7 +185,7 @@ public class UserCollectionResourceTest extends BaseSpringRestTestCase {
         requestNode.put("id", "kermit");
         requestNode.put("firstName", "Frederik");
         requestNode.put("lastName", "Heremans");
-        requestNode.put("email", "no-reply@activiti.org");
+        requestNode.put("email", "no-reply@flowable.org");
 
         httpPost.setEntity(new StringEntity(requestNode.toString()));
         closeResponse(executeRequest(httpPost, HttpStatus.SC_CONFLICT));

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserInfoResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/identity/UserInfoResourceTest.java
@@ -13,10 +13,8 @@
 
 package org.flowable.rest.service.api.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -48,38 +46,29 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
             identityService.setUserInfo(newUser.getId(), "key1", "Value 1");
             identityService.setUserInfo(newUser.getId(), "key2", "Value 2");
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO_COLLECTION, newUser.getId())), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO_COLLECTION, newUser.getId())), HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertTrue(responseNode.isArray());
-            assertEquals(2, responseNode.size());
-
-            boolean foundFirst = false;
-            boolean foundSecond = false;
-
-            for (int i = 0; i < responseNode.size(); i++) {
-                ObjectNode info = (ObjectNode) responseNode.get(i);
-                assertNotNull(info.get("key").textValue());
-                assertNotNull(info.get("url").textValue());
-
-                if (info.get("key").textValue().equals("key1")) {
-                    foundFirst = true;
-                    assertTrue(info.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")));
-                } else if (info.get("key").textValue().equals("key2")) {
-                    assertTrue(info.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key2")));
-                    foundSecond = true;
-                }
-            }
-            assertTrue(foundFirst);
-            assertTrue(foundSecond);
+            assertThat(responseNode).isNotNull();
+            assertThat(responseNode.isArray()).isTrue();
+            assertThatJson(responseNode)
+                    .isEqualTo("[ {"
+                            + "  key: 'key1',"
+                            + "  url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1") + "'"
+                            + "},"
+                            + "{"
+                            + "  key: 'key2',"
+                            + "  url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key2") + "'"
+                            + "}"
+                            + "]");
 
         } finally {
 
@@ -100,19 +89,22 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
             identityService.setUserInfo(newUser.getId(), "key1", "Value 1");
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")), HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals("key1", responseNode.get("key").textValue());
-            assertEquals("Value 1", responseNode.get("value").textValue());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")));
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "key: 'key1',"
+                            + "value: 'Value 1',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1") + "'"
+                            + "}");
 
         } finally {
 
@@ -141,7 +133,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -166,7 +158,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -175,7 +167,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")), HttpStatus.SC_NO_CONTENT));
 
             // Check if info is actually deleted
-            assertNull(identityService.getUserInfo(newUser.getId(), "key1"));
+            assertThat(identityService.getUserInfo(newUser.getId(), "key1")).isNull();
         } finally {
 
             // Delete user after test passes or fails
@@ -195,7 +187,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -209,13 +201,15 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals("key1", responseNode.get("key").textValue());
-            assertEquals("Updated value", responseNode.get("value").textValue());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")));
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "key: 'key1',"
+                            + "value: 'Updated value',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1") + "'"
+                            + "}");
 
             // Check if info is actually updated
-            assertEquals("Updated value", identityService.getUserInfo(newUser.getId(), "key1"));
+            assertThat(identityService.getUserInfo(newUser.getId(), "key1")).isEqualTo("Updated value");
 
         } finally {
 
@@ -249,7 +243,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -287,7 +281,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -309,7 +303,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 
@@ -322,10 +316,12 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals("key1", responseNode.get("key").textValue());
-            assertEquals("Value 1", responseNode.get("value").textValue());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1")));
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "key: 'key1',"
+                            + "value: 'Value 1',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_USER_INFO, newUser.getId(), "key1") + "'"
+                            + "}");
 
         } finally {
 
@@ -343,7 +339,7 @@ public class UserInfoResourceTest extends BaseSpringRestTestCase {
             User newUser = identityService.newUser("testuser");
             newUser.setFirstName("Fred");
             newUser.setLastName("McDonald");
-            newUser.setEmail("no-reply@activiti.org");
+            newUser.setEmail("no-reply@flowable.org");
             identityService.saveUser(newUser);
             savedUser = newUser;
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/JobCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/JobCollectionResourceTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -50,7 +49,7 @@ public class JobCollectionResourceTest extends BaseSpringRestTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerProcess", Collections.singletonMap("error", (Object) Boolean.TRUE));
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).timers().singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION);
         assertResultsPresentInDataResponse(url, timerJob.getId());
@@ -74,28 +73,28 @@ public class JobCollectionResourceTest extends BaseSpringRestTestCase {
         
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION) + "?elementId=unknown";
         assertEmptyResultsPresentInDataResponse(url);
-        
+
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION) + "?elementName=Escalation";
         assertResultsPresentInDataResponse(url, timerJob.getId());
-        
+
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION) + "?elementName=unknown";
         assertEmptyResultsPresentInDataResponse(url);
 
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TIMER_JOB_COLLECTION) + "?withoutTenantId=true";
         assertResultsPresentInDataResponse(url, timerJob.getId());
 
-        for (int i = 0; i < timerJob.getRetries(); i++) {
+        Job timerJob2 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).timers().singleResult();
+        for (int i = 0; i < timerJob2.getRetries(); i++) {
             // Force execution of job until retries are exhausted
-            try {
-                managementService.moveTimerToExecutableJob(timerJob.getId());
-                managementService.executeJob(timerJob.getId());
-                fail();
-            } catch (FlowableException expected) {
-                // Ignore, we expect the exception
-            }
+            assertThatThrownBy(() -> {
+                managementService.moveTimerToExecutableJob(timerJob2.getId());
+                managementService.executeJob(timerJob2.getId());
+            })
+                    .isExactlyInstanceOf(FlowableException.class);
         }
+
         timerJob = managementService.createDeadLetterJobQuery().processInstanceId(processInstance.getId()).timers().singleResult();
-        assertEquals(0, timerJob.getRetries());
+        assertThat(timerJob.getRetries()).isZero();
 
         // Fetch the async-job (which has retries left)
         Job asyncJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/JobResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/JobResourceTest.java
@@ -16,7 +16,6 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
-import java.util.Date;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -30,8 +29,6 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.rest.service.BaseSpringRestTestCase;
 import org.flowable.rest.service.api.RestUrls;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -193,12 +190,5 @@ public class JobResourceTest extends BaseSpringRestTestCase {
         HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_JOB, "unexistingjob"));
         CloseableHttpResponse response = executeRequest(httpDelete, HttpStatus.SC_NOT_FOUND);
         closeResponse(response);
-    }
-
-    protected String getISODateStringWithTZ(Date date) {
-        if (date == null) {
-            return null;
-        }
-        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/PropertiesCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/PropertiesCollectionResourceTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -28,8 +27,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * Test for all REST-operations related to the Job collection and a single job resource.
- * 
+ * Test for all REST-operations related to Properties
+ *
  * @author Frederik Heremans
  */
 public class PropertiesCollectionResourceTest extends BaseSpringRestTestCase {
@@ -39,22 +38,23 @@ public class PropertiesCollectionResourceTest extends BaseSpringRestTestCase {
      */
     @Test
     public void testGetProperties() throws Exception {
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROPERTIES_COLLECTION)), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROPERTIES_COLLECTION)),
+                HttpStatus.SC_OK);
 
         Map<String, String> properties = managementService.getProperties();
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(properties.size(), responseNode.size());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode).hasSize(properties.size());
 
         Iterator<Map.Entry<String, JsonNode>> nodes = responseNode.fields();
         Map.Entry<String, JsonNode> node = null;
         while (nodes.hasNext()) {
             node = nodes.next();
             String propValue = properties.get(node.getKey());
-            assertNotNull(propValue);
-            assertEquals(propValue, node.getValue().textValue());
+            assertThat(propValue).isNotNull();
+            assertThat(node.getValue().textValue()).isEqualTo(propValue);
         }
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableColumnsResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableColumnsResourceTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -42,25 +41,26 @@ public class TableColumnsResourceTest extends BaseSpringRestTestCase {
 
         TableMetaData metaData = managementService.getTableMetaData(tableName);
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_COLUMNS, tableName)), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_COLUMNS, tableName)), HttpStatus.SC_OK);
 
         // Check table
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(tableName, responseNode.get("tableName").textValue());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.get("tableName").textValue()).isEqualTo(tableName);
 
         ArrayNode names = (ArrayNode) responseNode.get("columnNames");
         ArrayNode types = (ArrayNode) responseNode.get("columnTypes");
-        assertNotNull(names);
-        assertNotNull(types);
+        assertThat(names).isNotNull();
+        assertThat(types).isNotNull();
 
-        assertEquals(metaData.getColumnNames().size(), names.size());
-        assertEquals(metaData.getColumnTypes().size(), types.size());
+        assertThat(names).hasSize(metaData.getColumnNames().size());
+        assertThat(types).hasSize(metaData.getColumnTypes().size());
 
         for (int i = 0; i < names.size(); i++) {
-            assertEquals(names.get(i).textValue(), metaData.getColumnNames().get(i));
-            assertEquals(types.get(i).textValue(), metaData.getColumnTypes().get(i));
+            assertThat(metaData.getColumnNames().get(i)).isEqualTo(names.get(i).textValue());
+            assertThat(metaData.getColumnTypes().get(i)).isEqualTo(types.get(i).textValue());
         }
     }
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableDataResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableDataResourceTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -28,7 +27,8 @@ import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEnt
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to the Table columns.
@@ -53,72 +53,121 @@ public class TableDataResourceTest extends BaseSpringRestTestCase {
             // We use variable-table as a reference
             String tableName = managementService.getTableName(VariableInstanceEntity.class);
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName)), HttpStatus.SC_OK);
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName)), HttpStatus.SC_OK);
 
             // Check paging result
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(3, responseNode.get("total").intValue());
-            assertEquals(3, responseNode.get("size").intValue());
-            assertEquals(0, responseNode.get("start").intValue());
-            assertTrue(responseNode.get("order").isNull());
-            assertTrue(responseNode.get("sort").isNull());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "total: 3,"
+                            + "size: 3,"
+                            + "start: 0,"
+                            + "order: null,"
+                            + "sort: null"
+                            + "}");
 
             // Check variables are actually returned
-            ArrayNode rows = (ArrayNode) responseNode.get("data");
-            assertNotNull(rows);
-            assertEquals(3, rows.size());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + "data: [ {"
+                            + "      },"
+                            + "      {"
+                            + "      },"
+                            + "      {"
+                            + "      }"
+                            + "]"
+                            + "}");
 
             // Check sorting, ascending
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderAscendingColumn=LONG_"), HttpStatus.SC_OK);
-            responseNode = objectMapper.readTree(response.getEntity().getContent());
-            closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(3, responseNode.get("total").intValue());
-            assertEquals(3, responseNode.get("size").intValue());
-            assertEquals(0, responseNode.get("start").intValue());
-            assertEquals("asc", responseNode.get("order").textValue());
-            assertEquals("LONG_", responseNode.get("sort").textValue());
-            rows = (ArrayNode) responseNode.get("data");
-            assertNotNull(rows);
-            assertEquals(3, rows.size());
-
-            assertEquals("var1", rows.get(0).get("NAME_").textValue());
-            assertEquals("var2", rows.get(1).get("NAME_").textValue());
-            assertEquals("var3", rows.get(2).get("NAME_").textValue());
-
-            // Check sorting, descending
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderDescendingColumn=LONG_"), HttpStatus.SC_OK);
-            responseNode = objectMapper.readTree(response.getEntity().getContent());
-            closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(3, responseNode.get("total").intValue());
-            assertEquals(3, responseNode.get("size").intValue());
-            assertEquals(0, responseNode.get("start").intValue());
-            assertEquals("desc", responseNode.get("order").textValue());
-            assertEquals("LONG_", responseNode.get("sort").textValue());
-            rows = (ArrayNode) responseNode.get("data");
-            assertNotNull(rows);
-            assertEquals(3, rows.size());
-
-            assertEquals("var3", rows.get(0).get("NAME_").textValue());
-            assertEquals("var2", rows.get(1).get("NAME_").textValue());
-            assertEquals("var1", rows.get(2).get("NAME_").textValue());
-
-            // Finally, check result limiting
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderAscendingColumn=LONG_&start=1&size=1"),
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderAscendingColumn=LONG_"),
                     HttpStatus.SC_OK);
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(3, responseNode.get("total").intValue());
-            assertEquals(1, responseNode.get("size").intValue());
-            assertEquals(1, responseNode.get("start").intValue());
-            rows = (ArrayNode) responseNode.get("data");
-            assertNotNull(rows);
-            assertEquals(1, rows.size());
-            assertEquals("var2", rows.get(0).get("NAME_").textValue());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "total: 3,"
+                            + "size: 3,"
+                            + "start: 0,"
+                            + "order: 'asc',"
+                            + "sort: 'LONG_'"
+                            + "}");
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + "data: [ {"
+                            + "            NAME_: 'var1'"
+                            + "      },"
+                            + "      {"
+                            + "            NAME_: 'var2'"
+                            + "      },"
+                            + "      {"
+                            + "            NAME_: 'var3'"
+                            + "      }"
+                            + "]"
+                            + "}");
+
+            // Check sorting, descending
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderDescendingColumn=LONG_"),
+                    HttpStatus.SC_OK);
+            responseNode = objectMapper.readTree(response.getEntity().getContent());
+            closeResponse(response);
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "total: 3,"
+                            + "size: 3,"
+                            + "start: 0,"
+                            + "order: 'desc',"
+                            + "sort: 'LONG_'"
+                            + "}");
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + "data: [ {"
+                            + "            NAME_: 'var3'"
+                            + "      },"
+                            + "      {"
+                            + "            NAME_: 'var2'"
+                            + "      },"
+                            + "      {"
+                            + "            NAME_: 'var1'"
+                            + "      }"
+                            + "]"
+                            + "}");
+
+            // Finally, check result limiting
+            response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE_DATA, tableName) + "?orderAscendingColumn=LONG_&start=1&size=1"),
+                    HttpStatus.SC_OK);
+            responseNode = objectMapper.readTree(response.getEntity().getContent());
+            closeResponse(response);
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "total: 3,"
+                            + "size: 1,"
+                            + "start: 1,"
+                            + "order: 'asc',"
+                            + "sort: 'LONG_'"
+                            + "}");
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + "data: [ {"
+                            + "            NAME_: 'var2'"
+                            + "      } ]"
+                            + "}");
 
         } finally {
             // Clean adhoc-tasks even if test fails

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/management/TableResourceTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.rest.service.api.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -42,22 +41,22 @@ public class TableResourceTest extends BaseSpringRestTestCase {
     public void testGetTables() throws Exception {
         Map<String, Long> tableCounts = managementService.getTableCount();
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLES_COLLECTION)), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLES_COLLECTION)),
+                HttpStatus.SC_OK);
 
         // Check table array
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertTrue(responseNode.isArray());
-        assertEquals(tableCounts.size(), responseNode.size());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.isArray()).isTrue();
+        assertThat(responseNode).hasSize(tableCounts.size());
 
         for (int i = 0; i < responseNode.size(); i++) {
             ObjectNode table = (ObjectNode) responseNode.get(i);
-            assertNotNull(table.get("name").textValue());
-            assertNotNull(table.get("count").longValue());
-            assertTrue(table.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, table.get("name").textValue())));
-
-            assertEquals(tableCounts.get(table.get("name").textValue()).longValue(), table.get("count").longValue());
+            assertThat(table.get("name").textValue()).isNotNull();
+            assertThat(table.get("count").longValue()).isNotNull();
+            assertThat(table.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, table.get("name").textValue()))).isTrue();
+            assertThat(table.get("count").longValue()).isEqualTo(tableCounts.get(table.get("name").textValue()).longValue());
         }
     }
 
@@ -70,15 +69,19 @@ public class TableResourceTest extends BaseSpringRestTestCase {
 
         String tableNameToGet = tableCounts.keySet().iterator().next();
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, tableNameToGet)), HttpStatus.SC_OK);
+        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, tableNameToGet)),
+                HttpStatus.SC_OK);
 
         // Check table
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(tableNameToGet, responseNode.get("name").textValue());
-        assertEquals(tableCounts.get(responseNode.get("name").textValue()).longValue(), responseNode.get("count").longValue());
-        assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, tableNameToGet)));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .isEqualTo("{"
+                        + "name: '" + tableNameToGet + "',"
+                        + "count: " + tableCounts.get(tableNameToGet) + ","
+                        + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TABLE, tableNameToGet) + "'"
+                        + "}");
     }
 
     @Test

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/DeploymentCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/DeploymentCollectionResourceTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.rest.service.api.repository;
 
-import static org.junit.Assert.assertEquals;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import java.util.Calendar;
 import java.util.List;
@@ -27,9 +27,11 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to the Deployment collection.
- * 
+ *
  * @author Frederik Heremans
  */
 public class DeploymentCollectionResourceTest extends BaseSpringRestTestCase {
@@ -89,40 +91,67 @@ public class DeploymentCollectionResourceTest extends BaseSpringRestTestCase {
             assertResultsPresentInDataResponse(url, firstDeployment.getId());
 
             // Check ordering by name
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=name&order=asc"),
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=name&order=asc"),
                     HttpStatus.SC_OK);
             JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
-            assertEquals(2L, dataNode.size());
-            assertEquals(firstDeployment.getId(), dataNode.get(0).get("id").textValue());
-            assertEquals(secondDeployment.getId(), dataNode.get(1).get("id").textValue());
+            assertThatJson(dataNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("[ {"
+                            + "  id: '" + firstDeployment.getId() + "'"
+                            + "}, {"
+                            + "  id: '" + secondDeployment.getId() + "'"
+                            + "} ]"
+                    );
 
             // Check ordering by deploy time
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=deployTime&order=asc"), HttpStatus.SC_OK);
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=deployTime&order=asc"),
+                    HttpStatus.SC_OK);
             dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
-            assertEquals(2L, dataNode.size());
-            assertEquals(firstDeployment.getId(), dataNode.get(0).get("id").textValue());
-            assertEquals(secondDeployment.getId(), dataNode.get(1).get("id").textValue());
+            assertThatJson(dataNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("[ {"
+                            + "  id: '" + firstDeployment.getId() + "'"
+                            + "}, {"
+                            + "  id: '" + secondDeployment.getId() + "'"
+                            + "} ]"
+                    );
 
             // Check ordering by tenantId
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=tenantId&order=desc"), HttpStatus.SC_OK);
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=tenantId&order=desc"),
+                    HttpStatus.SC_OK);
             dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
-            assertEquals(2L, dataNode.size());
-            assertEquals(secondDeployment.getId(), dataNode.get(0).get("id").textValue());
-            assertEquals(firstDeployment.getId(), dataNode.get(1).get("id").textValue());
+            assertThatJson(dataNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("[ {"
+                            + "  id: '" + secondDeployment.getId() + "'"
+                            + "}, {"
+                            + "  id: '" + firstDeployment.getId() + "'"
+                            + "} ]"
+                    );
 
             // Check paging
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=deployTime&order=asc&start=1&size=1"), HttpStatus.SC_OK);
+            response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION) + "?sort=deployTime&order=asc&start=1&size=1"),
+                    HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            dataNode = responseNode.get("data");
-            assertEquals(1L, dataNode.size());
-            assertEquals(secondDeployment.getId(), dataNode.get(0).get("id").textValue());
-            assertEquals(2L, responseNode.get("total").longValue());
-            assertEquals(1L, responseNode.get("start").longValue());
-            assertEquals(1L, responseNode.get("size").longValue());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "   data: [ {"
+                            + "             id: '" + secondDeployment.getId() + "'"
+                            + "         } ],"
+                            + "   total: 2,"
+                            + "   start: 1,"
+                            + "   size: 1"
+                            + "}"
+                    );
 
         } finally {
             // Always cleanup any created deployments, even if the test failed

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/DeploymentResourceResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/DeploymentResourceResourceTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.rest.service.api.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -32,9 +32,11 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to a resources that is part of a deployment.
- * 
+ *
  * @author Frederik Heremans
  */
 public class DeploymentResourceResourceTest extends BaseSpringRestTestCase {
@@ -56,12 +58,14 @@ public class DeploymentResourceResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-
-            // Check URL's for the resource
-            assertEquals(responseNode.get("url").textValue(), buildUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, deployment.getId(), rawResourceName));
-            assertEquals(responseNode.get("contentUrl").textValue(), buildUrl(RestUrls.URL_DEPLOYMENT_RESOURCE_CONTENT, deployment.getId(), rawResourceName));
-            assertEquals("text/xml", responseNode.get("mediaType").textValue());
-            assertEquals("processDefinition", responseNode.get("type").textValue());
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "    url: '" + buildUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, deployment.getId(), rawResourceName) + "',"
+                            + "    contentUrl: '" + buildUrl(RestUrls.URL_DEPLOYMENT_RESOURCE_CONTENT, deployment.getId(), rawResourceName) + "',"
+                            + "    mediaType: 'text/xml',"
+                            + "    type: 'processDefinition'"
+                            + "}");
 
         } finally {
             // Always cleanup any created deployments, even if the test failed
@@ -109,15 +113,17 @@ public class DeploymentResourceResourceTest extends BaseSpringRestTestCase {
     @Test
     public void testGetDeploymentResourceContent() throws Exception {
         try {
-            Deployment deployment = repositoryService.createDeployment().name("Deployment 1").addInputStream("test.txt", new ByteArrayInputStream("Test content".getBytes())).deploy();
+            Deployment deployment = repositoryService.createDeployment().name("Deployment 1")
+                    .addInputStream("test.txt", new ByteArrayInputStream("Test content".getBytes())).deploy();
 
-            HttpGet httpGet = new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE_CONTENT, deployment.getId(), "test.txt"));
+            HttpGet httpGet = new HttpGet(
+                    SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE_CONTENT, deployment.getId(), "test.txt"));
             httpGet.addHeader(new BasicHeader(HttpHeaders.ACCEPT, "text/plain"));
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             String responseAsString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             closeResponse(response);
-            assertNotNull(responseAsString);
-            assertEquals("Test content", responseAsString);
+            assertThat(responseAsString).isNotNull();
+            assertThat(responseAsString).isEqualTo("Test content");
 
         } finally {
             // Always cleanup any created deployments, even if the test failed

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/DeploymentResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/DeploymentResourceTest.java
@@ -12,10 +12,8 @@
  */
 package org.flowable.rest.service.api.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -39,6 +37,8 @@ import org.flowable.rest.service.api.RestUrls;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to a single Deployment resource.
@@ -64,32 +64,23 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
             closeResponse(response);
 
             String deploymentId = responseNode.get("id").textValue();
-            String name = responseNode.get("name").textValue();
-            String category = responseNode.get("category").textValue();
-            String deployTime = responseNode.get("deploymentTime").textValue();
-            String url = responseNode.get("url").textValue();
-            String tenantId = responseNode.get("tenantId").textValue();
-
-            assertEquals("", tenantId);
-
-            assertNotNull(deploymentId);
-            assertEquals(1L, repositoryService.createDeploymentQuery().deploymentId(deploymentId).count());
-
-            assertNotNull(name);
-            assertEquals("oneTaskProcess", name);
-
-            assertNotNull(url);
-            assertTrue(url.endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId)));
-
-            // No deployment-category should have been set
-            assertNull(category);
-            assertNotNull(deployTime);
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id: '${json-unit.any-string}',"
+                            + "name: 'oneTaskProcess',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId) + "',"
+                            + "category: null,"
+                            + "deploymentTime: '${json-unit.any-string}',"
+                            + "tenantId: ''"
+                            + "}");
+            assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId).count()).isEqualTo(1L);
 
             // Check if process is actually deployed in the deployment
             List<String> resources = repositoryService.getDeploymentResourceNames(deploymentId);
-            assertEquals(1L, resources.size());
-            assertEquals("oneTaskProcess.bpmn20.xml", resources.get(0));
-            assertEquals(1L, repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).count());
+            assertThat(resources)
+                    .containsExactly("oneTaskProcess.bpmn20.xml");
+            assertThat(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).count()).isEqualTo(1L);
 
         } finally {
             // Always cleanup any created deployments, even if the test failed
@@ -123,7 +114,8 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
 
             // Upload a bar-file using multipart-data
             HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION));
-            httpPost.setEntity(HttpMultipartHelper.getMultiPartEntity("test-deployment.bar", "application/zip", new ByteArrayInputStream(zipOutput.toByteArray()), null));
+            httpPost.setEntity(
+                    HttpMultipartHelper.getMultiPartEntity("test-deployment.bar", "application/zip", new ByteArrayInputStream(zipOutput.toByteArray()), null));
             CloseableHttpResponse response = executeBinaryRequest(httpPost, HttpStatus.SC_CREATED);
 
             // Check deployment
@@ -131,31 +123,23 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
             closeResponse(response);
 
             String deploymentId = responseNode.get("id").textValue();
-            String name = responseNode.get("name").textValue();
-            String category = responseNode.get("category").textValue();
-            String deployTime = responseNode.get("deploymentTime").textValue();
-            String url = responseNode.get("url").textValue();
-            String tenantId = responseNode.get("tenantId").textValue();
-
-            assertEquals("", tenantId);
-            assertNotNull(deploymentId);
-            assertEquals(1L, repositoryService.createDeploymentQuery().deploymentId(deploymentId).count());
-
-            assertNotNull(name);
-            assertEquals("test-deployment", name);
-
-            assertNotNull(url);
-            assertTrue(url.endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId)));
-
-            // No deployment-category should have been set
-            assertNull(category);
-            assertNotNull(deployTime);
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id: '${json-unit.any-string}',"
+                            + "name: 'test-deployment',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId) + "',"
+                            + "category: null,"
+                            + "deploymentTime: '${json-unit.any-string}',"
+                            + "tenantId: ''"
+                            + "}");
+            assertThat(repositoryService.createDeploymentQuery().deploymentId(deploymentId).count()).isEqualTo(1L);
 
             // Check if both resources are deployed and process is actually
             // deployed in the deployment
             List<String> resources = repositoryService.getDeploymentResourceNames(deploymentId);
-            assertEquals(2L, resources.size());
-            assertEquals(1L, repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).count());
+            assertThat(resources).hasSize(2);
+            assertThat(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).count()).isEqualTo(1L);
         } finally {
             // Always cleanup any created deployments, even if the test failed
             List<Deployment> deployments = repositoryService.createDeploymentQuery().list();
@@ -188,21 +172,25 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
 
             // Upload a bar-file using multipart-data
             HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_COLLECTION));
-            httpPost.setEntity(HttpMultipartHelper.getMultiPartEntity("test-deployment.bar", "application/zip", new ByteArrayInputStream(zipOutput.toByteArray()),
-                    Collections.singletonMap("tenantId", "myTenant")));
+            httpPost.setEntity(
+                    HttpMultipartHelper.getMultiPartEntity("test-deployment.bar", "application/zip", new ByteArrayInputStream(zipOutput.toByteArray()),
+                            Collections.singletonMap("tenantId", "myTenant")));
             CloseableHttpResponse response = executeBinaryRequest(httpPost, HttpStatus.SC_CREATED);
 
             // Check deployment
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
 
-            String tenantId = responseNode.get("tenantId").textValue();
-            assertEquals("myTenant", tenantId);
-            String id = responseNode.get("id").textValue();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "tenantId: 'myTenant'"
+                            + "}");
 
+            String id = responseNode.get("id").textValue();
             Deployment deployment = repositoryService.createDeploymentQuery().deploymentId(id).singleResult();
-            assertNotNull(deployment);
-            assertEquals("myTenant", deployment.getTenantId());
+            assertThat(deployment).isNotNull();
+            assertThat(deployment.getTenantId()).isEqualTo("myTenant");
 
         } finally {
             // Always cleanup any created deployments, even if the test failed
@@ -237,29 +225,18 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
-        
+
         closeResponse(response);
-
-        String deploymentId = responseNode.get("id").textValue();
-        String name = responseNode.get("name").textValue();
-        String category = responseNode.get("category").textValue();
-        String deployTime = responseNode.get("deploymentTime").textValue();
-        String url = responseNode.get("url").textValue();
-        String tenantId = responseNode.get("tenantId").textValue();
-
-        assertEquals("", tenantId);
-        assertNotNull(deploymentId);
-        assertEquals(existingDeployment.getId(), deploymentId);
-
-        assertNotNull(name);
-        assertEquals(existingDeployment.getName(), name);
-
-        assertEquals(existingDeployment.getCategory(), category);
-
-        assertNotNull(deployTime);
-
-        assertNotNull(url);
-        assertTrue(url.endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId)));
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + existingDeployment.getId() + "',"
+                        + "name: '" + existingDeployment.getName() + "',"
+                        + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, existingDeployment.getId()) + "',"
+                        + "category: " + existingDeployment.getCategory() + ","
+                        + "deploymentTime: '${json-unit.any-string}',"
+                        + "tenantId: ''"
+                        + "}");
     }
 
     /**
@@ -279,7 +256,7 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
     @org.flowable.engine.test.Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml" })
     public void testDeleteDeployment() throws Exception {
         Deployment existingDeployment = repositoryService.createDeploymentQuery().singleResult();
-        assertNotNull(existingDeployment);
+        assertThat(existingDeployment).isNotNull();
 
         // Delete the deployment
         HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, existingDeployment.getId()));
@@ -287,7 +264,7 @@ public class DeploymentResourceTest extends BaseSpringRestTestCase {
         closeResponse(response);
 
         existingDeployment = repositoryService.createDeploymentQuery().singleResult();
-        assertNull(existingDeployment);
+        assertThat(existingDeployment).isNull();
     }
 
     /**

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/DeploymentResourcesResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/DeploymentResourcesResourceTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.rest.service.api.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -29,9 +28,11 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to listing the resources that are part of a deployment.
- * 
+ *
  * @author Frederik Heremans
  */
 public class DeploymentResourcesResourceTest extends BaseSpringRestTestCase {
@@ -43,32 +44,29 @@ public class DeploymentResourcesResourceTest extends BaseSpringRestTestCase {
     public void testGetDeploymentResources() throws Exception {
 
         try {
-            Deployment deployment = repositoryService.createDeployment().name("Deployment 1").addClasspathResource("org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml")
+            Deployment deployment = repositoryService.createDeployment().name("Deployment 1")
+                    .addClasspathResource("org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml")
                     .addInputStream("test.txt", new ByteArrayInputStream("Test content".getBytes())).deploy();
 
             HttpGet httpGet = new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCES, deployment.getId()));
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertTrue(responseNode.isArray());
-            assertEquals(2, responseNode.size());
 
-            // Since resources can be returned in any arbitrary order, find the
-            // right one to check
-            JsonNode txtNode = null;
-            for (int i = 0; i < responseNode.size(); i++) {
-                if ("test.txt".equals(responseNode.get(i).get("id").textValue())) {
-                    txtNode = responseNode.get(i);
-                    break;
-                }
-            }
+            assertThat(responseNode.isArray()).isTrue();
+            assertThat(responseNode).hasSize(2);
 
-            // Check URL's for the resource
-            assertNotNull(txtNode);
-            assertTrue(txtNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, deployment.getId(), "test.txt")));
-            assertTrue(txtNode.get("contentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE_CONTENT, deployment.getId(), "test.txt")));
-            assertTrue(txtNode.get("mediaType").isNull());
-            assertEquals("resource", txtNode.get("type").textValue());
+            // Since resources can be returned in any arbitrary order, find the right one to check
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS, Option.IGNORING_ARRAY_ORDER)
+                    .isEqualTo("[{"
+                            + "    url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, deployment.getId(), "test.txt") + "',"
+                            + "    contentUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE_CONTENT, deployment.getId(), "test.txt") + "',"
+                            + "    mediaType: null,"
+                            + "    type: 'resource'"
+                            + "}]");
 
         } finally {
             // Always cleanup any created deployments, even if the test failed

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ModelCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ModelCollectionResourceTest.java
@@ -17,7 +17,6 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
-import java.util.Date;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -27,8 +26,6 @@ import org.flowable.engine.repository.Model;
 import org.flowable.engine.test.Deployment;
 import org.flowable.rest.service.BaseSpringRestTestCase;
 import org.flowable.rest.service.api.RestUrls;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -226,12 +223,5 @@ public class ModelCollectionResourceTest extends BaseSpringRestTestCase {
                 }
             }
         }
-    }
-
-    private String getISODateStringWithTZ(Date date) {
-        if (date == null) {
-            return null;
-        }
-        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ModelResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ModelResourceTest.java
@@ -13,12 +13,11 @@
 
 package org.flowable.rest.service.api.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
+import java.util.Date;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -30,10 +29,15 @@ import org.flowable.engine.repository.Model;
 import org.flowable.engine.test.Deployment;
 import org.flowable.rest.service.BaseSpringRestTestCase;
 import org.flowable.rest.service.api.RestUrls;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Frederik Heremans
@@ -68,24 +72,25 @@ public class ModelResourceTest extends BaseSpringRestTestCase {
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("Model name", responseNode.get("name").textValue());
-            assertEquals("Model key", responseNode.get("key").textValue());
-            assertEquals("Model category", responseNode.get("category").textValue());
-            assertEquals(2, responseNode.get("version").intValue());
-            assertEquals("Model metainfo", responseNode.get("metaInfo").textValue());
-            assertEquals(deploymentId, responseNode.get("deploymentId").textValue());
-            assertEquals(model.getId(), responseNode.get("id").textValue());
-            assertEquals("myTenant", responseNode.get("tenantId").textValue());
-
-            assertEquals(now.getTime().getTime(), getDateFromISOString(responseNode.get("createTime").textValue()).getTime());
-            assertEquals(now.getTime().getTime(), getDateFromISOString(responseNode.get("lastUpdateTime").textValue()).getTime());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, model.getId())));
-            assertTrue(responseNode.get("deploymentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId)));
-
-            assertTrue(responseNode.get("sourceUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL_SOURCE, model.getId())));
-            assertTrue(responseNode.get("sourceExtraUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL_SOURCE_EXTRA, model.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "name: 'Model name',"
+                            + "key: 'Model key',"
+                            + "category: 'Model category',"
+                            + "version: 2,"
+                            + "metaInfo: 'Model metainfo',"
+                            + "deploymentId: '" + deploymentId + "',"
+                            + "id: '" + model.getId() + "',"
+                            + "tenantId: 'myTenant',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, model.getId()) + "',"
+                            + "deploymentUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId) + "',"
+                            + "sourceUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL_SOURCE, model.getId()) + "',"
+                            + "sourceExtraUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL_SOURCE_EXTRA, model.getId())
+                            + "',"
+                            + "createTime: " + new TextNode(getISODateStringWithTZ(now.getTime())) + ","
+                            + "lastUpdateTime: " + new TextNode(getISODateStringWithTZ(now.getTime()))
+                            + "}");
 
         } finally {
             try {
@@ -122,7 +127,7 @@ public class ModelResourceTest extends BaseSpringRestTestCase {
             closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
             // Check if the model is really gone
-            assertNull(repositoryService.createModelQuery().modelId(model.getId()).singleResult());
+            assertThat(repositoryService.createModelQuery().modelId(model.getId()).singleResult()).isNull();
 
             model = null;
         } finally {
@@ -181,21 +186,23 @@ public class ModelResourceTest extends BaseSpringRestTestCase {
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("Updated name", responseNode.get("name").textValue());
-            assertEquals("Updated key", responseNode.get("key").textValue());
-            assertEquals("Updated category", responseNode.get("category").textValue());
-            assertEquals(3, responseNode.get("version").intValue());
-            assertEquals("Updated metainfo", responseNode.get("metaInfo").textValue());
-            assertEquals(deploymentId, responseNode.get("deploymentId").textValue());
-            assertEquals(model.getId(), responseNode.get("id").textValue());
-            assertEquals("myTenant", responseNode.get("tenantId").textValue());
-
-            assertEquals(createTime.getTime().getTime(), getDateFromISOString(responseNode.get("createTime").textValue()).getTime());
-            assertEquals(updateTime.getTime().getTime(), getDateFromISOString(responseNode.get("lastUpdateTime").textValue()).getTime());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, model.getId())));
-            assertTrue(responseNode.get("deploymentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId)));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "name: 'Updated name',"
+                            + "key: 'Updated key',"
+                            + "category: 'Updated category',"
+                            + "version: 3,"
+                            + "metaInfo: 'Updated metainfo',"
+                            + "deploymentId: '" + deploymentId + "',"
+                            + "id: '" + model.getId() + "',"
+                            + "tenantId: 'myTenant',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, model.getId()) + "',"
+                            + "deploymentUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId) + "',"
+                            + "createTime: " + new TextNode(getISODateStringWithTZ(createTime.getTime())) + ","
+                            + "lastUpdateTime: " + new TextNode(getISODateStringWithTZ(updateTime.getTime()))
+                            + "}");
 
         } finally {
             try {
@@ -243,28 +250,30 @@ public class ModelResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertNull(responseNode.get("name").textValue());
-            assertNull(responseNode.get("key").textValue());
-            assertNull(responseNode.get("category").textValue());
-            assertNull(responseNode.get("version").textValue());
-            assertNull(responseNode.get("metaInfo").textValue());
-            assertNull(responseNode.get("deploymentId").textValue());
-            assertNull(responseNode.get("tenantId").textValue());
-            assertEquals(model.getId(), responseNode.get("id").textValue());
-
-            assertEquals(createTime.getTime().getTime(), getDateFromISOString(responseNode.get("createTime").textValue()).getTime());
-            assertEquals(updateTime.getTime().getTime(), getDateFromISOString(responseNode.get("lastUpdateTime").textValue()).getTime());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, model.getId())));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "name: null,"
+                            + "key: null,"
+                            + "category: null,"
+                            + "version: null,"
+                            + "metaInfo: null,"
+                            + "deploymentId: null,"
+                            + "id: '" + model.getId() + "',"
+                            + "tenantId: null,"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, model.getId()) + "',"
+                            + "createTime: " + new TextNode(getISODateStringWithTZ(createTime.getTime())) + ","
+                            + "lastUpdateTime: " + new TextNode(getISODateStringWithTZ(updateTime.getTime()))
+                            + "}");
 
             model = repositoryService.getModel(model.getId());
-            assertNull(model.getName());
-            assertNull(model.getKey());
-            assertNull(model.getCategory());
-            assertNull(model.getMetaInfo());
-            assertNull(model.getDeploymentId());
-            assertEquals("", model.getTenantId());
+            assertThat(model.getName()).isNull();
+            assertThat(model.getKey()).isNull();
+            assertThat(model.getCategory()).isNull();
+            assertThat(model.getMetaInfo()).isNull();
+            assertThat(model.getDeploymentId()).isNull();
+            assertThat(model.getTenantId()).isEqualTo("");
 
         } finally {
             try {
@@ -302,20 +311,22 @@ public class ModelResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("Model name", responseNode.get("name").textValue());
-            assertEquals("Model key", responseNode.get("key").textValue());
-            assertEquals("Model category", responseNode.get("category").textValue());
-            assertEquals(2, responseNode.get("version").intValue());
-            assertEquals("Model metainfo", responseNode.get("metaInfo").textValue());
-            assertEquals(deploymentId, responseNode.get("deploymentId").textValue());
-            assertEquals(model.getId(), responseNode.get("id").textValue());
-
-            assertEquals(now.getTime().getTime(), getDateFromISOString(responseNode.get("createTime").textValue()).getTime());
-            assertEquals(now.getTime().getTime(), getDateFromISOString(responseNode.get("lastUpdateTime").textValue()).getTime());
-
-            assertTrue(responseNode.get("url").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, model.getId())));
-            assertTrue(responseNode.get("deploymentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId)));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "name: 'Model name',"
+                            + "key: 'Model key',"
+                            + "category: 'Model category',"
+                            + "version: 2,"
+                            + "metaInfo: 'Model metainfo',"
+                            + "deploymentId: '" + deploymentId + "',"
+                            + "id: '" + model.getId() + "',"
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, model.getId()) + "',"
+                            + "deploymentUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, deploymentId) + "',"
+                            + "createTime: " + new TextNode(getISODateStringWithTZ(now.getTime())) + ","
+                            + "lastUpdateTime: " + new TextNode(getISODateStringWithTZ(now.getTime()))
+                            + "}");
 
         } finally {
             try {
@@ -331,5 +342,12 @@ public class ModelResourceTest extends BaseSpringRestTestCase {
         HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, "unexisting"));
         httpPut.setEntity(new StringEntity(objectMapper.createObjectNode().toString()));
         closeResponse(executeRequest(httpPut, HttpStatus.SC_NOT_FOUND));
+    }
+
+    private String getISODateStringWithTZ(Date date) {
+        if (date == null) {
+            return null;
+        }
+        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ModelResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ModelResourceTest.java
@@ -17,7 +17,6 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
-import java.util.Date;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -29,8 +28,6 @@ import org.flowable.engine.repository.Model;
 import org.flowable.engine.test.Deployment;
 import org.flowable.rest.service.BaseSpringRestTestCase;
 import org.flowable.rest.service.api.RestUrls;
-import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -342,12 +339,5 @@ public class ModelResourceTest extends BaseSpringRestTestCase {
         HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_MODEL, "unexisting"));
         httpPut.setEntity(new StringEntity(objectMapper.createObjectNode().toString()));
         closeResponse(executeRequest(httpPut, HttpStatus.SC_NOT_FOUND));
-    }
-
-    private String getISODateStringWithTZ(Date date) {
-        if (date == null) {
-            return null;
-        }
-        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionCollectionResourceTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.rest.service.api.repository;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -62,8 +61,7 @@ public class ProcessDefinitionCollectionResourceTest extends BaseSpringRestTestC
             String baseUrl = RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION_COLLECTION);
             assertResultsPresentInDataResponse(baseUrl, oneTaskProcess.getId(), twoTaskprocess.getId(), latestOneTaskProcess.getId(), oneTaskWithDiProcess.getId());
 
-            // Verify ACT-2141 Persistent isGraphicalNotation flag for process
-            // definitions
+            // Verify ACT-2141 Persistent isGraphicalNotation flag for process definitions
             CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + baseUrl), HttpStatus.SC_OK);
             JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
@@ -73,9 +71,9 @@ public class ProcessDefinitionCollectionResourceTest extends BaseSpringRestTestC
                 String key = processDefinitionJson.get("key").asText();
                 JsonNode graphicalNotationNode = processDefinitionJson.get("graphicalNotationDefined");
                 if (key.equals("oneTaskProcessWithDi")) {
-                    assertTrue(graphicalNotationNode.asBoolean());
+                    assertThat(graphicalNotationNode.asBoolean()).isTrue();
                 } else {
-                    assertFalse(graphicalNotationNode.asBoolean());
+                    assertThat(graphicalNotationNode.asBoolean()).isFalse();
                 }
 
             }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionImageResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionImageResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -34,10 +33,11 @@ public class ProcessDefinitionImageResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml", "org/flowable/rest/service/api/repository/oneTaskProcess.png" })
     public void testGetProcessDefinitionImage() throws Exception {
         ProcessDefinition oneTaskProcess = repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").singleResult();
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION_IMAGE, oneTaskProcess.getId())),
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION_IMAGE, oneTaskProcess.getId())),
                 HttpStatus.SC_OK);
-        assertNotNull(response.getEntity().getContent());
-        assertEquals("image/png", response.getEntity().getContentType().getValue());
+        assertThat(response.getEntity().getContent()).isNotNull();
+        assertThat(response.getEntity().getContentType().getValue()).isEqualTo("image/png");
         closeResponse(response);
     }
 
@@ -50,7 +50,7 @@ public class ProcessDefinitionImageResourceTest extends BaseSpringRestTestCase {
                 HttpStatus.SC_BAD_REQUEST);
 
         // response content type application/json;charset=UTF-8
-        assertEquals("application/json", response.getEntity().getContentType().getValue().split(";")[0]);
+        assertThat(response.getEntity().getContentType().getValue().split(";")[0]).isEqualTo("application/json");
         closeResponse(response);
     }
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionResourceTest.java
@@ -12,12 +12,9 @@
  */
 package org.flowable.rest.service.api.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 
@@ -37,6 +34,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to single a Process Definition resource.
@@ -58,21 +57,25 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals(processDefinition.getId(), responseNode.get("id").textValue());
-        assertEquals(processDefinition.getKey(), responseNode.get("key").textValue());
-        assertEquals(processDefinition.getCategory(), responseNode.get("category").textValue());
-        assertEquals(processDefinition.getVersion(), responseNode.get("version").intValue());
-        assertEquals(processDefinition.getDescription(), responseNode.get("description").textValue());
-        assertEquals(processDefinition.getName(), responseNode.get("name").textValue());
-        assertFalse(responseNode.get("graphicalNotationDefined").booleanValue());
-
-        // Check URL's
-        assertEquals(httpGet.getURI().toString(), responseNode.get("url").asText());
-        assertEquals(processDefinition.getDeploymentId(), responseNode.get("deploymentId").textValue());
-        assertTrue(responseNode.get("deploymentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, processDefinition.getDeploymentId())));
-        assertTrue(URLDecoder.decode(responseNode.get("resource").textValue(), "UTF-8").endsWith(
-                RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, processDefinition.getDeploymentId(), processDefinition.getResourceName())));
-        assertTrue(responseNode.get("diagramResource").isNull());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processDefinition.getId() + "',"
+                        + "name: '" + processDefinition.getName() + "',"
+                        + "key: '" + processDefinition.getKey() + "',"
+                        + "category: '" + processDefinition.getCategory() + "',"
+                        + "version: " + processDefinition.getVersion() + ","
+                        + "description: '" + processDefinition.getDescription() + "',"
+                        + "url: '" + httpGet.getURI().toString() + "',"
+                        + "deploymentId: '" + processDefinition.getDeploymentId() + "',"
+                        + "deploymentUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, processDefinition.getDeploymentId()) + "',"
+                        + "resource: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, processDefinition.getDeploymentId(), processDefinition.getResourceName())
+                        + "',"
+                        + "graphicalNotationDefined: false,"
+                        + "diagramResource: null"
+                        + "}");
     }
 
     /**
@@ -88,22 +91,27 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals(processDefinition.getId(), responseNode.get("id").textValue());
-        assertEquals(processDefinition.getKey(), responseNode.get("key").textValue());
-        assertEquals(processDefinition.getCategory(), responseNode.get("category").textValue());
-        assertEquals(processDefinition.getVersion(), responseNode.get("version").intValue());
-        assertEquals(processDefinition.getDescription(), responseNode.get("description").textValue());
-        assertEquals(processDefinition.getName(), responseNode.get("name").textValue());
-        assertTrue(responseNode.get("graphicalNotationDefined").booleanValue());
-
-        // Check URL's
-        assertEquals(httpGet.getURI().toString(), responseNode.get("url").asText());
-        assertEquals(processDefinition.getDeploymentId(), responseNode.get("deploymentId").textValue());
-        assertTrue(responseNode.get("deploymentUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, processDefinition.getDeploymentId())));
-        assertTrue(URLDecoder.decode(responseNode.get("resource").textValue(), "UTF-8").endsWith(
-                RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, processDefinition.getDeploymentId(), processDefinition.getResourceName())));
-        assertTrue(URLDecoder.decode(responseNode.get("diagramResource").textValue(), "UTF-8").endsWith(
-                RestUrls.createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, processDefinition.getDeploymentId(), processDefinition.getDiagramResourceName())));
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processDefinition.getId() + "',"
+                        + "name: " + processDefinition.getName() + ","
+                        + "key: '" + processDefinition.getKey() + "',"
+                        + "category: '" + processDefinition.getCategory() + "',"
+                        + "version: " + processDefinition.getVersion() + ","
+                        + "description: " + processDefinition.getDescription() + ","
+                        + "url: '" + httpGet.getURI().toString() + "',"
+                        + "deploymentId: '" + processDefinition.getDeploymentId() + "',"
+                        + "deploymentUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT, processDefinition.getDeploymentId()) + "',"
+                        + "resource: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, processDefinition.getDeploymentId(), processDefinition.getResourceName())
+                        + "',"
+                        + "graphicalNotationDefined: true,"
+                        + "diagramResource: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_DEPLOYMENT_RESOURCE, processDefinition.getDeploymentId(),
+                                processDefinition.getDiagramResourceName()) + "'"
+                        + "}");
     }
 
     /**
@@ -123,7 +131,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml" })
     public void testSuspendProcessDefinition() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertFalse(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isFalse();
 
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("action", "suspend");
@@ -135,11 +143,15 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         // Check "OK" status
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertTrue(responseNode.get("suspended").booleanValue());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "suspended: true"
+                        + "}");
 
         // Check if process-definition is suspended
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertTrue(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isTrue();
     }
 
     /**
@@ -149,7 +161,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml" })
     public void testSuspendProcessDefinitionDelayed() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertFalse(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isFalse();
 
         ObjectNode requestNode = objectMapper.createObjectNode();
 
@@ -170,11 +182,15 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         // Check "OK" status
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertTrue(responseNode.get("suspended").booleanValue());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "suspended: true"
+                        + "}");
 
         // Check if process-definition is not yet suspended
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertFalse(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isFalse();
 
         // Force suspension by altering time
         cal.add(Calendar.HOUR, 1);
@@ -183,7 +199,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
 
         // Check if process-definition is suspended
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertTrue(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isTrue();
     }
 
     /**
@@ -196,7 +212,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         repositoryService.suspendProcessDefinitionById(processDefinition.getId());
 
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertTrue(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isTrue();
 
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("action", "suspend");
@@ -217,7 +233,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         repositoryService.suspendProcessDefinitionById(processDefinition.getId());
 
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertTrue(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isTrue();
 
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("action", "activate");
@@ -229,11 +245,15 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         // Check "OK" status
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertFalse(responseNode.get("suspended").booleanValue());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "suspended: false"
+                        + "}");
 
         // Check if process-definition is suspended
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertFalse(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isFalse();
     }
 
     /**
@@ -246,7 +266,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         repositoryService.suspendProcessDefinitionById(processDefinition.getId());
 
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertTrue(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isTrue();
 
         ObjectNode requestNode = objectMapper.createObjectNode();
 
@@ -267,11 +287,15 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         // Check "OK" status
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertFalse(responseNode.get("suspended").booleanValue());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "suspended: false"
+                        + "}");
 
         // Check if process-definition is not yet active
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertTrue(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isTrue();
 
         // Force activation by altering time
         cal.add(Calendar.HOUR, 1);
@@ -280,7 +304,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
 
         // Check if process-definition is activated
         processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertFalse(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isFalse();
     }
 
     /**
@@ -290,7 +314,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml" })
     public void testActivateAlreadyActiveProcessDefinition() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertFalse(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isFalse();
 
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("action", "activate");
@@ -310,7 +334,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml" })
     public void testIllegalAction() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertFalse(processDefinition.isSuspended());
+        assertThat(processDefinition.isSuspended()).isFalse();
 
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("action", "unexistingaction");
@@ -326,14 +350,14 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
     public void testGetProcessDefinitionResourceData() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
 
-        HttpGet httpGet = new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION_RESOURCE_CONTENT, processDefinition.getId()));
+        HttpGet httpGet = new HttpGet(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION_RESOURCE_CONTENT, processDefinition.getId()));
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
 
         // Check "OK" status
         String content = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
         closeResponse(response);
-        assertNotNull(content);
-        assertTrue(content.contains("The One Task Process"));
+        assertThat(content).contains("The One Task Process");
     }
 
     @Test
@@ -347,12 +371,16 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         // Check "OK" status
         JsonNode resultNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(resultNode);
-        JsonNode processes = resultNode.get("processes");
-        assertNotNull(processes);
-        assertTrue(processes.isArray());
-        assertEquals(1, processes.size());
-        assertEquals("oneTaskProcess", processes.get(0).get("id").textValue());
+        assertThatJson(resultNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "processes : [ "
+                        + "              {"
+                        + "                id: 'oneTaskProcess'"
+                        + "              }"
+                        + "            ]"
+                        + "}"
+                );
     }
 
     /**
@@ -382,7 +410,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = { "org/flowable/rest/service/api/repository/oneTaskProcess.bpmn20.xml" })
     public void testUpdateProcessDefinitionCategory() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().processDefinitionCategory("OneTaskCategory").count());
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionCategory("OneTaskCategory").count()).isEqualTo(1);
 
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("category", "updatedcategory");
@@ -394,10 +422,15 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         // Check "OK" status
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals("updatedcategory", responseNode.get("category").textValue());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "   category: 'updatedcategory'"
+                        + "}"
+                );
 
         // Check actual entry in DB
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().processDefinitionCategory("updatedcategory").count());
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionCategory("updatedcategory").count()).isEqualTo(1);
 
     }
 


### PR DESCRIPTION
The module had a mix of assertion styles.  This is part 4 for this module.
This is for the `org.flowable.rest.service.api.repository` package.

