### PR TITLE
Use assertj fluent style in flowable-rest module.

### DIFF
--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/SerializableVariablesDiabledTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/SerializableVariablesDiabledTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.rest.service.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -47,7 +50,6 @@ import org.flowable.rest.util.TestServerUtil;
 import org.flowable.rest.util.TestServerUtil.TestServer;
 import org.flowable.task.api.Task;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -183,7 +185,7 @@ public class SerializableVariablesDiabledTest {
 
             response = (CloseableHttpResponse) client.execute(request);
             int statusCode = response.getStatusLine().getStatusCode();
-            Assert.assertEquals(expectedStatusCode, statusCode);
+            assertThat(statusCode).isEqualTo(expectedStatusCode);
 
             if (client instanceof CloseableHttpClient) {
                 ((CloseableHttpClient) client).close();
@@ -192,9 +194,9 @@ public class SerializableVariablesDiabledTest {
             response.close();
 
         } catch (ClientProtocolException e) {
-            Assert.fail(e.getMessage());
+            fail(e.getMessage());
         } catch (IOException e) {
-            Assert.fail(e.getMessage());
+            fail(e.getMessage());
         }
 
     }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskAttachmentResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskAttachmentResourceTest.java
@@ -131,9 +131,9 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
                             .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId()) + "',"
                             + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
                             + "contentUrl: null,"
-                            + "processInstanceUrl: null"
+                            + "processInstanceUrl: null,"
+                            + "time: '${json-unit.any-string}'"
                             + "}");
-            assertThat(responseNode.get("time")).isNotNull();
 
             // Get binary attachment
             response = executeRequest(
@@ -154,9 +154,9 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
                             + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
                             + "contentUrl: '" + SERVER_URL_PREFIX + RestUrls
                             .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId()) + "',"
-                            + "processInstanceUrl: null"
+                            + "processInstanceUrl: null,"
+                            + "time: '${json-unit.any-string}'"
                             + "}");
-            assertThat(responseNode.get("time").isNull()).isFalse();
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -338,9 +338,9 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
                             .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId()) + "',"
                             + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
                             + "contentUrl: null,"
-                            + "processInstanceUrl: null"
+                            + "processInstanceUrl: null,"
+                            + "time: '${json-unit.any-string}'"
                             + "}");
-            assertThat(responseNode.get("time")).isNotNull();
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -397,9 +397,9 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
                             + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
                             + "contentUrl: '" + SERVER_URL_PREFIX + RestUrls
                             .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT_DATA, task.getId(), binaryAttachment.getId()) + "',"
-                            + "processInstanceUrl: null"
+                            + "processInstanceUrl: null,"
+                            + "time: '${json-unit.any-string}'"
                             + "}");
-            assertThat(responseNode.get("time")).isNotNull();
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -514,9 +514,9 @@ public class TaskAttachmentResourceTest extends BaseSpringRestTestCase {
                             .createRelativeResourceUrl(RestUrls.URL_TASK_ATTACHMENT, task.getId(), urlAttachment.getId()) + "',"
                             + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
                             + "contentUrl: null,"
-                            + "processInstanceUrl: null"
+                            + "processInstanceUrl: null,"
+                            + "time: '${json-unit.any-string}'"
                             + "}");
