### PR TITLE
Use assertj fluent style in flowable-rest module.

### DIFF
--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionActiveActivitiesCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionActiveActivitiesCollectionResourceTest.java
@@ -13,12 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.HashSet;
-import java.util.Set;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -41,21 +37,18 @@ public class ExecutionActiveActivitiesCollectionResourceTest extends BaseSpringR
     public void testGetActivities() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("processOne");
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_ACTIVITIES_COLLECTION, processInstance.getId())),
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_ACTIVITIES_COLLECTION, processInstance.getId())),
                 HttpStatus.SC_OK);
 
         // Check resulting instance
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertTrue(responseNode.isArray());
-        assertEquals(2, responseNode.size());
-
-        Set<String> states = new HashSet<>();
-        states.add(responseNode.get(0).textValue());
-        states.add(responseNode.get(1).textValue());
-
-        assertTrue(states.contains("waitState"));
-        assertTrue(states.contains("anotherWaitState"));
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.isArray()).isTrue();
+        assertThatJson(responseNode)
+                .isEqualTo("["
+                        + "'waitState', 'anotherWaitState'"
+                        + "]");
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionCollectionResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -50,10 +49,10 @@ public class ExecutionCollectionResourceTest extends BaseSpringRestTestCase {
         runtimeService.addUserIdentityLink(id, "kermit", "whatever");
 
         Execution childExecutionInTask = runtimeService.createExecutionQuery().activityId("processTask").singleResult();
-        assertNotNull(childExecutionInTask);
+        assertThat(childExecutionInTask).isNotNull();
 
         Execution childExecutionInSubProcess = runtimeService.createExecutionQuery().activityId("subProcess").singleResult();
-        assertNotNull(childExecutionInSubProcess);
+        assertThat(childExecutionInSubProcess).isNotNull();
 
         // Test without any parameters
         String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_COLLECTION);
@@ -134,14 +133,14 @@ public class ExecutionCollectionResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = { "org/flowable/rest/service/api/runtime/ExecutionResourceTest.process-with-signal-event.bpmn20.xml" })
     public void testSignalEventExecutions() throws Exception {
         Execution signalExecution = runtimeService.startProcessInstanceByKey("processOne");
-        assertNotNull(signalExecution);
+        assertThat(signalExecution).isNotNull();
 
         ObjectNode requestNode = objectMapper.createObjectNode();
         requestNode.put("action", "signalEventReceived");
         requestNode.put("signalName", "alert");
 
         Execution waitingExecution = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
-        assertNotNull(waitingExecution);
+        assertThat(waitingExecution).isNotNull();
 
         // Sending signal event causes the execution to end (scope-execution for
         // the catching event)
@@ -151,7 +150,7 @@ public class ExecutionCollectionResourceTest extends BaseSpringRestTestCase {
 
         // Check if process is moved on to the other wait-state
         waitingExecution = runtimeService.createExecutionQuery().activityId("anotherWaitState").singleResult();
-        assertNotNull(waitingExecution);
+        assertThat(waitingExecution).isNotNull();
     }
 
     /**
@@ -161,7 +160,7 @@ public class ExecutionCollectionResourceTest extends BaseSpringRestTestCase {
     @Deployment(resources = { "org/flowable/rest/service/api/runtime/ExecutionResourceTest.process-with-signal-event.bpmn20.xml" })
     public void testSignalEventExecutionsWithvariables() throws Exception {
         Execution signalExecution = runtimeService.startProcessInstanceByKey("processOne");
-        assertNotNull(signalExecution);
+        assertThat(signalExecution).isNotNull();
 
         ArrayNode variables = objectMapper.createArrayNode();
         ObjectNode requestNode = objectMapper.createObjectNode();
@@ -175,7 +174,7 @@ public class ExecutionCollectionResourceTest extends BaseSpringRestTestCase {
         varNode.put("value", "Variable set when signal event is received");
 
         Execution waitingExecution = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
-        assertNotNull(waitingExecution);
+        assertThat(waitingExecution).isNotNull();
 
         // Sending signal event causes the execution to end (scope-execution for
         // the catching event)
@@ -185,11 +184,11 @@ public class ExecutionCollectionResourceTest extends BaseSpringRestTestCase {
 
         // Check if process is moved on to the other wait-state
         waitingExecution = runtimeService.createExecutionQuery().activityId("anotherWaitState").singleResult();
-        assertNotNull(waitingExecution);
+        assertThat(waitingExecution).isNotNull();
 
         Map<String, Object> vars = runtimeService.getVariables(waitingExecution.getId());
-        assertEquals(1, vars.size());
+        assertThat(vars).hasSize(1);
 
-        assertEquals("Variable set when signal event is received", vars.get("myVar"));
+        assertThat(vars.get("myVar")).isEqualTo("Variable set when signal event is received");
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionQueryResourceTest.java
@@ -13,7 +13,7 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 
@@ -47,10 +47,10 @@ public class ExecutionQueryResourceTest extends BaseSpringRestTestCase {
         Execution parentExecution = runtimeService.startProcessInstanceByKey("processOne", processVariables);
 
         Execution subProcessExecution = runtimeService.createExecutionQuery().activityId("subProcess").singleResult();
-        assertNotNull(subProcessExecution);
+        assertThat(subProcessExecution).isNotNull();
 
         Execution childExecution = runtimeService.createExecutionQuery().activityId("processTask").singleResult();
-        assertNotNull(childExecution);
+        assertThat(childExecution).isNotNull();
 
         String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_QUERY);
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionVariableResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionVariableResourceTest.java
@@ -13,10 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -44,9 +42,11 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to a single execution variable.
- * 
+ *
  * @author Frederik Heremans
  */
 public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
@@ -62,42 +62,58 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         runtimeService.setVariable(processInstance.getId(), "variable", "processValue");
 
         Execution childExecution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
-        assertNotNull(childExecution);
+        assertThat(childExecution).isNotNull();
         runtimeService.setVariableLocal(childExecution.getId(), "variable", "childValue");
 
         // Get local scope variable
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "variable")),
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "variable")),
                 HttpStatus.SC_OK);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("local", responseNode.get("scope").asText());
