### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.java
@@ -119,8 +119,9 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
             latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("process3").singleResult();
             assertThat(latestProcessDef).isNotNull();
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertThat(links).hasSize(1);
-            assertThat(links.get(0).getUserId()).isEqualTo("user1");
+            assertThat(links)
+                    .extracting(IdentityLink::getUserId)
+                    .containsExactly("user1");
 
             latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("process4").singleResult();
             assertThat(latestProcessDef).isNotNull();
@@ -151,8 +152,9 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
 
             repositoryService.addCandidateStarterGroup(latestProcessDef.getId(), "group1");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertThat(links).hasSize(1);
-            assertThat(links.get(0).getGroupId()).isEqualTo("group1");
+            assertThat(links)
+                    .extracting(IdentityLink::getGroupId)
+                    .containsExactly("group1");
 
             repositoryService.addCandidateStarterUser(latestProcessDef.getId(), "user1");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
@@ -166,8 +168,9 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
 
             repositoryService.deleteCandidateStarterGroup(latestProcessDef.getId(), "group1");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertThat(links).hasSize(1);
-            assertThat(links.get(0).getUserId()).isEqualTo("user1");
+            assertThat(links)
+                    .extracting(IdentityLink::getUserId)
+                    .containsExactly("user1");
 
             repositoryService.deleteCandidateStarterUser(latestProcessDef.getId(), "user1");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.java
@@ -105,31 +105,31 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
 
         try {
             ProcessDefinition latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("process1").singleResult();
-            assertNotNull(latestProcessDef);
+            assertThat(latestProcessDef).isNotNull();
             List<IdentityLink> links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(0, links.size());
+            assertThat(links).isEmpty();
 
             latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("process2").singleResult();
-            assertNotNull(latestProcessDef);
+            assertThat(latestProcessDef).isNotNull();
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(2, links.size());
-            assertTrue(containsUserOrGroup("user1", null, links));
-            assertTrue(containsUserOrGroup("user2", null, links));
+            assertThat(links).hasSize(2);
+            assertThat(containsUserOrGroup("user1", null, links)).isTrue();
+            assertThat(containsUserOrGroup("user2", null, links)).isTrue();
 
             latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("process3").singleResult();
-            assertNotNull(latestProcessDef);
+            assertThat(latestProcessDef).isNotNull();
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(1, links.size());
-            assertEquals("user1", links.get(0).getUserId());
+            assertThat(links).hasSize(1);
+            assertThat(links.get(0).getUserId()).isEqualTo("user1");
 
             latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("process4").singleResult();
-            assertNotNull(latestProcessDef);
+            assertThat(latestProcessDef).isNotNull();
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(4, links.size());
-            assertTrue(containsUserOrGroup("userInGroup2", null, links));
-            assertTrue(containsUserOrGroup(null, "group1", links));
-            assertTrue(containsUserOrGroup(null, "group2", links));
-            assertTrue(containsUserOrGroup(null, "group3", links));
+            assertThat(links).hasSize(4);
+            assertThat(containsUserOrGroup("userInGroup2", null, links)).isTrue();
+            assertThat(containsUserOrGroup(null, "group1", links)).isTrue();
+            assertThat(containsUserOrGroup(null, "group2", links)).isTrue();
+            assertThat(containsUserOrGroup(null, "group3", links)).isTrue();
 
         } finally {
             tearDownUsersAndGroups();
@@ -143,34 +143,35 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
         setUpUsersAndGroups();
 
         try {
-            ProcessDefinition latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarterNoDefinition").singleResult();
-            assertNotNull(latestProcessDef);
+            ProcessDefinition latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarterNoDefinition")
+                    .singleResult();
+            assertThat(latestProcessDef).isNotNull();
             List<IdentityLink> links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(0, links.size());
+            assertThat(links).isEmpty();
 
             repositoryService.addCandidateStarterGroup(latestProcessDef.getId(), "group1");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(1, links.size());
-            assertEquals("group1", links.get(0).getGroupId());
+            assertThat(links).hasSize(1);
+            assertThat(links.get(0).getGroupId()).isEqualTo("group1");
 
             repositoryService.addCandidateStarterUser(latestProcessDef.getId(), "user1");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(2, links.size());
-            assertTrue(containsUserOrGroup(null, "group1", links));
-            assertTrue(containsUserOrGroup("user1", null, links));
+            assertThat(links).hasSize(2);
+            assertThat(containsUserOrGroup(null, "group1", links)).isTrue();
+            assertThat(containsUserOrGroup("user1", null, links)).isTrue();
 
             repositoryService.deleteCandidateStarterGroup(latestProcessDef.getId(), "nonexisting");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(2, links.size());
+            assertThat(links).hasSize(2);
 
             repositoryService.deleteCandidateStarterGroup(latestProcessDef.getId(), "group1");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(1, links.size());
-            assertEquals("user1", links.get(0).getUserId());
+            assertThat(links).hasSize(1);
+            assertThat(links.get(0).getUserId()).isEqualTo("user1");
 
             repositoryService.deleteCandidateStarterUser(latestProcessDef.getId(), "user1");
             links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
-            assertEquals(0, links.size());
+            assertThat(links).isEmpty();
 
         } finally {
             tearDownUsersAndGroups();
@@ -205,7 +206,6 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
             identityService.setAuthenticatedUserId("unauthorizedUser");
             try {
                 runtimeService.startProcessInstanceByKey("potentialStarter");
-
             } catch (Exception e) {
                 fail("No StartAuthorizationException expected, " + e.getClass().getName() + " caught.");
             }
@@ -215,21 +215,24 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
             identityService.setAuthenticatedUserId("user1");
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("potentialStarter");
             assertProcessEnded(processInstance.getId());
-            assertTrue(processInstance.isEnded());
+            assertThat(processInstance.isEnded()).isTrue();
 
             // check extensionElements with : <formalExpression>group2,
             // group(group3), user(user3)</formalExpression>
             ProcessDefinition potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("user1").latestVersion().singleResult();
-            assertNotNull(potentialStarter);
+            assertThat(potentialStarter).isNotNull();
 
-            potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("user3").latestVersion().singleResult();
-            assertNotNull(potentialStarter);
+            potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("user3")
+                    .latestVersion().singleResult();
+            assertThat(potentialStarter).isNotNull();
 
-            potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("userInGroup2").latestVersion().singleResult();
-            assertNotNull(potentialStarter);
+            potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("userInGroup2")
+                    .latestVersion().singleResult();
+            assertThat(potentialStarter).isNotNull();
 
-            potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("userInGroup3").latestVersion().singleResult();
-            assertNotNull(potentialStarter);
+            potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("userInGroup3")
+                    .latestVersion().singleResult();
+            assertThat(potentialStarter).isNotNull();
         } finally {
 
             tearDownUsersAndGroups();
@@ -246,9 +249,9 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
 
         identityService.setAuthenticatedUserId("someOneFromMars");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("potentialStarterNoDefinition");
-        assertNotNull(processInstance.getId());
+        assertThat(processInstance.getId()).isNotNull();
         assertProcessEnded(processInstance.getId());
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
 
     // this test checks the list without user constraint

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/ExpressionServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/ExpressionServiceTaskTest.java
@@ -39,7 +39,7 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
         Map<String, Object> variables = new HashMap<>();
         variables.put("bean", new ValueBean("ok"));
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariables", variables);
-        assertEquals("ok", runtimeService.getVariable(pi.getId(), "result"));
+        assertThat(runtimeService.getVariable(pi.getId(), "result")).isEqualTo("ok");
     }
 
     @Test
@@ -50,29 +50,30 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
         variables.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", true);
         variables.put("skip", false);
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables);
-        assertEquals("ok", runtimeService.getVariable(pi.getId(), "result"));
+        assertThat(runtimeService.getVariable(pi.getId(), "result")).isEqualTo("ok");
 
         Map<String, Object> variables2 = new HashMap<>();
         variables2.put("bean", new ValueBean("ok"));
         variables2.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", true);
         variables2.put("skip", true);
         ProcessInstance pi2 = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables2);