-            assertThat(responseNode.get("time")).isNotNull();
 
             // Get binary attachment
             response = executeRequest(

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCollectionResourceTest.java
@@ -13,7 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.HashMap;
@@ -34,15 +35,16 @@ import org.flowable.rest.service.BaseSpringRestTestCase;
 import org.flowable.rest.service.api.RestUrls;
 import org.flowable.task.api.DelegationState;
 import org.flowable.task.api.Task;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to the Task collection resource.
- * 
+ *
  * @author Frederik Heremans
  */
 public class TaskCollectionResourceTest extends BaseSpringRestTestCase {
@@ -82,16 +84,16 @@ public class TaskCollectionResourceTest extends BaseSpringRestTestCase {
 
             // Check if task is created with right arguments
             Task task = taskService.createTaskQuery().taskId(createdTaskId).singleResult();
-            assertEquals("New task name", task.getName());
-            assertEquals("New task description", task.getDescription());
-            assertEquals("assignee", task.getAssignee());
-            assertEquals("owner", task.getOwner());
-            assertEquals(20, task.getPriority());
-            assertEquals(DelegationState.RESOLVED, task.getDelegationState());
-            assertEquals(dateFormat.parse(dueDateString), task.getDueDate());
-            assertEquals(parentTask.getId(), task.getParentTaskId());
-            assertEquals("testKey", task.getFormKey());
-            assertEquals("test", task.getTenantId());
+            assertThat(task.getName()).isEqualTo("New task name");
+            assertThat(task.getDescription()).isEqualTo("New task description");
+            assertThat(task.getAssignee()).isEqualTo("assignee");
+            assertThat(task.getOwner()).isEqualTo("owner");
+            assertThat(task.getPriority()).isEqualTo(20);
+            assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
+            assertThat(task.getDueDate()).isEqualTo(dateFormat.parse(dueDateString));
+            assertThat(task.getParentTaskId()).isEqualTo(parentTask.getId());
+            assertThat(task.getFormKey()).isEqualTo("testKey");
+            assertThat(task.getTenantId()).isEqualTo("test");
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -369,60 +371,61 @@ public class TaskCollectionResourceTest extends BaseSpringRestTestCase {
             // Active filtering
             url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?active=true";
             assertResultsPresentInDataResponse(url, adhocTask.getId());
-            
+
             url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?includeTaskLocalVariables=true";
             CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
 
             // Check status and size
             JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
-            Assert.assertEquals(2, dataNode.size());
-            
+            assertThat(dataNode).hasSize(2);
+
             Map<String, JsonNode> taskNodeMap = new HashMap<>();
             for (JsonNode taskNode : dataNode) {
                 taskNodeMap.put(taskNode.get("id").asText(), taskNode);
             }
-            
-            Assert.assertTrue(taskNodeMap.containsKey(processTask.getId()));
+
+            assertThat(taskNodeMap).containsKey(processTask.getId());
+
             JsonNode processTaskNode = taskNodeMap.get(processTask.getId());
-            JsonNode variablesNode = processTaskNode.get("variables");
-            assertEquals(1, variablesNode.size());
-            JsonNode variableNode = variablesNode.get(0);
-            assertEquals("localVariable", variableNode.get("name").asText());
-            assertEquals("local", variableNode.get("scope").asText());
-            assertEquals("localtest", variableNode.get("value").asText());
-            
+            assertThatJson(processTaskNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "variables: [ {"
+                            + "name: 'localVariable',"
+                            + "value: 'localtest',"
+                            + "scope: 'local'"
+                            + "} ]"
+                            + "}");
+
             url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?includeTaskLocalVariables=true&includeProcessVariables=true";
             response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
 
             // Check status and size
             dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
             closeResponse(response);
-            Assert.assertEquals(2, dataNode.size());
-            
+            assertThat(dataNode).hasSize(2);
+
             taskNodeMap = new HashMap<>();
             for (JsonNode taskNode : dataNode) {
                 taskNodeMap.put(taskNode.get("id").asText(), taskNode);
             }
-            
-            Assert.assertTrue(taskNodeMap.containsKey(processTask.getId()));
+
+            assertThat(taskNodeMap).containsKey(processTask.getId());
             processTaskNode = taskNodeMap.get(processTask.getId());
-            variablesNode = processTaskNode.get("variables");
-            assertEquals(2, variablesNode.size());
-            Map<String, JsonNode> variableMap = new HashMap<>();
-            for (JsonNode variableResponseNode : variablesNode) {
-                variableMap.put(variableResponseNode.get("name").asText(), variableResponseNode);
-            }
-            
-            variableNode = variableMap.get("localVariable");
-            assertEquals("localVariable", variableNode.get("name").asText());
-            assertEquals("local", variableNode.get("scope").asText());
-            assertEquals("localtest", variableNode.get("value").asText());
-            
-            variableNode = variableMap.get("variable");
-            assertEquals("variable", variableNode.get("name").asText());
-            assertEquals("global", variableNode.get("scope").asText());
-            assertEquals("globaltest", variableNode.get("value").asText());
+            assertThatJson(processTaskNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_ARRAY_ORDER)
+                    .isEqualTo("{"
+                            + "variables: [ {"
+                            + "    name: 'variable',"
+                            + "    value: 'globaltest',"
+                            + "    scope: 'global'"
+                            + "  }, {"
+                            + "    name: 'localVariable',"
+                            + "    value: 'localtest',"
+                            + "    scope: 'local'"
+                            + "  } ]"
+                            + "}");
 
         } finally {
             // Clean adhoc-tasks even if test fails

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCommentResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCommentResourceTest.java
@@ -13,9 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -36,6 +35,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Frederik Heremans
@@ -60,18 +61,19 @@ public class TaskCommentResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertTrue(responseNode.isArray());
-            assertEquals(1, responseNode.size());
-
-            ObjectNode commentNode = (ObjectNode) responseNode.get(0);
-            assertEquals("kermit", commentNode.get("author").textValue());
-            assertEquals("This is a comment...", commentNode.get("message").textValue());
-            assertEquals(comment.getId(), commentNode.get("id").textValue());
-            assertTrue(commentNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), comment.getId())));
-            assertEquals(task.getId(), commentNode.get("taskId").asText());
-            assertTrue(commentNode.get("processInstanceUrl").isNull());
-            assertTrue(commentNode.get("processInstanceId").isNull());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("[ {"
+                            + "id: '" + comment.getId() + "',"
+                            + "author: 'kermit',"
+                            + "message: 'This is a comment...',"
+                            + "taskId: '" + task.getId() + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), comment.getId())
+                            + "',"
+                            + "processInstanceId: null,"
+                            + "processInstanceUrl: null"
+                            + "} ]");
 
             // Test with unexisting task
             httpGet = new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT_COLLECTION, "unexistingtask"));