-        assertEquals("childValue", responseNode.get("value").asText());
-        assertEquals("variable", responseNode.get("name").asText());
-        assertEquals("string", responseNode.get("type").asText());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .isEqualTo("{"
+                        + "   name: 'variable',"
+                        + "   type: 'string',"
+                        + "   value: 'childValue',"
+                        + "   scope: 'local'"
+                        + "}");
 
         // Get global scope variable
-        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "variable") + "?scope=global"),
-                HttpStatus.SC_OK);
-        responseNode = objectMapper.readTree(response.getEntity().getContent());
+        response =
+
+                executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE,
+                        childExecution.getId(), "variable") + "?scope=global"),
+                        HttpStatus.SC_OK);
+        responseNode = objectMapper.readTree(response.getEntity().
+
+                getContent());
+
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("global", responseNode.get("scope").asText());
-        assertEquals("processValue", responseNode.get("value").asText());
-        assertEquals("variable", responseNode.get("name").asText());
-        assertEquals("string", responseNode.get("type").asText());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .isEqualTo("{"
+                        + "   name: 'variable',"
+                        + "   type: 'string',"
+                        + "   value: 'processValue',"
+                        + "   scope: 'global'"
+                        + "}");
 
         // Illegal scope
-        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, processInstance.getId(), "variable") + "?scope=illegal"),
-                HttpStatus.SC_BAD_REQUEST);
+        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE,
+                processInstance.getId(), "variable") + "?scope=illegal"), HttpStatus.SC_BAD_REQUEST);
         closeResponse(response);
 
         // Unexisting process
-        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, "unexisting", "variable")), HttpStatus.SC_NOT_FOUND);
+        response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, "unexisting", "variable")),
+                HttpStatus.SC_NOT_FOUND);
         closeResponse(response);
 
         // Unexisting variable
-        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, processInstance.getId(), "unexistingVariable")),
+        response = executeRequest(new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, processInstance.getId(), "unexistingVariable")),
                 HttpStatus.SC_NOT_FOUND);
         closeResponse(response);
     }
@@ -112,23 +128,25 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         runtimeService.setVariableLocal(processInstance.getId(), "var", "This is a binary piece of text".getBytes());
 
         Execution childExecution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
-        assertNotNull(childExecution);
+        assertThat(childExecution).isNotNull();
         runtimeService.setVariableLocal(childExecution.getId(), "var", "This is a binary piece of text in the child execution".getBytes());
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, childExecution.getId(), "var")),
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, childExecution.getId(), "var")),
                 HttpStatus.SC_OK);
         String actualResponseBytesAsText = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
         closeResponse(response);
-        assertEquals("This is a binary piece of text in the child execution", actualResponseBytesAsText);
-        assertEquals("application/octet-stream", response.getEntity().getContentType().getValue());
+        assertThat(actualResponseBytesAsText).isEqualTo("This is a binary piece of text in the child execution");
+        assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/octet-stream");
 
         // Test global scope
-        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, childExecution.getId(), "var") + "?scope=global"),
+        response = executeRequest(new HttpGet(
+                        SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, childExecution.getId(), "var") + "?scope=global"),
                 HttpStatus.SC_OK);
         actualResponseBytesAsText = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
         closeResponse(response);