-        assertNull(runtimeService.getVariable(pi2.getId(), "result"));
-        
+        assertThat(runtimeService.getVariable(pi2.getId(), "result")).isNull();
+
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricActivityInstance skipActivityInstance = historyService.createHistoricActivityInstanceQuery().processInstanceId(pi2.getId())
                     .activityId("valueExpressionServiceWithResultVariableNameSet")
                     .singleResult();
-            assertActivityInstancesAreSame(skipActivityInstance, runtimeService.createActivityInstanceQuery().activityInstanceId(skipActivityInstance .getId()).singleResult());
+            assertActivityInstancesAreSame(skipActivityInstance,
+                    runtimeService.createActivityInstanceQuery().activityInstanceId(skipActivityInstance.getId()).singleResult());
 
-            assertNotNull(skipActivityInstance);
+            assertThat(skipActivityInstance).isNotNull();
         }
 
         Map<String, Object> variables3 = new HashMap<>();
         variables3.put("bean", new ValueBean("okBean"));
         variables3.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", false);
         ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables3);
-        assertEquals("okBean", runtimeService.getVariable(pi3.getId(), "result"));
+        assertThat(runtimeService.getVariable(pi3.getId(), "result")).isEqualTo("okBean");
     }
 
     @Test
@@ -81,7 +82,7 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
         Map<String, Object> variables = new HashMap<>();
         variables.put("var", "---");
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("BackwardsCompatibleExpressionProcess", variables);
-        assertEquals("...---...", runtimeService.getVariable(pi.getId(), "result"));
+        assertThat(runtimeService.getVariable(pi.getId(), "result")).isEqualTo("...---...");
     }
 
     @Test
@@ -93,14 +94,14 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setServiceResultToWithParallelMultiInstance", variables);
 
-        assertEquals("NOT_OK", runtimeService.getVariable(pi.getId(), "subProcessVar"));
+        assertThat(runtimeService.getVariable(pi.getId(), "subProcessVar")).isEqualTo("NOT_OK");
 
         List<Task> tasks = taskService.createTaskQuery()
-            .processInstanceId(pi.getProcessInstanceId())
-            .list();
-
-        assertThat(tasks.size()).isEqualTo(1);
-        assertThat(tasks.get(0).getTaskDefinitionKey()).isEqualTo("processWaitState");
+                .processInstanceId(pi.getProcessInstanceId())
+                .list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("processWaitState");
     }
 
     @Test
@@ -112,14 +113,16 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setServiceLocalScopedResultWithParallelMultiInstance", variables);
 
-        assertNull("subProcessVar should not be on process instance scope", runtimeService.getVariable(pi.getId(), "subProcessVar"));
+        assertThat(runtimeService.getVariable(pi.getId(), "subProcessVar"))
+                .as("subProcessVar should not be on process instance scope")
+                .isNull();
 
         List<Task> tasks = taskService.createTaskQuery()
-            .processInstanceId(pi.getProcessInstanceId())
-            .list();
-
-        assertThat(tasks.size()).isEqualTo(1);
-        assertThat(tasks.get(0).getTaskDefinitionKey()).isEqualTo("subProcessWaitState");
+                .processInstanceId(pi.getProcessInstanceId())
+                .list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("subProcessWaitState");
     }
 
     @Test
@@ -128,6 +131,6 @@ public class ExpressionServiceTaskTest extends PluggableFlowableTestCase {
         Map<String, Object> variables = new HashMap<>();
         variables.put("bean", new TestVarargsBean());
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("testVarargsInExpression", variables);
-        assertEquals("ABC", runtimeService.getVariable(pi.getId(), "result"));
+        assertThat(runtimeService.getVariable(pi.getId(), "result")).isEqualTo("ABC");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
@@ -33,8 +33,8 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     public void testTaskCreateListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Schedule meeting", task.getName());
-        assertEquals("TaskCreateListener is listening!", task.getDescription());
+        assertThat(task.getName()).isEqualTo("Schedule meeting");
+        assertThat(task.getDescription()).isEqualTo("TaskCreateListener is listening!");
 
         // Manually cleanup the process instance. If we don't do this, the
         // following actions will occur:
@@ -53,8 +53,8 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     public void testTaskCreateListenerInSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerInSubProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Schedule meeting", task.getName());
-        assertEquals("TaskCreateListener is listening!", task.getDescription());
+        assertThat(task.getName()).isEqualTo("Schedule meeting");
+        assertThat(task.getDescription()).isEqualTo("TaskCreateListener is listening!");
 
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
     }