@@ -102,19 +104,24 @@ public class TaskCommentResourceTest extends BaseSpringRestTestCase {
             httpPost.setEntity(new StringEntity(requestNode.toString()));
             CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
             List<Comment> commentsOnTask = taskService.getTaskComments(task.getId());
-            assertNotNull(commentsOnTask);
-            assertEquals(1, commentsOnTask.size());
+            assertThat(commentsOnTask).isNotNull();
+            assertThat(commentsOnTask).hasSize(1);
 
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("kermit", responseNode.get("author").textValue());
-            assertEquals("This is a comment...", responseNode.get("message").textValue());
-            assertEquals(commentsOnTask.get(0).getId(), responseNode.get("id").textValue());
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), commentsOnTask.get(0).getId())));
-            assertEquals(task.getId(), responseNode.get("taskId").asText());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
-            assertTrue(responseNode.get("processInstanceId").isNull());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id: '" + commentsOnTask.get(0).getId() + "',"
+                            + "author: 'kermit',"
+                            + "message: 'This is a comment...',"
+                            + "taskId: '" + task.getId() + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), commentsOnTask.get(0).getId()) + "',"
+                            + "processInstanceId: null,"
+                            + "processInstanceUrl: null"
+                            + "}");
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -141,20 +148,25 @@ public class TaskCommentResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpPost, HttpStatus.SC_CREATED);
 
         List<Comment> commentsOnTask = taskService.getTaskComments(task.getId());