-        assertEquals("This is a binary piece of text", actualResponseBytesAsText);
-        assertEquals("application/octet-stream", response.getEntity().getContentType().getValue());
+        assertThat(actualResponseBytesAsText).isEqualTo("This is a binary piece of text");
+        assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/octet-stream");
     }
 
     /**
@@ -144,19 +162,19 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("processOne");
         runtimeService.setVariableLocal(processInstance.getId(), "var", originalSerializable);
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, processInstance.getId(), "var")),
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, processInstance.getId(), "var")),
                 HttpStatus.SC_OK);
 
         // Read the serializable from the stream
         ObjectInputStream stream = new ObjectInputStream(response.getEntity().getContent());
         Object readSerializable = stream.readObject();
-        
+
         closeResponse(response);
-        
-        assertNotNull(readSerializable);
-        assertTrue(readSerializable instanceof TestSerializableVariable);
-        assertEquals("This is some field", ((TestSerializableVariable) readSerializable).getSomeField());
-        assertEquals("application/x-java-serialized-object", response.getEntity().getContentType().getValue());
+
+        assertThat(readSerializable).isInstanceOf(TestSerializableVariable.class);
+        assertThat(((TestSerializableVariable) readSerializable).getSomeField()).isEqualTo("This is some field");
+        assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/x-java-serialized-object");
     }
 
     /**
@@ -186,28 +204,32 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
     @Test
     @Deployment(resources = { "org/flowable/rest/service/api/runtime/ExecutionResourceTest.process-with-subprocess.bpmn20.xml" })
     public void testDeleteExecutionVariable() throws Exception {
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("processOne", Collections.singletonMap("myVariable", (Object) "processValue"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("processOne", Collections.singletonMap("myVariable", (Object) "processValue"));
 
         Execution childExecution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
-        assertNotNull(childExecution);
+        assertThat(childExecution).isNotNull();
         runtimeService.setVariableLocal(childExecution.getId(), "myVariable", "childValue");
 
         // Delete variable local
-        HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "myVariable"));
+        HttpDelete httpDelete = new HttpDelete(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "myVariable"));
         CloseableHttpResponse response = executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT);
         closeResponse(response);
 
-        assertFalse(runtimeService.hasVariableLocal(childExecution.getId(), "myVariable"));
+        assertThat(runtimeService.hasVariableLocal(childExecution.getId(), "myVariable")).isFalse();
         // Global variable should remain unaffected
-        assertTrue(runtimeService.hasVariable(childExecution.getId(), "myVariable"));
+        assertThat(runtimeService.hasVariable(childExecution.getId(), "myVariable")).isTrue();
 
         // Delete variable global
-        httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "myVariable") + "?scope=global");
+        httpDelete = new HttpDelete(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "myVariable")
+                        + "?scope=global");
         response = executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT);
         closeResponse(response);
 
-        assertFalse(runtimeService.hasVariableLocal(childExecution.getId(), "myVariable"));
-        assertFalse(runtimeService.hasVariable(childExecution.getId(), "myVariable"));
+        assertThat(runtimeService.hasVariableLocal(childExecution.getId(), "myVariable")).isFalse();
+        assertThat(runtimeService.hasVariable(childExecution.getId(), "myVariable")).isFalse();
 
         // Run the same delete again, variable is not there so 404 should be
         // returned
@@ -225,7 +247,7 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         runtimeService.setVariableLocal(processInstance.getId(), "myVar", "processValue");
 
         Execution childExecution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
-        assertNotNull(childExecution);
+        assertThat(childExecution).isNotNull();
         runtimeService.setVariableLocal(childExecution.getId(), "myVar", "childValue");
 
         // Update variable local
@@ -239,13 +261,17 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("updatedValue", responseNode.get("value").asText());
-        assertEquals("local", responseNode.get("scope").asText());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "   value: 'updatedValue',"
+                        + "   scope: 'local'"
+                        + "}");
 
         // Global value should be unaffected
-        assertEquals("processValue", runtimeService.getVariable(processInstance.getId(), "myVar"));
-        assertEquals("updatedValue", runtimeService.getVariableLocal(childExecution.getId(), "myVar"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "myVar")).isEqualTo("processValue");
+        assertThat(runtimeService.getVariableLocal(childExecution.getId(), "myVar")).isEqualTo("updatedValue");
 
         // Update variable global
         requestNode = objectMapper.createObjectNode();
@@ -259,13 +285,17 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         response = executeRequest(httpPut, HttpStatus.SC_OK);
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("updatedValueGlobal", responseNode.get("value").asText());
-        assertEquals("global", responseNode.get("scope").asText());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "   value: 'updatedValueGlobal',"
+                        + "   scope: 'global'"
+                        + "}");
 
         // Local value should be unaffected
-        assertEquals("updatedValueGlobal", runtimeService.getVariable(processInstance.getId(), "myVar"));
-        assertEquals("updatedValue", runtimeService.getVariableLocal(childExecution.getId(), "myVar"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "myVar")).isEqualTo("updatedValueGlobal");
+        assertThat(runtimeService.getVariableLocal(childExecution.getId(), "myVar")).isEqualTo("updatedValue");
 
         requestNode.put("name", "unexistingVariable");
 
@@ -273,7 +303,8 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         response = executeRequest(httpPut, HttpStatus.SC_BAD_REQUEST);
         closeResponse(response);
 
-        httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "unexistingVariable"));
+        httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "unexistingVariable"));
         httpPut.setEntity(new StringEntity(requestNode.toString()));
         response = executeRequest(httpPut, HttpStatus.SC_NOT_FOUND);
         closeResponse(response);
@@ -290,7 +321,7 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         runtimeService.setVariableLocal(processInstance.getId(), "binaryVariable", "Initial binary value".getBytes());
 
         Execution childExecution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
-        assertNotNull(childExecution);
+        assertThat(childExecution).isNotNull();
         runtimeService.setVariableLocal(childExecution.getId(), "binaryVariable", "Initial binary value child".getBytes());
 
         InputStream binaryContent = new ByteArrayInputStream("This is binary content".getBytes());
@@ -300,53 +331,58 @@ public class ExecutionVariableResourceTest extends BaseSpringRestTestCase {
         additionalFields.put("name", "binaryVariable");
         additionalFields.put("type", "binary");
 
-        HttpPut httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "binaryVariable"));
+        HttpPut httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "binaryVariable"));
         httpPut.setEntity(HttpMultipartHelper.getMultiPartEntity("value", "application/octet-stream", binaryContent, additionalFields));
         CloseableHttpResponse response = executeBinaryRequest(httpPut, HttpStatus.SC_OK);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("binaryVariable", responseNode.get("name").asText());
-        assertTrue(responseNode.get("value").isNull());
-        assertEquals("local", responseNode.get("scope").asText());
-        assertEquals("binary", responseNode.get("type").asText());
-        assertNotNull(responseNode.get("valueUrl"));
-        assertTrue(responseNode.get("valueUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, childExecution.getId(), "binaryVariable")));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .isEqualTo("{"
+                        + "   name: 'binaryVariable',"
+                        + "   type: 'binary',"
+                        + "   value: null,"
+                        + "   scope: 'local',"
+                        + "   valueUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, childExecution.getId(), "binaryVariable") + "'"
+                        + "}");
 
         // Check actual value of variable in engine
         Object variableValue = runtimeService.getVariableLocal(childExecution.getId(), "binaryVariable");
-        assertNotNull(variableValue);
-        assertTrue(variableValue instanceof byte[]);
-        assertEquals("This is binary content", new String((byte[]) variableValue));
+        assertThat(variableValue).isInstanceOf(byte[].class);
+        assertThat(new String((byte[]) variableValue)).isEqualTo("This is binary content");
 
         // Update variable in global scope
         additionalFields.put("scope", "global");
         binaryContent = new ByteArrayInputStream("This is binary content global".getBytes());
 
-        httpPut = new HttpPut(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "binaryVariable"));
+        httpPut = new HttpPut(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE, childExecution.getId(), "binaryVariable"));
         httpPut.setEntity(HttpMultipartHelper.getMultiPartEntity("value", "application/octet-stream", binaryContent, additionalFields));
         response = executeBinaryRequest(httpPut, HttpStatus.SC_OK);
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("binaryVariable", responseNode.get("name").asText());
-        assertTrue(responseNode.get("value").isNull());
-        assertEquals("global", responseNode.get("scope").asText());
-        assertEquals("binary", responseNode.get("type").asText());
-        assertNotNull(responseNode.get("valueUrl"));
-        assertTrue(responseNode.get("valueUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, childExecution.getId(), "binaryVariable")));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .isEqualTo("{"
+                        + "   name: 'binaryVariable',"
+                        + "   type: 'binary',"
+                        + "   value: null,"
+                        + "   scope: 'global',"
+                        + "   valueUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_EXECUTION_VARIABLE_DATA, childExecution.getId(), "binaryVariable") + "'"
+                        + "}");
 
         // Check actual global value of variable in engine
         variableValue = runtimeService.getVariableLocal(processInstance.getId(), "binaryVariable");
-        assertNotNull(variableValue);
-        assertTrue(variableValue instanceof byte[]);
-        assertEquals("This is binary content global", new String((byte[]) variableValue));
+        assertThat(variableValue).isInstanceOf(byte[].class);
+        assertThat(new String((byte[]) variableValue)).isEqualTo("This is binary content global");
 
         // local value should remain unchanged
         variableValue = runtimeService.getVariableLocal(childExecution.getId(), "binaryVariable");
-        assertNotNull(variableValue);
-        assertTrue(variableValue instanceof byte[]);
-        assertEquals("This is binary content", new String((byte[]) variableValue));
+        assertThat(variableValue).isInstanceOf(byte[].class);
+        assertThat(new String((byte[]) variableValue)).isEqualTo("This is binary content");
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,12 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -51,9 +47,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to a single Process instance resource.
- * 
+ *
  * @author Frederik Heremans
  * @author Saeid Mirzaei
  * @author Filip Hrisafov
@@ -77,14 +75,17 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
 
         JsonNode rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertTrue(rootNode.size() > 0);
-        assertEquals(1, rootNode.get("data").size());
-        JsonNode dataNode = rootNode.get("data").get(0);
-        assertEquals(processId, dataNode.get("id").asText());
-        assertEquals(processInstance.getProcessDefinitionId(), dataNode.get("processDefinitionId").asText());
-        assertTrue(dataNode.get("processDefinitionUrl").asText().contains(processInstance.getProcessDefinitionId()));
-        JsonNode variableNodes = dataNode.get("variables");
-        assertEquals(0, variableNodes.size());
+        assertThatJson(rootNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "data: [ {"
+                        + "   id: '" + processId + "',"
+                        + "   processDefinitionId: '" + processInstance.getProcessDefinitionId() + "',"
+                        + "   processDefinitionUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId()) + "',"
+                        + "   variables: [ ]"
+                        + "} ]"
+                        + "}");
 
         // check that the right process is returned along with the variables
         // when includeProcessvariable is set
@@ -94,22 +95,20 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
 
         rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertTrue(rootNode.size() > 0);
-        assertEquals(1, rootNode.get("data").size());
-        dataNode = rootNode.get("data").get(0);
-        assertEquals(processId, dataNode.get("id").textValue());
-        assertEquals(processInstance.getProcessDefinitionId(), dataNode.get("processDefinitionId").asText());
-        assertTrue(dataNode.get("processDefinitionUrl").asText().contains(processInstance.getProcessDefinitionId()));
-        variableNodes = dataNode.get("variables");
-        assertEquals(1, variableNodes.size());
-
-        variableNodes = dataNode.get("variables");
-        assertEquals(1, variableNodes.size());
-        assertNotNull(variableNodes.get(0).get("name"));
-        assertNotNull(variableNodes.get(0).get("value"));
-
-        assertEquals("myVar1", variableNodes.get(0).get("name").asText());
-        assertEquals("myVar1", variableNodes.get(0).get("value").asText());
+        assertThatJson(rootNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "data: [ {"
+                        + "   id: '" + processId + "',"
+                        + "   processDefinitionId: '" + processInstance.getProcessDefinitionId() + "',"
+                        + "   processDefinitionUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId()) + "',"
+                        + "   variables: [ {"
+                        + "                name: 'myVar1',"
+                        + "                value: 'myVar1'"
+                        + "   } ]"
+                        + "} ]"
+                        + "}");
     }
 
     /**
@@ -139,7 +138,7 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
 
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION) + "?businessKey=anotherBusinessKey";
         assertResultsPresentInDataResponse(url);
-        
+
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION) + "?businessKeyLike=" + encode("%BusinessKey");
         assertResultsPresentInDataResponse(url, id);
 
@@ -184,7 +183,7 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
         taskService.complete(taskService.createTaskQuery().processInstanceId(id).singleResult().getId());
 
         ProcessInstance subProcess = runtimeService.createProcessInstanceQuery().superProcessInstanceId(id).singleResult();
-        assertNotNull(subProcess);
+        assertThat(subProcess).isNotNull();
 
         // Super-process instance id
         url = RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION) + "?superProcessInstanceId=" + id;
@@ -287,21 +286,26 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
         CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
 
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
-        HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(historicProcessInstance);
-        assertEquals("kermit", historicProcessInstance.getStartUserId());
+        HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId())
+                .singleResult();
+        assertThat(historicProcessInstance).isNotNull();
+        assertThat(historicProcessInstance.getStartUserId()).isEqualTo("kermit");
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("id").textValue());
-        assertTrue(responseNode.get("businessKey").isNull());
-        assertFalse(responseNode.get("suspended").booleanValue());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processInstance.getId() + "',"
+                        + "businessKey: null,"
+                        + "suspended: false,"
+                        + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId()) + "',"
+                        + "processDefinitionUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId()) + "'"
+                        + "}");
 
-        assertTrue(responseNode.get("url").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId())));
-        assertTrue(responseNode.get("processDefinitionUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId())));
         runtimeService.deleteProcessInstance(processInstance.getId(), "testing");
 
         // Start using process definition id
@@ -311,17 +315,22 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
         response = executeRequest(httpPost, HttpStatus.SC_CREATED);
 
         processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("id").textValue());
-        assertTrue(responseNode.get("businessKey").isNull());
-        assertFalse(responseNode.get("suspended").booleanValue());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processInstance.getId() + "',"
+                        + "businessKey: null,"
+                        + "suspended: false,"
+                        + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId()) + "',"
+                        + "processDefinitionUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId()) + "'"
+                        + "}");
 
-        assertTrue(responseNode.get("url").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId())));
-        assertTrue(responseNode.get("processDefinitionUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId())));
         runtimeService.deleteProcessInstance(processInstance.getId(), "testing");
 
         // Start using message
@@ -331,17 +340,21 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
         response = executeRequest(httpPost, HttpStatus.SC_CREATED);
 
         processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("id").textValue());
-        assertTrue(responseNode.get("businessKey").isNull());
-        assertFalse(responseNode.get("suspended").booleanValue());
-
-        assertTrue(responseNode.get("url").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId())));
-        assertTrue(responseNode.get("processDefinitionUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId())));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processInstance.getId() + "',"
+                        + "businessKey: null,"
+                        + "suspended: false,"
+                        + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId()) + "',"
+                        + "processDefinitionUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId()) + "'"
+                        + "}");
 
         // Start using process definition id and business key
         requestNode = objectMapper.createObjectNode();
@@ -352,8 +365,8 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
 
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("myBusinessKey", responseNode.get("businessKey").textValue());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.get("businessKey").textValue()).isEqualTo("myBusinessKey");
     }
 
     /**
@@ -415,24 +428,28 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertFalse(responseNode.get("ended").asBoolean());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "   ended: false"
+                        + "}");
         JsonNode variablesArrayNode = responseNode.get("variables");
-        assertEquals(7, variablesArrayNode.size());
+        assertThat(variablesArrayNode).hasSize(7);
 
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check if engine has correct variables set
         Map<String, Object> processVariables = runtimeService.getVariables(processInstance.getId());
-        assertEquals(7, processVariables.size());
+        assertThat(processVariables).hasSize(7);
 
-        assertEquals("simple string value", processVariables.get("stringVariable"));
-        assertEquals(1234, processVariables.get("integerVariable"));
-        assertEquals((short) 123, processVariables.get("shortVariable"));
-        assertEquals(4567890L, processVariables.get("longVariable"));
-        assertEquals(123.456, processVariables.get("doubleVariable"));
-        assertEquals(Boolean.TRUE, processVariables.get("booleanVariable"));
-        assertEquals(dateFormat.parse(isoString), processVariables.get("dateVariable"));
+        assertThat(processVariables.get("stringVariable")).isEqualTo("simple string value");
+        assertThat(processVariables.get("integerVariable")).isEqualTo(1234);
+        assertThat(processVariables.get("shortVariable")).isEqualTo((short) 123);
+        assertThat(processVariables.get("longVariable")).isEqualTo(4567890L);
+        assertThat(processVariables.get("doubleVariable")).isEqualTo(123.456);
+        assertThat(processVariables.get("booleanVariable")).isEqualTo(Boolean.TRUE);
+        assertThat(processVariables.get("dateVariable")).isEqualTo(dateFormat.parse(isoString));
     }
 
     /**
@@ -466,55 +483,57 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
         CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertFalse(responseNode.get("ended").asBoolean());
-        JsonNode variablesArrayNode = responseNode.get("variables");
-        assertEquals(2, variablesArrayNode.size());
-        for (JsonNode variableNode : variablesArrayNode) {
-            if ("stringVariable".equals(variableNode.get("name").asText())) {
-                assertEquals("simple string value", variableNode.get("value").asText());
-                assertEquals("string", variableNode.get("type").asText());
-
-            } else if ("integerVariable".equals(variableNode.get("name").asText())) {
-                assertEquals(1234, variableNode.get("value").asInt());
-                assertEquals("integer", variableNode.get("type").asText());
-
-            } else {
-                fail("Unexpected variable " + variableNode.get("name").asText());
-            }
-        }
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_ARRAY_ORDER)
+                .isEqualTo("{"
+                        + "  ended: false,"
+                        + "  variables: [ {"
+                        + "               value: 'simple string value',"
+                        + "               type: 'string'"
+                        + "              }, {"
+                        + "               value: 1234,"
+                        + "               type: 'integer'"
+                        + "              } ]"
+                        + "}");
 
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check if engine has correct variables set
         Map<String, Object> processVariables = runtimeService.getVariables(processInstance.getId());
-        assertEquals(2, processVariables.size());
+        assertThat(processVariables).hasSize(2);
 
-        assertEquals("simple string value", processVariables.get("stringVariable"));
-        assertEquals(1234, processVariables.get("integerVariable"));
+        assertThat(processVariables.get("stringVariable")).isEqualTo("simple string value");
+        assertThat(processVariables.get("integerVariable")).isEqualTo(1234);
     }
-    
+
     @Test
     @Deployment(resources = { "org/flowable/rest/service/api/runtime/ProcessInstanceResourceTest.process-with-form.bpmn20.xml",
-                    "org/flowable/rest/service/api/runtime/simple.form"})
+            "org/flowable/rest/service/api/runtime/simple.form" })
     public void testStartProcessWithForm() throws Exception {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("processOne").singleResult();
         try {
             FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-            assertNotNull(formDefinition);
-            
+            assertThat(formDefinition).isNotNull();
+
             FormInstance formInstance = formEngineFormService.createFormInstanceQuery().formDefinitionId(formDefinition.getId()).singleResult();
-            assertNull(formInstance);
-            
+            assertThat(formInstance).isNull();
+
             String url = RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_DEFINITION_START_FORM, processDefinition.getId());
             CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertEquals(formDefinition.getId(), responseNode.get("id").asText());
-            assertEquals(formDefinition.getKey(), responseNode.get("key").asText());
-            assertEquals(formDefinition.getName(), responseNode.get("name").asText());
-            assertEquals(2, responseNode.get("fields").size());
-            
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .isEqualTo("{"
+                            + " id: '" + formDefinition.getId() + "',"
+                            + " key: '" + formDefinition.getKey() + "',"
+                            + " name: '" + formDefinition.getName() + "',"
+                            + " fields : [ {"
+                            + "          }, {"
+                            + "          } ]"
+                            + "}");
+
             ArrayNode formVariablesNode = objectMapper.createArrayNode();
 
             // String variable
@@ -537,27 +556,35 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
             HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_COLLECTION));
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             response = executeRequest(httpPost, HttpStatus.SC_CREATED);
-            
+
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertFalse(responseNode.get("ended").asBoolean());
-            
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "   ended: false"
+                            + "}");
+
             String processInstanceId = responseNode.get("id").asText();
-            assertEquals("simple string value", runtimeService.getVariable(processInstanceId, "user"));
-            assertEquals(1234, runtimeService.getVariable(processInstanceId, "number"));
-            
+            assertThat(runtimeService.getVariable(processInstanceId, "user")).isEqualTo("simple string value");
+            assertThat(runtimeService.getVariable(processInstanceId, "number")).isEqualTo(1234);
+
             formInstance = formEngineFormService.createFormInstanceQuery().formDefinitionId(formDefinition.getId()).singleResult();
-            assertNotNull(formInstance);
+            assertThat(formInstance).isNotNull();
             byte[] valuesBytes = formEngineFormService.getFormInstanceValues(formInstance.getId());
-            assertNotNull(valuesBytes);
+            assertThat(valuesBytes).isNotNull();
             JsonNode instanceNode = objectMapper.readTree(valuesBytes);
-            JsonNode valuesNode = instanceNode.get("values");
-            assertEquals("simple string value", valuesNode.get("user").asText());
-            assertEquals(1234, valuesNode.get("number").asInt());
-            
+            assertThatJson(instanceNode)
+                    .isEqualTo("{"
+                            + "values: {"
+                            + "        number: '1234',"
+                            + "        user: 'simple string value'"
+                            + "        }"
+                            + "}");
+
         } finally {
             formEngineFormService.deleteFormInstancesByProcessDefinition(processDefinition.getId());
-            
+
             List<FormDeployment> formDeployments = formRepositoryService.createDeploymentQuery().list();
             for (FormDeployment formDeployment : formDeployments) {
                 formRepositoryService.deleteDeployment(formDeployment.getId(), true);
@@ -587,8 +614,8 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
 
             // Only one process should have been started
             ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-            assertNotNull(processInstance);
-            assertEquals("tenant1", processInstance.getTenantId());
+            assertThat(processInstance).isNotNull();
+            assertThat(processInstance.getTenantId()).isEqualTo("tenant1");
 
             // Start using an unexisting tenant
             requestNode.put("processDefinitionKey", "oneTaskProcess");
@@ -678,11 +705,12 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
         closeResponse(executeRequest(httpPost, HttpStatus.SC_CREATED));
 
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).hasSize(2);
         for (ProcessInstance processInstance : processInstances) {
-            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(historicProcessInstance);
-            assertEquals("kermit", historicProcessInstance.getStartUserId());
+            HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId())
+                    .singleResult();
+            assertThat(historicProcessInstance).isNotNull();
+            assertThat(historicProcessInstance.getStartUserId()).isEqualTo("kermit");
         }
 
     }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
@@ -488,9 +488,11 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
                 .isEqualTo("{"
                         + "  ended: false,"
                         + "  variables: [ {"
+                        + "               name: 'stringVariable',"
                         + "               value: 'simple string value',"
                         + "               type: 'string'"
                         + "              }, {"
+                        + "               name: 'integerVariable',"
                         + "               value: 1234,"
                         + "               type: 'integer'"
                         + "              } ]"
@@ -524,13 +526,15 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
             assertThatJson(responseNode)
-                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS, Option.IGNORING_ARRAY_ORDER)
                     .isEqualTo("{"
                             + " id: '" + formDefinition.getId() + "',"
                             + " key: '" + formDefinition.getKey() + "',"
                             + " name: '" + formDefinition.getName() + "',"
                             + " fields : [ {"
+                            + "               id: 'user'"
                             + "          }, {"
+                            + "               id: 'number'"
                             + "          } ]"
                             + "}");
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
@@ -526,7 +526,7 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
             assertThatJson(responseNode)
-                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS, Option.IGNORING_ARRAY_ORDER)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_ARRAY_ORDER)
                     .isEqualTo("{"
                             + " id: '" + formDefinition.getId() + "',"
                             + " key: '" + formDefinition.getKey() + "',"

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceDiagramResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceDiagramResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -35,10 +34,11 @@ public class ProcessInstanceDiagramResourceTest extends BaseSpringRestTestCase {
     public void testGetProcessDiagram() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleProcess");
 
-        CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_DIAGRAM, processInstance.getId())),
+        CloseableHttpResponse response = executeRequest(
+                new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE_DIAGRAM, processInstance.getId())),
                 HttpStatus.SC_OK);
-        assertNotNull(response.getEntity().getContent());
-        assertEquals("image/png", response.getEntity().getContentType().getValue());
+        assertThat(response.getEntity().getContent()).isNotNull();
+        assertThat(response.getEntity().getContentType().getValue()).isEqualTo("image/png");
         closeResponse(response);
     }
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceQueryResourceTest.java
@@ -13,7 +13,7 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import java.util.HashMap;
 
@@ -31,6 +31,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to the process instance query resource.
@@ -167,12 +169,17 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         // Check order
         JsonNode rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        JsonNode dataNode = rootNode.get("data");
-        assertThat(dataNode).hasSize(3);
-
-        assertThat(dataNode.get(0).get("id").asText()).isEqualTo(processInstance3.getId());
-        assertThat(dataNode.get(1).get("id").asText()).isEqualTo(processInstance2.getId());
-        assertThat(dataNode.get(2).get("id").asText()).isEqualTo(processInstance1.getId());
+        assertThatJson(rootNode)
+                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                .isEqualTo("{"
+                        + "data: [ {"
+                        + "         id: '" + processInstance3.getId() + "'"
+                        + "      }, {"
+                        + "         id: '" + processInstance2.getId() + "'"
+                        + "      }, {"
+                        + "         id: '" + processInstance1.getId() + "'"
+                        + "      } ]"
+                        + "}");
 
         // Check paging size
         requestNode = objectMapper.createObjectNode();
@@ -183,8 +190,13 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         response = executeRequest(httpPost, HttpStatus.SC_OK);
         rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        dataNode = rootNode.get("data");
-        assertThat(dataNode).hasSize(1);
+        assertThatJson(rootNode)
+                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                .isEqualTo("{"
+                        + "data: [ {"
+                        + "         id: '" + processInstance1.getId() + "'"
+                        + "      } ]"
+                        + "}");
 
         // Check paging start and size
         requestNode = objectMapper.createObjectNode();
@@ -197,14 +209,17 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         response = executeRequest(httpPost, HttpStatus.SC_OK);
         rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        dataNode = rootNode.get("data");
-        assertThat(dataNode).hasSize(1);
-        JsonNode valueNode = dataNode.get(0);
-        assertThat(valueNode.get("id").asText()).isEqualTo(processInstance2.getId());
-        assertThat(valueNode.get("processDefinitionName").asText()).isEqualTo("The One Task Process");
-        assertThat(valueNode.get("processDefinitionDescription").asText()).isEqualTo("One task process description");
-        assertThat(valueNode.has("startTime")).as("has startTime").isTrue();
-        assertThat(valueNode.get("startUserId").textValue()).as("startUserId").isEqualTo(processInstance2.getStartUserId());
-    }
+        assertThatJson(rootNode)
+                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                .isEqualTo("{"
+                        + "data: [ {"
+                        + "        id: '" + processInstance2.getId() + "',"
+                        + "        processDefinitionName: 'The One Task Process',"
+                        + "        processDefinitionDescription: 'One task process description',"
+                        + "        startUserId: '" + processInstance2.getStartUserId() + "',"
+                        + "        startTime: '${json-unit.any-string}'"
+                        + "      } ]"
+                        + "}");
 
+    }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceQueryResourceTest.java
@@ -170,7 +170,7 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         JsonNode rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
         assertThatJson(rootNode)
-                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                .when(Option.IGNORING_EXTRA_FIELDS)
                 .isEqualTo("{"
                         + "data: [ {"
                         + "         id: '" + processInstance3.getId() + "'"
@@ -191,7 +191,7 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
         assertThatJson(rootNode)
-                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                .when(Option.IGNORING_EXTRA_FIELDS)
                 .isEqualTo("{"
                         + "data: [ {"
                         + "         id: '" + processInstance1.getId() + "'"
@@ -210,7 +210,7 @@ public class ProcessInstanceQueryResourceTest extends BaseSpringRestTestCase {
         rootNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
         assertThatJson(rootNode)
-                .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_EXTRA_ARRAY_ITEMS)
+                .when(Option.IGNORING_EXTRA_FIELDS)
                 .isEqualTo("{"
                         + "data: [ {"
                         + "        id: '" + processInstance2.getId() + "',"

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceResourceTest.java
@@ -13,11 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -36,9 +33,11 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to a single Process instance resource.
- * 
+ *
  * @author Frederik Heremans
  */
 public class ProcessInstanceResourceTest extends BaseSpringRestTestCase {
@@ -51,13 +50,13 @@ public class ProcessInstanceResourceTest extends BaseSpringRestTestCase {
     public void testGetProcessInstance() throws Exception {
         Authentication.setAuthenticatedUserId("testUser");
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-            .processDefinitionKey("processOne")
-            .businessKey("myBusinessKey")
-            .callbackId("testCallbackId")
-            .callbackType("testCallbackType")
-            .referenceId("testReferenceId")
-            .referenceType("testReferenceType")
-            .start();
+                .processDefinitionKey("processOne")
+                .businessKey("myBusinessKey")
+                .callbackId("testCallbackId")
+                .callbackType("testCallbackType")
+                .referenceId("testReferenceId")
+                .referenceType("testReferenceType")
+                .start();
         Authentication.setAuthenticatedUserId(null);
 
         String url = buildUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId());
@@ -66,32 +65,36 @@ public class ProcessInstanceResourceTest extends BaseSpringRestTestCase {
         // Check resulting instance
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("id").textValue());
-        assertTrue("has startTime", responseNode.has("startTime"));
-        assertNotNull("startTime", responseNode.get("startTime").textValue());
-        assertEquals(processInstance.getStartUserId(), responseNode.get("startUserId").textValue());
-        assertEquals(processInstance.getProcessDefinitionName(), responseNode.get("processDefinitionName").textValue());
-        assertEquals("myBusinessKey", responseNode.get("businessKey").textValue());
-        assertEquals("testCallbackId", responseNode.get("callbackId").textValue());
-        assertEquals("testCallbackType", responseNode.get("callbackType").textValue());
-        assertEquals("testReferenceId", responseNode.get("referenceId").textValue());
-        assertEquals("testReferenceType", responseNode.get("referenceType").textValue());
-        assertFalse(responseNode.get("suspended").booleanValue());
-        assertEquals("", responseNode.get("tenantId").textValue());
-
-        assertEquals(responseNode.get("url").asText(), url);
-        assertEquals(responseNode.get("processDefinitionUrl").asText(), buildUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId()));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processInstance.getId() + "',"
+                        + "startTime: '${json-unit.any-string}',"
+                        + "startUserId: '" + processInstance.getStartUserId() + "',"
+                        + "processDefinitionName: '" + processInstance.getProcessDefinitionName() + "',"
+                        + "businessKey: 'myBusinessKey',"
+                        + "callbackId: 'testCallbackId',"
+                        + "callbackType: 'testCallbackType',"
+                        + "referenceId: 'testReferenceId',"
+                        + "referenceType: 'testReferenceType',"
+                        + "suspended: false,"
+                        + "tenantId: '',"
+                        + "url: '" + url + "',"
+                        + "processDefinitionUrl: '" + buildUrl(RestUrls.URL_PROCESS_DEFINITION, processInstance.getProcessDefinitionId()) + "'"
+                        + "}"
+                );
 
         // Check result after tenant has been changed
         managementService.executeCommand(new ChangeDeploymentTenantIdCmd(deploymentId, "myTenant"));