@@ -64,12 +64,12 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     public void testTaskAssignmentListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("TaskCreateListener is listening!", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("TaskCreateListener is listening!");
 
         // Set assignee and check if event is received
         taskService.setAssignee(task.getId(), "kermit");
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("TaskAssignmentListener is listening: kermit", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("TaskAssignmentListener is listening: kermit");
 
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
         
@@ -84,41 +84,41 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     public void testTaskAssignmentListenerNotCalledWhenAssigneeNotUpdated() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("TaskCreateListener is listening!", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("TaskCreateListener is listening!");
 
         // Set assignee and check if event is received
         taskService.setAssignee(task.getId(), "kermit");
         task = taskService.createTaskQuery().singleResult();
 
-        assertEquals("TaskAssignmentListener is listening: kermit", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("TaskAssignmentListener is listening: kermit");
 
         // Reset description and assign to same person. This should NOT trigger an assignment
         task.setDescription("Clear");
         taskService.saveTask(task);
         taskService.setAssignee(task.getId(), "kermit");
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Clear", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("Clear");
 
         // Set assignee through task-update
         task.setAssignee("kermit");
         taskService.saveTask(task);
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Clear", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("Clear");
 
         // Update another property should not trigger assignment
         task.setName("test");
         taskService.saveTask(task);
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Clear", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("Clear");
 
         // Update to different
         task.setAssignee("john");
         taskService.saveTask(task);
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("TaskAssignmentListener is listening: john", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("TaskAssignmentListener is listening: john");
 
         // Manually cleanup the process instance.
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
@@ -135,22 +135,22 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         // Set assignee and check if event is received
         taskService.claim(task.getId(), "kermit");
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("TaskAssignmentListener is listening: kermit", task.getDescription());
-        
+        assertThat(task.getDescription()).isEqualTo("TaskAssignmentListener is listening: kermit");
+
         taskService.unclaim(task.getId());
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("TaskAssignmentListener is listening: null", task.getDescription());
-        
+        assertThat(task.getDescription()).isEqualTo("TaskAssignmentListener is listening: null");
+
         taskService.setAssignee(task.getId(), "kermit");
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("TaskAssignmentListener is listening: kermit", task.getDescription());
-        
+        assertThat(task.getDescription()).isEqualTo("TaskAssignmentListener is listening: kermit");
+
         taskService.setAssignee(task.getId(), null);
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("TaskAssignmentListener is listening: null", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("TaskAssignmentListener is listening: null");
 
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
-        
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
@@ -165,8 +165,8 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
 
-        assertEquals("Hello from The Process", runtimeService.getVariable(processInstance.getId(), "greeting"));
-        assertEquals("Act", runtimeService.getVariable(processInstance.getId(), "shortName"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "greeting")).isEqualTo("Hello from The Process");
+        assertThat(runtimeService.getVariable(processInstance.getId(), "shortName")).isEqualTo("Act");
     }
 
     @Test
@@ -179,7 +179,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
 
-        assertEquals("Write meeting notes", runtimeService.getVariable(processInstance.getId(), "greeting2"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "greeting2")).isEqualTo("Write meeting notes");
     }
 
     @Test
@@ -194,8 +194,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         // Verify the all-listener has received all events
         String eventsReceived = (String) runtimeService.getVariable(task.getProcessInstanceId(), "events");
-        assertEquals("create - assignment - complete - delete", eventsReceived);
-        
+        assertThat(eventsReceived).isEqualTo("create - assignment - complete - delete");
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
     }
 
@@ -206,27 +205,27 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("executionListenersOnDelete");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(1);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("User Task 1").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
-        assertEquals(0, TaskDeleteListener.getCurrentMessages().size());
-        assertEquals(0, TaskSimpleCompleteListener.getCurrentMessages().size());
+        assertThat(TaskDeleteListener.getCurrentMessages()).isEmpty();
+        assertThat(TaskSimpleCompleteListener.getCurrentMessages()).isEmpty();
 
         taskService.complete(task.getId());
 
         tasks = taskService.createTaskQuery().list();
 
-        assertNotNull(tasks);
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).isEmpty();
 
-        assertEquals(1, TaskDeleteListener.getCurrentMessages().size());
-        assertEquals("Delete Task Listener executed.", TaskDeleteListener.getCurrentMessages().get(0));
+        assertThat(TaskDeleteListener.getCurrentMessages())
+                .containsOnly("Delete Task Listener executed.");
 
-        assertEquals(1, TaskSimpleCompleteListener.getCurrentMessages().size());
-        assertEquals("Complete Task Listener executed.", TaskSimpleCompleteListener.getCurrentMessages().get(0));
+        assertThat(TaskSimpleCompleteListener.getCurrentMessages())
+                .containsOnly("Complete Task Listener executed.");
     }
 
     @Test
@@ -236,26 +235,26 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersOnDelete");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).hasSize(1);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("User Task 1").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
-        assertEquals(0, TaskDeleteListener.getCurrentMessages().size());
-        assertEquals(0, TaskSimpleCompleteListener.getCurrentMessages().size());
+        assertThat(TaskDeleteListener.getCurrentMessages()).isEmpty();
+        assertThat(TaskSimpleCompleteListener.getCurrentMessages()).isEmpty();
 
         runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), "");
 
         tasks = taskService.createTaskQuery().list();
 
-        assertNotNull(tasks);
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks).isEmpty();
 
-        assertEquals(1, TaskDeleteListener.getCurrentMessages().size());
-        assertEquals("Delete Task Listener executed.", TaskDeleteListener.getCurrentMessages().get(0));
+        assertThat(TaskDeleteListener.getCurrentMessages())
+                .containsOnly("Delete Task Listener executed.");
 
-        assertEquals(0, TaskSimpleCompleteListener.getCurrentMessages().size());
+        assertThat(TaskSimpleCompleteListener.getCurrentMessages()).isEmpty();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -189,12 +189,10 @@ public class VariablesTest extends PluggableFlowableTestCase {
         // Try setting the value of the variable that was initially created with value 'null'
         runtimeService.setVariable(processInstance.getId(), "nullVar", "a value");
         Object newValue = runtimeService.getVariable(processInstance.getId(), "nullVar");
-        assertThat(newValue).isNotNull();
         assertThat(newValue).isEqualTo("a value");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
-
     }
 
     @Test
@@ -207,7 +205,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         Map<String, VariableInstance> variableInstances = runtimeService.getVariableInstances(processInstance.getId());
         assertThat(variableInstances.get("stringVar"))
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "coca-cola");
 
         List<String> variableNames = new ArrayList<>();