-        assertNotNull(commentsOnTask);
-        assertEquals(1, commentsOnTask.size());
+        assertThat(commentsOnTask).isNotNull();
+        assertThat(commentsOnTask).hasSize(1);
 
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals(processInstance.getId(), responseNode.get("processInstanceId").asText());
-        assertEquals(task.getId(), responseNode.get("taskId").asText());
-        assertEquals(message, responseNode.get("message").asText());
-        assertNotNull(responseNode.get("time").asText());
-
-        assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), commentsOnTask.get(0).getId())));
-        assertTrue(responseNode.get("processInstanceUrl").textValue()
-                .endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE_COMMENT, processInstance.getId(), commentsOnTask.get(0).getId())));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "message: '" + message + "',"
+                        + "time: '${json-unit.any-string}',"
+                        + "taskId: '" + task.getId() + "',"
+                        + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), commentsOnTask.get(0).getId()) + "',"
+                        + "processInstanceId: '" + processInstance.getId() + "',"
+                        + "processInstanceUrl: '" + SERVER_URL_PREFIX + RestUrls
+                        .createRelativeResourceUrl(RestUrls.URL_HISTORIC_PROCESS_INSTANCE_COMMENT, processInstance.getId(),
+                                commentsOnTask.get(0).getId()) + "'"
+                        + "}");
     }
 
     /**
@@ -175,15 +187,19 @@ public class TaskCommentResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-
-            assertEquals("kermit", responseNode.get("author").textValue());
-            assertEquals("This is a comment...", responseNode.get("message").textValue());
-            assertEquals(comment.getId(), responseNode.get("id").textValue());
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), comment.getId())));
-            assertEquals(task.getId(), responseNode.get("taskId").asText());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
-            assertTrue(responseNode.get("processInstanceId").isNull());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id: '" + comment.getId() + "',"
+                            + "author: 'kermit',"
+                            + "message: 'This is a comment...',"
+                            + "taskId: '" + task.getId() + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), comment.getId())
+                            + "',"
+                            + "processInstanceId: null,"
+                            + "processInstanceUrl: null"
+                            + "}");
 
             // Test with unexisting task
             httpGet = new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, "unexistingtask", "123"));
@@ -256,15 +272,19 @@ public class TaskCommentResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-
-            assertEquals("kermit", responseNode.get("author").textValue());
-            assertEquals("This is a comment...", responseNode.get("message").textValue());
-            assertEquals(comment.getId(), responseNode.get("id").textValue());
-            assertTrue(responseNode.get("taskUrl").textValue().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), comment.getId())));
-            assertEquals(task.getId(), responseNode.get("taskId").asText());
-            assertTrue(responseNode.get("processInstanceUrl").isNull());
-            assertTrue(responseNode.get("processInstanceId").isNull());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "author: 'kermit',"
+                            + "message: 'This is a comment...',"
+                            + "id: '" + comment.getId() + "',"
+                            + "taskId: '" + task.getId() + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_COMMENT, task.getId(), comment.getId()) + "',"
+                            + "processInstanceId: null,"
+                            + "processInstanceUrl: null"
+                            + "}");
 
         } finally {
             // Clean adhoc-tasks even if test fails

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskEventResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskEventResourceTest.java
@@ -13,9 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.List;
@@ -31,6 +30,9 @@ import org.flowable.task.api.Task;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Frederik Heremans
@@ -52,11 +54,11 @@ public class TaskEventResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertTrue(responseNode.isArray());
+            assertThat(responseNode).isNotNull();
+            assertThat(responseNode.isArray()).isTrue();
 
             // 2 events expected: assigned event and involvement event.
-            assertEquals(2, responseNode.size());
+            assertThat(responseNode).hasSize(2);
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -87,13 +89,17 @@ public class TaskEventResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals(event.getId(), responseNode.get("id").textValue());
-            assertEquals(event.getAction(), responseNode.get("action").textValue());
-            assertEquals(event.getUserId(), responseNode.get("userId").textValue());
-            assertTrue(responseNode.get("url").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_EVENT, task.getId(), event.getId())));
-            assertTrue(responseNode.get("taskUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId())));
-            assertEquals(now.getTime(), getDateFromISOString(responseNode.get("time").textValue()));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "id: '" + event.getId() + "',"
+                            + "action: '" + event.getAction() + "',"
+                            + "userId: " + event.getUserId() + ","
+                            + "url: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_EVENT, task.getId(), event.getId()) + "',"
+                            + "taskUrl: '" + SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, task.getId()) + "',"
+                            + "time: " + new TextNode(getISODateStringWithTZ(now.getTime()))
+                            + "}");
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -141,14 +147,14 @@ public class TaskEventResourceTest extends BaseSpringRestTestCase {
             taskService.addUserIdentityLink(task.getId(), "gonzo", "someType");
 
             List<Event> events = taskService.getTaskEvents(task.getId());
-            assertEquals(2, events.size());
+            assertThat(events).hasSize(2);
             for (Event event : events) {
                 HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_EVENT, task.getId(), event.getId()));
                 closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
             }
 
             events = taskService.getTaskEvents(task.getId());
-            assertEquals(0, events.size());
+            assertThat(events).isEmpty();
 
         } finally {
             // Clean adhoc-tasks even if test fails

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskIdentityLinkResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskIdentityLinkResourceTest.java
@@ -108,12 +108,15 @@ public class TaskIdentityLinkResourceTest extends BaseSpringRestTestCase {
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
             assertThat(responseNode).isNotNull();
-            assertThat(responseNode.get("user").textValue()).isEqualTo("kermit");
-            assertThat(responseNode.get("type").textValue()).isEqualTo("myType");
-            assertThat(responseNode.get("group").isNull()).isTrue();
-            assertThat(responseNode.get("url").textValue()
-                    .endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_IDENTITYLINK, task.getId(), RestUrls.SEGMENT_IDENTITYLINKS_FAMILY_USERS,
-                            "kermit", "myType"))).isTrue();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "  url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_IDENTITYLINK, task.getId(), RestUrls.SEGMENT_IDENTITYLINKS_FAMILY_USERS,
+                                    "kermit", "myType") + "',"
+                            + "  user: 'kermit',"
+                            + "  group: null,"
+                            + "  type: 'myType'"
+                            + "}");
 
             // Add group link
             requestNode = objectMapper.createObjectNode();
@@ -125,12 +128,15 @@ public class TaskIdentityLinkResourceTest extends BaseSpringRestTestCase {
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
             assertThat(responseNode).isNotNull();
-            assertThat(responseNode.get("group").textValue()).isEqualTo("sales");
-            assertThat(responseNode.get("type").textValue()).isEqualTo("myType");
-            assertThat(responseNode.get("user").isNull()).isTrue();
-            assertThat(responseNode.get("url").textValue()
-                    .endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_IDENTITYLINK, task.getId(), RestUrls.SEGMENT_IDENTITYLINKS_FAMILY_GROUPS,
-                            "sales", "myType"))).isTrue();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "  url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_IDENTITYLINK, task.getId(), RestUrls.SEGMENT_IDENTITYLINKS_FAMILY_GROUPS,
+                                    "sales", "myType") + "',"
+                            + "  user: null,"
+                            + "  group: 'sales',"
+                            + "  type: 'myType'"
+                            + "}");
 
             // Test with unexisting task
             httpPost = new HttpPost(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_IDENTITYLINKS_COLLECTION, "unexistingtask"));
@@ -185,12 +191,15 @@ public class TaskIdentityLinkResourceTest extends BaseSpringRestTestCase {
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
             assertThat(responseNode).isNotNull();
-            assertThat(responseNode.get("user").textValue()).isEqualTo("kermit");
-            assertThat(responseNode.get("type").textValue()).isEqualTo("myType");
-            assertThat(responseNode.get("group").isNull()).isTrue();
-            assertThat(responseNode.get("url").textValue()
-                    .endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_IDENTITYLINK, task.getId(), RestUrls.SEGMENT_IDENTITYLINKS_FAMILY_USERS,
-                            "kermit", "myType"))).isTrue();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "  url: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_IDENTITYLINK, task.getId(), RestUrls.SEGMENT_IDENTITYLINKS_FAMILY_USERS,
+                                    "kermit", "myType") + "',"
+                            + "  user: 'kermit',"
+                            + "  group: null,"
+                            + "  type: 'myType'"
+                            + "}");
 
             // Test with unexisting task
             httpGet = new HttpGet(SERVER_URL_PREFIX + RestUrls

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskQueryResourceTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,6 +39,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * Test for all REST-operations related to the Task collection resource.
@@ -675,13 +676,13 @@ public class TaskQueryResourceTest extends BaseSpringRestTestCase {
 
         // Check status and size
         JsonNode rootNode = objectMapper.readTree(response.getEntity().getContent());
-        JsonNode dataNode = rootNode.get("data");
-        assertEquals(1, dataNode.size());
-
-        // Check presence of tenantId
-        assertNotNull(dataNode.get(0).get("tenantId"));
-        assertEquals("testTenant", dataNode.get(0).get("tenantId").textValue());
-
+        assertThatJson(rootNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "data: [ {"
+                        + "          tenantId: 'testTenant'"
+                        + "      } ]"
+                        + "}");
         closeResponse(response);
     }
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskResourceTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 import net.javacrumbs.jsonunit.core.Option;
 
@@ -94,10 +95,10 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
                         + "executionUrl: '" + buildUrl(RestUrls.URL_EXECUTION, task.getExecutionId()) + "',"
                         + "processInstanceUrl: '" + buildUrl(RestUrls.URL_PROCESS_INSTANCE, task.getProcessInstanceId()) + "',"
                         + "processDefinitionUrl: '" + buildUrl(RestUrls.URL_PROCESS_DEFINITION, task.getProcessDefinitionId()) + "',"
-                        + "url: '" + url + "'"
+                        + "url: '" + url + "',"
+                        + "dueDate: " + new TextNode(getISODateStringWithTZ(task.getDueDate())) + ","
+                        + "createTime: " + new TextNode(getISODateStringWithTZ(task.getCreateTime()))
                         + "}");
-        assertThat(getDateFromISOString(responseNode.get("dueDate").asText())).isEqualTo(task.getDueDate());
-        assertThat(getDateFromISOString(responseNode.get("createTime").asText())).isEqualTo(task.getCreateTime());
 
         // Set tenant on deployment
         managementService.executeCommand(new ChangeDeploymentTenantIdCmd(deploymentId, "myTenant"));
@@ -154,10 +155,10 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
                             + "processInstanceId: null,"
                             + "processDefinitionId: null,"
                             + "url: '" + url + "',"
-                            + "parentTaskUrl: '" + buildUrl(RestUrls.URL_TASK, parentTask.getId()) + "'"
+                            + "parentTaskUrl: '" + buildUrl(RestUrls.URL_TASK, parentTask.getId()) + "',"
+                            + "dueDate: " + new TextNode(getISODateStringWithTZ(task.getDueDate())) + ","
+                            + "createTime: " + new TextNode(getISODateStringWithTZ(task.getCreateTime()))
                             + "}");
-            assertThat(getDateFromISOString(responseNode.get("dueDate").asText())).isEqualTo(task.getDueDate());
-            assertThat(getDateFromISOString(responseNode.get("createTime").asText())).isEqualTo(task.getCreateTime());
 
         } finally {
 
@@ -649,7 +650,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
             assertThat(task).isNotNull();
             assertThat(task.getAssignee()).isEqualTo("newAssignee");
-            assertThat(taskService.createTaskQuery().taskCandidateUser("newAssignee").count()).isEqualTo(0L);
+            assertThat(taskService.createTaskQuery().taskCandidateUser("newAssignee").count()).isZero();
 
             // Claiming with the same user should not cause an exception
             httpPost.setEntity(new StringEntity(requestNode.toString()));
@@ -657,7 +658,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
             task = taskService.createTaskQuery().taskId(taskId).singleResult();
             assertThat(task).isNotNull();
             assertThat(task.getAssignee()).isEqualTo("newAssignee");
-            assertThat(taskService.createTaskQuery().taskCandidateUser("newAssignee").count()).isEqualTo(0L);
+            assertThat(taskService.createTaskQuery().taskCandidateUser("newAssignee").count()).isZero();
 
             // Claiming with another user should cause exception
             requestNode.put("assignee", "anotherUser");
@@ -691,8 +692,11 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url), HttpStatus.SC_OK);
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        String taskId = ((ArrayNode) dataNode).get(0).get("id").asText();
-        assertThat(taskId).isNotNull();
+        assertThatJson(dataNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("[ {"
+                        + "      id: '${json-unit.any-string}'"
+                        + "} ]");
 
         // Claim
         assertThat(taskService.createTaskQuery().taskAssignee("kermit").count()).isZero();
@@ -700,6 +704,7 @@ public class TaskResourceTest extends BaseSpringRestTestCase {
         requestNode.put("action", "claim");
         requestNode.put("assignee", "kermit");
 
+        String taskId = ((ArrayNode) dataNode).get(0).get("id").asText();
         HttpPost httpPost = new HttpPost(SERVER_URL_PREFIX +
                 RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK, taskId));
         httpPost.setEntity(new StringEntity(requestNode.toString()));

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskVariableResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskVariableResourceTest.java
@@ -13,10 +13,8 @@
 
 package org.flowable.rest.service.api.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -45,6 +43,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * Test for all REST-operations related to a single task variable.
  * 
@@ -64,63 +64,88 @@ public class TaskVariableResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
             taskService.setVariableLocal(task.getId(), "localTaskVariable", "localValue");
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, task.getId(), "localTaskVariable")),
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, task.getId(), "localTaskVariable")),
                     HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("local", responseNode.get("scope").asText());
-            assertEquals("localValue", responseNode.get("value").asText());
-            assertEquals("localTaskVariable", responseNode.get("name").asText());
-            assertEquals("string", responseNode.get("type").asText());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "scope: 'local',"
+                            + "value: 'localValue',"
+                            + "name: 'localTaskVariable',"
+                            + "type: 'string'"
+                            + "}");
 
             // Test variable behaviour for a process-task
-            ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("sharedVariable", (Object) "processValue"));
+            ProcessInstance processInstance = runtimeService
+                    .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("sharedVariable", (Object) "processValue"));
             Task processTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
             taskService.setVariableLocal(processTask.getId(), "sharedVariable", "taskValue");
 
             // ANY scope, local should get precedence
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "sharedVariable")), HttpStatus.SC_OK);
+            response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "sharedVariable")),
+                    HttpStatus.SC_OK);
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("local", responseNode.get("scope").asText());
-            assertEquals("taskValue", responseNode.get("value").asText());
-            assertEquals("sharedVariable", responseNode.get("name").asText());
-            assertEquals("string", responseNode.get("type").asText());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "scope: 'local',"
+                            + "value: 'taskValue',"
+                            + "name: 'sharedVariable',"
+                            + "type: 'string'"
+                            + "}");
 
             // LOCAL scope
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "sharedVariable") + "?scope=local"),
+            response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "sharedVariable") + "?scope=local"),
                     HttpStatus.SC_OK);
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("local", responseNode.get("scope").asText());
-            assertEquals("taskValue", responseNode.get("value").asText());
-            assertEquals("sharedVariable", responseNode.get("name").asText());
-            assertEquals("string", responseNode.get("type").asText());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "scope: 'local',"
+                            + "value: 'taskValue',"
+                            + "name: 'sharedVariable',"
+                            + "type: 'string'"
+                            + "}");
 
             // GLOBAL scope
-            response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "sharedVariable") + "?scope=global"),
+            response = executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "sharedVariable")
+                                    + "?scope=global"),
                     HttpStatus.SC_OK);
             responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("global", responseNode.get("scope").asText());
-            assertEquals("processValue", responseNode.get("value").asText());
-            assertEquals("sharedVariable", responseNode.get("name").asText());
-            assertEquals("string", responseNode.get("type").asText());
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "scope: 'global',"
+                            + "value: 'processValue',"
+                            + "name: 'sharedVariable',"
+                            + "type: 'string'"
+                            + "}");
 
             // Illegal scope
-            closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "sharedVariable") + "?scope=illegal"),
+            closeResponse(executeRequest(new HttpGet(
+                            SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "sharedVariable")
+                                    + "?scope=illegal"),
                     HttpStatus.SC_BAD_REQUEST));
 
             // Unexisting task
-            closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, "unexisting", "sharedVariable")), HttpStatus.SC_NOT_FOUND));
+            closeResponse(executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, "unexisting", "sharedVariable")),
+                    HttpStatus.SC_NOT_FOUND));
 
             // Unexisting variable
-            closeResponse(executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "unexistingVariable")), HttpStatus.SC_NOT_FOUND));
+            closeResponse(executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, processTask.getId(), "unexistingVariable")),
+                    HttpStatus.SC_NOT_FOUND));
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -146,13 +171,14 @@ public class TaskVariableResourceTest extends BaseSpringRestTestCase {
 
             // Force content-type to TEXT_PLAIN to make sure this is ignored and
             // application-octect-stream is always returned
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "localTaskVariable")),
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "localTaskVariable")),
                     HttpStatus.SC_OK);
 
             String actualResponseBytesAsText = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             closeResponse(response);
-            assertEquals("This is a binary piece of text", actualResponseBytesAsText);
-            assertEquals("application/octet-stream", response.getEntity().getContentType().getValue());
+            assertThat(actualResponseBytesAsText).isEqualTo("This is a binary piece of text");
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/octet-stream");
 
         } finally {
             // Clean adhoc-tasks even if test fails
@@ -177,16 +203,16 @@ public class TaskVariableResourceTest extends BaseSpringRestTestCase {
             taskService.saveTask(task);
             taskService.setVariableLocal(task.getId(), "localTaskVariable", originalSerializable);
 
-            CloseableHttpResponse response = executeRequest(new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "localTaskVariable")),
+            CloseableHttpResponse response = executeRequest(
+                    new HttpGet(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "localTaskVariable")),
                     HttpStatus.SC_OK);
 
             // Read the serializable from the stream
             ObjectInputStream stream = new ObjectInputStream(response.getEntity().getContent());
             Object readSerializable = stream.readObject();
-            assertNotNull(readSerializable);
-            assertTrue(readSerializable instanceof TestSerializableVariable);
-            assertEquals("This is some field", ((TestSerializableVariable) readSerializable).getSomeField());
-            assertEquals("application/x-java-serialized-object", response.getEntity().getContentType().getValue());
+            assertThat(readSerializable).isInstanceOf(TestSerializableVariable.class);
+            assertThat(((TestSerializableVariable) readSerializable).getSomeField()).isEqualTo("This is some field");
+            assertThat(response.getEntity().getContentType().getValue()).isEqualTo("application/x-java-serialized-object");
             closeResponse(response);
 
         } finally {
@@ -232,34 +258,37 @@ public class TaskVariableResourceTest extends BaseSpringRestTestCase {
     @Test
     @Deployment
     public void testDeleteTaskVariable() throws Exception {
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("overlappingVariable", (Object) "processValue"));
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.setVariableLocal(task.getId(), "overlappingVariable", "taskValue");
         taskService.setVariableLocal(task.getId(), "anotherTaskVariable", "taskValue");
 
         // Delete variable without scope, local should be presumed -> local
         // removed and global should be retained
-        HttpDelete httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, task.getId(), "overlappingVariable"));
+        HttpDelete httpDelete = new HttpDelete(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, task.getId(), "overlappingVariable"));
         closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
-        assertFalse(taskService.hasVariableLocal(task.getId(), "overlappingVariable"));
-        assertTrue(taskService.hasVariable(task.getId(), "overlappingVariable"));
+        assertThat(taskService.hasVariableLocal(task.getId(), "overlappingVariable")).isFalse();
+        assertThat(taskService.hasVariable(task.getId(), "overlappingVariable")).isTrue();
 
         // Delete local scope variable
-        httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, task.getId(), "anotherTaskVariable") + "?scope=local");
+        httpDelete = new HttpDelete(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, task.getId(), "anotherTaskVariable") + "?scope=local");
         closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
-        assertFalse(taskService.hasVariableLocal(task.getId(), "anotherTaskVariable"));
+        assertThat(taskService.hasVariableLocal(task.getId(), "anotherTaskVariable")).isFalse();
 
         // Delete global scope variable
-        assertTrue(taskService.hasVariable(task.getId(), "overlappingVariable"));
-        httpDelete = new HttpDelete(SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, task.getId(), "overlappingVariable") + "?scope=global");
+        assertThat(taskService.hasVariable(task.getId(), "overlappingVariable")).isTrue();
+        httpDelete = new HttpDelete(
+                SERVER_URL_PREFIX + RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE, task.getId(), "overlappingVariable") + "?scope=global");
         closeResponse(executeRequest(httpDelete, HttpStatus.SC_NO_CONTENT));
 
-        assertFalse(taskService.hasVariable(task.getId(), "overlappingVariable"));
+        assertThat(taskService.hasVariable(task.getId(), "overlappingVariable")).isFalse();
 
-        // Run the same delete again, variable is not there so 404 should be
-        // returned
+        // Run the same delete again, variable is not there so 404 should be returned
         closeResponse(executeRequest(httpDelete, HttpStatus.SC_NOT_FOUND));
     }
 
@@ -287,13 +316,16 @@ public class TaskVariableResourceTest extends BaseSpringRestTestCase {
         CloseableHttpResponse response = executeRequest(httpPut, HttpStatus.SC_OK);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("updatedLocalValue", responseNode.get("value").asText());
-        assertEquals("local", responseNode.get("scope").asText());
-        // Check local value is changed in engine and global one remains
-        // unchanged
-        assertEquals("updatedLocalValue", taskService.getVariableLocal(task.getId(), "overlappingVariable"));
-        assertEquals("processValue", runtimeService.getVariable(task.getExecutionId(), "overlappingVariable"));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "scope: 'local',"
+                        + "value: 'updatedLocalValue'"
+                        + "}");
+        // Check local value is changed in engine and global one remains unchanged
+        assertThat(taskService.getVariableLocal(task.getId(), "overlappingVariable")).isEqualTo("updatedLocalValue");
+        assertThat(runtimeService.getVariable(task.getExecutionId(), "overlappingVariable")).isEqualTo("processValue");
 
         // Update variable in local scope
         requestNode = objectMapper.createObjectNode();
@@ -305,13 +337,16 @@ public class TaskVariableResourceTest extends BaseSpringRestTestCase {
         response = executeRequest(httpPut, HttpStatus.SC_OK);
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("updatedLocalValueOnceAgain", responseNode.get("value").asText());
-        assertEquals("local", responseNode.get("scope").asText());
-        // Check local value is changed in engine and global one remains
-        // unchanged
-        assertEquals("updatedLocalValueOnceAgain", taskService.getVariableLocal(task.getId(), "overlappingVariable"));
-        assertEquals("processValue", runtimeService.getVariable(task.getExecutionId(), "overlappingVariable"));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "scope: 'local',"
+                        + "value: 'updatedLocalValueOnceAgain'"
+                        + "}");
+        // Check local value is changed in engine and global one remains unchanged
+        assertThat(taskService.getVariableLocal(task.getId(), "overlappingVariable")).isEqualTo("updatedLocalValueOnceAgain");
+        assertThat(runtimeService.getVariable(task.getExecutionId(), "overlappingVariable")).isEqualTo("processValue");
 
         // Update variable in global scope
         requestNode = objectMapper.createObjectNode();
@@ -323,13 +358,16 @@ public class TaskVariableResourceTest extends BaseSpringRestTestCase {
         response = executeRequest(httpPut, HttpStatus.SC_OK);
         responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(responseNode);
-        assertEquals("updatedInGlobalScope", responseNode.get("value").asText());
-        assertEquals("global", responseNode.get("scope").asText());
-        // Check global value is changed in engine and local one remains
-        // unchanged
-        assertEquals("updatedLocalValueOnceAgain", taskService.getVariableLocal(task.getId(), "overlappingVariable"));
-        assertEquals("updatedInGlobalScope", runtimeService.getVariable(task.getExecutionId(), "overlappingVariable"));
+        assertThat(responseNode).isNotNull();
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "scope: 'global',"
+                        + "value: 'updatedInGlobalScope'"
+                        + "}");
+        // Check global value is changed in engine and local one remains unchanged
+        assertThat(taskService.getVariableLocal(task.getId(), "overlappingVariable")).isEqualTo("updatedLocalValueOnceAgain");
+        assertThat(runtimeService.getVariable(task.getExecutionId(), "overlappingVariable")).isEqualTo("updatedInGlobalScope");
 
         // Try updating with mismatch between URL and body variableName
         // unexisting property
@@ -368,19 +406,21 @@ public class TaskVariableResourceTest extends BaseSpringRestTestCase {
             CloseableHttpResponse response = executeBinaryRequest(httpPut, HttpStatus.SC_OK);
             JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
             closeResponse(response);
-            assertNotNull(responseNode);
-            assertEquals("binaryVariable", responseNode.get("name").asText());
-            assertTrue(responseNode.get("value").isNull());
-            assertEquals("local", responseNode.get("scope").asText());
-            assertEquals("binary", responseNode.get("type").asText());
-            assertNotNull(responseNode.get("valueUrl"));
-            assertTrue(responseNode.get("valueUrl").asText().endsWith(RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "binaryVariable")));
+            assertThat(responseNode).isNotNull();
+            assertThatJson(responseNode)
+                    .isEqualTo("{"
+                            + "name: 'binaryVariable',"
+                            + "value: null,"
+                            + "scope: 'local',"
+                            + "type: 'binary',"
+                            + "valueUrl: '" + SERVER_URL_PREFIX + RestUrls
+                            .createRelativeResourceUrl(RestUrls.URL_TASK_VARIABLE_DATA, task.getId(), "binaryVariable") + "'"
+                            + "}");
 
             // Check actual value of variable in engine
             Object variableValue = taskService.getVariableLocal(task.getId(), "binaryVariable");
-            assertNotNull(variableValue);
-            assertTrue(variableValue instanceof byte[]);
-            assertEquals("This is binary content", new String((byte[]) variableValue));
+            assertThat(variableValue).isInstanceOf(byte[].class);
+            assertThat(new String((byte[]) variableValue)).isEqualTo("This is binary content");
 
         } finally {
             // Clean adhoc-tasks even if test fails

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskVariablesCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskVariablesCollectionResourceTest.java
@@ -310,7 +310,6 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
 
             // Check actual value of variable in engine
             Object variableValue = taskService.getVariableLocal(task.getId(), "binaryVariable");
-            assertThat(variableValue).isNotNull();
             assertThat(variableValue).isInstanceOf(byte[].class);
             assertThat(new String((byte[]) variableValue)).isEqualTo("This is binary content");
 
@@ -369,7 +368,6 @@ public class TaskVariablesCollectionResourceTest extends BaseSpringRestTestCase 
 
             // Check actual value of variable in engine
             Object variableValue = taskService.getVariableLocal(task.getId(), "serializableVariable");
-            assertThat(variableValue).isNotNull();
             assertThat(variableValue).isInstanceOf(TestSerializableVariable.class);
             assertThat(((TestSerializableVariable) variableValue).getSomeField()).isEqualTo("some value");
         } finally {


### PR DESCRIPTION
The module had a mix of assertion styles.  This is part 6 for this module.
This finishes the `org.flowable.rest.service.api.runtime` package.