-        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId())), HttpStatus.SC_OK);
+        response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId())),
+                HttpStatus.SC_OK);
 
         // Check resulting instance tenant id
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("myTenant", responseNode.get("tenantId").textValue());
+        assertThat(responseNode).isNotNull();
+        assertThat(responseNode.get("tenantId").textValue()).isEqualTo("myTenant");
     }
 
     /**
@@ -112,7 +115,7 @@ public class ProcessInstanceResourceTest extends BaseSpringRestTestCase {
         closeResponse(executeRequest(new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_PROCESS_INSTANCE, processInstance.getId())), HttpStatus.SC_NO_CONTENT));
 
         // Check if process-instance is gone
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     /**
@@ -139,14 +142,18 @@ public class ProcessInstanceResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
 
         // Check engine id instance is suspended
-        assertEquals(1, runtimeService.createProcessInstanceQuery().suspended().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().suspended().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
         // Check resulting instance is suspended
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("id").textValue());
-        assertTrue(responseNode.get("suspended").booleanValue());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processInstance.getId() + "',"
+                        + "suspended: true"
+                        + "}");
 
         // Suspending again should result in conflict
         httpPut.setEntity(new StringEntity(requestNode.toString()));
@@ -170,14 +177,18 @@ public class ProcessInstanceResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
 
         // Check engine id instance is suspended
-        assertEquals(1, runtimeService.createProcessInstanceQuery().active().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().active().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
         // Check resulting instance is suspended
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("id").textValue());
-        assertFalse(responseNode.get("suspended").booleanValue());
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "id: '" + processInstance.getId() + "',"
+                        + "suspended: false"
+                        + "}");
 
         // Activating again should result in conflict
         httpPut.setEntity(new StringEntity(requestNode.toString()));
@@ -194,22 +205,22 @@ public class ProcessInstanceResourceTest extends BaseSpringRestTestCase {
         httpPut.setEntity(new StringEntity("{\"name\": \"name one\"}"));
         closeResponse(executeRequest(httpPut, HttpStatus.SC_OK));
 
-        assertEquals("name one", runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getName());
-        assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getBusinessKey());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("name one");
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getBusinessKey()).isNull();
 
         httpPut = new HttpPut(url);
         httpPut.setEntity(new StringEntity("{\"businessKey\": \"key one\"}"));
         closeResponse(executeRequest(httpPut, HttpStatus.SC_OK));
 
-        assertEquals("name one", runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getName());
-        assertEquals("key one", runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getBusinessKey());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("name one");
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getBusinessKey()).isEqualTo("key one");
 
         httpPut = new HttpPut(url);
         httpPut.setEntity(new StringEntity("{\"businessKey\": \"key two\"}"));
         closeResponse(executeRequest(httpPut, HttpStatus.SC_OK));
 
-        assertEquals("name one", runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getName());
-        assertEquals("key two", runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getBusinessKey());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("name one");
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getBusinessKey()).isEqualTo("key two");
 
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceVariableResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceVariableResourceTest.java
@@ -217,7 +217,6 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         // Read the serializable from the stream
         ObjectInputStream stream = new ObjectInputStream(response.getEntity().getContent());
         Object readSerializable = stream.readObject();
-        assertThat(readSerializable).isNotNull();
         assertThat(readSerializable).isInstanceOf(TestSerializableVariable.class);
         assertThat(((TestSerializableVariable) readSerializable).getSomeField()).isEqualTo("This is some field");
         assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/x-java-serialized-object");
@@ -399,7 +398,8 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
         httpPut.setEntity(new StringEntity(requestNode.toString()));
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
 
-        assertThatJson(runtimeService.getVariable(processInstance.getId(), "myVar")).isEqualTo(tenDaysLater);
+        assertThatJson(runtimeService.getVariable(processInstance.getId(), "myVar"))
+                .isEqualTo(tenDaysLater);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
@@ -449,7 +449,6 @@ public class ProcessInstanceVariableResourceTest extends BaseSpringRestTestCase 
 
         // Check actual value of variable in engine
         Object variableValue = runtimeService.getVariableLocal(processInstance.getId(), "binaryVariable");
-        assertThat(variableValue).isNotNull();
         assertThat(variableValue).isInstanceOf(byte[].class);
         assertThat(new String((byte[]) variableValue)).isEqualTo("This is binary content");
     }


### PR DESCRIPTION
The module had a mix of assertion styles.  This is part 5 for this module.
This is for the `org.flowable.rest.service.api.runtime` package.