@@ -216,25 +214,25 @@ public class VariablesTest extends PluggableFlowableTestCase {
         // getVariablesInstances via names
         variableInstances = runtimeService.getVariableInstances(processInstance.getId(), variableNames);
         assertThat(variableInstances.get("stringVar"))
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "coca-cola");
 
         // getVariableInstancesLocal via names
         variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), variableNames);
         assertThat(variableInstances.get("stringVar"))
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "coca-cola");
 
         // getVariableInstance
         VariableInstance variableInstance = runtimeService.getVariableInstance(processInstance.getId(), "stringVar");
         assertThat(variableInstance)
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "coca-cola");
 
         // getVariableInstanceLocal
         variableInstance = runtimeService.getVariableInstanceLocal(processInstance.getId(), "stringVar");
         assertThat(variableInstance)
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "coca-cola");
 
         // Verify TaskService behavior
@@ -243,10 +241,10 @@ public class VariablesTest extends PluggableFlowableTestCase {
         variableInstances = taskService.getVariableInstances(task.getId());
         assertThat(variableInstances).hasSize(2);
         assertThat(variableInstances.get("stringVar"))
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "coca-cola");
         assertThat(variableInstances.get("intVar"))
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("intVar", null);
 
         variableNames = new ArrayList<>();
@@ -255,7 +253,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         // getVariablesInstances via names
         variableInstances = taskService.getVariableInstances(task.getId(), variableNames);
         assertThat(variableInstances.get("stringVar"))
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "coca-cola");
 
         taskService.setVariableLocal(task.getId(), "stringVar", "pepsi-cola");
@@ -263,19 +261,19 @@ public class VariablesTest extends PluggableFlowableTestCase {
         // getVariableInstancesLocal via names
         variableInstances = taskService.getVariableInstancesLocal(task.getId(), variableNames);
         assertThat(variableInstances.get("stringVar"))
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "pepsi-cola");
 
         // getVariableInstance
         variableInstance = taskService.getVariableInstance(task.getId(), "stringVar");
         assertThat(variableInstance)
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "pepsi-cola");
 
         // getVariableInstanceLocal
         variableInstance = taskService.getVariableInstanceLocal(task.getId(), "stringVar");
         assertThat(variableInstance)
-                .extracting("name", "value")
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
                 .containsExactly("stringVar", "pepsi-cola");
     }
 
@@ -307,58 +305,82 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         Map<String, DataObject> dataObjects = runtimeService.getDataObjects(processInstance.getId(), "es", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        DataObject dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "it", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObjects
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-US", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-AU", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-GB", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-GB", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         List<String> variableNames = new ArrayList<>();
         variableNames.add("stringVar");
@@ -366,936 +388,1233 @@ public class VariablesTest extends PluggableFlowableTestCase {
         // getDataObjects via names
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "es", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "it", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-US", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-AU", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-GB", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-GB", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObjectsLocal
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "es", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "it", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-US", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-AU", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-GB", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-GB", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "ja-JA", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObjectsLocal via names
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "es", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "it", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-US", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-AU", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-GB", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-GB", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObject
-        DataObject dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "es", false);
+        dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "es", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "it", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-US", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-AU", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", true);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObjectLocal
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "es", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "it", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-US", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-AU", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-GB", true);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-GB", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         Execution subprocess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subprocess1").singleResult();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "es", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
-                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObjects
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "es", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'es' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'es' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "it", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'it' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'it' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-US", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-US' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-US' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-AU", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-AU' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-AU' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-GB", true);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-GB", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         // getDataObjects via names (from subprocess)
 
         variableNames.add("intVar");
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "es", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'es' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'es' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "it", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'it' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'it' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-US", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-US' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-US' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-AU", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-AU' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-AU' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-GB", true);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-GB", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getValue()).isNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         // getDataObjectsLocal
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "es", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "it", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-US", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-AU", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-GB", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-GB", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "ja-JA", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObjectsLocal via names
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "es", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "it", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-US", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-AU", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-GB", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-GB", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObject (in subprocess)
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "es", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "it", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-US", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-AU", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", true);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObjectLocal (in subprocess)
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "es", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "it", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-US", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-AU", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-GB", true);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-GB", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey,
-                        DataObject::getType)
-                .containsExactly("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int");
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getValue()).isNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // Verify TaskService behavior
         dataObjects = taskService.getDataObjects(task.getId());
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         // getDataObjects
         dataObjects = taskService.getDataObjects(task.getId());
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = taskService.getDataObjects(task.getId(), "es", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'es' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'es' Name");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = taskService.getDataObjects(task.getId(), "it", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'it' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'it' Name");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-US", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-US' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-US' Name");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-AU", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-AU' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-AU' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-GB", true);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'en' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en' Name");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-GB", false);
         assertThat(dataObjects).hasSize(2);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("intVar"))
-                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
-                        DataObject::getId)
-                .contains("intVar", "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
-                        processInstance.getId());
-        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
-        assertThat(dataObjects.get("intVar").getId()).isNotNull();
+        dataObject = dataObjects.get("intVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
+        assertThat(dataObject.getId()).isNotNull();
+        assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
+        assertThat(dataObject.getName()).isEqualTo("intVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("int");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         variableNames = new ArrayList<>();
         variableNames.add("stringVar");
@@ -1303,146 +1622,187 @@ public class VariablesTest extends PluggableFlowableTestCase {
         // getDataObjects via names
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "es", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "it", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-US", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-AU", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-GB", true);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-GB", false);
         assertThat(dataObjects).hasSize(1);
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
-                        processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         // getDataObject
         dataObject = taskService.getDataObject(task.getId(), "stringVar");
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
-                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "es", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'es' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'es' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "it", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'it' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'it' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
-                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-US", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-US' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-US' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-AU", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en-AU' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en-AU' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", true);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
-                .containsExactly("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar 'en' Name");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'en' Description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", false);
         assertThat(dataObject).isNotNull();
-        assertThat(dataObject)
-                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
-                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
-                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string");
-        assertThat(dataObjects.get("stringVar"))
-                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
-                .contains(processInstance.getId(), processInstance.getId())
-                .doesNotContainNull();
+        assertThat(dataObject.getName()).isEqualTo("stringVar");
+        assertThat(dataObject.getValue()).isEqualTo("coca-cola");
+        assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
+        assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
+        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
+        assertThat(dataObject.getType()).isEqualTo("string");
+        dataObject = dataObjects.get("stringVar");
+        assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getExecutionId()).isEqualTo(processInstance.getId());
+        assertThat(dataObject.getId()).isNotNull();
     }
 
     // Test case for ACT-1839

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -13,6 +13,9 @@
 package org.flowable.examples.variables;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +27,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.UUID;
 
+import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -96,18 +100,20 @@ public class VariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskAssigneeProcess", variables);
 
         variables = runtimeService.getVariables(processInstance.getId());
-        assertEquals(928374L, variables.get("longVar"));
-        assertEquals((short) 123, variables.get("shortVar"));
-        assertEquals(1234, variables.get("integerVar"));
-        assertEquals("coca-cola", variables.get("stringVar"));
-        assertEquals(long2000StringBuilder.toString(), variables.get("longString2000chars"));
-        assertEquals(now, variables.get("dateVar"));
-        assertNull(variables.get("nullVar"));
-        assertEquals(serializable, variables.get("serializableVar"));
-        assertTrue(Arrays.equals(bytes1, (byte[]) variables.get("bytesVar")));
-        assertEquals(new CustomType(bytes2), variables.get("customVar1"));
-        assertNull(variables.get("customVar2"));
-        assertEquals(11, variables.size());
+        assertThat(variables)
+                .containsOnly(
+                        entry("longVar", 928374L),
+                        entry("shortVar", (short) 123),
+                        entry("integerVar", 1234),
+                        entry("stringVar", "coca-cola"),
+                        entry("longString2000chars", long2000StringBuilder.toString()),
+                        entry("dateVar", now),
+                        entry("nullVar", null),
+                        entry("serializableVar", serializable),
+                        entry("bytesVar", bytes1),
+                        entry("customVar1", new CustomType(bytes2)),
+                        entry("customVar2", null)
+                );
 
         // Set all existing variables values to null
         runtimeService.setVariable(processInstance.getId(), "longVar", null);
@@ -124,19 +130,21 @@ public class VariablesTest extends PluggableFlowableTestCase {
         runtimeService.setVariable(processInstance.getId(), "customVar2", null);
 
         variables = runtimeService.getVariables(processInstance.getId());
-        assertNull(variables.get("longVar"));
-        assertNull(variables.get("shortVar"));
-        assertNull(variables.get("integerVar"));
-        assertNull(variables.get("stringVar"));
-        assertNull(variables.get("longString2000chars"));
-        assertNull(variables.get("longString4000chars"));
-        assertNull(variables.get("dateVar"));
-        assertNull(variables.get("nullVar"));
-        assertNull(variables.get("serializableVar"));
-        assertNull(variables.get("bytesVar"));
-        assertNull(variables.get("customVar1"));
-        assertNull(variables.get("customVar2"));
-        assertEquals(12, variables.size());
+        assertThat(variables)
+                .containsOnly(
+                        entry("longVar", null),
+                        entry("shortVar", null),
+                        entry("integerVar", null),
+                        entry("stringVar", null),
+                        entry("longString2000chars", null),
+                        entry("longString4000chars", null),
+                        entry("dateVar", null),
+                        entry("nullVar", null),
+                        entry("serializableVar", null),
+                        entry("bytesVar", null),
+                        entry("customVar1", null),
+                        entry("customVar2", null)
+                );
 
         // Update existing variable values again, and add a new variable
         runtimeService.setVariable(processInstance.getId(), "new var", "hi");
@@ -153,35 +161,36 @@ public class VariablesTest extends PluggableFlowableTestCase {
         runtimeService.setVariable(processInstance.getId(), "customVar2", new CustomType(bytes1));
 
         variables = runtimeService.getVariables(processInstance.getId());
-        assertEquals("hi", variables.get("new var"));
-        assertEquals(9987L, variables.get("longVar"));
-        assertEquals((short) 456, variables.get("shortVar"));
-        assertEquals(4567, variables.get("integerVar"));
-        assertEquals("colgate", variables.get("stringVar"));
-        assertEquals(long2001StringBuilder.toString(), variables.get("longString2000chars"));
-        assertEquals(long4001StringBuilder.toString(), variables.get("longString4000chars"));
-        assertEquals(now, variables.get("dateVar"));
-        assertNull(variables.get("nullVar"));
-        assertEquals(serializable, variables.get("serializableVar"));
-        assertTrue(Arrays.equals(bytes1, (byte[]) variables.get("bytesVar")));
-        assertEquals(new CustomType(bytes2), variables.get("customVar1"));
-        assertEquals(new CustomType(bytes1), variables.get("customVar2"));
-        assertEquals(13, variables.size());
+        assertThat(variables)
+                .containsOnly(
+                        entry("new var", "hi"),
+                        entry("longVar", 9987L),
+                        entry("shortVar", (short) 456),
+                        entry("integerVar", 4567),
+                        entry("stringVar", "colgate"),
+                        entry("longString2000chars", long2001StringBuilder.toString()),
+                        entry("longString4000chars", long4001StringBuilder.toString()),
+                        entry("dateVar", now),
+                        entry("nullVar", null),
+                        entry("serializableVar", serializable),
+                        entry("bytesVar", bytes1),
+                        entry("customVar1", new CustomType(bytes2)),
+                        entry("customVar2", new CustomType(bytes1))
+                );
 
         Collection<String> varFilter = new ArrayList<>(2);
         varFilter.add("stringVar");
         varFilter.add("integerVar");
 
         Map<String, Object> filteredVariables = runtimeService.getVariables(processInstance.getId(), varFilter);
-        assertEquals(2, filteredVariables.size());
-        assertTrue(filteredVariables.containsKey("stringVar"));
-        assertTrue(filteredVariables.containsKey("integerVar"));
+        assertThat(filteredVariables)
+                .containsOnlyKeys("stringVar", "integerVar");
 
         // Try setting the value of the variable that was initially created with value 'null'
         runtimeService.setVariable(processInstance.getId(), "nullVar", "a value");
         Object newValue = runtimeService.getVariable(processInstance.getId(), "nullVar");
-        assertNotNull(newValue);
-        assertEquals("a value", newValue);
+        assertThat(newValue).isNotNull();
+        assertThat(newValue).isEqualTo("a value");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
@@ -197,75 +206,77 @@ public class VariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("localizeVariables", variables);
 
         Map<String, VariableInstance> variableInstances = runtimeService.getVariableInstances(processInstance.getId());
-        assertEquals(1, variableInstances.size());
-        assertEquals("stringVar", variableInstances.get("stringVar").getName());
-        assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+        assertThat(variableInstances.get("stringVar"))
+                .extracting("name", "value")
+                .containsExactly("stringVar", "coca-cola");
 
         List<String> variableNames = new ArrayList<>();
         variableNames.add("stringVar");
 
         // getVariablesInstances via names
         variableInstances = runtimeService.getVariableInstances(processInstance.getId(), variableNames);
-        assertEquals(1, variableInstances.size());
-        assertEquals("stringVar", variableInstances.get("stringVar").getName());
-        assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+        assertThat(variableInstances.get("stringVar"))
+                .extracting("name", "value")
+                .containsExactly("stringVar", "coca-cola");
 
         // getVariableInstancesLocal via names
         variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), variableNames);
-        assertEquals(1, variableInstances.size());
-        assertEquals("stringVar", variableInstances.get("stringVar").getName());
-        assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+        assertThat(variableInstances.get("stringVar"))
+                .extracting("name", "value")
+                .containsExactly("stringVar", "coca-cola");
 
         // getVariableInstance
         VariableInstance variableInstance = runtimeService.getVariableInstance(processInstance.getId(), "stringVar");
-        assertNotNull(variableInstance);
-        assertEquals("stringVar", variableInstance.getName());
-        assertEquals("coca-cola", variableInstance.getValue());
+        assertThat(variableInstance)
+                .extracting("name", "value")
+                .containsExactly("stringVar", "coca-cola");
 
         // getVariableInstanceLocal
         variableInstance = runtimeService.getVariableInstanceLocal(processInstance.getId(), "stringVar");
-        assertNotNull(variableInstance);
-        assertEquals("stringVar", variableInstance.getName());
-        assertEquals("coca-cola", variableInstance.getValue());
+        assertThat(variableInstance)
+                .extracting("name", "value")
+                .containsExactly("stringVar", "coca-cola");
 
         // Verify TaskService behavior
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         variableInstances = taskService.getVariableInstances(task.getId());
-        assertEquals(2, variableInstances.size());
-        assertEquals("stringVar", variableInstances.get("stringVar").getName());
-        assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
-        assertEquals("intVar", variableInstances.get("intVar").getName());
-        assertNull(variableInstances.get("intVar").getValue());
+        assertThat(variableInstances).hasSize(2);
+        assertThat(variableInstances.get("stringVar"))
+                .extracting("name", "value")
+                .containsExactly("stringVar", "coca-cola");
+        assertThat(variableInstances.get("intVar"))
+                .extracting("name", "value")
+                .containsExactly("intVar", null);
 
         variableNames = new ArrayList<>();
         variableNames.add("stringVar");
 
         // getVariablesInstances via names
         variableInstances = taskService.getVariableInstances(task.getId(), variableNames);
-        assertEquals(1, variableInstances.size());
-        assertEquals("stringVar", variableInstances.get("stringVar").getName());
-        assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+        assertThat(variableInstances.get("stringVar"))
+                .extracting("name", "value")
+                .containsExactly("stringVar", "coca-cola");
 
         taskService.setVariableLocal(task.getId(), "stringVar", "pepsi-cola");
 
         // getVariableInstancesLocal via names
         variableInstances = taskService.getVariableInstancesLocal(task.getId(), variableNames);
-        assertEquals(1, variableInstances.size());
-        assertEquals("stringVar", variableInstances.get("stringVar").getName());
-        assertEquals("pepsi-cola", variableInstances.get("stringVar").getValue());
+        assertThat(variableInstances.get("stringVar"))
+                .extracting("name", "value")
+                .containsExactly("stringVar", "pepsi-cola");
 
         // getVariableInstance
         variableInstance = taskService.getVariableInstance(task.getId(), "stringVar");
-        assertNotNull(variableInstance);
-        assertEquals("stringVar", variableInstance.getName());
-        assertEquals("pepsi-cola", variableInstance.getValue());
+        assertThat(variableInstance)
+                .extracting("name", "value")
+                .containsExactly("stringVar", "pepsi-cola");
 
         // getVariableInstanceLocal
         variableInstance = taskService.getVariableInstanceLocal(task.getId(), "stringVar");
-        assertNotNull(variableInstance);
-        assertEquals("stringVar", variableInstance.getName());
-        assertEquals("pepsi-cola", variableInstance.getValue());
+        assertThat(variableInstance)
+                .extracting("name", "value")
+                .containsExactly("stringVar", "pepsi-cola");
     }
 
     @Test
@@ -295,1392 +306,1143 @@ public class VariablesTest extends PluggableFlowableTestCase {
         dynamicBpmnService.saveProcessDefinitionInfo(processInstance.getProcessDefinitionId(), infoNode);
 
         Map<String, DataObject> dataObjects = runtimeService.getDataObjects(processInstance.getId(), "es", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "it", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'it' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // getDataObjects
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-US", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-US' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-AU", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-GB", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), "en-GB", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         List<String> variableNames = new ArrayList<>();
         variableNames.add("stringVar");
 
         // getDataObjects via names
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "es", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "it", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'it' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-US", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-US' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-AU", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-GB", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjects(processInstance.getId(), variableNames, "en-GB", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // getDataObjectsLocal
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "es", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "it", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'it' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-US", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-US' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-AU", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-GB", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "en-GB", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), "ja-JA", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // getDataObjectsLocal via names
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "es", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "it", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'it' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-US", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-US' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-AU", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-GB", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(processInstance.getId(), variableNames, "en-GB", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // getDataObject
         DataObject dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "es", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'es' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "it", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'it' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar", dataObject.getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-US", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en-US' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-AU", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", true);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(processInstance.getId(), "stringVar", "en-GB", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar", dataObject.getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // getDataObjectLocal
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "es", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'es' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "it", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'it' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-US", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en-US' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-AU", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-GB", true);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(processInstance.getId(), "stringVar", "en-GB", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar", dataObject.getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         Execution subprocess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subprocess1").singleResult();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "es", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription)
+                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVarId", "string", processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // getDataObjects
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "es", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'es' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'es' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "it", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'it' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'it' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'it' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-US", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-US' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en-US' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-US' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-AU", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en-AU' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-AU' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-GB", true);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), "en-GB", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'default' description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         // getDataObjects via names (from subprocess)
 
         variableNames.add("intVar");
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "es", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'es' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'es' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "it", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'it' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'it' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'it' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-US", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-US' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en-US' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-US' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-AU", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en-AU' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-AU' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-GB", true);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subprocess.getId(), variableNames, "en-GB", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'default' description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         // getDataObjectsLocal
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "es", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'es' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'es' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "it", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'it' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'it' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-US", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en-US' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-US' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-AU", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en-AU' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-AU' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-GB", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "en-GB", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'default' description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), "ja-JA", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'default' description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         // getDataObjectsLocal via names
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "es", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'es' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'es' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "it", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'it' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'it' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-US", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en-US' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-US' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-AU", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en-AU' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-AU' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-GB", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar 'en' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = runtimeService.getDataObjectsLocal(subprocess.getId(), variableNames, "en-GB", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertNull(dataObjects.get("intVar").getValue());
-        assertEquals("intVar", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'default' description", dataObjects.get("intVar").getDescription());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         // getDataObject (in subprocess)
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "es", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'es' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'es' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "it", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'it' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'it' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar", dataObject.getLocalizedName());
-        assertEquals("intVar 'default' description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-US", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'en-US' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'en-US' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-AU", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'en-AU' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'en-AU' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", true);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'en' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'en' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObject(subprocess.getId(), "intVar", "en-GB", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar", dataObject.getLocalizedName());
-        assertEquals("intVar 'default' description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // getDataObjectLocal (in subprocess)
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "es", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'es' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'es' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "it", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'it' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'it' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-US", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'en-US' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'en-US' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-AU", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'en-AU' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'en-AU' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-GB", true);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar 'en' Name", dataObject.getLocalizedName());
-        assertEquals("intVar 'en' Description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = runtimeService.getDataObjectLocal(subprocess.getId(), "intVar", "en-GB", false);
-        assertNotNull(dataObject);
-        assertEquals("intVar", dataObject.getName());
-        assertNull(dataObject.getValue());
-        assertEquals("intVar", dataObject.getLocalizedName());
-        assertEquals("intVar 'default' description", dataObject.getDescription());
-        assertEquals("intVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("int", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey,
+                        DataObject::getType)
+                .containsExactly("intVar", null, "intVar", "intVar 'default' description", "intVarId", "int");
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // Verify TaskService behavior
         dataObjects = taskService.getDataObjects(task.getId());
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObject.getName());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertEquals("intVar 'default' description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         // getDataObjects
         dataObjects = taskService.getDataObjects(task.getId());
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObject.getName());
-        assertEquals("intVar", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'default' description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), "es", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObject.getName());
-        assertEquals("intVar 'es' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'es' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", "intVar 'es' Name", "intVar 'es' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), "it", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'it' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObject.getName());
-        assertEquals("intVar 'it' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'it' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", "intVar 'it' Name", "intVar 'it' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-US", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-US' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObject.getName());
-        assertEquals("intVar 'en-US' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-US' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", "intVar 'en-US' Name", "intVar 'en-US' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-AU", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertEquals("intVar 'en-AU' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en-AU' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", "intVar 'en-AU' Name", "intVar 'en-AU' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-GB", true);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertEquals("intVar 'en' Name", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'en' Description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", "intVar 'en' Name", "intVar 'en' Description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), "en-GB", false);
-        assertEquals(2, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals("intVar", dataObjects.get("intVar").getName());
-        assertEquals("intVar", dataObjects.get("intVar").getLocalizedName());
-        assertEquals("intVar 'default' description", dataObjects.get("intVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-        assertEquals("int", dataObjects.get("intVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertEquals(processInstance.getId(), dataObjects.get("intVar").getProcessInstanceId());
-        assertEquals(subprocess.getId(), dataObjects.get("intVar").getExecutionId());
-        assertNotNull(dataObjects.get("intVar").getId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("intVar"))
+                .extracting(DataObject::getName, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId,
+                        DataObject::getId)
+                .contains("intVar", "intVar", "intVar 'default' description", "intVarId", "int", processInstance.getId(),
+                        processInstance.getId());
+        assertThat(dataObjects.get("stringVar").getId()).isNotNull();
+        assertThat(dataObjects.get("intVar").getId()).isNotNull();
 
         variableNames = new ArrayList<>();
         variableNames.add("stringVar");
 
         // getDataObjects via names
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "es", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'es' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "it", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'it' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-US", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-US' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-AU", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-GB", true);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-GB", false);
-        assertEquals(1, dataObjects.size());
-        assertEquals("stringVar", dataObjects.get("stringVar").getName());
-        assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
-        assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-        assertEquals("string", dataObjects.get("stringVar").getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObjects).hasSize(1);
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType, DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string",
+                        processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         // getDataObject
         dataObject = taskService.getDataObject(task.getId(), "stringVar");
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar", dataObject.getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("string", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
+                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "es", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'es' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'es' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("string", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'es' Name", "stringVar 'es' Description", "stringVarId", "string");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "it", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'it' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'it' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("string", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'it' Name", "stringVar 'it' Description", "stringVarId", "string");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar", dataObject.getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("string", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
+                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-US", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en-US' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en-US' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("string", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en-US' Name", "stringVar 'en-US' Description", "stringVarId", "string");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-AU", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en-AU' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en-AU' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("string", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en-AU' Name", "stringVar 'en-AU' Description", "stringVarId", "string");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", true);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar 'en' Name", dataObject.getLocalizedName());
-        assertEquals("stringVar 'en' Description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("string", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
+                .containsExactly("stringVar", "coca-cola", "stringVar 'en' Name", "stringVar 'en' Description", "stringVarId", "string");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
 
         dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", false);
-        assertNotNull(dataObject);
-        assertEquals("stringVar", dataObject.getName());
-        assertEquals("coca-cola", dataObject.getValue());
-        assertEquals("stringVar", dataObject.getLocalizedName());
-        assertEquals("stringVar 'default' description", dataObject.getDescription());
-        assertEquals("stringVarId", dataObject.getDataObjectDefinitionKey());
-        assertEquals("string", dataObject.getType());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getProcessInstanceId());
-        assertEquals(processInstance.getId(), dataObjects.get("stringVar").getExecutionId());
-        assertNotNull(dataObjects.get("stringVar").getId());
+        assertThat(dataObject).isNotNull();
+        assertThat(dataObject)
+                .extracting(DataObject::getName, DataObject::getValue, DataObject::getLocalizedName, DataObject::getDescription,
+                        DataObject::getDataObjectDefinitionKey, DataObject::getType)
+                .containsExactly("stringVar", "coca-cola", "stringVar", "stringVar 'default' description", "stringVarId", "string");
+        assertThat(dataObjects.get("stringVar"))
+                .extracting(DataObject::getProcessInstanceId, DataObject::getExecutionId)
+                .contains(processInstance.getId(), processInstance.getId())
+                .doesNotContainNull();
     }
 
     // Test case for ACT-1839
@@ -1688,11 +1450,11 @@ public class VariablesTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/examples/variables/VariablesTest.testChangeTypeSerializable.bpmn20.xml" })
     public void testChangeTypeSerializable() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("variable-type-change-test");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Activiti is awesome!", task.getName());
+        assertThat(task.getName()).isEqualTo("Activiti is awesome!");
         SomeSerializable myVar = (SomeSerializable) runtimeService.getVariable(processInstance.getId(), "myVar");
-        assertEquals("someValue", myVar.getValue());
+        assertThat(myVar.getValue()).isEqualTo("someValue");
     }
 
     public String getVariableInstanceId(String executionId, String name) {
@@ -1725,15 +1487,17 @@ public class VariablesTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskAssigneeProcess", variables);
 
         variables = runtimeService.getVariables(processInstance.getId());
-        assertEquals(928374L, variables.get("longVar"));
-        assertEquals((short) 123, variables.get("shortVar"));
-        assertEquals(1234, variables.get("integerVar"));
-        assertEquals("coca-cola", variables.get("stringVar"));
-        assertEquals(now, variables.get("dateVar"));
-        assertNull(variables.get("nullVar"));
-        assertEquals(serializable, variables.get("serializableVar"));
-        assertTrue(Arrays.equals(bytes, (byte[]) variables.get("bytesVar")));
-        assertEquals(8, variables.size());
+        assertThat(variables)
+                .containsOnly(
+                        entry("longVar", 928374L),
+                        entry("shortVar", (short) 123),
+                        entry("integerVar", 1234),
+                        entry("stringVar", "coca-cola"),
+                        entry("dateVar", now),
+                        entry("nullVar", null),
+                        entry("serializableVar", serializable),
+                        entry("bytesVar", bytes)
+                );
 
         // check if the id of the variable is the same or not
 
@@ -1746,21 +1510,21 @@ public class VariablesTest extends PluggableFlowableTestCase {
             newVariables.put("serializableVar", (short) 222);
             runtimeService.setVariables(processInstance.getId(), newVariables);
             variables = runtimeService.getVariables(processInstance.getId());
-            assertEquals((short) 222, variables.get("serializableVar"));
+            assertThat(variables.get("serializableVar")).isEqualTo((short) 222);
 
             String newSerializableVarId = getVariableInstanceId(processInstance.getId(), "serializableVar");
 
-            assertEquals(oldSerializableVarId, newSerializableVarId);
+            assertThat(newSerializableVarId).isEqualTo(oldSerializableVarId);
 
             // Change type of a longVar from Long to Short
             newVariables = new HashMap<>();
             newVariables.put("longVar", (short) 123);
             runtimeService.setVariables(processInstance.getId(), newVariables);
             variables = runtimeService.getVariables(processInstance.getId());
-            assertEquals((short) 123, variables.get("longVar"));
+            assertThat(variables.get("longVar")).isEqualTo((short) 123);
 
             String newLongVar = getVariableInstanceId(processInstance.getId(), "longVar");
-            assertEquals(oldLongVar, newLongVar);
+            assertThat(newLongVar).isEqualTo(oldLongVar);
         }
     }
 
@@ -1777,38 +1541,34 @@ public class VariablesTest extends PluggableFlowableTestCase {
         formService.submitTaskFormData(task.getId(), variables);
         String resultVar = (String) runtimeService.getVariable(processInstance.getId(), "testProperty");
 
-        assertEquals("434", resultVar);
+        assertThat(resultVar).isEqualTo("434");
 
         task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
 
         // If no variable is given, no variable should be set and script test should throw exception
         processInstance = runtimeService.startProcessInstanceByKey("taskAssigneeProcess");
-        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        variables = new HashMap<>();
+        String processId = processInstance.getId();
+        task = taskService.createTaskQuery().processInstanceId(processId).singleResult();
+        String taskId = task.getId();
         try {
-            formService.submitTaskFormData(task.getId(), variables);
-            fail("Should throw exception as testProperty is not defined and used in Script task");
-        } catch (Exception e) {
-            runtimeService.deleteProcessInstance(processInstance.getId(), "intentional exception in script task");
-
-            assertEquals("class org.flowable.common.engine.api.FlowableException", e.getClass().toString());
+            assertThatThrownBy(() -> formService.submitTaskFormData(taskId, new HashMap<String, String>()))
+                    .isExactlyInstanceOf(FlowableException.class);
+        } finally {
+            runtimeService.deleteProcessInstance(processId, "intentional exception in script task");
         }
 
         // No we put null property, This should be put into the variable. We do not expect exceptions
         processInstance = runtimeService.startProcessInstanceByKey("taskAssigneeProcess");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        variables = new HashMap<>();
-        variables.put("testProperty", null);
-
-        try {
-            formService.submitTaskFormData(task.getId(), variables);
-        } catch (Exception e) {
-            fail("Should not throw exception as the testProperty is defined, although null");
-        }
+        String finalTaskId = task.getId();
+        Map<String, String> finalVariables = new HashMap<>();
+        finalVariables.put("testProperty", null);
+        assertThatCode(() -> formService.submitTaskFormData(finalTaskId, finalVariables))
+                .doesNotThrowAnyException();
         resultVar = (String) runtimeService.getVariable(processInstance.getId(), "testProperty");
 
-        assertNull(resultVar);
+        assertThat(resultVar).isNull();
 
         runtimeService.deleteProcessInstance(processInstance.getId(), "intentional exception in script task");
     }
@@ -1820,17 +1580,17 @@ public class VariablesTest extends PluggableFlowableTestCase {
     @Deployment
     public void testUUIDVariableAndQuery() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Check UUID variable type query on task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         UUID randomUUID = UUID.randomUUID();
         taskService.setVariableLocal(task.getId(), "conversationId", randomUUID);
 
         org.flowable.task.api.Task resultingTask = taskService.createTaskQuery().taskVariableValueEquals("conversationId", randomUUID).singleResult();
-        assertNotNull(resultingTask);
-        assertEquals(task.getId(), resultingTask.getId());
+        assertThat(resultingTask).isNotNull();
+        assertThat(resultingTask.getId()).isEqualTo(task.getId());
 
         randomUUID = UUID.randomUUID();
 
@@ -1838,8 +1598,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
         runtimeService.setVariable(processInstance.getId(), "uuidVar", randomUUID);
         ProcessInstance result = runtimeService.createProcessInstanceQuery().variableValueEquals("uuidVar", randomUUID).singleResult();
 
-        assertNotNull(result);
-        assertEquals(processInstance.getId(), result.getId());
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(processInstance.getId());
     }
 
     @Test


### PR DESCRIPTION
In the `org.flowable.examples` package there were 4 files that had a mixture of unit testing styles within the same file.    They now all are using assertj tests.

