### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.engine.test.api.task;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -76,21 +76,21 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
     public void testQuery() {
         org.flowable.task.api.Task task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("gonzo").singleResult();
         Map<String, Object> variableMap = task.getTaskLocalVariables();
-        assertEquals(3, variableMap.size());
-        assertEquals(0, task.getProcessVariables().size());
-        assertNotNull(variableMap.get("testVar"));
-        assertEquals("someVariable", variableMap.get("testVar"));
-        assertNotNull(variableMap.get("testVar2"));
-        assertEquals(123, variableMap.get("testVar2"));
-        assertNotNull(variableMap.get("testVarBinary"));
-        assertEquals("This is a binary variable", new String((byte[]) variableMap.get("testVarBinary")));
+        assertThat(variableMap).hasSize(3);
+        assertThat(task.getProcessVariables()).isEmpty();
+        assertThat(variableMap.get("testVar")).isNotNull();
+        assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
+        assertThat(variableMap.get("testVar2")).isNotNull();
+        assertThat(variableMap.get("testVar2")).isEqualTo(123);
+        assertThat(variableMap.get("testVarBinary")).isNotNull();
+        assertThat(new String((byte[]) variableMap.get("testVarBinary"))).isEqualTo("This is a binary variable");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
         task = taskService.createTaskQuery().includeProcessVariables().taskAssignee("gonzo").singleResult();
-        assertEquals(0, task.getProcessVariables().size());
-        assertEquals(0, task.getTaskLocalVariables().size());
+        assertThat(task.getProcessVariables()).isEmpty();
+        assertThat(task.getTaskLocalVariables()).isEmpty();
 
         Map<String, Object> startMap = new HashMap<>();
         startMap.put("processVar", true);
@@ -98,55 +98,55 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
 
         task = taskService.createTaskQuery().includeProcessVariables().taskAssignee("kermit").singleResult();
-        assertEquals(2, task.getProcessVariables().size());
-        assertEquals(0, task.getTaskLocalVariables().size());
-        assertTrue((Boolean) task.getProcessVariables().get("processVar"));
-        assertEquals("This is a binary process variable", new String((byte[]) task.getProcessVariables().get("binaryVariable")));
+        assertThat(task.getProcessVariables()).hasSize(2);
+        assertThat(task.getTaskLocalVariables()).isEmpty();
+        assertThat((Boolean) task.getProcessVariables().get("processVar")).isTrue();
+        assertThat(new String((byte[]) task.getProcessVariables().get("binaryVariable"))).isEqualTo("This is a binary process variable");
 
         taskService.setVariable(task.getId(), "anotherProcessVar", 123);
         taskService.setVariableLocal(task.getId(), "localVar", "test");
 
         task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("kermit").singleResult();
-        assertEquals(0, task.getProcessVariables().size());
-        assertEquals(1, task.getTaskLocalVariables().size());
-        assertEquals("test", task.getTaskLocalVariables().get("localVar"));
+        assertThat(task.getProcessVariables()).isEmpty();
+        assertThat(task.getTaskLocalVariables()).hasSize(1);
+        assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
 
         task = taskService.createTaskQuery().includeProcessVariables().taskAssignee("kermit").singleResult();
-        assertEquals(3, task.getProcessVariables().size());
-        assertEquals(0, task.getTaskLocalVariables().size());
-        assertEquals(true, task.getProcessVariables().get("processVar"));
-        assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
-        assertEquals("This is a binary process variable", new String((byte[]) task.getProcessVariables().get("binaryVariable")));
+        assertThat(task.getProcessVariables()).hasSize(3);
+        assertThat(task.getTaskLocalVariables()).isEmpty();
+        assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(new String((byte[]) task.getProcessVariables().get("binaryVariable"))).isEqualTo("This is a binary process variable");
 
         tasks = taskService.createTaskQuery().includeTaskLocalVariables().taskCandidateUser("kermit").list();
-        assertEquals(2, tasks.size());
-        assertEquals(2, tasks.get(0).getTaskLocalVariables().size());
-        assertEquals("test", tasks.get(0).getTaskLocalVariables().get("test"));
-        assertEquals(0, tasks.get(0).getProcessVariables().size());
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get(0).getTaskLocalVariables()).hasSize(2);
+        assertThat(tasks.get(0).getTaskLocalVariables().get("test")).isEqualTo("test");
+        assertThat(tasks.get(0).getProcessVariables()).isEmpty();
 
         tasks = taskService.createTaskQuery().includeProcessVariables().taskCandidateUser("kermit").list();
-        assertEquals(2, tasks.size());
-        assertEquals(0, tasks.get(0).getProcessVariables().size());
-        assertEquals(0, tasks.get(0).getTaskLocalVariables().size());
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get(0).getProcessVariables()).isEmpty();
+        assertThat(tasks.get(0).getTaskLocalVariables()).isEmpty();
 
         task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("kermit").taskVariableValueEquals("localVar", "test").singleResult();
-        assertEquals(0, task.getProcessVariables().size());
-        assertEquals(1, task.getTaskLocalVariables().size());
-        assertEquals("test", task.getTaskLocalVariables().get("localVar"));
+        assertThat(task.getProcessVariables()).isEmpty();
+        assertThat(task.getTaskLocalVariables()).hasSize(1);
+        assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
 
         task = taskService.createTaskQuery().includeProcessVariables().taskAssignee("kermit").taskVariableValueEquals("localVar", "test").singleResult();
-        assertEquals(3, task.getProcessVariables().size());
-        assertEquals(0, task.getTaskLocalVariables().size());
-        assertEquals(true, task.getProcessVariables().get("processVar"));
-        assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+        assertThat(task.getProcessVariables()).hasSize(3);
+        assertThat(task.getTaskLocalVariables()).isEmpty();
+        assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
         task = taskService.createTaskQuery().includeTaskLocalVariables().includeProcessVariables().taskAssignee("kermit").singleResult();
-        assertEquals(3, task.getProcessVariables().size());
-        assertEquals(1, task.getTaskLocalVariables().size());
-        assertEquals("test", task.getTaskLocalVariables().get("localVar"));
-        assertEquals(true, task.getProcessVariables().get("processVar"));
-        assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
-        assertEquals("This is a binary process variable", new String((byte[]) task.getProcessVariables().get("binaryVariable")));
+        assertThat(task.getProcessVariables()).hasSize(3);
+        assertThat(task.getTaskLocalVariables()).hasSize(1);
+        assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
+        assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
+        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(new String((byte[]) task.getProcessVariables().get("binaryVariable"))).isEqualTo("This is a binary process variable");
     }
     
     @Test
@@ -158,77 +158,84 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).processVariableExists("processVar").singleResult();
-        assertNotNull(task);
-        
+        assertThat(task).isNotNull();
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).processVariableNotExists("processVar").singleResult();
-        assertNull(task);
-        
+        assertThat(task).isNull();
+
         task = taskService.createTaskQuery().or().processVariableExists("processVar").processVariableExists("test").endOr().singleResult();
-        assertNotNull(task);
-        
+        assertThat(task).isNotNull();
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskVariableExists("processVar").singleResult();
-        assertNull(task);
-        
+        assertThat(task).isNull();
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskVariableNotExists("processVar").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.setVariable(task.getId(), "anotherProcessVar", 123);
         taskService.setVariableLocal(task.getId(), "localVar", "test");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskVariableExists("localVar").singleResult();
-        assertNotNull(task);
-        
+        assertThat(task).isNotNull();
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskVariableNotExists("localVar").singleResult();
-        assertNull(task);
-        
+        assertThat(task).isNull();
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().processVariableExists("processVar")
-                        .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertNotNull(task);
-        
+                .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
+        assertThat(task).isNotNull();
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().processVariableNotExists("processVar")
-                        .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertNotNull(task);
-        
+                .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
+        assertThat(task).isNotNull();
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().processVariableExists("processVar").endOr().or()
-                        .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertNotNull(task);
-        
+                .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
+        assertThat(task).isNotNull();
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().processVariableNotExists("processVar").endOr().or()
-                        .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertNull(task);
+                .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
+        assertThat(task).isNull();
     }
 
     @Test
     public void testQueryWithPagingAndVariables() {
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().desc().listPage(0, 1);
-        assertEquals(1, tasks.size());
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority()
+                .desc().listPage(0, 1);
+        assertThat(tasks).hasSize(1);
         org.flowable.task.api.Task task = tasks.get(0);
         Map<String, Object> variableMap = task.getTaskLocalVariables();
-        assertEquals(3, variableMap.size());
-        assertEquals("someVariable", variableMap.get("testVar"));
-        assertEquals(123, variableMap.get("testVar2"));
-        assertEquals("This is a binary variable", new String((byte[]) variableMap.get("testVarBinary")));
+        assertThat(variableMap)
+                .containsOnly(
+                        entry("testVar", "someVariable"),
+                        entry("testVar2", 123),
+                        entry("testVarBinary", "This is a binary variable".getBytes())
+                );
 
         tasks = taskService.createTaskQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc().listPage(1, 2);
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         task = tasks.get(1);
         variableMap = task.getTaskLocalVariables();
-        assertEquals(3, variableMap.size());
-        assertEquals("someVariable", variableMap.get("testVar"));
-        assertEquals(123, variableMap.get("testVar2"));
-        assertEquals("This is a binary variable", new String((byte[]) variableMap.get("testVarBinary")));
+        assertThat(variableMap)
+                .containsOnly(
+                        entry("testVar", "someVariable"),
+                        entry("testVar2", 123),
+                        entry("testVarBinary", "This is a binary variable".getBytes())
+                );
 
         tasks = taskService.createTaskQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc().listPage(2, 4);
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
         task = tasks.get(0);
         variableMap = task.getTaskLocalVariables();
-        assertEquals(3, variableMap.size());
-        assertEquals("someVariable", variableMap.get("testVar"));
-        assertEquals(123, variableMap.get("testVar2"));
-        assertEquals("This is a binary variable", new String((byte[]) variableMap.get("testVarBinary")));
+        assertThat(variableMap)
+                .containsOnly(
+                        entry("testVar", "someVariable"),
+                        entry("testVar2", 123),
+                        entry("testVarBinary", "This is a binary variable".getBytes())
+                );
 
         tasks = taskService.createTaskQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc().listPage(4, 2);
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
     }
 
     // Unit test for https://activiti.atlassian.net/browse/ACT-4152
@@ -236,20 +243,20 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
     public void testQueryWithIncludeTaskVariableAndTaskCategory() {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("gonzo").list();
         for (org.flowable.task.api.Task task : tasks) {
-            assertNotNull(task.getCategory());
-            assertEquals("testCategory", task.getCategory());
+            assertThat(task.getCategory()).isNotNull();
+            assertThat(task.getCategory()).isEqualTo("testCategory");
         }
 
         tasks = taskService.createTaskQuery().taskAssignee("gonzo").includeTaskLocalVariables().list();
         for (org.flowable.task.api.Task task : tasks) {
-            assertNotNull(task.getCategory());
-            assertEquals("testCategory", task.getCategory());
+            assertThat(task.getCategory()).isNotNull();
+            assertThat(task.getCategory()).isEqualTo("testCategory");
         }
 
         tasks = taskService.createTaskQuery().taskAssignee("gonzo").includeProcessVariables().list();
         for (org.flowable.task.api.Task task : tasks) {
-            assertNotNull(task.getCategory());
-            assertEquals("testCategory", task.getCategory());
+            assertThat(task.getCategory()).isNotNull();
+            assertThat(task.getCategory()).isEqualTo("testCategory");
         }
     }
 
@@ -273,7 +280,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
                     .asc()
                     .listPage(0, 200);
             // 100 tasks created by generateMultipleTestTasks and 3 created previously at setUp
-            assertEquals(expectedNumberOfTasks, tasks.size());
+            assertThat(tasks).hasSize(expectedNumberOfTasks);
 
             tasks = taskService.createTaskQuery()
                     .includeProcessVariables()
@@ -282,7 +289,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
                     .limitTaskVariables(taskVariablesLimit)
                     .asc()
                     .listPage(50, 100);
-            assertEquals(53, tasks.size());
+            assertThat(tasks).hasSize(53);
         } finally {
             taskService.deleteTasks(multipleTaskIds, true);
         }
@@ -295,27 +302,30 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         startMap.put("anotherProcessVar", 123);
         runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("undefined", 999).processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertEquals(1, task.getProcessVariables().size());
-        assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+        org.flowable.task.api.Task task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("undefined", 999)
+                .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
+        assertThat(task.getProcessVariables()).hasSize(1);
+        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
         task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("undefined", 999).endOr().singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
-        task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 123).processVariableValueEquals("undefined", 999).endOr().singleResult();
-        assertEquals(1, task.getProcessVariables().size());
-        assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+        task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 123)
+                .processVariableValueEquals("undefined", 999).endOr().singleResult();
+        assertThat(task.getProcessVariables()).hasSize(1);
+        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
         task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertEquals(1, task.getProcessVariables().size());
-        assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+        assertThat(task.getProcessVariables()).hasSize(1);
+        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
 
         task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 999).endOr().singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
-        task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 999).processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertEquals(1, task.getProcessVariables().size());
-        assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+        task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 999)
+                .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
+        assertThat(task.getProcessVariables()).hasSize(1);
+        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
     }
 
     @Test
@@ -331,7 +341,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
             query0 = query0.processVariableValueEquals("anotherProcessVar", i);
         }
         query0 = query0.endOr();
-        assertNull(query0.singleResult());
+        assertThat(query0.singleResult()).isNull();
 
         TaskQuery query1 = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 123);
         for (int i = 0; i < 20; i++) {
@@ -339,8 +349,8 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         }
         query1 = query1.endOr();
         org.flowable.task.api.Task task = query1.singleResult();
-        assertEquals(2, task.getProcessVariables().size());
-        assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
+        assertThat(task.getProcessVariables()).hasSize(2);
+        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
     }
 
     @Test
@@ -350,13 +360,14 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
             this.taskService.saveTask(taskWithDefinitionId);
 
             Task updatedTask = taskService.createTaskQuery().taskDefinitionId("testTaskDefinitionId").singleResult();
-            assertThat(updatedTask.getName(), is("taskWithDefinitionId"));
-            assertThat(updatedTask.getTaskDefinitionId(), is("testTaskDefinitionId"));
+            assertThat(updatedTask.getName()).isEqualTo("taskWithDefinitionId");
+            assertThat(updatedTask.getTaskDefinitionId()).isEqualTo("testTaskDefinitionId");
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-                HistoricTaskInstance updatedHistoricTask = historyService.createHistoricTaskInstanceQuery().taskDefinitionId("testTaskDefinitionId").singleResult();
-                assertThat(updatedHistoricTask.getName(), is("taskWithDefinitionId"));
-                assertThat(updatedHistoricTask.getTaskDefinitionId(), is("testTaskDefinitionId"));
+                HistoricTaskInstance updatedHistoricTask = historyService.createHistoricTaskInstanceQuery().taskDefinitionId("testTaskDefinitionId")
+                        .singleResult();
+                assertThat(updatedHistoricTask.getName()).isEqualTo("taskWithDefinitionId");
+                assertThat(updatedHistoricTask.getTaskDefinitionId()).isEqualTo("testTaskDefinitionId");
             }
         } finally {
             this.taskService.deleteTask("testTaskId", true);
@@ -372,11 +383,11 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
             this.taskService.saveTask(taskWithDefinitionId2);
 
             List<Task> updatedTasks = taskService.createTaskQuery().taskDefinitionId("testTaskDefinitionId").list();
-            assertThat(updatedTasks.size(), is(2));
+            assertThat(updatedTasks).hasSize(2);
             
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
                 List<HistoricTaskInstance> updatedHistoricTasks = historyService.createHistoricTaskInstanceQuery().taskDefinitionId("testTaskDefinitionId").list();
-                assertThat(updatedHistoricTasks.size(), is(2));
+                assertThat(updatedHistoricTasks).hasSize(2);
             }
         } finally {
             this.taskService.deleteTask("testTaskId1", true);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskInfoQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskInfoQueryTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 import java.util.List;
 
@@ -40,22 +42,10 @@ public class TaskInfoQueryTest extends PluggableFlowableTestCase {
         Date now = processEngineConfiguration.getClock().getCurrentTime();
 
         // 4 tasks with a due date
-        createTask("task0", new Date(now.getTime() + (4L * 7L * 24L * 60L * 60L * 1000L))); // 4
-                                                                                            // weeks
-                                                                                            // in
-                                                                                            // future
-        createTask("task1", new Date(now.getTime() + (2 * 24L * 60L * 60L * 1000L))); // 2
-                                                                                      // days
-                                                                                      // in
-                                                                                      // future
-        createTask("task2", new Date(now.getTime() + (7L * 24L * 60L * 60L * 1000L))); // 1
-                                                                                       // week
-                                                                                       // in
-                                                                                       // future
-        createTask("task3", new Date(now.getTime() + (24L * 60L * 60L * 1000L))); // 1
-                                                                                  // day
-                                                                                  // in
-                                                                                  // future
+        createTask("task0", new Date(now.getTime() + (4L * 7L * 24L * 60L * 60L * 1000L))); // 4 weeks in future
+        createTask("task1", new Date(now.getTime() + (2 * 24L * 60L * 60L * 1000L))); // 2 days in future
+        createTask("task2", new Date(now.getTime() + (7L * 24L * 60L * 60L * 1000L))); // 1 week in future
+        createTask("task3", new Date(now.getTime() + (24L * 60L * 60L * 1000L))); // 1 day in future
 
         // 2 tasks without a due date
         createTask("task4", null);
@@ -63,16 +53,18 @@ public class TaskInfoQueryTest extends PluggableFlowableTestCase {
 
         // Runtime
         TaskInfoQueryWrapper taskInfoQueryWrapper = new TaskInfoQueryWrapper(taskService.createTaskQuery());
-        List<? extends TaskInfo> taskInfos = taskInfoQueryWrapper.getTaskInfoQuery().or().taskNameLike("%k1%").taskDueAfter(new Date(now.getTime() + (3 * 24L * 60L * 60L * 1000L))).endOr().list();
+        List<? extends TaskInfo> taskInfos = taskInfoQueryWrapper.getTaskInfoQuery().or().taskNameLike("%k1%")
+                .taskDueAfter(new Date(now.getTime() + (3 * 24L * 60L * 60L * 1000L))).endOr().list();
 
-        assertEquals(3, taskInfos.size());
+        assertThat(taskInfos).hasSize(3);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
             taskInfoQueryWrapper = new TaskInfoQueryWrapper(historyService.createHistoricTaskInstanceQuery());
-            taskInfos = taskInfoQueryWrapper.getTaskInfoQuery().or().taskNameLike("%k1%").taskDueAfter(new Date(now.getTime() + (3 * 24L * 60L * 60L * 1000L))).endOr().list();
+            taskInfos = taskInfoQueryWrapper.getTaskInfoQuery().or().taskNameLike("%k1%").taskDueAfter(new Date(now.getTime() + (3 * 24L * 60L * 60L * 1000L)))
+                    .endOr().list();
 
-            assertEquals(3, taskInfos.size());
+            assertThat(taskInfos).hasSize(3);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.api.task;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.text.SimpleDateFormat;
@@ -86,127 +87,99 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     @Test
     public void testBasicTaskPropertiesNotNull() {
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskId(taskIds.get(0)).singleResult();
-        assertNotNull(task.getDescription());
-        assertNotNull(task.getId());
-        assertNotNull(task.getName());
-        assertNotNull(task.getCreateTime());
+        assertThat(task.getDescription()).isNotNull();
+        assertThat(task.getId()).isNotNull();
+        assertThat(task.getName()).isNotNull();
+        assertThat(task.getCreateTime()).isNotNull();
     }
 
     @Test
     public void testQueryNoCriteria() {
         TaskQuery query = taskService.createTaskQuery();
-        assertEquals(12, query.count());
-        assertEquals(12, query.list().size());
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThat(query.count()).isEqualTo(12);
+        assertThat(query.list()).hasSize(12);
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testQueryByTaskId() {
         TaskQuery query = taskService.createTaskQuery().taskId(taskIds.get(0));
-        assertNotNull(query.singleResult());
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
+        assertThat(query.singleResult()).isNotNull();
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByTaskIdOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId(taskIds.get(0)).taskName("INVALID NAME").endOr();
-        assertNotNull(query.singleResult());
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
+        assertThat(query.singleResult()).isNotNull();
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidTaskId() {
         TaskQuery query = taskService.createTaskQuery().taskId("invalid");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().taskId(null);
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskId(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByInvalidTaskIdOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskName("invalid");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().taskId(null);
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskId(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByName() {
         TaskQuery query = taskService.createTaskQuery().taskName("testTask");
-        assertEquals(6, query.list().size());
-        assertEquals(6, query.count());
+        assertThat(query.list()).hasSize(6);
+        assertThat(query.count()).isEqualTo(6);
 
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testQueryByNameOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskName("testTask").taskId("invalid");
-        assertEquals(6, query.list().size());
-        assertEquals(6, query.count());
+        assertThat(query.list()).hasSize(6);
+        assertThat(query.count()).isEqualTo(6);
 
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testQueryByInvalidName() {
         TaskQuery query = taskService.createTaskQuery().taskName("invalid");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskName(null).singleResult();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskName(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByInvalidNameOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskName("invalid");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskName(null).singleResult();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskName(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -216,15 +189,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskNameList.add("gonzoTask");
 
         TaskQuery query = taskService.createTaskQuery().taskNameIn(taskNameList);
-        assertEquals(7, query.list().size());
-        assertEquals(7, query.count());
+        assertThat(query.list()).hasSize(7);
+        assertThat(query.count()).isEqualTo(7);
 
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
@@ -234,15 +203,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskNameList.add("gonzotask");
 
         TaskQuery query = taskService.createTaskQuery().taskNameInIgnoreCase(taskNameList);
-        assertEquals(7, query.list().size());
-        assertEquals(7, query.count());
+        assertThat(query.list()).hasSize(7);
+        assertThat(query.count()).isEqualTo(7);
 
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
@@ -252,15 +217,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskNameList.add("gonzoTask");
 
         TaskQuery query = taskService.createTaskQuery().or().taskNameIn(taskNameList).taskId("invalid");
-        assertEquals(7, query.list().size());
-        assertEquals(7, query.count());
+        assertThat(query.list()).hasSize(7);
+        assertThat(query.count()).isEqualTo(7);
 
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
@@ -270,15 +231,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskNameList.add("gonzotask");
 
         TaskQuery query = taskService.createTaskQuery().or().taskNameInIgnoreCase(taskNameList).taskId("invalid");
-        assertEquals(7, query.list().size());
-        assertEquals(7, query.count());
+        assertThat(query.list()).hasSize(7);
+        assertThat(query.count()).isEqualTo(7);
 
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
@@ -287,15 +244,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskNameList.add("invalid");
 
         TaskQuery query = taskService.createTaskQuery().taskNameIn(taskNameList);
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskNameIn(null).singleResult();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskNameIn(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -304,15 +257,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskNameList.add("invalid");
 
         TaskQuery query = taskService.createTaskQuery().taskNameInIgnoreCase(taskNameList);
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskNameIn(null).singleResult();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskNameIn(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -321,15 +270,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskNameList.add("invalid");
 
         TaskQuery query = taskService.createTaskQuery().or().taskNameIn(taskNameList).taskId("invalid");
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskNameIn(null).singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskNameIn(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -338,161 +283,129 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskNameList.add("invalid");
 
         TaskQuery query = taskService.createTaskQuery().or().taskNameInIgnoreCase(taskNameList).taskId("invalid");
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskNameIn(null).singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskNameIn(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByNameLike() {
         TaskQuery query = taskService.createTaskQuery().taskNameLike("gonzo%");
-        assertNotNull(query.singleResult());
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
+        assertThat(query.singleResult()).isNotNull();
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByNameLikeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskNameLike("gonzo%");
-        assertNotNull(query.singleResult());
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
+        assertThat(query.singleResult()).isNotNull();
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidNameLike() {
         TaskQuery query = taskService.createTaskQuery().taskNameLike("1");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskNameLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskNameLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByInvalidNameLikeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskNameLike("1");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskNameLike(null).singleResult();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskNameLike(null).singleResult())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByDescription() {
         TaskQuery query = taskService.createTaskQuery().taskDescription("testTask description");
-        assertEquals(6, query.list().size());
-        assertEquals(6, query.count());
+        assertThat(query.list()).hasSize(6);
+        assertThat(query.count()).isEqualTo(6);
 
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testQueryByDescriptionOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDescription("testTask description");
-        assertEquals(6, query.list().size());
-        assertEquals(6, query.count());
+        assertThat(query.list()).hasSize(6);
+        assertThat(query.count()).isEqualTo(6);
 
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> query.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testQueryByInvalidDescription() {
         TaskQuery query = taskService.createTaskQuery().taskDescription("invalid");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskDescription(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskDescription(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByInvalidDescriptionOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDescription("invalid");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskDescription(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskDescription(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByDescriptionLike() {
         TaskQuery query = taskService.createTaskQuery().taskDescriptionLike("%gonzo%");
-        assertNotNull(query.singleResult());
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
+        assertThat(query.singleResult()).isNotNull();
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByDescriptionLikeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDescriptionLike("%gonzo%");
-        assertNotNull(query.singleResult());
-        assertEquals(1, query.list().size());
-        assertEquals(1, query.count());
+        assertThat(query.singleResult()).isNotNull();
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryByInvalidDescriptionLike() {
         TaskQuery query = taskService.createTaskQuery().taskDescriptionLike("invalid");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskDescriptionLike(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskDescriptionLike(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByInvalidDescriptionLikeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDescriptionLike("invalid");
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskDescriptionLike(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskDescriptionLike(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -503,16 +416,17 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskIds.add(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().taskFormKey("testFormKey").list();
-
-        assertEquals(1, tasks.size());
-        assertEquals("testFormKey", tasks.get(0).getFormKey());
+        assertThat(tasks)
+                .extracting(Task::getFormKey)
+                .containsExactly("testFormKey");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                .taskFormKey("testFormKey")
-                .list();
-            assertEquals(1, historicTasks.size());
-            assertEquals("testFormKey", historicTasks.get(0).getFormKey());
+                    .taskFormKey("testFormKey")
+                    .list();
+            assertThat(historicTasks)
+                    .extracting(HistoricTaskInstance::getFormKey)
+                    .containsExactly("testFormKey");
         }
     }
 
@@ -524,16 +438,17 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskIds.add(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().or().taskId("invalid").taskFormKey("testFormKey").list();
-
-        assertEquals(1, tasks.size());
-        assertEquals("testFormKey", tasks.get(0).getFormKey());
+        assertThat(tasks)
+                .extracting(Task::getFormKey)
+                .containsExactly("testFormKey");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery().or()
-                .taskFormKey("testFormKey")
-                .list();
-            assertEquals(1, historicTasks.size());
-            assertEquals("testFormKey", historicTasks.get(0).getFormKey());
+                    .taskFormKey("testFormKey")
+                    .list();
+            assertThat(historicTasks)
+                    .extracting(HistoricTaskInstance::getFormKey)
+                    .containsExactly("testFormKey");
         }
     }
 
@@ -545,141 +460,130 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskIds.add(task.getId());
 
         List<Task> tasks = taskService.createTaskQuery().taskWithFormKey().list();
-
-        assertEquals(1, tasks.size());
-        assertEquals("testFormKey", tasks.get(0).getFormKey());
+        assertThat(tasks)
+                .extracting(Task::getFormKey)
+                .containsExactly("testFormKey");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
-                .taskWithFormKey()
-                .list();
-            assertEquals(1, historicTasks.size());
-            assertEquals("testFormKey", historicTasks.get(0).getFormKey());
+                    .taskWithFormKey()
+                    .list();
+            assertThat(historicTasks)
+                    .extracting(HistoricTaskInstance::getFormKey)
+                    .containsExactly("testFormKey");
         }
     }
 
     @Test
     public void testQueryByPriority() {
         TaskQuery query = taskService.createTaskQuery().taskPriority(10);
-        assertEquals(2, query.list().size());
-        assertEquals(2, query.count());
+        assertThat(query.list()).hasSize(2);
+        assertThat(query.count()).isEqualTo(2);
 
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        TaskQuery finalQuery = query;
+        assertThatThrownBy(() -> finalQuery.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
 
         query = taskService.createTaskQuery().taskPriority(100);
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
         query = taskService.createTaskQuery().taskMinPriority(50);
-        assertEquals(3, query.list().size());
+        assertThat(query.list()).hasSize(3);
 
         query = taskService.createTaskQuery().taskMinPriority(10);
-        assertEquals(5, query.list().size());
+        assertThat(query.list()).hasSize(5);
 
         query = taskService.createTaskQuery().taskMaxPriority(10);
-        assertEquals(9, query.list().size());
+        assertThat(query.list()).hasSize(9);
 
         query = taskService.createTaskQuery().taskMaxPriority(3);
-        assertEquals(6, query.list().size());
+        assertThat(query.list()).hasSize(6);
     }
 
     @Test
     public void testQueryByPriorityOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskPriority(10);
-        assertEquals(2, query.list().size());
-        assertEquals(2, query.count());
+        assertThat(query.list()).hasSize(2);
+        assertThat(query.count()).isEqualTo(2);
 
-        try {
-            query.singleResult();
-            fail();
-        } catch (FlowableException e) {
-        }
+        TaskQuery finalQuery = query;
+        assertThatThrownBy(() -> finalQuery.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskPriority(100);
-        assertNull(query.singleResult());
-        assertEquals(0, query.list().size());
-        assertEquals(0, query.count());
+        assertThat(query.singleResult()).isNull();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.count()).isZero();
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskMinPriority(50);
-        assertEquals(3, query.list().size());
+        assertThat(query.list()).hasSize(3);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskMinPriority(10);
-        assertEquals(5, query.list().size());
+        assertThat(query.list()).hasSize(5);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskMaxPriority(10);
-        assertEquals(9, query.list().size());
+        assertThat(query.list()).hasSize(9);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskMaxPriority(3);
-        assertEquals(6, query.list().size());
+        assertThat(query.list()).hasSize(6);
     }
 
     @Test
     public void testQueryByInvalidPriority() {
-        try {
-            taskService.createTaskQuery().taskPriority(null);
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskPriority(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByInvalidPriorityOr() {
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskPriority(null);
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskPriority(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByAssignee() {
         TaskQuery query = taskService.createTaskQuery().taskAssignee("gonzo");
-        assertEquals(1, query.count());
-        assertEquals(1, query.list().size());
-        assertNotNull(query.singleResult());
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.singleResult()).isNotNull();
 
         query = taskService.createTaskQuery().taskAssignee("kermit");
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.singleResult()).isNull();
     }
 
     @Test
     public void testQueryByAssigneeOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssignee("gonzo");
-        assertEquals(1, query.count());
-        assertEquals(1, query.list().size());
-        assertNotNull(query.singleResult());
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.singleResult()).isNotNull();
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskAssignee("kermit");
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.singleResult()).isNull();
     }
 
     @Test
     public void testQueryByAssigneeIds() {
         TaskQuery query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("gonzo", "kermit"));
-        assertEquals(1, query.count());
-        assertEquals(1, query.list().size());
-        assertNotNull(query.singleResult());
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.singleResult()).isNotNull();
 
         query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("kermit", "kermit2"));
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.singleResult()).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("gonzo", "kermit")).count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("kermit", "kermit2")).count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("gonzo", "kermit")).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("kermit", "kermit2")).count()).isZero();
         }
 
         org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -688,12 +592,12 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.saveTask(adhocTask);
 
         query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("gonzo", "testAssignee"));
-        assertEquals(2, query.count());
-        assertEquals(2, query.list().size());
+        assertThat(query.count()).isEqualTo(2);
+        assertThat(query.list()).hasSize(2);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(2, historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("gonzo", "testAssignee")).count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("gonzo", "testAssignee")).count()).isEqualTo(2);
         }
 
         taskService.deleteTask(adhocTask.getId(), true);
@@ -702,19 +606,21 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     @Test
     public void testQueryByAssigneeIdsOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "kermit"));
-        assertEquals(1, query.count());
-        assertEquals(1, query.list().size());
-        assertNotNull(query.singleResult());
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
+        assertThat(query.singleResult()).isNotNull();
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("kermit", "kermit2"));
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.singleResult()).isNull();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "kermit")).count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("kermit", "kermit2")).count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "kermit")).count())
+                    .isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("kermit", "kermit2")).count())
+                    .isZero();
         }
 
         org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -723,12 +629,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.saveTask(adhocTask);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "testAssignee"));
-        assertEquals(2, query.count());
-        assertEquals(2, query.list().size());
+        assertThat(query.count()).isEqualTo(2);
+        assertThat(query.list()).hasSize(2);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(2, historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "testAssignee")).count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "testAssignee")).count())
+                    .isEqualTo(2);
         }
 
         taskService.deleteTask(adhocTask.getId(), true);
@@ -743,11 +650,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.saveTask(adhocTask);
             taskService.addUserIdentityLink(adhocTask.getId(), "gonzo", "customType");
 
-            assertEquals(3, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(3);
 
-            assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("gonzo").count());
-            assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("kermit").count());
-            assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("fozzie").count());
+            assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("gonzo").count()).isEqualTo(1);
+            assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("kermit").count()).isEqualTo(1);
+            assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("fozzie").count()).isEqualTo(1);
 
         } finally {
             deleteAllTasks();
@@ -763,14 +670,15 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.saveTask(adhocTask);
             taskService.addUserIdentityLink(adhocTask.getId(), "gonzo", "customType");
 
-            assertEquals(3, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(3);
 
-            assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("gonzo").count());
-            assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("kermit").count());
-            assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("fozzie").count());
+            assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("gonzo").count()).isEqualTo(1);
+            assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("kermit").count()).isEqualTo(1);
+            assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("fozzie").count()).isEqualTo(1);
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("fozzie").count());
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("fozzie").count())
+                        .isEqualTo(1);
             }
 
         } finally {
@@ -785,9 +693,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.saveTask(adhocTask);
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
-            assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedGroups(Collections.singleton("testGroup")).count());
+            assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
 
         } finally {
             deleteAllTasks();
@@ -801,12 +709,14 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.saveTask(adhocTask);
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
-            assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedGroups(Collections.singleton("testGroup")).count());
+            assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedGroups(Collections.singleton("testGroup"))
+                    .count()).isEqualTo(1);
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedGroups(Collections.singleton("testGroup")).count());
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskId(adhocTask.getId()).or().taskId("invalid")
+                        .taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
             }
 
         } finally {
@@ -835,14 +745,14 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.saveTask(adhocTask3);
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
-            assertEquals(2, taskService.createTaskQuery().
-                or().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count());
+            assertThat(taskService.createTaskQuery().or().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count())
+                    .isEqualTo(2);
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(2, historyService.createHistoricTaskInstanceQuery().
-                        or().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count());
+                assertThat(historyService.createHistoricTaskInstanceQuery().
+                        or().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(2);
             }
 
         } finally {
@@ -862,14 +772,15 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.saveTask(adhocTask3);
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
-            assertEquals(2, taskService.createTaskQuery().
-                or().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count());
+            assertThat(taskService.createTaskQuery().or().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count())
+                    .isEqualTo(2);
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(2, historyService.createHistoricTaskInstanceQuery().
-                        or().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count());
+                assertThat(
+                        historyService.createHistoricTaskInstanceQuery().or().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr()
+                                .count()).isEqualTo(2);
             }
 
         } finally {
@@ -891,14 +802,12 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.createTaskQuery().
-                taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).
-                count());
+            assertThat(taskService.createTaskQuery().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
-                        taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).
-                        count());
+                assertThat(
+                        historyService.createHistoricTaskInstanceQuery().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).count())
+                        .isEqualTo(1);
             }
 
         } finally {
@@ -920,16 +829,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
-            assertEquals(1, taskService.createTaskQuery().
-                taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).
-                count());
+            assertThat(taskService.createTaskQuery().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
-                        taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).
-                        count());
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).count())
+                        .isEqualTo(1);
             }
 
         } finally {
@@ -951,15 +857,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
-            assertEquals(1, taskService.createTaskQuery().
-                taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).
-                count());
+            assertThat(taskService.createTaskQuery().taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
-                        taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).
-                        count());
+                assertThat(
+                        historyService.createHistoricTaskInstanceQuery().taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).count())
+                        .isEqualTo(1);
             }
 
         } finally {
@@ -981,16 +885,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
-            assertEquals(1, taskService.createTaskQuery().
-                taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).
-                count());
-            
+            assertThat(taskService.createTaskQuery().taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
-                        taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).
-                        count());
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup"))
+                        .count()).isEqualTo(1);
             }
 
         } finally {
@@ -1012,16 +913,14 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(1, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+            assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
-            assertEquals(1, taskService.createTaskQuery().
-                taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup")).
-                count());
-            
+            assertThat(taskService.createTaskQuery().taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup"))
+                    .count()).isEqualTo(1);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
-                        taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup")).
-                        count());
+                assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Collections.singletonList("kermit"))
+                        .taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
             }
 
         } finally {
@@ -1043,18 +942,18 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(3, taskService.createTaskQuery().
-                or().
-                    taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).
-                endOr().
-                count());
-            
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup"))
+                    .endOr()
+                    .count()).isEqualTo(3);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(3, historyService.createHistoricTaskInstanceQuery().
-                    or().
-                        taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).
-                    endOr().
-                    count());
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup"))
+                        .endOr()
+                        .count()).isEqualTo(3);
             }
 
         } finally {
@@ -1076,18 +975,18 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(3, taskService.createTaskQuery().
-                or().
-                    taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).
-                endOr().
-                count());
-            
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup"))
+                    .endOr()
+                    .count()).isEqualTo(3);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(3, historyService.createHistoricTaskInstanceQuery().
-                        or().
-                            taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).
-                        endOr().
-                        count());
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup"))
+                        .endOr()
+                        .count()).isEqualTo(3);
             }
 
         } finally {
@@ -1109,18 +1008,18 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(3, taskService.createTaskQuery().
-                or().
-                    taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup")).
-                endOr().
-                count());
-            
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup"))
+                    .endOr()
+                    .count()).isEqualTo(3);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(3, historyService.createHistoricTaskInstanceQuery().
-                        or().
-                            taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup")).
-                        endOr().
-                        count());
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup"))
+                        .endOr()
+                        .count()).isEqualTo(3);
             }
 
         } finally {
@@ -1142,18 +1041,18 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
 
-            assertEquals(3, taskService.createTaskQuery().
-                or().
-                    taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).
-                endOr().
-                count());
-            
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup"))
+                    .endOr()
+                    .count()).isEqualTo(3);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(3, historyService.createHistoricTaskInstanceQuery().
-                        or().
-                            taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).
-                        endOr().
-                        count());
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup"))
+                        .endOr()
+                        .count()).isEqualTo(3);
             }
 
         } finally {
@@ -1178,27 +1077,27 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", "customType");
             taskService.addGroupIdentityLink(adhocTask4.getId(), "testGroup", "customType");
 
-            assertEquals(4, taskService.createTaskQuery().
-                or().
-                    taskName("testName").
-                    taskInvolvedGroups(Collections.singleton("testGroup")).
-                endOr().
-                count());
-            assertEquals(1, taskService.createTaskQuery().
-                    taskName("testName").
-                    taskInvolvedGroups(Collections.singleton("testGroup")).
-                count());
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(4, historyService.createHistoricTaskInstanceQuery().
+            assertThat(taskService.createTaskQuery().
                     or().
-                        taskName("testName").
-                        taskInvolvedGroups(Collections.singleton("testGroup")).
+                    taskName("testName").
+                    taskInvolvedGroups(Collections.singleton("testGroup")).
                     endOr().
-                    count());
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
+                    count()).isEqualTo(4);
+            assertThat(taskService.createTaskQuery().
+                    taskName("testName").
+                    taskInvolvedGroups(Collections.singleton("testGroup")).
+                    count()).isEqualTo(1);
+            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+                assertThat(historyService.createHistoricTaskInstanceQuery().
+                        or().
                         taskName("testName").
                         taskInvolvedGroups(Collections.singleton("testGroup")).
-                    count());
+                        endOr().
+                        count()).isEqualTo(4);
+                assertThat(historyService.createHistoricTaskInstanceQuery().
+                        taskName("testName").
+                        taskInvolvedGroups(Collections.singleton("testGroup")).
+                        count()).isEqualTo(1);
             }
 
         } finally {
@@ -1223,28 +1122,28 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", IdentityLinkType.CANDIDATE);
             taskService.addGroupIdentityLink(adhocTask4.getId(), "testGroup", IdentityLinkType.CANDIDATE);
 
-            assertEquals(4, taskService.createTaskQuery().
-                or().
+            assertThat(taskService.createTaskQuery().
+                    or().
                     taskName("testName").
                     taskCandidateGroupIn(Collections.singletonList("testGroup")).
-                endOr().
-                count());
-            assertEquals(1, taskService.createTaskQuery().
+                    endOr().
+                    count()).isEqualTo(4);
+            assertThat(taskService.createTaskQuery().
                     taskName("testName").
                     taskCandidateGroupIn(Collections.singletonList("testGroup")).
-                count());
-            
+                    count()).isEqualTo(1);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(4, historyService.createHistoricTaskInstanceQuery().
+                assertThat(historyService.createHistoricTaskInstanceQuery().
                         or().
-                            taskName("testName").
-                            taskCandidateGroupIn(Collections.singletonList("testGroup")).
+                        taskName("testName").
+                        taskCandidateGroupIn(Collections.singletonList("testGroup")).
                         endOr().
-                        count());
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
-                    taskName("testName").
-                    taskCandidateGroupIn(Collections.singletonList("testGroup")).
-                    count());
+                        count()).isEqualTo(4);
+                assertThat(historyService.createHistoricTaskInstanceQuery().
+                        taskName("testName").
+                        taskCandidateGroupIn(Collections.singletonList("testGroup")).
+                        count()).isEqualTo(1);
             }
 
         } finally {
@@ -1269,28 +1168,28 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addUserIdentityLink(adhocTask3.getId(), "homer", IdentityLinkType.CANDIDATE);
             taskService.addUserIdentityLink(adhocTask4.getId(), "homer", IdentityLinkType.CANDIDATE);
 
-            assertEquals(4, taskService.createTaskQuery().
-                or().
+            assertThat(taskService.createTaskQuery().
+                    or().
                     taskName("testName").
                     taskCandidateUser("homer").
-                endOr().
-                count());
-            assertEquals(1, taskService.createTaskQuery().
-                taskName("testName").
-                taskCandidateUser("homer").
-                count());
-            
+                    endOr().
+                    count()).isEqualTo(4);
+            assertThat(taskService.createTaskQuery().
+                    taskName("testName").
+                    taskCandidateUser("homer").
+                    count()).isEqualTo(1);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(4, historyService.createHistoricTaskInstanceQuery().
-                    or().
+                assertThat(historyService.createHistoricTaskInstanceQuery().
+                        or().
                         taskName("testName").
                         taskCandidateUser("homer").
-                    endOr().
-                    count());
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
-                    taskName("testName").
-                    taskCandidateUser("homer").
-                    count());
+                        endOr().
+                        count()).isEqualTo(4);
+                assertThat(historyService.createHistoricTaskInstanceQuery().
+                        taskName("testName").
+                        taskCandidateUser("homer").
+                        count()).isEqualTo(1);
             }
 
         } finally {
@@ -1315,28 +1214,28 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             taskService.addGroupIdentityLink(adhocTask3.getId(), "testGroup", IdentityLinkType.CANDIDATE);
             taskService.addGroupIdentityLink(adhocTask4.getId(), "testGroup", IdentityLinkType.CANDIDATE);
 
-            assertEquals(4, taskService.createTaskQuery().
-                or().
+            assertThat(taskService.createTaskQuery().
+                    or().
                     taskName("testName").
                     taskCandidateGroup("testGroup").
-                endOr().
-                count());
-            assertEquals(1, taskService.createTaskQuery().
-                taskName("testName").
-                taskCandidateGroup("testGroup").
-                count());
-            
+                    endOr().
+                    count()).isEqualTo(4);
+            assertThat(taskService.createTaskQuery().
+                    taskName("testName").
+                    taskCandidateGroup("testGroup").
+                    count()).isEqualTo(1);
+
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                assertEquals(4, historyService.createHistoricTaskInstanceQuery().
-                    or().
+                assertThat(historyService.createHistoricTaskInstanceQuery().
+                        or().
                         taskName("testName").
                         taskCandidateGroup("testGroup").
-                    endOr().
-                    count());
-                assertEquals(1, historyService.createHistoricTaskInstanceQuery().
-                    taskName("testName").
-                    taskCandidateGroup("testGroup").
-                    count());
+                        endOr().
+                        count()).isEqualTo(4);
+                assertThat(historyService.createHistoricTaskInstanceQuery().
+                        taskName("testName").
+                        taskCandidateGroup("testGroup").
+                        count()).isEqualTo(1);
             }
 
         } finally {
@@ -1346,142 +1245,110 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testQueryByNullAssignee() {
-        try {
-            taskService.createTaskQuery().taskAssignee(null).list();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskAssignee(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByNullAssigneeOr() {
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskAssignee(null).list();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskAssignee(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByUnassigned() {
         TaskQuery query = taskService.createTaskQuery().taskUnassigned();
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
     }
 
     @Test
     public void testQueryByUnassignedOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskUnassigned();
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
     }
 
     @Test
     public void testQueryByCandidateUser() {
         TaskQuery query = taskService.createTaskQuery().taskCandidateUser("kermit");
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
+        TaskQuery finalQuery = query;
+        assertThatThrownBy(() -> finalQuery.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
 
         query = taskService.createTaskQuery().taskCandidateUser("fozzie");
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
+        TaskQuery finalQuery2 = query;
+        assertThatThrownBy(() -> finalQuery2.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testQueryByCandidateUserOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateUser("kermit");
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
+        TaskQuery finalQuery = query;
+        assertThatThrownBy(() -> finalQuery.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateUser("fozzie");
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
+        TaskQuery finalQuery2 = query;
+        assertThatThrownBy(() -> finalQuery2.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     public void testQueryByNullCandidateUser() {
-        try {
-            taskService.createTaskQuery().taskCandidateUser(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCandidateUser(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByNullCandidateUserOr() {
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskCandidateUser(null).list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskCandidateUser(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByCandidateGroup() {
         TaskQuery query = taskService.createTaskQuery().taskCandidateGroup("management");
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
+        TaskQuery finalQuery = query;
+        assertThatThrownBy(() -> finalQuery.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
 
         query = taskService.createTaskQuery().taskCandidateGroup("sales");
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
     }
 
     @Test
     public void testQueryByCandidateGroupOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroup("management");
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
+        TaskQuery finalQuery = query;
+        assertThatThrownBy(() -> finalQuery.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroup("sales");
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
     }
 
     @Test
     public void testQueryByCandidateOrAssigned() {
         TaskQuery query = taskService.createTaskQuery().taskCandidateOrAssigned("kermit");
-        assertEquals(11, query.count());
+        assertThat(query.count()).isEqualTo(11);
         List<org.flowable.task.api.Task> tasks = query.list();
-        assertEquals(11, tasks.size());
+        assertThat(tasks).hasSize(11);
 
         // if dbIdentityUsed set false in process engine configuration of using
         // custom session factory of GroupIdentityManager
@@ -1490,13 +1357,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         candidateGroups.add("accountancy");
         candidateGroups.add("noexist");
         query = taskService.createTaskQuery().taskCandidateGroupIn(candidateGroups).taskCandidateOrAssigned("kermit");
-        assertEquals(11, query.count());
+        assertThat(query.count()).isEqualTo(11);
         tasks = query.list();
-        assertEquals(11, tasks.size());
+        assertThat(tasks).hasSize(11);
 
         query = taskService.createTaskQuery().taskCandidateOrAssigned("fozzie");
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
 
         // create a new task that no identity link and assignee to kermit
         org.flowable.task.api.Task task = taskService.newTask();
@@ -1507,9 +1374,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.saveTask(task);
 
         query = taskService.createTaskQuery().taskCandidateOrAssigned("kermit");
-        assertEquals(12, query.count());
+        assertThat(query.count()).isEqualTo(12);
         tasks = query.list();
-        assertEquals(12, tasks.size());
+        assertThat(tasks).hasSize(12);
 
         org.flowable.task.api.Task assigneeToKermit = taskService.createTaskQuery().taskName("assigneeToKermit").singleResult();
         taskService.deleteTask(assigneeToKermit.getId(), true);
@@ -1518,9 +1385,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     @Test
     public void testQueryByCandidateOrAssignedOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateOrAssigned("kermit");
-        assertEquals(11, query.count());
+        assertThat(query.count()).isEqualTo(11);
         List<org.flowable.task.api.Task> tasks = query.list();
-        assertEquals(11, tasks.size());
+        assertThat(tasks).hasSize(11);
 
         // if dbIdentityUsed set false in process engine configuration of using
         // custom session factory of GroupIdentityManager
@@ -1529,13 +1396,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         candidateGroups.add("accountancy");
         candidateGroups.add("noexist");
         query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(candidateGroups).taskCandidateOrAssigned("kermit");
-        assertEquals(11, query.count());
+        assertThat(query.count()).isEqualTo(11);
         tasks = query.list();
-        assertEquals(11, tasks.size());
+        assertThat(tasks).hasSize(11);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateOrAssigned("fozzie");
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
 
         // create a new task that no identity link and assignee to kermit
         org.flowable.task.api.Task task = taskService.newTask();
@@ -1546,9 +1413,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.saveTask(task);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateOrAssigned("kermit");
-        assertEquals(12, query.count());
+        assertThat(query.count()).isEqualTo(12);
         tasks = query.list();
-        assertEquals(12, tasks.size());
+        assertThat(tasks).hasSize(12);
 
         org.flowable.task.api.Task assigneeToKermit = taskService.createTaskQuery().or().taskId("invalid").taskName("assigneeToKermit").singleResult();
         taskService.deleteTask(assigneeToKermit.getId(), true);
@@ -1583,37 +1450,37 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         List<Task> tasks = taskService.createTaskQuery()
                 .taskCandidateUser("kermit")
                 .list();
-        assertEquals(5, tasks.size());
+        assertThat(tasks).hasSize(5);
 
         tasks = taskService.createTaskQuery()
                 .taskCandidateUser("kermit")
                 .ignoreAssigneeValue()
                 .list();
-        assertEquals(12, tasks.size());
+        assertThat(tasks).hasSize(12);
 
         tasks = taskService.createTaskQuery()
                 .taskCandidateOrAssigned("kermit")
                 .list();
-        assertEquals(6, tasks.size());
+        assertThat(tasks).hasSize(6);
 
         tasks = taskService.createTaskQuery()
                 .taskCandidateOrAssigned("kermit")
                 .ignoreAssigneeValue()
                 .list();
-        assertEquals(13, tasks.size());
+        assertThat(tasks).hasSize(13);
 
         tasks = taskService.createTaskQuery()
                 .taskCandidateOrAssigned("gonzo")
                 .taskCandidateGroup("management")
                 .list();
-        assertEquals(10, tasks.size());
+        assertThat(tasks).hasSize(10);
 
         tasks = taskService.createTaskQuery()
                 .taskCandidateOrAssigned("gonzo")
                 .taskCandidateGroup("management")
                 .ignoreAssigneeValue()
                 .list();
-        assertEquals(11, tasks.size());
+        assertThat(tasks).hasSize(11);
 
         taskService.deleteTasks(createdTasks, true);
     }
@@ -1650,7 +1517,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .taskCandidateGroup("management")
                 .endOr()
                 .list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
         tasks = taskService.createTaskQuery()
                 .or()
@@ -1659,14 +1526,14 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .ignoreAssigneeValue()
                 .endOr()
                 .list();
-        assertEquals(10, tasks.size());
+        assertThat(tasks).hasSize(10);
 
         tasks = taskService.createTaskQuery()
                 .or()
                 .taskCandidateOrAssigned("kermit")
                 .endOr()
                 .list();
-        assertEquals(6, tasks.size());
+        assertThat(tasks).hasSize(6);
 
         tasks = taskService.createTaskQuery()
                 .or()
@@ -1674,7 +1541,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .ignoreAssigneeValue()
                 .endOr()
                 .list();
-        assertEquals(13, tasks.size());
+        assertThat(tasks).hasSize(13);
 
         tasks = taskService.createTaskQuery()
                 .or()
@@ -1682,7 +1549,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .taskCandidateGroup("management")
                 .endOr()
                 .list();
-        assertEquals(10, tasks.size());
+        assertThat(tasks).hasSize(10);
 
         tasks = taskService.createTaskQuery()
                 .or()
@@ -1691,209 +1558,179 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .ignoreAssigneeValue()
                 .endOr()
                 .list();
-        assertEquals(11, tasks.size());
+        assertThat(tasks).hasSize(11);
 
         taskService.deleteTasks(createdTasks, true);
     }
 
     @Test
     public void testQueryByNullCandidateGroup() {
-        try {
-            taskService.createTaskQuery().taskCandidateGroup(null).list();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCandidateGroup(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByNullCandidateGroupOr() {
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroup(null).list();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroup(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByCandidateGroupIn() {
         List<String> groups = Arrays.asList("management", "accountancy");
         TaskQuery query = taskService.createTaskQuery().taskCandidateGroupIn(groups);
-        assertEquals(5, query.count());
-        assertEquals(5, query.list().size());
+        assertThat(query.count()).isEqualTo(5);
+        assertThat(query.list()).hasSize(5);
 
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        TaskQuery finalQuery = query;
+        assertThatThrownBy(() -> finalQuery.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
 
         query = taskService.createTaskQuery().taskCandidateUser("kermit").taskCandidateGroupIn(groups);
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
 
         query = taskService.createTaskQuery().taskCandidateUser("kermit").taskCandidateGroup("unexisting");
-        assertEquals(6, query.count());
-        assertEquals(6, query.list().size());
+        assertThat(query.count()).isEqualTo(6);
+        assertThat(query.list()).hasSize(6);
 
         query = taskService.createTaskQuery().taskCandidateUser("unexisting").taskCandidateGroup("unexisting");
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
 
         // Unexisting groups or groups that don't have candidate tasks shouldn't
         // influence other results
         groups = Arrays.asList("management", "accountancy", "sales", "unexising");
         query = taskService.createTaskQuery().taskCandidateGroupIn(groups);
-        assertEquals(5, query.count());
-        assertEquals(5, query.list().size());
+        assertThat(query.count()).isEqualTo(5);
+        assertThat(query.list()).hasSize(5);
     }
 
     @Test
     public void testQueryByCandidateGroupInOr() {
         List<String> groups = Arrays.asList("management", "accountancy");
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(groups);
-        assertEquals(5, query.count());
-        assertEquals(5, query.list().size());
+        assertThat(query.count()).isEqualTo(5);
+        assertThat(query.list()).hasSize(5);
 
-        try {
-            query.singleResult();
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // OK
-        }
+        TaskQuery finalQuery = query;
+        assertThatThrownBy(() -> finalQuery.singleResult())
+                .isExactlyInstanceOf(FlowableException.class);
 
         query = taskService.createTaskQuery().or().taskCandidateUser("kermit").taskCandidateGroupIn(groups).endOr();
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
 
         query = taskService.createTaskQuery().or().taskCandidateUser("kermit").taskCandidateGroup("unexisting").endOr();
-        assertEquals(6, query.count());
-        assertEquals(6, query.list().size());
+        assertThat(query.count()).isEqualTo(6);
+        assertThat(query.list()).hasSize(6);
 
         query = taskService.createTaskQuery().or().taskCandidateUser("unexisting").taskCandidateGroup("unexisting").endOr();
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
 
         query = taskService.createTaskQuery().or().taskCandidateUser("kermit").taskCandidateGroupIn(groups).endOr()
                 .or().taskCandidateUser("gonzo").taskCandidateGroupIn(groups);
-        assertEquals(5, query.count());
-        assertEquals(5, query.list().size());
+        assertThat(query.count()).isEqualTo(5);
+        assertThat(query.list()).hasSize(5);
 
         // Unexisting groups or groups that don't have candidate tasks shouldn't influence other results
         groups = Arrays.asList("management", "accountancy", "sales", "unexising");
         query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(groups);
-        assertEquals(5, query.count());
-        assertEquals(5, query.list().size());
+        assertThat(query.count()).isEqualTo(5);
+        assertThat(query.list()).hasSize(5);
     }
 
     @Test
     public void testQueryByNullCandidateGroupIn() {
-        try {
-            taskService.createTaskQuery().taskCandidateGroupIn(null).list();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
-        try {
-            taskService.createTaskQuery().taskCandidateGroupIn(new ArrayList<>()).list();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCandidateGroupIn(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCandidateGroupIn(new ArrayList<>()).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByNullCandidateGroupInOr() {
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(null).list();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
-        try {
-            taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(new ArrayList<>()).list();
-            fail("expected exception");
-        } catch (FlowableIllegalArgumentException e) {
-            // OK
-        }
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(null).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+        assertThatThrownBy(() -> taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(new ArrayList<>()).list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
     public void testQueryByDelegationState() {
         TaskQuery query = taskService.createTaskQuery().taskDelegationState(null);
-        assertEquals(12, query.count());
-        assertEquals(12, query.list().size());
+        assertThat(query.count()).isEqualTo(12);
+        assertThat(query.list()).hasSize(12);
         query = taskService.createTaskQuery().taskDelegationState(DelegationState.PENDING);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
         query = taskService.createTaskQuery().taskDelegationState(DelegationState.RESOLVED);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
 
         String taskId = taskService.createTaskQuery().taskAssignee("gonzo").singleResult().getId();
         taskService.delegateTask(taskId, "kermit");
 
         query = taskService.createTaskQuery().taskDelegationState(null);
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
         query = taskService.createTaskQuery().taskDelegationState(DelegationState.PENDING);
-        assertEquals(1, query.count());
-        assertEquals(1, query.list().size());
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
         query = taskService.createTaskQuery().taskDelegationState(DelegationState.RESOLVED);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
 
         taskService.resolveTask(taskId);
 
         query = taskService.createTaskQuery().taskDelegationState(null);
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
         query = taskService.createTaskQuery().taskDelegationState(DelegationState.PENDING);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
         query = taskService.createTaskQuery().taskDelegationState(DelegationState.RESOLVED);
-        assertEquals(1, query.count());
-        assertEquals(1, query.list().size());
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
     }
 
     @Test
     public void testQueryByDelegationStateOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(null);
-        assertEquals(12, query.count());
-        assertEquals(12, query.list().size());
+        assertThat(query.count()).isEqualTo(12);
+        assertThat(query.list()).hasSize(12);
         query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(DelegationState.PENDING);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
         query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(DelegationState.RESOLVED);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
 
         String taskId = taskService.createTaskQuery().or().taskId("invalid").taskAssignee("gonzo").singleResult().getId();
         taskService.delegateTask(taskId, "kermit");
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(null);
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
         query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(DelegationState.PENDING);
-        assertEquals(1, query.count());
-        assertEquals(1, query.list().size());
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
         query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(DelegationState.RESOLVED);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
 
         taskService.resolveTask(taskId);
 
         query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(null);
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
         query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(DelegationState.PENDING);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
         query = taskService.createTaskQuery().or().taskId("invalid").taskDelegationState(DelegationState.RESOLVED);
-        assertEquals(1, query.count());
-        assertEquals(1, query.list().size());
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
     }
 
     @Test
@@ -1904,8 +1741,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         Date createTime = sdf.parse("01/01/2001 01:01:01.000");
 
         TaskQuery query = taskService.createTaskQuery().taskCreatedOn(createTime);
-        assertEquals(6, query.count());
-        assertEquals(6, query.list().size());
+        assertThat(query.count()).isEqualTo(6);
+        assertThat(query.list()).hasSize(6);
     }
 
     @Test
@@ -1916,8 +1753,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         Date createTime = sdf.parse("01/01/2001 01:01:01.000");
 
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCreatedOn(createTime);
-        assertEquals(6, query.count());
-        assertEquals(6, query.list().size());
+        assertThat(query.count()).isEqualTo(6);
+        assertThat(query.list()).hasSize(6);
     }
 
     @Test
@@ -1928,13 +1765,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         Date before = sdf.parse("03/02/2002 02:02:02.000");
 
         TaskQuery query = taskService.createTaskQuery().taskCreatedBefore(before);
-        assertEquals(7, query.count());
-        assertEquals(7, query.list().size());
+        assertThat(query.count()).isEqualTo(7);
+        assertThat(query.list()).hasSize(7);
 
         before = sdf.parse("01/01/2001 01:01:01.000");
         query = taskService.createTaskQuery().taskCreatedBefore(before);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
     }
 
     @Test
@@ -1945,13 +1782,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         Date before = sdf.parse("03/02/2002 02:02:02.000");
 
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCreatedBefore(before);
-        assertEquals(7, query.count());
-        assertEquals(7, query.list().size());
+        assertThat(query.count()).isEqualTo(7);
+        assertThat(query.list()).hasSize(7);
 
         before = sdf.parse("01/01/2001 01:01:01.000");
         query = taskService.createTaskQuery().or().taskId("invalid").taskCreatedBefore(before);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
     }
 
     @Test
@@ -1962,13 +1799,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         Date after = sdf.parse("03/03/2003 03:03:03.000");
 
         TaskQuery query = taskService.createTaskQuery().taskCreatedAfter(after);
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
 
         after = sdf.parse("05/05/2005 05:05:05.000");
         query = taskService.createTaskQuery().taskCreatedAfter(after);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
     }
 
     @Test
@@ -1979,13 +1816,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         Date after = sdf.parse("03/03/2003 03:03:03.000");
 
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCreatedAfter(after);
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
 
         after = sdf.parse("05/05/2005 05:05:05.000");
         query = taskService.createTaskQuery().or().taskId("invalid").taskCreatedAfter(after);
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
     }
 
     @Test
@@ -1997,14 +1834,14 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         // 1 task should exist with key "taskKey1"
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("taskKey1").list();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
-
-        assertEquals("taskKey1", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskKey1");
 
         // No task should be found with unexisting key
         Long count = taskService.createTaskQuery().taskDefinitionKey("unexistingKey").count();
-        assertEquals(0L, count.longValue());
+        assertThat(count.longValue()).isZero();
     }
 
     @Test
@@ -2016,14 +1853,14 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         // 1 task should exist with key "taskKey1"
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKey("taskKey1").list();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
-
-        assertEquals("taskKey1", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskKey1");
 
         // No task should be found with unexisting key
         Long count = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKey("unexistingKey").count();
-        assertEquals(0L, count.longValue());
+        assertThat(count.longValue()).isZero();
     }
 
     @Test
@@ -2041,9 +1878,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 tuple("taskKey123", "Task B")
             );
 
-        assertThat(taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid")).count()).isEqualTo(2L);
+        assertThat(taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid")).count()).isEqualTo(2);
 
-        assertThat(taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).count()).isEqualTo(0L);
+        assertThat(taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).count()).isZero();
         assertThat(taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).list()).isEmpty();
     }
 
@@ -2064,10 +1901,10 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             );
 
         assertThat(taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid")).endOr().count())
-            .isEqualTo(2L);
+                .isEqualTo(2);
 
         assertThat(taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).endOr().count())
-            .isEqualTo(0L);
+                .isZero();
 
         assertThat(taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).endOr().list())
             .isEmpty();
@@ -2082,29 +1919,28 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         // Ends with matching, TaskKey1 and TaskKey123 match
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKeyLike("taskKey1%").orderByTaskName().asc().list();
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
-
-        assertEquals("taskKey1", tasks.get(0).getTaskDefinitionKey());
-        assertEquals("taskKey123", tasks.get(1).getTaskDefinitionKey());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskKey1", "taskKey123");
 
         // Starts with matching, TaskKey123 matches
         tasks = taskService.createTaskQuery().taskDefinitionKeyLike("%123").orderByTaskName().asc().list();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
-
-        assertEquals("taskKey123", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskKey123");
 
         // Contains matching, TaskKey123 matches
         tasks = taskService.createTaskQuery().taskDefinitionKeyLike("%Key12%").orderByTaskName().asc().list();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
-
-        assertEquals("taskKey123", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskKey123");
 
         // No task should be found with unexisting key
         Long count = taskService.createTaskQuery().taskDefinitionKeyLike("%unexistingKey%").count();
-        assertEquals(0L, count.longValue());
+        assertThat(count.longValue()).isZero();
     }
 
     @Test
@@ -2115,30 +1951,30 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("taskDefinitionKeyProcess");
 
         // Ends with matching, TaskKey1 and TaskKey123 match
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeyLike("taskKey1%").orderByTaskName().asc().list();
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
-
-        assertEquals("taskKey1", tasks.get(0).getTaskDefinitionKey());
-        assertEquals("taskKey123", tasks.get(1).getTaskDefinitionKey());
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeyLike("taskKey1%").orderByTaskName().asc()
+                .list();
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskKey1", "taskKey123");
 
         // Starts with matching, TaskKey123 matches
         tasks = taskService.createTaskQuery().or().taskDefinitionKeyLike("%123").taskId("invalid").orderByTaskName().asc().list();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
-
-        assertEquals("taskKey123", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskKey123");
 
         // Contains matching, TaskKey123 matches
         tasks = taskService.createTaskQuery().or().taskDefinitionKeyLike("%Key12%").taskId("invalid").orderByTaskName().asc().list();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
-
-        assertEquals("taskKey123", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("taskKey123");
 
         // No task should be found with unexisting key
         Long count = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeyLike("%unexistingKey%").count();
-        assertEquals(0L, count.longValue());
+        assertThat(count.longValue()).isZero();
     }
 
     @Test
@@ -2148,7 +1984,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         // No task should be found for an unexisting var
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("unexistingVar", "value").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("unexistingVar", "value").count()).isZero();
 
         // Create a map with a variable for all default types
         Map<String, Object> variables = new HashMap<>();
@@ -2164,67 +2000,67 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.setVariablesLocal(task.getId(), variables);
 
         // Test query matches
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals("longVar", 928374L).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals("shortVar", (short) 123).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals("integerVar", 1234).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals("stringVar", "stringValue").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals("booleanVar", true).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals("dateVar", date).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals("nullVar", null).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("longVar", 928374L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("shortVar", (short) 123).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("integerVar", 1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("stringVar", "stringValue").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("booleanVar", true).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("dateVar", date).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("nullVar", null).count()).isEqualTo(1);
 
         // Test query for other values on existing variables
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("longVar", 999L).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("shortVar", (short) 999).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("integerVar", 999).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("stringVar", "999").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("booleanVar", false).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("longVar", 999L).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("shortVar", (short) 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("integerVar", 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("stringVar", "999").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("booleanVar", false).count()).isZero();
         Calendar otherDate = Calendar.getInstance();
         otherDate.add(Calendar.YEAR, 1);
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("dateVar", otherDate.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("nullVar", "999").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("dateVar", otherDate.getTime()).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("nullVar", "999").count()).isZero();
 
         // Test query for not equals
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueNotEquals("longVar", 999L).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueNotEquals("shortVar", (short) 999).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueNotEquals("integerVar", 999).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueNotEquals("stringVar", "999").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueNotEquals("booleanVar", false).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("longVar", 999L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("shortVar", (short) 999).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("integerVar", 999).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("stringVar", "999").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("booleanVar", false).count()).isEqualTo(1);
 
         // Test value-only variable equals
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals(928374L).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals((short) 123).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals(1234).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals("stringValue").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals(true).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals(date).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEquals(null).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(928374L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals((short) 123).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("stringValue").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(true).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(date).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(null).count()).isEqualTo(1);
 
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals(999999L).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals((short) 999).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals(9999).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("unexistingstringvalue").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals(false).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals(otherDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(999999L).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals((short) 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(9999).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("unexistingstringvalue").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(false).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals(otherDate.getTime()).count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueLike("stringVar", "string%").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueLike("stringVar", "String%").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueLike("stringVar", "%Value").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueLike("stringVar", "string%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueLike("stringVar", "String%").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueLike("stringVar", "%Value").count()).isEqualTo(1);
 
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThan("integerVar", 1000).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThan("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThan("integerVar", 1240).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueGreaterThan("integerVar", 1000).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueGreaterThan("integerVar", 1234).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueGreaterThan("integerVar", 1240).count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThanOrEqual("integerVar", 1000).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThanOrEqual("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThanOrEqual("integerVar", 1240).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueGreaterThanOrEqual("integerVar", 1000).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueGreaterThanOrEqual("integerVar", 1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueGreaterThanOrEqual("integerVar", 1240).count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThan("integerVar", 1240).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThan("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThan("integerVar", 1000).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueLessThan("integerVar", 1240).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueLessThan("integerVar", 1234).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueLessThan("integerVar", 1000).count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThanOrEqual("integerVar", 1240).count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThanOrEqual("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThanOrEqual("integerVar", 1000).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueLessThanOrEqual("integerVar", 1240).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueLessThanOrEqual("integerVar", 1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueLessThanOrEqual("integerVar", 1000).count()).isZero();
     }
 
     @Test
@@ -2234,7 +2070,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         // No task should be found for an unexisting var
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("unexistingVar", "value").count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("unexistingVar", "value").count()).isZero();
 
         // Create a map with a variable for all default types
         Map<String, Object> variables = new HashMap<>();
@@ -2250,67 +2086,67 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.setVariablesLocal(task.getId(), variables);
 
         // Test query matches
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("longVar", 928374L).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("shortVar", (short) 123).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("integerVar", 1234).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("stringVar", "stringValue").count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("booleanVar", true).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("dateVar", date).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("nullVar", null).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("longVar", 928374L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("shortVar", (short) 123).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("integerVar", 1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("stringVar", "stringValue").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("booleanVar", true).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("dateVar", date).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("nullVar", null).count()).isEqualTo(1);
 
         // Test query for other values on existing variables
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("longVar", 999L).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("shortVar", (short) 999).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("integerVar", 999).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("stringVar", "999").count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("booleanVar", false).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("longVar", 999L).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("shortVar", (short) 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("integerVar", 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("stringVar", "999").count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("booleanVar", false).count()).isZero();
         Calendar otherDate = Calendar.getInstance();
         otherDate.add(Calendar.YEAR, 1);
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("dateVar", otherDate.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("nullVar", "999").count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("dateVar", otherDate.getTime()).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("nullVar", "999").count()).isZero();
 
         // Test query for not equals
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("longVar", 999L).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("shortVar", (short) 999).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("integerVar", 999).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("stringVar", "999").count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("booleanVar", false).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("longVar", 999L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("shortVar", (short) 999).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("integerVar", 999).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("stringVar", "999").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueNotEquals("booleanVar", false).count()).isEqualTo(1);
 
         // Test value-only variable equals
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(928374L).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals((short) 123).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(1234).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("stringValue").count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(true).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(date).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(null).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(928374L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals((short) 123).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("stringValue").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(true).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(date).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(null).count()).isEqualTo(1);
 
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(999999L).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals((short) 999).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(9999).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("unexistingstringvalue").count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(false).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(otherDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(999999L).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals((short) 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(9999).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("unexistingstringvalue").count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(false).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals(otherDate.getTime()).count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLike("stringVar", "string%").count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLike("stringVar", "String%").count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLike("stringVar", "%Value").count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLike("stringVar", "string%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLike("stringVar", "String%").count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLike("stringVar", "%Value").count()).isEqualTo(1);
 
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThan("integerVar", 1000).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThan("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThan("integerVar", 1240).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThan("integerVar", 1000).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThan("integerVar", 1234).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThan("integerVar", 1240).count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThanOrEqual("integerVar", 1000).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThanOrEqual("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThanOrEqual("integerVar", 1240).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThanOrEqual("integerVar", 1000).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThanOrEqual("integerVar", 1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueGreaterThanOrEqual("integerVar", 1240).count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThan("integerVar", 1240).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThan("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThan("integerVar", 1000).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThan("integerVar", 1240).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThan("integerVar", 1234).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThan("integerVar", 1000).count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThanOrEqual("integerVar", 1240).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThanOrEqual("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThanOrEqual("integerVar", 1000).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThanOrEqual("integerVar", 1240).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThanOrEqual("integerVar", 1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueLessThanOrEqual("integerVar", 1000).count()).isZero();
     }
 
     @Test
@@ -2330,73 +2166,74 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
         // Test query matches
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("longVar", 928374L).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("shortVar", (short) 123).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("integerVar", 1234).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("stringVar", "stringValue").count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("booleanVar", true).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("dateVar", date).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("nullVar", null).count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("longVar", 928374L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("shortVar", (short) 123).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("integerVar", 1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("stringVar", "stringValue").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("booleanVar", true).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("dateVar", date).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("nullVar", null).count()).isEqualTo(1);
 
         // Test query for other values on existing variables
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals("longVar", 999L).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals("shortVar", (short) 999).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals("integerVar", 999).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals("stringVar", "999").count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals("booleanVar", false).count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("longVar", 999L).count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("shortVar", (short) 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("integerVar", 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("stringVar", "999").count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("booleanVar", false).count()).isZero();
         Calendar otherDate = Calendar.getInstance();
         otherDate.add(Calendar.YEAR, 1);
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals("dateVar", otherDate.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals("nullVar", "999").count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("dateVar", otherDate.getTime()).count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("nullVar", "999").count()).isZero();
 
         // Test querying for task variables don't match the process-variables
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("longVar", 928374L).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("shortVar", (short) 123).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("stringVar", "stringValue").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("booleanVar", true).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("dateVar", date).count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEquals("nullVar", null).count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("longVar", 928374L).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("shortVar", (short) 123).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("integerVar", 1234).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("stringVar", "stringValue").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("booleanVar", true).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("dateVar", date).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("nullVar", null).count()).isZero();
 
         // Test querying for task variables not equals
-        assertEquals(1, taskService.createTaskQuery().processVariableValueNotEquals("longVar", 999L).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueNotEquals("shortVar", (short) 999).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueNotEquals("integerVar", 999).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueNotEquals("stringVar", "999").count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueNotEquals("booleanVar", false).count());
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("longVar", 999L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("shortVar", (short) 999).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("integerVar", 999).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("stringVar", "999").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("booleanVar", false).count()).isEqualTo(1);
 
-        // and query for the existing variable with NOT should result in nothing
-        // found:
-        assertEquals(0, taskService.createTaskQuery().processVariableValueNotEquals("longVar", 928374L).count());
+        // and query for the existing variable with NOT should result in nothing found:
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("longVar", 928374L).count()).isZero();
 
         // Test value-only variable equals
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals(928374L).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals((short) 123).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals(1234).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("stringValue").count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals(true).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals(date).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals(null).count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(928374L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals((short) 123).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("stringValue").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(true).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(date).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(null).count()).isEqualTo(1);
 
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals(999999L).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals((short) 999).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals(9999).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals("unexistingstringvalue").count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals(false).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEquals(otherDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(999999L).count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals((short) 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(9999).count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("unexistingstringvalue").count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(false).count()).isZero();
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(otherDate.getTime()).count()).isZero();
 
         // Test combination of task-variable and process-variable
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.setVariableLocal(task.getId(), "taskVar", "theValue");
         taskService.setVariableLocal(task.getId(), "longVar", 928374L);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("longVar", 928374L).taskVariableValueEquals("taskVar", "theValue").count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("longVar", 928374L).taskVariableValueEquals("taskVar", "theValue").count())
+                .isEqualTo(1);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals("longVar", 928374L).taskVariableValueEquals("longVar", 928374L).count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("longVar", 928374L).taskVariableValueEquals("longVar", 928374L).count())
+                .isEqualTo(1);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals(928374L).taskVariableValueEquals("theValue").count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(928374L).taskVariableValueEquals("theValue").count()).isEqualTo(1);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEquals(928374L).taskVariableValueEquals(928374L).count());
+        assertThat(taskService.createTaskQuery().processVariableValueEquals(928374L).taskVariableValueEquals(928374L).count()).isEqualTo(1);
     }
 
     @Test
@@ -2416,60 +2253,59 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
         // Test query matches
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("longVar", 928374L).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("shortVar", (short) 123).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("integerVar", 1234).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("stringVar", "stringValue").count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("booleanVar", true).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("dateVar", date).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("nullVar", null).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("longVar", 928374L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("shortVar", (short) 123).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("integerVar", 1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("stringVar", "stringValue").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("booleanVar", true).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("dateVar", date).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("nullVar", null).count()).isEqualTo(1);
 
         // Test query for other values on existing variables
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("longVar", 999L).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("shortVar", (short) 999).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("integerVar", 999).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("stringVar", "999").count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("booleanVar", false).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("longVar", 999L).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("shortVar", (short) 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("integerVar", 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("stringVar", "999").count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("booleanVar", false).count()).isZero();
         Calendar otherDate = Calendar.getInstance();
         otherDate.add(Calendar.YEAR, 1);
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("dateVar", otherDate.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("nullVar", "999").count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("dateVar", otherDate.getTime()).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("nullVar", "999").count()).isZero();
 
         // Test querying for task variables don't match the process-variables
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("longVar", 928374L).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("shortVar", (short) 123).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("integerVar", 1234).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("stringVar", "stringValue").count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("booleanVar", true).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("dateVar", date).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("nullVar", null).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("longVar", 928374L).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("shortVar", (short) 123).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("integerVar", 1234).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("stringVar", "stringValue").count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("booleanVar", true).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("dateVar", date).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskVariableValueEquals("nullVar", null).count()).isZero();
 
         // Test querying for task variables not equals
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("longVar", 999L).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("shortVar", (short) 999).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("integerVar", 999).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("stringVar", "999").count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("booleanVar", false).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("longVar", 999L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("shortVar", (short) 999).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("integerVar", 999).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("stringVar", "999").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueNotEquals("booleanVar", false).count()).isEqualTo(1);
 
-        // and query for the existing variable with NOT should result in nothing
-        // found:
-        assertEquals(0, taskService.createTaskQuery().processVariableValueNotEquals("longVar", 928374L).count());
+        // and query for the existing variable with NOT should result in nothing found:
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("longVar", 928374L).count()).isZero();
 
         // Test value-only variable equals
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(928374L).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals((short) 123).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(1234).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("stringValue").count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(true).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(date).count());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(null).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(928374L).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals((short) 123).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(1234).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("stringValue").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(true).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(date).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(null).count()).isEqualTo(1);
 
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(999999L).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals((short) 999).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(9999).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("unexistingstringvalue").count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(false).count());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(otherDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(999999L).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals((short) 999).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(9999).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals("unexistingstringvalue").count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(false).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processVariableValueEquals(otherDate.getTime()).count()).isZero();
     }
 
     @Test
@@ -2478,7 +2314,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         Map<String, Object> variables = new HashMap<>();
         variables.put("mixed", "AzerTY");
@@ -2486,30 +2322,30 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         variables.put("lower", "azerty");
         taskService.setVariablesLocal(task.getId(), variables);
 
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("mixed", "azerTY").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("mixed", "azerty").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("mixed", "uiop").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("mixed", "azerTY").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("mixed", "azerty").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("mixed", "uiop").count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("upper", "azerTY").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("upper", "azerty").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("upper", "uiop").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("upper", "azerTY").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("upper", "azerty").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("upper", "uiop").count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("lower", "azerTY").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("lower", "azerty").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("lower", "uiop").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("lower", "azerTY").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("lower", "azerty").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("lower", "uiop").count()).isZero();
 
         // Test not-equals
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("mixed", "azerTY").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("mixed", "azerty").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("mixed", "uiop").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("mixed", "azerTY").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("mixed", "azerty").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("mixed", "uiop").count()).isEqualTo(1);
 
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("upper", "azerTY").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("upper", "azerty").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("upper", "uiop").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("upper", "azerTY").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("upper", "azerty").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("upper", "uiop").count()).isEqualTo(1);
 
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("lower", "azerTY").count());
-        assertEquals(0, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("lower", "azerty").count());
-        assertEquals(1, taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("lower", "uiop").count());
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("lower", "azerTY").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("lower", "azerty").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("lower", "uiop").count()).isEqualTo(1);
 
     }
 
@@ -2523,17 +2359,17 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("mixed", "azerTY").count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("mixed", "azerty").count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("mixed", "uiop").count());
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("mixed", "azerTY").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("mixed", "azerty").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("mixed", "uiop").count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("upper", "azerTY").count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("upper", "azerty").count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("upper", "uiop").count());
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("upper", "azerTY").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("upper", "azerty").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("upper", "uiop").count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("lower", "azerTY").count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("lower", "azerty").count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("lower", "uiop").count());
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("lower", "azerTY").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("lower", "azerty").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("lower", "uiop").count()).isZero();
     }
 
     @Test
@@ -2544,9 +2380,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueLike("mixed", "Azer%").count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueLike("mixed", "A%").count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueLike("mixed", "a%").count());
+        assertThat(taskService.createTaskQuery().processVariableValueLike("mixed", "Azer%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueLike("mixed", "A%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueLike("mixed", "a%").count()).isZero();
     }
 
     @Test
@@ -2557,9 +2393,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueLikeIgnoreCase("mixed", "azer%").count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueLikeIgnoreCase("mixed", "a%").count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueLikeIgnoreCase("mixed", "Azz%").count());
+        assertThat(taskService.createTaskQuery().processVariableValueLikeIgnoreCase("mixed", "azer%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueLikeIgnoreCase("mixed", "a%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueLikeIgnoreCase("mixed", "Azz%").count()).isZero();
     }
 
     @Test
@@ -2570,8 +2406,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThan("number", 5).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThan("number", 10).count());
+        assertThat(taskService.createTaskQuery().processVariableValueGreaterThan("number", 5).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueGreaterThan("number", 10).count()).isZero();
     }
 
     @Test
@@ -2582,9 +2418,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThanOrEqual("number", 5).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThanOrEqual("number", 10).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThanOrEqual("number", 11).count());
+        assertThat(taskService.createTaskQuery().processVariableValueGreaterThanOrEqual("number", 5).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueGreaterThanOrEqual("number", 10).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueGreaterThanOrEqual("number", 11).count()).isZero();
     }
 
     @Test
@@ -2595,8 +2431,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueLessThan("number", 12).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueLessThan("number", 10).count());
+        assertThat(taskService.createTaskQuery().processVariableValueLessThan("number", 12).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueLessThan("number", 10).count()).isZero();
     }
 
     @Test
@@ -2607,9 +2443,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-        assertEquals(1, taskService.createTaskQuery().processVariableValueLessThanOrEqual("number", 12).count());
-        assertEquals(1, taskService.createTaskQuery().processVariableValueLessThanOrEqual("number", 10).count());
-        assertEquals(0, taskService.createTaskQuery().processVariableValueLessThanOrEqual("number", 8).count());
+        assertThat(taskService.createTaskQuery().processVariableValueLessThanOrEqual("number", 12).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueLessThanOrEqual("number", 10).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processVariableValueLessThanOrEqual("number", 8).count()).isZero();
     }
 
     @Test
@@ -2618,10 +2454,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();
-        assertEquals(1, tasks.size());
-        assertEquals(processInstance.getId(), tasks.get(0).getProcessInstanceId());
+        assertThat(tasks)
+                .extracting(Task::getProcessInstanceId)
+                .containsExactly(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().processDefinitionId("unexisting").count());
+        assertThat(taskService.createTaskQuery().processDefinitionId("unexisting").count()).isZero();
     }
 
     @Test
@@ -2629,9 +2466,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testProcessDefinitionIdOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().or().taskId("invalid").processDefinitionId(processInstance.getProcessDefinitionId()).list();
-        assertEquals(1, tasks.size());
-        assertEquals(processInstance.getId(), tasks.get(0).getProcessInstanceId());
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().or().taskId("invalid")
+                .processDefinitionId(processInstance.getProcessDefinitionId()).list();
+        assertThat(tasks)
+                .extracting(Task::getProcessInstanceId)
+                .containsExactly(processInstance.getId());
 
         tasks = taskService.createTaskQuery()
                 .or()
@@ -2643,13 +2482,15 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .processDefinitionId("invalid")
                 .endOr()
                 .list();
-        assertEquals(1, tasks.size());
-        assertEquals(processInstance.getId(), tasks.get(0).getProcessInstanceId());
+        assertThat(tasks)
+                .extracting(Task::getProcessInstanceId)
+                .containsExactly(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery()
+        assertThat(taskService.createTaskQuery()
                 .or()
                 .taskId("invalid")
-                .processDefinitionId("unexisting").count());
+                .processDefinitionId("unexisting")
+                .count()).isZero();
     }
 
     @Test
@@ -2658,10 +2499,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processDefinitionKey("oneTaskProcess").list();
-        assertEquals(1, tasks.size());
-        assertEquals(processInstance.getId(), tasks.get(0).getProcessInstanceId());
+        assertThat(tasks)
+                .extracting(Task::getProcessInstanceId)
+                .containsExactly(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().processDefinitionKey("unexisting").count());
+        assertThat(taskService.createTaskQuery().processDefinitionKey("unexisting").count()).isZero();
     }
 
     @Test
@@ -2670,12 +2512,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().or().taskId("invalid").processDefinitionKey("oneTaskProcess").list();
-        assertEquals(1, tasks.size());
-        assertEquals(processInstance.getId(), tasks.get(0).getProcessInstanceId());
+        assertThat(tasks)
+                .extracting(Task::getProcessInstanceId)
+                .containsExactly(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processDefinitionKey("unexisting").count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processDefinitionKey("unexisting").count()).isZero();
 
-        assertEquals(1, taskService.createTaskQuery().or().taskId(taskIds.get(0)).processDefinitionKey("unexisting").endOr().count());
+        assertThat(taskService.createTaskQuery().or().taskId(taskIds.get(0)).processDefinitionKey("unexisting").endOr().count()).isEqualTo(1);
     }
 
     @Test
@@ -2684,11 +2527,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         List<String> includeIds = new ArrayList<>();
 
-        assertEquals(13, taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count());
+        assertThat(taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count()).isEqualTo(13);
         includeIds.add("unexisting");
-        assertEquals(0, taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count());
+        assertThat(taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count()).isZero();
         includeIds.add("oneTaskProcess");
-        assertEquals(1, taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count());
+        assertThat(taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count()).isEqualTo(1);
     }
 
     @Test
@@ -2697,22 +2540,22 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<String> includeIds = new ArrayList<>();
-        assertEquals(0, taskService.createTaskQuery()
+        assertThat(taskService.createTaskQuery()
                 .or().taskId("invalid")
                 .processDefinitionKeyIn(includeIds)
-                .count());
+                .count()).isZero();
 
         includeIds.add("unexisting");
-        assertEquals(0, taskService.createTaskQuery()
+        assertThat(taskService.createTaskQuery()
                 .or().taskId("invalid")
                 .processDefinitionKeyIn(includeIds)
-                .count());
+                .count()).isZero();
 
         includeIds.add("oneTaskProcess");
-        assertEquals(1, taskService.createTaskQuery()
+        assertThat(taskService.createTaskQuery()
                 .or().taskId("invalid")
                 .processDefinitionKeyIn(includeIds)
-                .count());
+                .count()).isEqualTo(1);
     }
 
     @Test
@@ -2721,10 +2564,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processDefinitionName("The One Task Process").list();
-        assertEquals(1, tasks.size());
-        assertEquals(processInstance.getId(), tasks.get(0).getProcessInstanceId());
+        assertThat(tasks)
+                .extracting(Task::getProcessInstanceId)
+                .containsExactly(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().processDefinitionName("unexisting").count());
+        assertThat(taskService.createTaskQuery().processDefinitionName("unexisting").count()).isZero();
     }
 
     @Test
@@ -2733,10 +2577,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().or().taskId("invalid").processDefinitionName("The One Task Process").list();
-        assertEquals(1, tasks.size());
-        assertEquals(processInstance.getId(), tasks.get(0).getProcessInstanceId());
+        assertThat(tasks)
+                .extracting(Task::getProcessInstanceId)
+                .containsExactly(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processDefinitionName("unexisting").count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processDefinitionName("unexisting").count()).isZero();
     }
 
     @Test
@@ -2745,11 +2590,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         final org.flowable.task.api.Task task = taskService.createTaskQuery().processCategoryIn(Collections.singletonList("Examples")).singleResult();
-        assertNotNull(task);
-        assertEquals("theTask", task.getTaskDefinitionKey());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().processCategoryIn(Collections.singletonList("unexisting")).count());
+        assertThat(taskService.createTaskQuery().processCategoryIn(Collections.singletonList("unexisting")).count()).isZero();
     }
 
     @Test
@@ -2761,9 +2606,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .or()
                 .taskId("invalid")
                 .processCategoryIn(Collections.singletonList("Examples")).singleResult();
-        assertNotNull(task);
-        assertEquals("theTask", task.getTaskDefinitionKey());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
         task = taskService.createTaskQuery()
                 .or()
@@ -2775,11 +2620,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .processCategoryIn(Collections.singletonList("Examples2"))
                 .endOr()
                 .singleResult();
-        assertNotNull(task);
-        assertEquals("theTask", task.getTaskDefinitionKey());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processCategoryIn(Collections.singletonList("unexisting")).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processCategoryIn(Collections.singletonList("unexisting")).count()).isZero();
     }
 
     @Test
@@ -2788,11 +2633,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         final org.flowable.task.api.Task task = taskService.createTaskQuery().processCategoryNotIn(Collections.singletonList("unexisting")).singleResult();
-        assertNotNull(task);
-        assertEquals("theTask", task.getTaskDefinitionKey());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().processCategoryNotIn(Collections.singletonList("Examples")).count());
+        assertThat(taskService.createTaskQuery().processCategoryNotIn(Collections.singletonList("Examples")).count()).isZero();
     }
 
     @Test
@@ -2800,12 +2645,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testProcessCategoryNotInOr() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        final org.flowable.task.api.Task task = taskService.createTaskQuery().or().taskId("invalid").processCategoryNotIn(Collections.singletonList("unexisting")).singleResult();
-        assertNotNull(task);
-        assertEquals("theTask", task.getTaskDefinitionKey());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
+        final org.flowable.task.api.Task task = taskService.createTaskQuery().or().taskId("invalid")
+                .processCategoryNotIn(Collections.singletonList("unexisting")).singleResult();
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processCategoryNotIn(Collections.singletonList("Examples")).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processCategoryNotIn(Collections.singletonList("Examples")).count()).isZero();
     }
 
     @Test
@@ -2813,12 +2659,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testProcessInstanceIdIn() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        final org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceIdIn(Collections.singletonList(processInstance.getId())).singleResult();
-        assertNotNull(task);
-        assertEquals("theTask", task.getTaskDefinitionKey());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
+        final org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceIdIn(Collections.singletonList(processInstance.getId()))
+                .singleResult();
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceIdIn(Collections.singletonList("unexisting")).count());
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(Collections.singletonList("unexisting")).count()).isZero();
     }
 
     @Test
@@ -2828,11 +2675,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         final org.flowable.task.api.Task task = taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Collections.singletonList(
                 processInstance.getId())).singleResult();
-        assertNotNull(task);
-        assertEquals("theTask", task.getTaskDefinitionKey());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
 
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Collections.singletonList("unexisting")).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Collections.singletonList("unexisting")).count()).isZero();
     }
 
     @Test
@@ -2841,10 +2688,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        assertEquals(2, taskService.createTaskQuery().processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId())).count());
-        assertEquals(2, taskService.createTaskQuery().processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId(), "unexisting")).count());
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId())).count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId(), "unexisting")).count())
+                .isEqualTo(2);
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceIdIn(Arrays.asList("unexisting1", "unexisting2")).count());
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(Arrays.asList("unexisting1", "unexisting2")).count()).isZero();
     }
 
     @Test
@@ -2853,10 +2701,12 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        assertEquals(2, taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId())).count());
-        assertEquals(2, taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId(), "unexisting")).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId()))
+                .count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid")
+                .processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId(), "unexisting")).count()).isEqualTo(2);
 
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList("unexisting1", "unexisting2")).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList("unexisting1", "unexisting2")).count()).isZero();
     }
 
     @Test
@@ -2864,9 +2714,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testProcessInstanceBusinessKey() throws Exception {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", "BUSINESS-KEY-1");
 
-        assertEquals(1, taskService.createTaskQuery().processDefinitionName("The One Task Process").processInstanceBusinessKey("BUSINESS-KEY-1").list().size());
-        assertEquals(1, taskService.createTaskQuery().processInstanceBusinessKey("BUSINESS-KEY-1").list().size());
-        assertEquals(0, taskService.createTaskQuery().processInstanceBusinessKey("NON-EXISTING").count());
+        assertThat(taskService.createTaskQuery().processDefinitionName("The One Task Process").processInstanceBusinessKey("BUSINESS-KEY-1").list()).hasSize(1);
+        assertThat(taskService.createTaskQuery().processInstanceBusinessKey("BUSINESS-KEY-1").list()).hasSize(1);
+        assertThat(taskService.createTaskQuery().processInstanceBusinessKey("NON-EXISTING").count()).isZero();
     }
 
     @Test
@@ -2874,9 +2724,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testProcessInstanceBusinessKeyOr() throws Exception {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", "BUSINESS-KEY-1");
 
-        assertEquals(1, taskService.createTaskQuery().processDefinitionName("The One Task Process").or().taskId("invalid").processInstanceBusinessKey("BUSINESS-KEY-1").list().size());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").processInstanceBusinessKey("BUSINESS-KEY-1").list().size());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processInstanceBusinessKey("NON-EXISTING").count());
+        assertThat(
+                taskService.createTaskQuery().processDefinitionName("The One Task Process").or().taskId("invalid").processInstanceBusinessKey("BUSINESS-KEY-1")
+                        .list()).hasSize(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceBusinessKey("BUSINESS-KEY-1").list()).hasSize(1);
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceBusinessKey("NON-EXISTING").count()).isZero();
     }
 
     @Test
@@ -2890,19 +2742,19 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(dueDate);
         taskService.saveTask(task);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueDate(dueDate).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueDate(dueDate).count()).isEqualTo(1);
 
         Calendar otherDate = Calendar.getInstance();
         otherDate.add(Calendar.YEAR, 1);
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueDate(otherDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueDate(otherDate.getTime()).count()).isZero();
 
         Calendar priorDate = Calendar.getInstance();
         priorDate.setTime(dueDate);
         priorDate.roll(Calendar.YEAR, -1);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(priorDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(priorDate.getTime()).count()).isEqualTo(1);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(otherDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(otherDate.getTime()).count()).isEqualTo(1);
     }
 
     @Test
@@ -2916,19 +2768,21 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(dueDate);
         taskService.saveTask(task);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueDate(dueDate).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueDate(dueDate).count()).isEqualTo(1);
 
         Calendar otherDate = Calendar.getInstance();
         otherDate.add(Calendar.YEAR, 1);
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueDate(otherDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueDate(otherDate.getTime()).count())
+                .isZero();
 
         Calendar priorDate = Calendar.getInstance();
         priorDate.setTime(dueDate);
         priorDate.roll(Calendar.YEAR, -1);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(priorDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(priorDate.getTime()).count())
+                .isEqualTo(1);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(otherDate.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(otherDate.getTime()).count()).isEqualTo(1);
     }
 
     @Test
@@ -2950,8 +2804,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         oneHourLater.setTime(dueDateCal.getTime());
         oneHourLater.add(Calendar.HOUR, 1);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourLater.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourAgo.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourLater.getTime()).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourAgo.getTime()).count()).isZero();
 
         // Update due-date to null, shouldn't show up anymore in query that
         // matched before
@@ -2959,8 +2813,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(null);
         taskService.saveTask(task);
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourLater.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourAgo.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourLater.getTime()).count()).isZero();
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueBefore(oneHourAgo.getTime()).count()).isZero();
     }
 
     @Test
@@ -2982,8 +2836,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         oneHourLater.setTime(dueDateCal.getTime());
         oneHourLater.add(Calendar.HOUR, 1);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourLater.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourAgo.getTime()).count());
+        assertThat(
+                taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourLater.getTime()).count())
+                .isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourAgo.getTime()).count())
+                .isZero();
 
         // Update due-date to null, shouldn't show up anymore in query that
         // matched before
@@ -2991,8 +2848,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(null);
         taskService.saveTask(task);
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourLater.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourAgo.getTime()).count());
+        assertThat(
+                taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourLater.getTime()).count())
+                .isZero();
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueBefore(oneHourAgo.getTime()).count())
+                .isZero();
     }
 
     @Test
@@ -3014,8 +2874,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         oneHourLater.setTime(dueDateCal.getTime());
         oneHourLater.add(Calendar.HOUR, 1);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourAgo.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourLater.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourAgo.getTime()).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourLater.getTime()).count()).isZero();
 
         // Update due-date to null, shouldn't show up anymore in query that
         // matched before
@@ -3023,8 +2883,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(null);
         taskService.saveTask(task);
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourLater.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourAgo.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourLater.getTime()).count()).isZero();
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDueAfter(oneHourAgo.getTime()).count()).isZero();
     }
 
     @Test
@@ -3046,8 +2906,10 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         oneHourLater.setTime(dueDateCal.getTime());
         oneHourLater.add(Calendar.HOUR, 1);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourAgo.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourLater.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourAgo.getTime()).count())
+                .isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourLater.getTime()).count())
+                .isZero();
 
         // Update due-date to null, shouldn't show up anymore in query that
         // matched before
@@ -3055,8 +2917,10 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(null);
         taskService.saveTask(task);
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourLater.getTime()).count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourAgo.getTime()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourLater.getTime()).count())
+                .isZero();
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").taskDueAfter(oneHourAgo.getTime()).count())
+                .isZero();
     }
 
     @Test
@@ -3070,7 +2934,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(dueDate);
         taskService.saveTask(task);
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count()).isZero();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -3078,7 +2942,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(null);
         taskService.saveTask(task);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count()).isEqualTo(1);
     }
 
     @Test
@@ -3092,7 +2956,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(dueDate);
         taskService.saveTask(task);
 
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").withoutTaskDueDate().count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").withoutTaskDueDate().count()).isZero();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -3100,138 +2964,149 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         task.setDueDate(null);
         taskService.saveTask(task);
 
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").withoutTaskDueDate().count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).or().taskId("invalid").withoutTaskDueDate().count()).isEqualTo(1);
     }
 
     @Test
     public void testQueryPaging() {
         TaskQuery query = taskService.createTaskQuery().taskCandidateUser("kermit");
 
-        assertEquals(11, query.listPage(0, Integer.MAX_VALUE).size());
+        assertThat(query.listPage(0, Integer.MAX_VALUE)).hasSize(11);
 
         // Verifying the un-paged results
-        assertEquals(11, query.count());
-        assertEquals(11, query.list().size());
+        assertThat(query.count()).isEqualTo(11);
+        assertThat(query.list()).hasSize(11);
 
         // Verifying paged results
-        assertEquals(2, query.listPage(0, 2).size());
-        assertEquals(2, query.listPage(2, 2).size());
-        assertEquals(3, query.listPage(4, 3).size());
-        assertEquals(1, query.listPage(10, 3).size());
-        assertEquals(1, query.listPage(10, 1).size());
+        assertThat(query.listPage(0, 2)).hasSize(2);
+        assertThat(query.listPage(2, 2)).hasSize(2);
+        assertThat(query.listPage(4, 3)).hasSize(3);
+        assertThat(query.listPage(10, 3)).hasSize(1);
+        assertThat(query.listPage(10, 1)).hasSize(1);
 
         // Verifying odd usages
-        assertEquals(0, query.listPage(0, 0).size());
-        assertEquals(0, query.listPage(11, 2).size()); // 10 is the last index
-                                                       // with a result
-        assertEquals(11, query.listPage(0, 15).size()); // there are only 11
-                                                        // tasks
+        assertThat(query.listPage(0, 0)).isEmpty();
+        assertThat(query.listPage(11, 2)).isEmpty(); // 10 is the last index
+        // with a result
+        assertThat(query.listPage(0, 15)).hasSize(11); // there are only 11
+        // tasks
     }
 
     @Test
     public void testQuerySorting() {
-        assertEquals(12, taskService.createTaskQuery().orderByTaskId().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskName().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskPriority().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskAssignee().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskDescription().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByProcessInstanceId().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByExecutionId().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskCreateTime().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskDueDate().asc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByCategory().asc().list().size());
+        assertThat(taskService.createTaskQuery().orderByTaskId().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskName().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskPriority().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskAssignee().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskDescription().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByProcessInstanceId().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByExecutionId().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskCreateTime().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskDueDate().asc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByCategory().asc().list()).hasSize(12);
 
-        assertEquals(12, taskService.createTaskQuery().orderByTaskId().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskName().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskPriority().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskAssignee().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskDescription().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByProcessInstanceId().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByExecutionId().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskCreateTime().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByTaskDueDate().desc().list().size());
-        assertEquals(12, taskService.createTaskQuery().orderByCategory().desc().list().size());
+        assertThat(taskService.createTaskQuery().orderByTaskId().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskName().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskPriority().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskAssignee().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskDescription().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByProcessInstanceId().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByExecutionId().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskCreateTime().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByTaskDueDate().desc().list()).hasSize(12);
+        assertThat(taskService.createTaskQuery().orderByCategory().desc().list()).hasSize(12);
 
-        assertEquals(6, taskService.createTaskQuery().orderByTaskId().taskName("testTask").asc().list().size());
-        assertEquals(6, taskService.createTaskQuery().orderByTaskId().taskName("testTask").desc().list().size());
+        assertThat(taskService.createTaskQuery().orderByTaskId().taskName("testTask").asc().list()).hasSize(6);
+        assertThat(taskService.createTaskQuery().orderByTaskId().taskName("testTask").desc().list()).hasSize(6);
     }
 
     @Test
     public void testNativeQueryPaging() {
-        assertEquals("ACT_RU_TASK", managementService.getTableName(org.flowable.task.api.Task.class, false));
-        assertEquals("ACT_RU_TASK", managementService.getTableName(TaskEntity.class, false));
-        assertEquals(5, taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).listPage(0, 5).size());
-        assertEquals(2, taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).listPage(10, 12).size());
+        assertThat(managementService.getTableName(org.flowable.task.api.Task.class, false)).isEqualTo("ACT_RU_TASK");
+        assertThat(managementService.getTableName(TaskEntity.class, false)).isEqualTo("ACT_RU_TASK");
+        assertThat(taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).listPage(0, 5))
+                .hasSize(5);
+        assertThat(
+                taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).listPage(10, 12))
+                .hasSize(2);
     }
 
     @Test
     public void testNativeQuery() {
-        assertEquals("ACT_RU_TASK", managementService.getTableName(org.flowable.task.api.Task.class, false));
-        assertEquals("ACT_RU_TASK", managementService.getTableName(TaskEntity.class, false));
-        assertEquals(12, taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).list().size());
-        assertEquals(12, taskService.createNativeTaskQuery().sql("SELECT count(*) FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).count());
+        assertThat(managementService.getTableName(org.flowable.task.api.Task.class, false)).isEqualTo("ACT_RU_TASK");
+        assertThat(managementService.getTableName(TaskEntity.class, false)).isEqualTo("ACT_RU_TASK");
+        assertThat(taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).list())
+                .hasSize(12);
+        assertThat(taskService.createNativeTaskQuery().sql("SELECT count(*) FROM " + managementService.getTableName(org.flowable.task.api.Task.class)).count())
+                .isEqualTo(12);
 
-        assertEquals(144, taskService.createNativeTaskQuery().sql("SELECT count(*) FROM "
-            + managementService.getTableName(Task.class) + " T1, " + managementService.getTableName(Task.class) + " T2").count());
+        assertThat(taskService.createNativeTaskQuery().sql("SELECT count(*) FROM "
+                + managementService.getTableName(Task.class) + " T1, " + managementService.getTableName(Task.class) + " T2").count()).isEqualTo(144);
 
         // join task and variable instances
-        assertEquals(
-                1,
-                taskService.createNativeTaskQuery()
-                        .sql("SELECT count(*) FROM " + managementService.getTableName(org.flowable.task.api.Task.class) + " T1, " + managementService.getTableName(VariableInstanceEntity.class) + " V1 WHERE V1.TASK_ID_ = T1.ID_")
-                        .count());
+        assertThat(taskService.createNativeTaskQuery()
+                .sql("SELECT count(*) FROM " + managementService.getTableName(org.flowable.task.api.Task.class) + " T1, " + managementService
+                        .getTableName(VariableInstanceEntity.class) + " V1 WHERE V1.TASK_ID_ = T1.ID_")
+                .count()).isEqualTo(1);
         List<org.flowable.task.api.Task> tasks = taskService.createNativeTaskQuery()
-                .sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class) + " T1, " + managementService.getTableName(VariableInstanceEntity.class) + " V1 WHERE V1.TASK_ID_ = T1.ID_").list();
-        assertEquals(1, tasks.size());
-        assertEquals("gonzoTask", tasks.get(0).getName());
+                .sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class) + " T1, " + managementService
+                        .getTableName(VariableInstanceEntity.class) + " V1 WHERE V1.TASK_ID_ = T1.ID_").list();
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("gonzoTask");
 
         // select with distinct
-        assertEquals(12, taskService.createNativeTaskQuery().sql("SELECT DISTINCT T1.* FROM " + managementService.getTableName(Task.class) + " T1").list().size());
+        assertThat(taskService.createNativeTaskQuery().sql("SELECT DISTINCT T1.* FROM " + managementService.getTableName(Task.class) + " T1").list())
+                .hasSize(12);
 
-        assertEquals(1, taskService.createNativeTaskQuery().sql("SELECT count(*) FROM " + managementService.getTableName(org.flowable.task.api.Task.class) + " T WHERE T.NAME_ = 'gonzoTask'").count());
-        assertEquals(1, taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class) + " T WHERE T.NAME_ = 'gonzoTask'").list().size());
+        assertThat(taskService.createNativeTaskQuery()
+                .sql("SELECT count(*) FROM " + managementService.getTableName(org.flowable.task.api.Task.class) + " T WHERE T.NAME_ = 'gonzoTask'").count())
+                .isEqualTo(1);
+        assertThat(taskService.createNativeTaskQuery()
+                .sql("SELECT * FROM " + managementService.getTableName(org.flowable.task.api.Task.class) + " T WHERE T.NAME_ = 'gonzoTask'").list()).hasSize(1);
 
         // use parameters
-        assertEquals(1, taskService.createNativeTaskQuery().sql("SELECT count(*) FROM " + managementService.getTableName(org.flowable.task.api.Task.class)
-            + " T WHERE T.NAME_ = #{taskName}").parameter("taskName", "gonzoTask").count());
+        assertThat(taskService.createNativeTaskQuery().sql("SELECT count(*) FROM " + managementService.getTableName(org.flowable.task.api.Task.class)
+                + " T WHERE T.NAME_ = #{taskName}").parameter("taskName", "gonzoTask").count()).isEqualTo(1);
     }
 
     @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testIncludeIdentityLinks() throws Exception {
         // Start process with a binary variable
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("binaryVariable", (Object) "It is I, le binary".getBytes()));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("binaryVariable", (Object) "It is I, le binary".getBytes()));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.setVariableLocal(task.getId(), "binaryTaskVariable", (Object) "It is I, le binary".getBytes());
 
         taskService.addCandidateGroup(task.getId(), "group1");
 
         // Query task, including identity links
         task = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
-        assertNotNull(task);
-        assertNotNull(task.getIdentityLinks());
-        assertEquals(1, task.getIdentityLinks().size());
+        assertThat(task).isNotNull();
+        assertThat(task.getIdentityLinks()).isNotNull();
+        assertThat(task.getIdentityLinks()).hasSize(1);
 
         // Query task, including identity links, process variables, and task variables
         task = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().includeProcessVariables().includeTaskLocalVariables().singleResult();
-        assertNotNull(task);
-        assertNotNull(task.getIdentityLinks());
-        assertEquals(1, task.getIdentityLinks().size());
+        assertThat(task).isNotNull();
+        assertThat(task.getIdentityLinks()).isNotNull();
+        assertThat(task.getIdentityLinks()).hasSize(1);
         IdentityLinkInfo identityLink = task.getIdentityLinks().get(0);
-        assertNull(identityLink.getProcessInstanceId());
-        assertEquals("candidate", identityLink.getType());
-        assertEquals("group1", identityLink.getGroupId());
-        assertNull(identityLink.getUserId());
-        assertEquals(task.getId(), identityLink.getTaskId());
+        assertThat(identityLink.getProcessInstanceId()).isNull();
+        assertThat(identityLink.getType()).isEqualTo("candidate");
+        assertThat(identityLink.getGroupId()).isEqualTo("group1");
+        assertThat(identityLink.getUserId()).isNull();
+        assertThat(identityLink.getTaskId()).isEqualTo(task.getId());
 
-        assertNotNull(task.getProcessVariables());
+        assertThat(task.getProcessVariables()).isNotNull();
         byte[] bytes = (byte[]) task.getProcessVariables().get("binaryVariable");
-        assertEquals("It is I, le binary", new String(bytes));
+        assertThat(new String(bytes)).isEqualTo("It is I, le binary");
 
-        assertNotNull(task.getTaskLocalVariables());
+        assertThat(task.getTaskLocalVariables()).isNotNull();
         bytes = (byte[]) task.getTaskLocalVariables().get("binaryTaskVariable");
-        assertEquals("It is I, le binary", new String(bytes));
+        assertThat(new String(bytes)).isEqualTo("It is I, le binary");
     }
 
     /**
@@ -3241,24 +3116,25 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testIncludeBinaryVariables() throws Exception {
         // Start process with a binary variable
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("binaryVariable", (Object) "It is I, le binary".getBytes()));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("binaryVariable", (Object) "It is I, le binary".getBytes()));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.setVariableLocal(task.getId(), "binaryTaskVariable", (Object) "It is I, le binary".getBytes());
 
         // Query task, including processVariables
         task = taskService.createTaskQuery().taskId(task.getId()).includeProcessVariables().singleResult();
-        assertNotNull(task);
-        assertNotNull(task.getProcessVariables());
+        assertThat(task).isNotNull();
+        assertThat(task.getProcessVariables()).isNotNull();
         byte[] bytes = (byte[]) task.getProcessVariables().get("binaryVariable");
-        assertEquals("It is I, le binary", new String(bytes));
+        assertThat(new String(bytes)).isEqualTo("It is I, le binary");
 
         // Query task, including taskVariables
         task = taskService.createTaskQuery().taskId(task.getId()).includeTaskLocalVariables().singleResult();
-        assertNotNull(task);
-        assertNotNull(task.getTaskLocalVariables());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskLocalVariables()).isNotNull();
         bytes = (byte[]) task.getTaskLocalVariables().get("binaryTaskVariable");
-        assertEquals("It is I, le binary", new String(bytes));
+        assertThat(new String(bytes)).isEqualTo("It is I, le binary");
     }
 
     /**
@@ -3268,24 +3144,25 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testIncludeBinaryVariablesOr() throws Exception {
         // Start process with a binary variable
-        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("binaryVariable", (Object) "It is I, le binary".getBytes()));
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskProcess", Collections.singletonMap("binaryVariable", (Object) "It is I, le binary".getBytes()));
         org.flowable.task.api.Task task = taskService.createTaskQuery().or().taskName("invalid").processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.setVariableLocal(task.getId(), "binaryTaskVariable", (Object) "It is I, le binary".getBytes());
 
         // Query task, including processVariables
         task = taskService.createTaskQuery().or().taskName("invalid").taskId(task.getId()).includeProcessVariables().singleResult();
-        assertNotNull(task);
-        assertNotNull(task.getProcessVariables());
+        assertThat(task).isNotNull();
+        assertThat(task.getProcessVariables()).isNotNull();
         byte[] bytes = (byte[]) task.getProcessVariables().get("binaryVariable");
-        assertEquals("It is I, le binary", new String(bytes));
+        assertThat(new String(bytes)).isEqualTo("It is I, le binary");
 
         // Query task, including taskVariables
         task = taskService.createTaskQuery().or().taskName("invalid").taskId(task.getId()).includeTaskLocalVariables().singleResult();
-        assertNotNull(task);
-        assertNotNull(task.getTaskLocalVariables());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskLocalVariables()).isNotNull();
         bytes = (byte[]) task.getTaskLocalVariables().get("binaryTaskVariable");
-        assertEquals("It is I, le binary", new String(bytes));
+        assertThat(new String(bytes)).isEqualTo("It is I, le binary");
     }
 
     @Test
@@ -3293,10 +3170,10 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryByDeploymentId() throws Exception {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(taskService.createTaskQuery().deploymentId(deployment.getId()).singleResult());
-        assertEquals(1, taskService.createTaskQuery().deploymentId(deployment.getId()).count());
-        assertNull(taskService.createTaskQuery().deploymentId("invalid").singleResult());
-        assertEquals(0, taskService.createTaskQuery().deploymentId("invalid").count());
+        assertThat(taskService.createTaskQuery().deploymentId(deployment.getId()).singleResult()).isNotNull();
+        assertThat(taskService.createTaskQuery().deploymentId(deployment.getId()).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().deploymentId("invalid").singleResult()).isNull();
+        assertThat(taskService.createTaskQuery().deploymentId("invalid").count()).isZero();
     }
 
     @Test
@@ -3304,10 +3181,10 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryByDeploymentIdOr() throws Exception {
         org.flowable.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(taskService.createTaskQuery().or().taskId("invalid").deploymentId(deployment.getId()).singleResult());
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").deploymentId(deployment.getId()).count());
-        assertNull(taskService.createTaskQuery().deploymentId("invalid").singleResult());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").deploymentId("invalid").count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentId(deployment.getId()).singleResult()).isNotNull();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentId(deployment.getId()).count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().deploymentId("invalid").singleResult()).isNull();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentId("invalid").count()).isZero();
     }
 
     @Test
@@ -3317,17 +3194,17 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
-        assertNotNull(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult());
-        assertEquals(1, taskService.createTaskQuery().deploymentIdIn(deploymentIds).count());
+        assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult()).isNotNull();
+        assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).count()).isEqualTo(1);
 
         deploymentIds.add("invalid");
-        assertNotNull(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult());
-        assertEquals(1, taskService.createTaskQuery().deploymentIdIn(deploymentIds).count());
+        assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult()).isNotNull();
+        assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).count()).isEqualTo(1);
 
         deploymentIds = new ArrayList<>();
         deploymentIds.add("invalid");
-        assertNull(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult());
-        assertEquals(0, taskService.createTaskQuery().deploymentIdIn(deploymentIds).count());
+        assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult()).isNull();
+        assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).count()).isZero();
     }
 
     @Test
@@ -3337,42 +3214,42 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         List<String> deploymentIds = new ArrayList<>();
         deploymentIds.add(deployment.getId());
-        assertNotNull(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).singleResult());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).singleResult()).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count()).isEqualTo(1);
 
         deploymentIds.add("invalid");
-        assertNotNull(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).singleResult());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).singleResult()).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count());
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count()).isEqualTo(1);
 
         deploymentIds = new ArrayList<>();
         deploymentIds.add("invalid");
-        assertNull(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult());
-        assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count());
+        assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult()).isNull();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count()).isZero();
     }
 
     @Test
     public void testQueryByTaskNameLikeIgnoreCase() {
 
         // Runtime
-        assertEquals(12, taskService.createTaskQuery().taskNameLikeIgnoreCase("%task%").count());
-        assertEquals(12, taskService.createTaskQuery().taskNameLikeIgnoreCase("%Task%").count());
-        assertEquals(12, taskService.createTaskQuery().taskNameLikeIgnoreCase("%TASK%").count());
-        assertEquals(12, taskService.createTaskQuery().taskNameLikeIgnoreCase("%TasK%").count());
-        assertEquals(1, taskService.createTaskQuery().taskNameLikeIgnoreCase("gonzo%").count());
-        assertEquals(1, taskService.createTaskQuery().taskNameLikeIgnoreCase("%Gonzo%").count());
-        assertEquals(0, taskService.createTaskQuery().taskNameLikeIgnoreCase("Task%").count());
+        assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("%task%").count()).isEqualTo(12);
+        assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("%Task%").count()).isEqualTo(12);
+        assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("%TASK%").count()).isEqualTo(12);
+        assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("%TasK%").count()).isEqualTo(12);
+        assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("gonzo%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("%Gonzo%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("Task%").count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(12, historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%task%").count());
-            assertEquals(12, historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%Task%").count());
-            assertEquals(12, historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%TASK%").count());
-            assertEquals(12, historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%TasK%").count());
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("gonzo%").count());
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%Gonzo%").count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("Task%").count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%task%").count()).isEqualTo(12);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%Task%").count()).isEqualTo(12);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%TASK%").count()).isEqualTo(12);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%TasK%").count()).isEqualTo(12);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("gonzo%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%Gonzo%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("Task%").count()).isZero();
         }
     }
 
@@ -3380,15 +3257,17 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryByTaskNameOrDescriptionLikeIgnoreCase() {
 
         // Runtime
-        assertEquals(12, taskService.createTaskQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%task%").endOr().count());
+        assertThat(taskService.createTaskQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%task%").endOr().count()).isEqualTo(12);
 
-        assertEquals(9, taskService.createTaskQuery().or().taskNameLikeIgnoreCase("ACCOUN%").taskDescriptionLikeIgnoreCase("%ESCR%").endOr().count());
+        assertThat(taskService.createTaskQuery().or().taskNameLikeIgnoreCase("ACCOUN%").taskDescriptionLikeIgnoreCase("%ESCR%").endOr().count()).isEqualTo(9);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(12, historyService.createHistoricTaskInstanceQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%task%").endOr().count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%task%").endOr()
+                    .count()).isEqualTo(12);
 
-            assertEquals(9, historyService.createHistoricTaskInstanceQuery().or().taskNameLikeIgnoreCase("ACCOUN%").taskDescriptionLikeIgnoreCase("%ESCR%").endOr().count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameLikeIgnoreCase("ACCOUN%").taskDescriptionLikeIgnoreCase("%ESCR%").endOr()
+                    .count()).isEqualTo(9);
         }
 
     }
@@ -3397,25 +3276,25 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryByTaskDescriptionLikeIgnoreCase() {
 
         // Runtime
-        assertEquals(6, taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%task%").count());
-        assertEquals(6, taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%Task%").count());
-        assertEquals(6, taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%TASK%").count());
-        assertEquals(6, taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%TaSk%").count());
-        assertEquals(0, taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("task%").count());
-        assertEquals(1, taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("gonzo%").count());
-        assertEquals(1, taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("Gonzo%").count());
-        assertEquals(0, taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%manage%").count());
+        assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%task%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%Task%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%TASK%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%TaSk%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("task%").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("gonzo%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("Gonzo%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%manage%").count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%task%").count());
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%Task%").count());
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%TASK%").count());
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%TaSk%").count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("task%").count());
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("gonzo%").count());
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("Gonzo%").count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%manage%").count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%task%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%Task%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%TASK%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%TaSk%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("task%").count()).isZero();
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("gonzo%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("Gonzo%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%manage%").count()).isZero();
         }
     }
 
@@ -3423,21 +3302,21 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryByAssigneeLikeIgnoreCase() {
 
         // Runtime
-        assertEquals(1, taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%gonzo%").count());
-        assertEquals(1, taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%GONZO%").count());
-        assertEquals(1, taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%Gon%").count());
-        assertEquals(1, taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("gon%").count());
-        assertEquals(1, taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%nzo%").count());
-        assertEquals(0, taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%doesnotexist%").count());
+        assertThat(taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%gonzo%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%GONZO%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%Gon%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("gon%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%nzo%").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%doesnotexist%").count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%gonzo%").count());
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%GONZO%").count());
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%Gon%").count());
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("gon%").count());
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%nzo%").count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%doesnotexist%").count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%gonzo%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%GONZO%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%Gon%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("gon%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%nzo%").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%doesnotexist%").count()).isZero();
         }
     }
 
@@ -3445,21 +3324,21 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryByOwnerLikeIgnoreCase() {
 
         // Runtime
-        assertEquals(6, taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%gonzo%").count());
-        assertEquals(6, taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%GONZO%").count());
-        assertEquals(6, taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%Gon%").count());
-        assertEquals(6, taskService.createTaskQuery().taskOwnerLikeIgnoreCase("gon%").count());
-        assertEquals(6, taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%nzo%").count());
-        assertEquals(0, taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%doesnotexist%").count());
+        assertThat(taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%gonzo%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%GONZO%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%Gon%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskOwnerLikeIgnoreCase("gon%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%nzo%").count()).isEqualTo(6);
+        assertThat(taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%doesnotexist%").count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%gonzo%").count());
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%GONZO%").count());
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%Gon%").count());
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("gon%").count());
-            assertEquals(6, historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%nzo%").count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%doesnotexist%").count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%gonzo%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%GONZO%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%Gon%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("gon%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%nzo%").count()).isEqualTo(6);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%doesnotexist%").count()).isZero();
         }
     }
 
@@ -3471,21 +3350,21 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess", "KeY-3");
 
         // Runtime
-        assertEquals(3, taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%key%").count());
-        assertEquals(3, taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%KEY%").count());
-        assertEquals(3, taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%EY%").count());
-        assertEquals(2, taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%business%").count());
-        assertEquals(2, taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("business%").count());
-        assertEquals(0, taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%doesnotexist%").count());
+        assertThat(taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%key%").count()).isEqualTo(3);
+        assertThat(taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%KEY%").count()).isEqualTo(3);
+        assertThat(taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%EY%").count()).isEqualTo(3);
+        assertThat(taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%business%").count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("business%").count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%doesnotexist%").count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(3, historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%key%").count());
-            assertEquals(3, historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%KEY%").count());
-            assertEquals(3, historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%EY%").count());
-            assertEquals(2, historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%business%").count());
-            assertEquals(2, historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("business%").count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%doesnotexist%").count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%key%").count()).isEqualTo(3);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%KEY%").count()).isEqualTo(3);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%EY%").count()).isEqualTo(3);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%business%").count()).isEqualTo(2);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("business%").count()).isEqualTo(2);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%doesnotexist%").count()).isZero();
         }
     }
 
@@ -3499,17 +3378,17 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        assertEquals(4, taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("%one%").count());
-        assertEquals(4, taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("%ONE%").count());
-        assertEquals(4, taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("ON%").count());
-        assertEquals(0, taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("%fake%").count());
+        assertThat(taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("%one%").count()).isEqualTo(4);
+        assertThat(taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("%ONE%").count()).isEqualTo(4);
+        assertThat(taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("ON%").count()).isEqualTo(4);
+        assertThat(taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("%fake%").count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(4, historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("%one%").count());
-            assertEquals(4, historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("%ONE%").count());
-            assertEquals(4, historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("ON%").count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("%fake%").count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("%one%").count()).isEqualTo(4);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("%ONE%").count()).isEqualTo(4);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("ON%").count()).isEqualTo(4);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("%fake%").count()).isZero();
         }
     }
 
@@ -3517,13 +3396,16 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     public void testCombinationOfOrAndLikeIgnoreCase() {
 
         // Runtime
-        assertEquals(12, taskService.createTaskQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%desc%").taskAssigneeLikeIgnoreCase("Gonz%").taskOwnerLike("G%").endOr()
-                .count());
+        assertThat(
+                taskService.createTaskQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%desc%").taskAssigneeLikeIgnoreCase("Gonz%")
+                        .taskOwnerLike("G%").endOr()
+                        .count()).isEqualTo(12);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // History
-            assertEquals(12, historyService.createHistoricTaskInstanceQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%desc%").taskAssigneeLikeIgnoreCase("Gonz%")
-                    .taskOwnerLike("G%").endOr().count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%desc%")
+                    .taskAssigneeLikeIgnoreCase("Gonz%")
+                    .taskOwnerLike("G%").endOr().count()).isEqualTo(12);
         }
     }
 
@@ -3537,7 +3419,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
 
         List<org.flowable.task.api.Task> allTasks = taskService.createTaskQuery().processDefinitionKey("oneTaskProcess").list();
-        assertEquals(10, allTasks.size());
+        assertThat(allTasks).hasSize(10);
 
         // Give two tasks a task local variable
         taskService.setVariableLocal(allTasks.get(0).getId(), "localVar", "someValue");
@@ -3548,15 +3430,15 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         runtimeService.setVariable(allTasks.get(3).getProcessInstanceId(), "var", "theValue");
         runtimeService.setVariable(allTasks.get(4).getProcessInstanceId(), "var", "theValue");
 
-        assertEquals(2, taskService.createTaskQuery().taskVariableValueEquals("localVar", "someValue").list().size());
-        assertEquals(3, taskService.createTaskQuery().processVariableValueEquals("var", "theValue").list().size());
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("localVar", "someValue").list()).hasSize(2);
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("var", "theValue").list()).hasSize(3);
 
-        assertEquals(5, taskService.createTaskQuery().or()
+        assertThat(taskService.createTaskQuery().or()
                 .taskVariableValueEquals("localVar", "someValue")
                 .processVariableValueEquals("var", "theValue")
-                .endOr().list().size());
+                .endOr().list()).hasSize(5);
 
-        assertEquals(5, taskService.createTaskQuery()
+        assertThat(taskService.createTaskQuery()
                 .or()
                 .taskVariableValueEquals("localVar", "someValue")
                 .processVariableValueEquals("var", "theValue")
@@ -3565,8 +3447,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .processDefinitionKey("oneTaskProcess")
                 .processDefinitionId("notexisting")
                 .endOr()
-                .list()
-                .size());
+                .list()).hasSize(5);
     }
 
     @Test
@@ -3582,9 +3463,9 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             includeProcessVariables().includeTaskLocalVariables()
             .list();
 
-        assertEquals(10, tasks.size());
+        assertThat(tasks).hasSize(10);
         for (Task task : tasks) {
-            assertEquals("testTenant", task.getTenantId());
+            assertThat(task.getTenantId()).isEqualTo("testTenant");
         }
     }
 
@@ -3594,19 +3475,19 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();
-        assertEquals(1, tasks.size());
-        assertEquals("my task", tasks.get(0).getName());
-        assertEquals("My Task Description", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("my task", "My Task Description"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("es").list();
-        assertEquals(1, tasks.size());
-        assertEquals("Mi Tarea", tasks.get(0).getName());
-        assertEquals("Mi Tarea Descripción", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("Mi Tarea", "Mi Tarea Descripción"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("it").list();
-        assertEquals(1, tasks.size());
-        assertEquals("Il mio compito", tasks.get(0).getName());
-        assertEquals("Il mio compito Descrizione", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("Il mio compito", "Il mio compito Descrizione"));
 
         ObjectNode infoNode = dynamicBpmnService.getProcessDefinitionInfo(processInstance.getProcessDefinitionId());
 
@@ -3619,72 +3500,73 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         dynamicBpmnService.saveProcessDefinitionInfo(processInstance.getProcessDefinitionId(), infoNode);
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();
-        assertEquals(1, tasks.size());
-        assertEquals("my task", tasks.get(0).getName());
-        assertEquals("My Task Description", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("my task", "My Task Description"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("es").list();
-        assertEquals(1, tasks.size());
-        assertEquals("Mi Tarea", tasks.get(0).getName());
-        assertEquals("Mi Tarea Descripción", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("Mi Tarea", "Mi Tarea Descripción"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("it").list();
-        assertEquals(1, tasks.size());
-        assertEquals("Il mio compito", tasks.get(0).getName());
-        assertEquals("Il mio compito Descrizione", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("Il mio compito", "Il mio compito Descrizione"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-GB").list();
-        assertEquals(1, tasks.size());
-        assertEquals("My 'en-GB' localized name", tasks.get(0).getName());
-        assertEquals("My 'en-GB' localized description", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("My 'en-GB' localized name", "My 'en-GB' localized description"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).listPage(0, 10);
-        assertEquals(1, tasks.size());
-        assertEquals("my task", tasks.get(0).getName());
-        assertEquals("My Task Description", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("my task", "My Task Description"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("es").listPage(0, 10);
-        assertEquals(1, tasks.size());
-        assertEquals("Mi Tarea", tasks.get(0).getName());
-        assertEquals("Mi Tarea Descripción", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("Mi Tarea", "Mi Tarea Descripción"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("it").listPage(0, 10);
-        assertEquals(1, tasks.size());
-        assertEquals("Il mio compito", tasks.get(0).getName());
-        assertEquals("Il mio compito Descrizione", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("Il mio compito", "Il mio compito Descrizione"));
 
         tasks = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-GB").listPage(0, 10);
-        assertEquals(1, tasks.size());
-        assertEquals("My 'en-GB' localized name", tasks.get(0).getName());
-        assertEquals("My 'en-GB' localized description", tasks.get(0).getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("My 'en-GB' localized name", "My 'en-GB' localized description"));
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).singleResult();
-        assertEquals("my task", task.getName());
-        assertEquals("My Task Description", task.getDescription());
+        assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task.getDescription()).isEqualTo("My Task Description");
 
         task = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("es").singleResult();
-        assertEquals("Mi Tarea", task.getName());
-        assertEquals("Mi Tarea Descripción", task.getDescription());
+        assertThat(task.getName()).isEqualTo("Mi Tarea");
+        assertThat(task.getDescription()).isEqualTo("Mi Tarea Descripción");
 
         task = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("it").singleResult();
-        assertEquals("Il mio compito", task.getName());
-        assertEquals("Il mio compito Descrizione", task.getDescription());
+        assertThat(task.getName()).isEqualTo("Il mio compito");
+        assertThat(task.getDescription()).isEqualTo("Il mio compito Descrizione");
 
         task = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-GB").singleResult();
-        assertEquals("My 'en-GB' localized name", task.getName());
-        assertEquals("My 'en-GB' localized description", task.getDescription());
+        assertThat(task.getName()).isEqualTo("My 'en-GB' localized name");
+        assertThat(task.getDescription()).isEqualTo("My 'en-GB' localized description");
 
         task = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).singleResult();
-        assertEquals("my task", task.getName());
-        assertEquals("My Task Description", task.getDescription());
+        assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task.getDescription()).isEqualTo("My Task Description");
 
         task = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en").singleResult();
-        assertEquals("My 'en' localized name", task.getName());
-        assertEquals("My 'en' localized description", task.getDescription());
+        assertThat(task.getName()).isEqualTo("My 'en' localized name");
+        assertThat(task.getDescription()).isEqualTo("My 'en' localized description");
 
-        task = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-AU").withLocalizationFallback().singleResult();
-        assertEquals("My 'en' localized name", task.getName());
-        assertEquals("My 'en' localized description", task.getDescription());
+        task = taskService.createTaskQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-AU").withLocalizationFallback()
+                .singleResult();
+        assertThat(task.getName()).isEqualTo("My 'en' localized name");
+        assertThat(task.getDescription()).isEqualTo("My 'en' localized description");
     }
 
     /**

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -14,11 +14,11 @@
 package org.flowable.engine.test.api.task;
 
 import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.flowable.engine.impl.test.HistoryTestHelper.isHistoryLevelAtLeast;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNull.notNullValue;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,37 +96,37 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         // We need to make sure the time ends on .000, .003 or .007 due to SQL Server rounding to that
         Date todayDate = Date.from(Instant.now().plus(1, ChronoUnit.SECONDS).plusMillis(133));
         task = taskService.createTaskBuilder().
-                        name("testName").
-                        description("testDescription").
-                        priority(35).
-                        owner("testOwner").
-                        assignee("testAssignee").
-                        dueDate(todayDate).
-                        category("testCategory").
-                        parentTaskId("testParentTaskId").
-                        tenantId("testTenantId").
-                        formKey("testFormKey").
-                        taskDefinitionId("testDefinitionId").
-                        taskDefinitionKey("testDefinitionKey").
-                        scopeType(ScopeTypes.TASK).
-                        scopeId("scopeIdValue").
-                        create();
+                name("testName").
+                description("testDescription").
+                priority(35).
+                owner("testOwner").
+                assignee("testAssignee").
+                dueDate(todayDate).
+                category("testCategory").
+                parentTaskId("testParentTaskId").
+                tenantId("testTenantId").
+                formKey("testFormKey").
+                taskDefinitionId("testDefinitionId").
+                taskDefinitionKey("testDefinitionKey").
+                scopeType(ScopeTypes.TASK).
+                scopeId("scopeIdValue").
+                create();
         Task updatedTask = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertThat(updatedTask, notNullValue());
-        assertThat(updatedTask.getName(), is("testName"));
-        assertThat(updatedTask.getDescription(), is("testDescription"));
-        assertThat(updatedTask.getPriority(), is(35));
-        assertThat(updatedTask.getOwner(), is("testOwner"));
-        assertThat(updatedTask.getAssignee(), is("testAssignee"));
-        assertThat(simpleDateFormat.format(updatedTask.getDueDate()), is(simpleDateFormat.format(todayDate)));
-        assertThat(updatedTask.getCategory(), is("testCategory"));
-        assertThat(updatedTask.getParentTaskId(), is("testParentTaskId"));
-        assertThat(updatedTask.getTenantId(), is("testTenantId"));
-        assertThat(updatedTask.getFormKey(), is("testFormKey"));
-        assertThat(updatedTask.getTaskDefinitionId(), is("testDefinitionId"));
-        assertThat(updatedTask.getTaskDefinitionKey(), is("testDefinitionKey"));
-        assertThat(updatedTask.getScopeId(), is("scopeIdValue"));
-        assertThat(updatedTask.getScopeType(), is(ScopeTypes.TASK));
+        assertThat(updatedTask).isNotNull();
+        assertThat(updatedTask.getName()).isEqualTo("testName");
+        assertThat(updatedTask.getDescription()).isEqualTo("testDescription");
+        assertThat(updatedTask.getPriority()).isEqualTo(35);
+        assertThat(updatedTask.getOwner()).isEqualTo("testOwner");
+        assertThat(updatedTask.getAssignee()).isEqualTo("testAssignee");
+        assertThat(simpleDateFormat.format(updatedTask.getDueDate())).isEqualTo(simpleDateFormat.format(todayDate));
+        assertThat(updatedTask.getCategory()).isEqualTo("testCategory");
+        assertThat(updatedTask.getParentTaskId()).isEqualTo("testParentTaskId");
+        assertThat(updatedTask.getTenantId()).isEqualTo("testTenantId");
+        assertThat(updatedTask.getFormKey()).isEqualTo("testFormKey");
+        assertThat(updatedTask.getTaskDefinitionId()).isEqualTo("testDefinitionId");
+        assertThat(updatedTask.getTaskDefinitionKey()).isEqualTo("testDefinitionKey");
+        assertThat(updatedTask.getScopeId()).isEqualTo("scopeIdValue");
+        assertThat(updatedTask.getScopeType()).isEqualTo(ScopeTypes.TASK);
     }
 
     @Test
@@ -139,9 +140,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
                     identityLinks(getDefaultIdentityLinks()).
                     create();
             Task updatedParentTask = taskService.createTaskQuery().taskId(parentTask.getId()).singleResult();
-            assertThat(((CountingTaskEntity) updatedParentTask).getSubTaskCount(), is(1));
+            assertThat(((CountingTaskEntity) updatedParentTask).getSubTaskCount()).isEqualTo(1);
             Task updatedTask = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
-            assertThat(((CountingTaskEntity) updatedTask).getIdentityLinkCount(), is(2));
+            assertThat(((CountingTaskEntity) updatedTask).getIdentityLinkCount()).isEqualTo(2);
         } finally {
             this.taskService.deleteTask(parentTask.getId(), true);
         }
@@ -150,25 +151,26 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     @Test
     public void testCreateTaskWithOwnerAssigneeAndIdentityLinks() {
         task = taskService.createTaskBuilder().
-                        name("testName").
-                        owner("testOwner").
-                        assignee("testAssignee").
-                        identityLinks(getDefaultIdentityLinks()).
-                        create();
+                name("testName").
+                owner("testOwner").
+                assignee("testAssignee").
+                identityLinks(getDefaultIdentityLinks()).
+                create();
         Task updatedTask = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
-        assertThat(updatedTask, notNullValue());
-        assertThat(updatedTask.getName(), is("testName"));
-        assertThat(updatedTask.getAssignee(), is("testAssignee"));
-        assertThat(updatedTask.getOwner(), is("testOwner"));
-        assertThat(updatedTask.getIdentityLinks().size(), is(2));
-        assertThat(updatedTask.getPriority(), is(Task.DEFAULT_PRIORITY));
-        
+        assertThat(updatedTask).isNotNull();
+        assertThat(updatedTask.getName()).isEqualTo("testName");
+        assertThat(updatedTask.getAssignee()).isEqualTo("testAssignee");
+        assertThat(updatedTask.getOwner()).isEqualTo("testOwner");
+        assertThat(updatedTask.getIdentityLinks()).hasSize(2);
+        assertThat(updatedTask.getPriority()).isEqualTo(Task.DEFAULT_PRIORITY);
+
         if (isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
-            assertThat(historicTaskInstance, notNullValue());
-            assertThat(historicTaskInstance.getName(), is("testName"));
-            assertThat(historicTaskInstance.getPriority(), is(Task.DEFAULT_PRIORITY));
-            assertThat(historicTaskInstance.getIdentityLinks().size(), is(2));
+            HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeIdentityLinks()
+                    .singleResult();
+            assertThat(historicTaskInstance).isNotNull();
+            assertThat(historicTaskInstance.getName()).isEqualTo("testName");
+            assertThat(historicTaskInstance.getPriority()).isEqualTo(Task.DEFAULT_PRIORITY);
+            assertThat(historicTaskInstance.getIdentityLinks()).hasSize(2);
         }
 
         taskService.deleteUserIdentityLink(updatedTask.getId(), "testUserBuilder", IdentityLinkType.CANDIDATE);
@@ -191,15 +193,16 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
                     name("testName").
                     create();
             Task updatedTask = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
-            assertThat(updatedTask, notNullValue());
-            assertThat(updatedTask.getName(), is("testName"));
-            assertThat(updatedTask.getIdentityLinks().size(), is(2));
-            
+            assertThat(updatedTask).isNotNull();
+            assertThat(updatedTask.getName()).isEqualTo("testName");
+            assertThat(updatedTask.getIdentityLinks()).hasSize(2);
+
             if (isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
-                assertThat(historicTaskInstance, notNullValue());
-                assertThat(historicTaskInstance.getName(), is("testName"));
-                assertThat(historicTaskInstance.getIdentityLinks().size(), is(2));
+                HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeIdentityLinks()
+                        .singleResult();
+                assertThat(historicTaskInstance).isNotNull();
+                assertThat(historicTaskInstance.getName()).isEqualTo("testName");
+                assertThat(historicTaskInstance.getIdentityLinks()).hasSize(2);
             }
 
             taskService.deleteUserIdentityLink(updatedTask.getId(), "testUser", IdentityLinkType.CANDIDATE);
@@ -230,17 +233,18 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
                     identityLinks(getDefaultIdentityLinks()).
                     create();
             Task updatedTask = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
-            assertThat(updatedTask, notNullValue());
-            assertThat(updatedTask.getName(), is("testNameFromPostProcessor"));
-            assertThat(updatedTask.getAssignee(), is("testAssignee"));
-            assertThat(updatedTask.getOwner(), is("testOwner"));
-            assertThat(updatedTask.getIdentityLinks().size(), is(4));
-            
+            assertThat(updatedTask).isNotNull();
+            assertThat(updatedTask.getName()).isEqualTo("testNameFromPostProcessor");
+            assertThat(updatedTask.getAssignee()).isEqualTo("testAssignee");
+            assertThat(updatedTask.getOwner()).isEqualTo("testOwner");
+            assertThat(updatedTask.getIdentityLinks()).hasSize(4);
+
             if (isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-                HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
-                assertThat(historicTaskInstance, notNullValue());
-                assertThat(historicTaskInstance.getName(), is("testNameFromPostProcessor"));
-                assertThat(historicTaskInstance.getIdentityLinks().size(), is(4));
+                HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeIdentityLinks()
+                        .singleResult();
+                assertThat(historicTaskInstance).isNotNull();
+                assertThat(historicTaskInstance.getName()).isEqualTo("testNameFromPostProcessor");
+                assertThat(historicTaskInstance.getIdentityLinks()).hasSize(4);
             }
 
             taskService.deleteUserIdentityLink(updatedTask.getId(), "testUserBuilder", IdentityLinkType.CANDIDATE);
@@ -268,14 +272,14 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch the task again and update
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals("description", task.getDescription());
-        assertEquals("taskname", task.getName());
-        assertEquals("taskassignee", task.getAssignee());
-        assertEquals("taskowner", task.getOwner());
-        assertEquals(dueDate, task.getDueDate());
-        assertEquals(0, task.getPriority());
-        assertNull(task.getScopeId());
-        assertNull(task.getScopeType());
+        assertThat(task.getDescription()).isEqualTo("description");
+        assertThat(task.getName()).isEqualTo("taskname");
+        assertThat(task.getAssignee()).isEqualTo("taskassignee");
+        assertThat(task.getOwner()).isEqualTo("taskowner");
+        assertThat(task.getDueDate()).isEqualTo(dueDate);
+        assertThat(task.getPriority()).isZero();
+        assertThat(task.getScopeId()).isNull();
+        assertThat(task.getScopeType()).isNull();
 
         task.setName("updatedtaskname");
         task.setDescription("updateddescription");
@@ -287,21 +291,21 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.saveTask(task);
 
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals("updatedtaskname", task.getName());
-        assertEquals("updateddescription", task.getDescription());
-        assertEquals("updatedassignee", task.getAssignee());
-        assertEquals("updatedowner", task.getOwner());
-        assertEquals(dueDate, task.getDueDate());
-        assertEquals(1, task.getPriority());
+        assertThat(task.getName()).isEqualTo("updatedtaskname");
+        assertThat(task.getDescription()).isEqualTo("updateddescription");
+        assertThat(task.getAssignee()).isEqualTo("updatedassignee");
+        assertThat(task.getOwner()).isEqualTo("updatedowner");
+        assertThat(task.getDueDate()).isEqualTo(dueDate);
+        assertThat(task.getPriority()).isEqualTo(1);
 
         if (isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
-            assertEquals("updatedtaskname", historicTaskInstance.getName());
-            assertEquals("updateddescription", historicTaskInstance.getDescription());
-            assertEquals("updatedassignee", historicTaskInstance.getAssignee());
-            assertEquals("updatedowner", historicTaskInstance.getOwner());
-            assertEquals(dueDate, historicTaskInstance.getDueDate());
-            assertEquals(1, historicTaskInstance.getPriority());
+            assertThat(historicTaskInstance.getName()).isEqualTo("updatedtaskname");
+            assertThat(historicTaskInstance.getDescription()).isEqualTo("updateddescription");
+            assertThat(historicTaskInstance.getAssignee()).isEqualTo("updatedassignee");
+            assertThat(historicTaskInstance.getOwner()).isEqualTo("updatedowner");
+            assertThat(historicTaskInstance.getDueDate()).isEqualTo(dueDate);
+            assertThat(historicTaskInstance.getPriority()).isEqualTo(1);
         }
 
         // Finally, delete task
@@ -316,13 +320,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch the task again and update
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals("johndoe", task.getOwner());
+        assertThat(task.getOwner()).isEqualTo("johndoe");
 
         task.setOwner("joesmoe");
         taskService.saveTask(task);
 
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals("joesmoe", task.getOwner());
+        assertThat(task.getOwner()).isEqualTo("joesmoe");
 
         // Finally, delete task
         taskService.deleteTask(task.getId(), true);
@@ -344,15 +348,14 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
                             null,
                             "look at this \n       isn't this great? slkdjf sldkfjs ldkfjs ldkfjs ldkfj sldkfj sldkfj sldkjg laksfg sdfgsd;flgkj ksajdhf skjdfh ksjdhf skjdhf kalskjgh lskh dfialurhg kajsh dfuieqpgkja rzvkfnjviuqerhogiuvysbegkjz lkhf ais liasduh flaisduh ajiasudh vaisudhv nsfd");
             Comment comment = taskService.getTaskComments(taskId).get(0);
-            assertEquals("johndoe", comment.getUserId());
-            assertEquals(taskId, comment.getTaskId());
-            assertNull(comment.getProcessInstanceId());
-            assertEquals("look at this isn't this great? slkdjf sldkfjs ldkfjs ldkfjs ldkfj sldkfj sldkfj sldkjg laksfg sdfgsd;flgkj ksajdhf skjdfh ksjdhf skjdhf kalskjgh lskh dfialurhg ...",
-                    ((Event) comment).getMessage());
-            assertEquals(
-                    "look at this \n       isn't this great? slkdjf sldkfjs ldkfjs ldkfjs ldkfj sldkfj sldkfj sldkjg laksfg sdfgsd;flgkj ksajdhf skjdfh ksjdhf skjdhf kalskjgh lskh dfialurhg kajsh dfuieqpgkja rzvkfnjviuqerhogiuvysbegkjz lkhf ais liasduh flaisduh ajiasudh vaisudhv nsfd",
-                    comment.getFullMessage());
-            assertNotNull(comment.getTime());
+            assertThat(comment.getUserId()).isEqualTo("johndoe");
+            assertThat(comment.getTaskId()).isEqualTo(taskId);
+            assertThat(comment.getProcessInstanceId()).isNull();
+            assertThat(((Event) comment).getMessage()).isEqualTo(
+                    "look at this isn't this great? slkdjf sldkfjs ldkfjs ldkfjs ldkfj sldkfj sldkfj sldkjg laksfg sdfgsd;flgkj ksajdhf skjdfh ksjdhf skjdhf kalskjgh lskh dfialurhg ...");
+            assertThat(comment.getFullMessage()).isEqualTo(
+                    "look at this \n       isn't this great? slkdjf sldkfjs ldkfjs ldkfjs ldkfj sldkfj sldkfj sldkjg laksfg sdfgsd;flgkj ksajdhf skjdfh ksjdhf skjdhf kalskjgh lskh dfialurhg kajsh dfuieqpgkja rzvkfnjviuqerhogiuvysbegkjz lkhf ais liasduh flaisduh ajiasudh vaisudhv nsfd");
+            assertThat(comment.getTime()).isNotNull();
 
             // Finally, delete task
             taskService.deleteTask(taskId, true);
@@ -376,26 +379,28 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             taskService.addComment(taskId, null, customType1, "This is another Type1 comment");
             Comment customComment3 = taskService.addComment(taskId, null, customType2, "This is another custom comment. Type2 this time!");
 
-            assertEquals(CommentEntity.TYPE_COMMENT, comment.getType());
-            assertEquals(customType1, customComment1.getType());
-            assertEquals(customType2, customComment3.getType());
+            assertThat(comment.getType()).isEqualTo(CommentEntity.TYPE_COMMENT);
+            assertThat(customComment1.getType()).isEqualTo(customType1);
+            assertThat(customComment3.getType()).isEqualTo(customType2);
 
-            assertNotNull(taskService.getComment(comment.getId()));
-            assertNotNull(taskService.getComment(customComment1.getId()));
+            assertThat(taskService.getComment(comment.getId())).isNotNull();
+            assertThat(taskService.getComment(customComment1.getId())).isNotNull();
 
             List<Comment> regularComments = taskService.getTaskComments(taskId);
-            assertEquals(1, regularComments.size());
-            assertEquals("This is a regular comment", regularComments.get(0).getFullMessage());
+            assertThat(regularComments)
+                    .extracting(Comment::getFullMessage)
+                    .containsExactly("This is a regular comment");
 
             List<Event> allComments = taskService.getTaskEvents(taskId);
-            assertEquals(4, allComments.size());
+            assertThat(allComments).hasSize(4);
 
             List<Comment> type2Comments = taskService.getCommentsByType(customType2);
-            assertEquals(1, type2Comments.size());
-            assertEquals("This is another custom comment. Type2 this time!", type2Comments.get(0).getFullMessage());
+            assertThat(type2Comments)
+                    .extracting(Comment::getFullMessage)
+                    .containsExactly("This is another custom comment. Type2 this time!");
 
             List<Comment> taskTypeComments = taskService.getTaskComments(taskId, customType1);
-            assertEquals(2, taskTypeComments.size());
+            assertThat(taskTypeComments).hasSize(2);
 
             // Clean up
             taskService.deleteTask(taskId, true);
@@ -414,19 +419,21 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
             Comment comment = taskService.addComment(taskId, null, "This is a regular comment");
 
-            assertEquals(CommentEntity.TYPE_COMMENT, comment.getType());
-            assertNotNull(taskService.getComment(comment.getId()));
-            
+            assertThat(comment.getType()).isEqualTo(CommentEntity.TYPE_COMMENT);
+            assertThat(taskService.getComment(comment.getId())).isNotNull();
+
             List<Comment> regularComments = taskService.getTaskComments(taskId);
-            assertEquals(1, regularComments.size());
-            assertEquals("This is a regular comment", regularComments.get(0).getFullMessage());
+            assertThat(regularComments)
+                    .extracting(Comment::getFullMessage)
+                    .containsExactly("This is a regular comment");
 
             comment.setFullMessage("Updated comment");
             taskService.saveComment(comment);
-            
+
             regularComments = taskService.getTaskComments(taskId);
-            assertEquals(1, regularComments.size());
-            assertEquals("Updated comment", regularComments.get(0).getFullMessage());
+            assertThat(regularComments)
+                    .extracting(Comment::getFullMessage)
+                    .containsExactly("Updated comment");
 
             // Clean up
             taskService.deleteTask(taskId, true);
@@ -444,21 +451,21 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             // Fetch the task again and update
             taskService.createAttachment("web page", taskId, null, "weatherforcast", "temperatures and more", "http://weather.com");
             Attachment attachment = taskService.getTaskAttachments(taskId).get(0);
-            assertEquals("weatherforcast", attachment.getName());
-            assertEquals("temperatures and more", attachment.getDescription());
-            assertEquals("web page", attachment.getType());
-            assertEquals(taskId, attachment.getTaskId());
-            assertNull(attachment.getProcessInstanceId());
-            assertEquals("http://weather.com", attachment.getUrl());
-            assertNull(taskService.getAttachmentContent(attachment.getId()));
+            assertThat(attachment.getName()).isEqualTo("weatherforcast");
+            assertThat(attachment.getDescription()).isEqualTo("temperatures and more");
+            assertThat(attachment.getType()).isEqualTo("web page");
+            assertThat(attachment.getTaskId()).isEqualTo(taskId);
+            assertThat(attachment.getProcessInstanceId()).isNull();
+            assertThat(attachment.getUrl()).isEqualTo("http://weather.com");
+            assertThat(taskService.getAttachmentContent(attachment.getId())).isNull();
 
             // Finally, clean up
             taskService.deleteTask(taskId);
 
-            assertEquals(0, taskService.getTaskComments(taskId).size());
-            
+            assertThat(taskService.getTaskComments(taskId)).isEmpty();
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(taskId).list().size());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskId(taskId).list()).hasSize(1);
 
             taskService.deleteTask(taskId, true);
         }
@@ -481,16 +488,16 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
             // Refetch and verify
             attachment = taskService.getTaskAttachments(taskId).get(0);
-            assertEquals("UpdatedName", attachment.getName());
+            assertThat(attachment.getName()).isEqualTo("UpdatedName");
 
             // Finally, clean up
             taskService.deleteTask(taskId);
 
-            assertEquals(0, taskService.getTaskComments(taskId).size());
-            
+            assertThat(taskService.getTaskComments(taskId)).isEmpty();
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(taskId).list().size());
+
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskId(taskId).list()).hasSize(1);
 
             taskService.deleteTask(taskId, true);
         }
@@ -506,13 +513,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             String processInstanceId = processInstance.getId();
             taskService.createAttachment("web page", null, processInstanceId, "weatherforcast", "temperatures and more", "http://weather.com");
             Attachment attachment = taskService.getProcessInstanceAttachments(processInstanceId).get(0);
-            assertEquals("weatherforcast", attachment.getName());
-            assertEquals("temperatures and more", attachment.getDescription());
-            assertEquals("web page", attachment.getType());
-            assertEquals(processInstanceId, attachment.getProcessInstanceId());
-            assertNull(attachment.getTaskId());
-            assertEquals("http://weather.com", attachment.getUrl());
-            assertNull(taskService.getAttachmentContent(attachment.getId()));
+            assertThat(attachment.getName()).isEqualTo("weatherforcast");
+            assertThat(attachment.getDescription()).isEqualTo("temperatures and more");
+            assertThat(attachment.getType()).isEqualTo("web page");
+            assertThat(attachment.getProcessInstanceId()).isEqualTo(processInstanceId);
+            assertThat(attachment.getTaskId()).isNull();
+            assertThat(attachment.getUrl()).isEqualTo("http://weather.com");
+            assertThat(taskService.getAttachmentContent(attachment.getId())).isNull();
 
             // Finally, clean up
             taskService.deleteAttachment(attachment.getId());
@@ -549,7 +556,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // See if there are tasks for kermit
         List<org.flowable.task.api.Task> tasks = processEngine.getTaskService().createTaskQuery().list();
-        assertEquals(20, tasks.size());
+        assertThat(tasks).hasSize(20);
     }
 
     @Test
@@ -561,38 +568,35 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         String taskId = task.getId();
 
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals("johndoe", task.getOwner());
-        assertEquals("joesmoe", task.getAssignee());
-        assertEquals(DelegationState.PENDING, task.getDelegationState());
+        assertThat(task.getOwner()).isEqualTo("johndoe");
+        assertThat(task.getAssignee()).isEqualTo("joesmoe");
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.PENDING);
 
         // try to complete (should fail)
-        try {
-            taskService.complete(task.getId());
-            fail();
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> taskService.complete(taskId))
+                .isExactlyInstanceOf(FlowableException.class);
 
         taskService.resolveTask(taskId);
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals("johndoe", task.getOwner());
-        assertEquals("johndoe", task.getAssignee());
-        assertEquals(DelegationState.RESOLVED, task.getDelegationState());
+        assertThat(task.getOwner()).isEqualTo("johndoe");
+        assertThat(task.getAssignee()).isEqualTo("johndoe");
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
 
         task.setAssignee(null);
         task.setDelegationState(null);
         taskService.saveTask(task);
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals("johndoe", task.getOwner());
-        assertNull(task.getAssignee());
-        assertNull(task.getDelegationState());
+        assertThat(task.getOwner()).isEqualTo("johndoe");
+        assertThat(task.getAssignee()).isNull();
+        assertThat(task.getDelegationState()).isNull();
 
         task.setAssignee("jackblack");
         task.setDelegationState(DelegationState.RESOLVED);
         taskService.saveTask(task);
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals("johndoe", task.getOwner());
-        assertEquals("jackblack", task.getAssignee());
-        assertEquals(DelegationState.RESOLVED, task.getDelegationState());
+        assertThat(task.getOwner()).isEqualTo("johndoe");
+        assertThat(task.getAssignee()).isEqualTo("jackblack");
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
 
         // Finally, delete task
         taskService.deleteTask(taskId, true);
@@ -611,16 +615,16 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.delegateTask(task.getId(), "joesmoe");
 
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals("johndoe", task.getOwner());
-        assertEquals("joesmoe", task.getAssignee());
-        assertEquals(DelegationState.PENDING, task.getDelegationState());
+        assertThat(task.getOwner()).isEqualTo("johndoe");
+        assertThat(task.getAssignee()).isEqualTo("joesmoe");
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.PENDING);
 
         taskService.resolveTask(taskId);
 
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals("johndoe", task.getOwner());
-        assertEquals("johndoe", task.getAssignee());
-        assertEquals(DelegationState.RESOLVED, task.getDelegationState());
+        assertThat(task.getOwner()).isEqualTo("johndoe");
+        assertThat(task.getAssignee()).isEqualTo("johndoe");
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
 
         // Finally, delete task
         taskService.deleteTask(taskId, true);
@@ -634,13 +638,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch the task again and update
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals("johndoe", task.getAssignee());
+        assertThat(task.getAssignee()).isEqualTo("johndoe");
 
         task.setAssignee("joesmoe");
         taskService.saveTask(task);
 
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals("joesmoe", task.getAssignee());
+        assertThat(task.getAssignee()).isEqualTo("joesmoe");
 
         // Finally, delete task
         taskService.deleteTask(task.getId(), true);
@@ -648,22 +652,15 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testSaveTaskNullTask() {
-        try {
-            taskService.saveTask(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("task is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.saveTask(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("task is null");
     }
 
     @Test
     public void testDeleteTaskNullTaskId() {
-        try {
-            taskService.deleteTask(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            // Expected exception
-        }
+        assertThatThrownBy(() -> taskService.deleteTask(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -674,12 +671,8 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testDeleteTasksNullTaskIds() {
-        try {
-            taskService.deleteTasks(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            // Expected exception
-        }
+        assertThatThrownBy(() -> taskService.deleteTasks(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     @Test
@@ -688,13 +681,11 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task existingTask = taskService.newTask();
         taskService.saveTask(existingTask);
 
-        // The unexisting taskId's should be silently ignored. Existing task
-        // should
-        // have been deleted.
+        // The unexisting taskId's should be silently ignored. Existing task should have been deleted.
         taskService.deleteTasks(Arrays.asList("unexistingtaskid1", existingTask.getId()), true);
 
         existingTask = taskService.createTaskQuery().taskId(existingTask.getId()).singleResult();
-        assertNull(existingTask);
+        assertThat(existingTask).isNull();
     }
 
     @Test
@@ -708,17 +699,17 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             taskService.addCandidateGroup(task.getId(), "sales");
             taskService.addCandidateUser(task.getId(), "kermit");
 
-            assertNotNull(taskService.createTaskQuery().taskCandidateGroup("sales").singleResult());
-            assertNotNull(taskService.createTaskQuery().taskCandidateUser("kermit").singleResult());
+            assertThat(taskService.createTaskQuery().taskCandidateGroup("sales").singleResult()).isNotNull();
+            assertThat(taskService.createTaskQuery().taskCandidateUser("kermit").singleResult()).isNotNull();
 
             // Delete identity link for group
             taskService.deleteGroupIdentityLink(task.getId(), "sales", "candidate");
 
             // Link should be removed
-            assertNull(taskService.createTaskQuery().taskCandidateGroup("sales").singleResult());
+            assertThat(taskService.createTaskQuery().taskCandidateGroup("sales").singleResult()).isNull();
 
             // User link should remain unaffected
-            assertNotNull(taskService.createTaskQuery().taskCandidateUser("kermit").singleResult());
+            assertThat(taskService.createTaskQuery().taskCandidateUser("kermit").singleResult()).isNotNull();
 
         } finally {
             // Adhoc task not part of deployment, cleanup
@@ -730,12 +721,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testClaimNullArguments() {
-        try {
-            taskService.claim(null, "userid");
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.claim(null, "userid"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
@@ -743,13 +731,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
 
-        try {
-            taskService.claim("unexistingtaskid", user.getId());
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingtaskid", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.claim("unexistingtaskid", user.getId()))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingtaskid");
 
         identityService.deleteUser(user.getId());
     }
@@ -766,12 +750,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         // Claim task the first time
         taskService.claim(task.getId(), user.getId());
 
-        try {
-            taskService.claim(task.getId(), secondUser.getId());
-            fail("ActivitiException expected");
-        } catch (FlowableTaskAlreadyClaimedException ae) {
-            assertTextPresent("Task '" + task.getId() + "' is already claimed by someone else.", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.claim(task.getId(), secondUser.getId()))
+                .isInstanceOf(FlowableTaskAlreadyClaimedException.class)
+                .hasMessage("Task '" + task.getId() + "' is already claimed by someone else.");
 
         taskService.deleteTask(task.getId(), true);
         identityService.deleteUser(user.getId());
@@ -789,8 +770,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.claim(task.getId(), user.getId());
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
 
-        // Claim the task again with the same user. No exception should be
-        // thrown
+        // Claim the task again with the same user. No exception should be thrown
         taskService.claim(task.getId(), user.getId());
 
         taskService.deleteTask(task.getId(), true);
@@ -807,13 +787,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         // Claim task the first time
         taskService.claim(task.getId(), user.getId());
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals(user.getId(), task.getAssignee());
+        assertThat(task.getAssignee()).isEqualTo(user.getId());
 
         // Unclaim the task
         taskService.unclaim(task.getId());
 
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertNull(task.getAssignee());
+        assertThat(task.getAssignee()).isNull();
 
         taskService.deleteTask(task.getId(), true);
         identityService.deleteUser(user.getId());
@@ -821,44 +801,30 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testCompleteTaskNullTaskId() {
-        try {
-            taskService.complete(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.complete(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
     public void testCompleteTaskUnexistingTaskId() {
-        try {
-            taskService.complete("unexistingtask");
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingtask", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.complete("unexistingtask"))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingtask");
     }
 
     @Test
     public void testCompleteTaskWithParametersNullTaskId() {
-        try {
-            taskService.complete(null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.complete(null, new HashMap<>()))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
     public void testCompleteTaskWithParametersUnexistingTaskId() {
-        try {
-            taskService.complete("unexistingtask");
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingtask", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.complete("unexistingtask", new HashMap<>()))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingtask");
     }
 
     @Test
@@ -875,7 +841,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch the task again
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         managementService.executeCommand(commandContext -> {
             CommandContextUtil.getHistoricTaskService(commandContext).deleteHistoricTaskLogEntriesForTaskId(taskId);
@@ -898,7 +864,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch the task again
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         managementService.executeCommand(commandContext -> {
             CommandContextUtil.getHistoricTaskService(commandContext).deleteHistoricTaskLogEntriesForTaskId(taskId);
@@ -913,7 +879,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
@@ -922,12 +888,12 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch second task
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Second task", task.getName());
+        assertThat(task.getName()).isEqualTo("Second task");
 
         // Verify task parameters set on execution
         Map<String, Object> variables = runtimeService.getVariables(processInstance.getId());
-        assertEquals(1, variables.size());
-        assertEquals("myValue", variables.get("myParam"));
+        assertThat(variables).hasSize(1);
+        assertThat(variables.get("myParam")).isEqualTo("myValue");
     }
 
     @Test
@@ -937,24 +903,24 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
         taskParams.put("myParam", "myValue");
         taskService.complete(task.getId(), taskParams, false); // Only
-                                                               // difference
-                                                               // with previous
-                                                               // test
+        // difference
+        // with previous
+        // test
 
         // Fetch second task
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Second task", task.getName());
+        assertThat(task.getName()).isEqualTo("Second task");
 
         // Verify task parameters set on execution
         Map<String, Object> variables = runtimeService.getVariables(processInstance.getId());
-        assertEquals(1, variables.size());
-        assertEquals("myValue", variables.get("myParam"));
+        assertThat(variables).hasSize(1);
+        assertThat(variables.get("myParam")).isEqualTo("myValue");
     }
 
     @Test
@@ -964,18 +930,14 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
         taskParams.put("${execution.myParam}", "myValue");
-        try {
-            taskService.complete(task.getId(), taskParams);
-            fail();
-        } catch (FlowableException e) {
-            assertEquals("new properties are not resolved", e.getCause().getMessage(),
-                    "Cannot write property: myParam");
-        }
+        assertThatThrownBy(() -> taskService.complete(task.getId(), taskParams))
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessage("Error while evaluating expression: ${execution.myParam}");
     }
 
     @Test
@@ -985,16 +947,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
         taskParams.put("${execution.id}", "myValue");
-        try {
-            taskService.complete(task.getId(), taskParams);
-        } catch (PersistenceException e) {
-            // expected exception.
-        }
+        assertThatThrownBy(() -> taskService.complete(task.getId(), taskParams))
+                .isExactlyInstanceOf(PersistenceException.class);
     }
 
     @Test
@@ -1004,7 +963,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
@@ -1013,7 +972,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Verify task parameters set on execution
         Execution subExecution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
-        assertEquals("myUpdatedName", subExecution.getName());
+        assertThat(subExecution.getName()).isEqualTo("myUpdatedName");
     }
 
     @Test
@@ -1025,7 +984,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
@@ -1035,13 +994,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         // Verify task parameters set on execution
         Execution subExecution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
         Map<String, VariableInstance> variableInstances = runtimeService.getVariableInstances(subExecution.getId());
-        assertEquals("newVariableValue", variableInstances.get("newVariable").getTextValue());
+        assertThat(variableInstances.get("newVariable").getTextValue()).isEqualTo("newVariableValue");
 
         if (isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration )) {
             HistoricVariableInstance historicVariableInstance = this.historyService.createHistoricVariableInstanceQuery()
                 .id(variableInstances.get("newVariable").getId())
                 .singleResult();
-            assertEquals("newVariableValue", historicVariableInstance.getValue());
+            assertThat(historicVariableInstance.getValue()).isEqualTo("newVariableValue");
         }
     }
 
@@ -1052,18 +1011,14 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
         taskParams.put("${newVariable}", "newVariableValue");
 
-        try {
-            taskService.complete(task.getId(), taskParams);
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // expected exception.
-        }
+        assertThatThrownBy(() -> taskService.complete(task.getId(), taskParams))
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
@@ -1073,40 +1028,33 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
         taskParams.put("${execution.newVariable}", "newVariableValue");
 
-        try {
-            taskService.complete(task.getId(), taskParams);
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // expected exception.
-        }
+        assertThatThrownBy(() -> taskService.complete(task.getId(), taskParams))
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
     @Deployment(resources = {"org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml"})
     public void testCompleteWithExistingVariableParametersTask() {
         runtimeService.startProcessInstanceByKey("twoTasksProcess",
-            Collections.singletonMap("newVariable", "oldValue")
+                Collections.singletonMap("newVariable", "oldValue")
         );
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
         taskParams.put("${execution.newVariable}", "newVariableValue");
-        try {
-            taskService.complete(task.getId(), taskParams);
-            fail("expected exception");
-        } catch (FlowableException e) {
-            // expected exception.
-        }
+
+        assertThatThrownBy(() -> taskService.complete(task.getId(), taskParams))
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
@@ -1124,15 +1072,14 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId(), taskParams, true);
 
         // Verify vars are not stored process instance wide
-        assertNull(runtimeService.getVariable(processInstance.getId(), "a"));
-        assertNull(runtimeService.getVariable(processInstance.getId(), "b"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "a")).isNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "b")).isNull();
 
         // verify script listener has done its job
-        assertEquals(2, runtimeService.getVariable(processInstance.getId(), "sum"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "sum")).isEqualTo(2);
 
         // Fetch second task
         taskService.createTaskQuery().singleResult();
-
     }
 
     @Test
@@ -1142,26 +1089,26 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch task
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("my task", task.getName());
-        assertEquals("myFormKey", task.getFormKey());
-        assertEquals("myAssignee", task.getAssignee());
-        assertEquals("myOwner", task.getOwner());
-        assertEquals("myCategory", task.getCategory());
-        assertEquals(60, task.getPriority());
-        assertNotNull(task.getDueDate());
+        assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task.getFormKey()).isEqualTo("myFormKey");
+        assertThat(task.getAssignee()).isEqualTo("myAssignee");
+        assertThat(task.getOwner()).isEqualTo("myOwner");
+        assertThat(task.getCategory()).isEqualTo("myCategory");
+        assertThat(task.getPriority()).isEqualTo(60);
+        assertThat(task.getDueDate()).isNotNull();
 
         // Complete task
         taskService.complete(task.getId());
 
         if (isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
-            assertEquals("my task", historicTask.getName());
-            assertEquals("myFormKey", historicTask.getFormKey());
-            assertEquals("myAssignee", historicTask.getAssignee());
-            assertEquals("myOwner", historicTask.getOwner());
-            assertEquals("myCategory", historicTask.getCategory());
-            assertEquals(60, historicTask.getPriority());
-            assertNotNull(historicTask.getDueDate());
+            assertThat(historicTask.getName()).isEqualTo("my task");
+            assertThat(historicTask.getFormKey()).isEqualTo("myFormKey");
+            assertThat(historicTask.getAssignee()).isEqualTo("myAssignee");
+            assertThat(historicTask.getOwner()).isEqualTo("myOwner");
+            assertThat(historicTask.getCategory()).isEqualTo("myCategory");
+            assertThat(historicTask.getPriority()).isEqualTo(60);
+            assertThat(historicTask.getDueDate()).isNotNull();
         }
     }
 
@@ -1171,7 +1118,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         identityService.saveUser(user);
 
         org.flowable.task.api.Task task = taskService.newTask();
-        assertNull(task.getAssignee());
+        assertThat(task.getAssignee()).isNull();
         taskService.saveTask(task);
 
         // Set assignee
@@ -1179,7 +1126,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch task again
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals(user.getId(), task.getAssignee());
+        assertThat(task.getAssignee()).isEqualTo(user.getId());
 
         // Set assignee to null
         taskService.setAssignee(task.getId(), null);
@@ -1190,12 +1137,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testSetAssigneeNullTaskId() {
-        try {
-            taskService.setAssignee(null, "userId");
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.setAssignee(null, "userId"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
@@ -1203,13 +1147,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
 
-        try {
-            taskService.setAssignee("unexistingTaskId", user.getId());
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.setAssignee("unexistingTaskId", user.getId()))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingTaskId");
 
         identityService.deleteUser(user.getId());
     }
@@ -1241,56 +1181,56 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         org.flowable.task.api.Task currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(0, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isZero();
 
         taskService.addUserIdentityLink(currentTask.getId(), "user01", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(1, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(1);
 
         taskService.addUserIdentityLink(currentTask.getId(), "user02", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(2, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(2);
 
         taskService.deleteUserIdentityLink(currentTask.getId(), "user01", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(1, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(1);
 
         taskService.addGroupIdentityLink(currentTask.getId(), "group01", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(2, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(2);
 
         taskService.addGroupIdentityLink(currentTask.getId(), "group02", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(3, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(3);
 
         taskService.addGroupIdentityLink(currentTask.getId(), "group02", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(4, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(4);
 
         // start removing identity links
         taskService.deleteGroupIdentityLink(currentTask.getId(), "group02", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
         // Two identityLinks with id "group02" are found. Both are deleted.
-        assertEquals(2, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(2);
 
         // remove "user02" once
         taskService.deleteUserIdentityLink(currentTask.getId(), "user02", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(1, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(1);
 
         // remove "user02" twice
         taskService.deleteUserIdentityLink(currentTask.getId(), "user02", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(1, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isEqualTo(1);
 
         taskService.deleteGroupIdentityLink(currentTask.getId(), "group01", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(0, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isZero();
 
         // make sure the "identityLinkCount" value does not go negative
         taskService.deleteGroupIdentityLink(currentTask.getId(), "group01", IdentityLinkType.PARTICIPANT);
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(0, ((CountingTaskEntity) currentTask).getIdentityLinkCount());
+        assertThat(((CountingTaskEntity) currentTask).getIdentityLinkCount()).isZero();
 
         processEngineConfiguration.setEnableTaskRelationshipCounts(false);
         taskServiceConfiguration.setEnableTaskRelationshipCounts(false);
@@ -1298,22 +1238,16 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testAddCandidateUserNullTaskId() {
-        try {
-            taskService.addCandidateUser(null, "userId");
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.addCandidateUser(null, "userId"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
     public void testAddCandidateUserNullUserId() {
-        try {
-            taskService.addCandidateUser("taskId", null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("identityId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.addCandidateUser("taskId", null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("identityId is null");
     }
 
     @Test
@@ -1321,69 +1255,49 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
 
-        try {
-            taskService.addCandidateUser("unexistingTaskId", user.getId());
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.addCandidateUser("unexistingTaskId", user.getId()))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingTaskId");
 
         identityService.deleteUser(user.getId());
     }
 
     @Test
     public void testAddCandidateGroupNullTaskId() {
-        try {
-            taskService.addCandidateGroup(null, "groupId");
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.addCandidateGroup(null, "groupId"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
     public void testAddCandidateGroupNullGroupId() {
-        try {
-            taskService.addCandidateGroup("taskId", null);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("identityId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.addCandidateGroup("taskId", null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("identityId is null");
     }
 
     @Test
     public void testAddCandidateGroupUnexistingTask() {
         Group group = identityService.newGroup("group");
         identityService.saveGroup(group);
-        try {
-            taskService.addCandidateGroup("unexistingTaskId", group.getId());
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.addCandidateGroup("unexistingTaskId", group.getId()))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingTaskId");
         identityService.deleteGroup(group.getId());
     }
 
     @Test
     public void testAddGroupIdentityLinkNullTaskId() {
-        try {
-            taskService.addGroupIdentityLink(null, "groupId", IdentityLinkType.CANDIDATE);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.addGroupIdentityLink(null, "groupId", IdentityLinkType.CANDIDATE))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
     public void testAddGroupIdentityLinkNullUserId() {
-        try {
-            taskService.addGroupIdentityLink("taskId", null, IdentityLinkType.CANDIDATE);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("identityId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.addGroupIdentityLink("taskId", null, IdentityLinkType.CANDIDATE))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("identityId is null");
     }
 
     @Test
@@ -1391,35 +1305,25 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
 
-        try {
-            taskService.addGroupIdentityLink("unexistingTaskId", user.getId(), IdentityLinkType.CANDIDATE);
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.addGroupIdentityLink("unexistingTaskId", user.getId(), IdentityLinkType.CANDIDATE))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingTaskId");
 
         identityService.deleteUser(user.getId());
     }
 
     @Test
     public void testAddUserIdentityLinkNullTaskId() {
-        try {
-            taskService.addUserIdentityLink(null, "userId", IdentityLinkType.CANDIDATE);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.addUserIdentityLink(null, "userId", IdentityLinkType.CANDIDATE))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
     public void testAddUserIdentityLinkNullUserId() {
-        try {
-            taskService.addUserIdentityLink("taskId", null, IdentityLinkType.CANDIDATE);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("identityId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.addUserIdentityLink("taskId", null, IdentityLinkType.CANDIDATE))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("identityId is null");
     }
 
     @Test
@@ -1427,13 +1331,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
 
-        try {
-            taskService.addUserIdentityLink("unexistingTaskId", user.getId(), IdentityLinkType.CANDIDATE);
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.addUserIdentityLink("unexistingTaskId", user.getId(), IdentityLinkType.CANDIDATE))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingTaskId");
 
         identityService.deleteUser(user.getId());
     }
@@ -1448,10 +1348,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         taskService.addCandidateUser(taskId, "kermit");
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        assertEquals(1, identityLinks.size());
-        assertEquals("kermit", identityLinks.get(0).getUserId());
-        assertNull(identityLinks.get(0).getGroupId());
-        assertEquals(IdentityLinkType.CANDIDATE, identityLinks.get(0).getType());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getUserId, IdentityLink::getGroupId, IdentityLink::getType)
+                .containsExactly(tuple("kermit", null, IdentityLinkType.CANDIDATE));
 
         // cleanup
         taskService.deleteTask(taskId, true);
@@ -1468,10 +1367,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         taskService.addCandidateGroup(taskId, "muppets");
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        assertEquals(1, identityLinks.size());
-        assertEquals("muppets", identityLinks.get(0).getGroupId());
-        assertNull(identityLinks.get(0).getUserId());
-        assertEquals(IdentityLinkType.CANDIDATE, identityLinks.get(0).getType());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getUserId, IdentityLink::getGroupId, IdentityLink::getType)
+                .containsExactly(tuple(null, "muppets", IdentityLinkType.CANDIDATE));
 
         // cleanup
         taskService.deleteTask(taskId, true);
@@ -1488,10 +1386,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         taskService.claim(taskId, "kermit");
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        assertEquals(1, identityLinks.size());
-        assertEquals("kermit", identityLinks.get(0).getUserId());
-        assertNull(identityLinks.get(0).getGroupId());
-        assertEquals(IdentityLinkType.ASSIGNEE, identityLinks.get(0).getType());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getUserId, IdentityLink::getGroupId, IdentityLink::getType)
+                .containsExactly(tuple("kermit", null, IdentityLinkType.ASSIGNEE));
 
         // cleanup
         taskService.deleteTask(taskId, true);
@@ -1506,10 +1403,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         taskService.claim(taskId, "nonExistingAssignee");
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        assertEquals(1, identityLinks.size());
-        assertEquals("nonExistingAssignee", identityLinks.get(0).getUserId());
-        assertNull(identityLinks.get(0).getGroupId());
-        assertEquals(IdentityLinkType.ASSIGNEE, identityLinks.get(0).getType());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getUserId, IdentityLink::getGroupId, IdentityLink::getType)
+                .containsExactly(tuple("nonExistingAssignee", null, IdentityLinkType.ASSIGNEE));
 
         // cleanup
         taskService.deleteTask(taskId, true);
@@ -1528,17 +1424,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.delegateTask(taskId, "fozzie");
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        assertEquals(2, identityLinks.size());
-
-        IdentityLink assignee = identityLinks.get(0);
-        assertEquals("fozzie", assignee.getUserId());
-        assertNull(assignee.getGroupId());
-        assertEquals(IdentityLinkType.ASSIGNEE, assignee.getType());
-
-        IdentityLink owner = identityLinks.get(1);
-        assertEquals("kermit", owner.getUserId());
-        assertNull(owner.getGroupId());
-        assertEquals(IdentityLinkType.OWNER, owner.getType());
+        assertThat(identityLinks).hasSize(2);
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getUserId, IdentityLink::getGroupId, IdentityLink::getType)
+                .containsExactly(
+                        tuple("fozzie", null, IdentityLinkType.ASSIGNEE),
+                        tuple("kermit", null, IdentityLinkType.OWNER)
+                );
 
         // cleanup
         taskService.deleteTask(taskId, true);
@@ -1555,17 +1447,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.claim(taskId, "nonExistingOwner");
         taskService.delegateTask(taskId, "nonExistingAssignee");
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        assertEquals(2, identityLinks.size());
 
-        IdentityLink assignee = identityLinks.get(0);
-        assertEquals("nonExistingAssignee", assignee.getUserId());
-        assertNull(assignee.getGroupId());
-        assertEquals(IdentityLinkType.ASSIGNEE, assignee.getType());
-
-        IdentityLink owner = identityLinks.get(1);
-        assertEquals("nonExistingOwner", owner.getUserId());
-        assertNull(owner.getGroupId());
-        assertEquals(IdentityLinkType.OWNER, owner.getType());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getUserId, IdentityLink::getGroupId, IdentityLink::getType)
+                .containsExactly(
+                        tuple("nonExistingAssignee", null, IdentityLinkType.ASSIGNEE),
+                        tuple("nonExistingOwner", null, IdentityLinkType.OWNER)
+                );
 
         // cleanup
         taskService.deleteTask(taskId, true);
@@ -1580,30 +1468,23 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch task again to check if the priority is set
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals(12345, task.getPriority());
+        assertThat(task.getPriority()).isEqualTo(12345);
 
         taskService.deleteTask(task.getId(), true);
     }
 
     @Test
     public void testSetPriorityUnexistingTaskId() {
-        try {
-            taskService.setPriority("unexistingtask", 12345);
-            fail("ActivitiException expected");
-        } catch (FlowableObjectNotFoundException ae) {
-            assertTextPresent("Cannot find task with id unexistingtask", ae.getMessage());
-            assertEquals(org.flowable.task.api.Task.class, ae.getObjectClass());
-        }
+        assertThatThrownBy(() -> taskService.setPriority("unexistingtask", 12345))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingtask");
     }
 
     @Test
     public void testSetPriorityNullTaskId() {
-        try {
-            taskService.setPriority(null, 12345);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.setPriority(null, 12345))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
@@ -1618,14 +1499,14 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch task to check if the due date was persisted
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertNotNull(task.getDueDate());
+        assertThat(task.getDueDate()).isNotNull();
 
         // Set the due date to null
         taskService.setDueDate(task.getId(), null);
 
         // Re-fetch the task to make sure the due date was set to null
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertNull(task.getDueDate());
+        assertThat(task.getDueDate()).isNull();
 
         // Call saveTask to update due date
         task = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
@@ -1634,29 +1515,23 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         task.setDueDate(now);
         taskService.saveTask(task);
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertEquals(now, task.getDueDate());
+        assertThat(task.getDueDate()).isEqualTo(now);
 
         taskService.deleteTask(task.getId(), true);
     }
 
     @Test
     public void testSetDueDateUnexistingTaskId() {
-        try {
-            taskService.setDueDate("unexistingtask", new Date());
-            fail("ActivitiException expected");
-        } catch (FlowableException ae) {
-            assertTextPresent("Cannot find task with id unexistingtask", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.setDueDate("unexistingtask", new Date()))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id unexistingtask");
     }
 
     @Test
     public void testSetDueDateNullTaskId() {
-        try {
-            taskService.setDueDate(null, new Date());
-            fail("ActivitiException expected");
-        } catch (FlowableException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.setDueDate(null, new Date()))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     /**
@@ -1671,17 +1546,17 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         String taskId = task.getId();
 
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals("wuzh", task.getOwner());
-        assertEquals("other", task.getAssignee());
-        assertEquals(DelegationState.PENDING, task.getDelegationState());
+        assertThat(task.getOwner()).isEqualTo("wuzh");
+        assertThat(task.getAssignee()).isEqualTo("other");
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.PENDING);
 
         task.setDelegationState(DelegationState.RESOLVED);
         taskService.saveTask(task);
 
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals("wuzh", task.getOwner());
-        assertEquals("other", task.getAssignee());
-        assertEquals(DelegationState.RESOLVED, task.getDelegationState());
+        assertThat(task.getOwner()).isEqualTo("wuzh");
+        assertThat(task.getAssignee()).isEqualTo("other");
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
 
         taskService.deleteTask(taskId, true);
     }
@@ -1692,7 +1567,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
             List<HistoricDetail> resultSet = historyService.createHistoricDetailQuery().processInstanceId(processInstanceId).list();
             for (HistoricDetail currentHistoricDetail : resultSet) {
-                assertTrue(currentHistoricDetail instanceof HistoricDetailVariableInstanceUpdateEntity);
+                assertThat(currentHistoricDetail instanceof HistoricDetailVariableInstanceUpdateEntity).isTrue();
                 HistoricDetailVariableInstanceUpdateEntity historicVariableUpdate = (HistoricDetailVariableInstanceUpdateEntity) currentHistoricDetail;
 
                 if (historicVariableUpdate.getName().equals(variableName)) {
@@ -1706,7 +1581,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
                 }
             }
 
-            assertTrue(deletedVariableUpdateFound);
+            assertThat(deletedVariableUpdateFound).isTrue();
         }
     }
 
@@ -1718,24 +1593,21 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task currentTask = taskService.createTaskQuery().singleResult();
 
         taskService.setVariable(currentTask.getId(), "variable1", "value1");
-        assertEquals("value1", taskService.getVariable(currentTask.getId(), "variable1"));
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable1"));
+        assertThat(taskService.getVariable(currentTask.getId(), "variable1")).isEqualTo("value1");
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable1")).isNull();
 
         taskService.removeVariable(currentTask.getId(), "variable1");
 
-        assertNull(taskService.getVariable(currentTask.getId(), "variable1"));
+        assertThat(taskService.getVariable(currentTask.getId(), "variable1")).isNull();
 
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
     }
 
     @Test
     public void testRemoveVariableNullTaskId() {
-        try {
-            taskService.removeVariable(null, "variable");
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.removeVariable(null, "variable"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
@@ -1751,22 +1623,22 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.setVariables(currentTask.getId(), varsToDelete);
         taskService.setVariable(currentTask.getId(), "variable3", "value3");
 
-        assertEquals("value1", taskService.getVariable(currentTask.getId(), "variable1"));
-        assertEquals("value2", taskService.getVariable(currentTask.getId(), "variable2"));
-        assertEquals("value3", taskService.getVariable(currentTask.getId(), "variable3"));
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable1"));
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable2"));
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable3"));
+        assertThat(taskService.getVariable(currentTask.getId(), "variable1")).isEqualTo("value1");
+        assertThat(taskService.getVariable(currentTask.getId(), "variable2")).isEqualTo("value2");
+        assertThat(taskService.getVariable(currentTask.getId(), "variable3")).isEqualTo("value3");
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable1")).isNull();
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable2")).isNull();
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable3")).isNull();
 
         taskService.removeVariables(currentTask.getId(), varsToDelete.keySet());
 
-        assertNull(taskService.getVariable(currentTask.getId(), "variable1"));
-        assertNull(taskService.getVariable(currentTask.getId(), "variable2"));
-        assertEquals("value3", taskService.getVariable(currentTask.getId(), "variable3"));
+        assertThat(taskService.getVariable(currentTask.getId(), "variable1")).isNull();
+        assertThat(taskService.getVariable(currentTask.getId(), "variable2")).isNull();
+        assertThat(taskService.getVariable(currentTask.getId(), "variable3")).isEqualTo("value3");
 
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable1"));
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable2"));
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable3"));
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable1")).isNull();
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable2")).isNull();
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable3")).isNull();
 
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
         checkHistoricVariableUpdateEntity("variable2", processInstance.getId());
@@ -1775,12 +1647,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     @SuppressWarnings("unchecked")
     @Test
     public void testRemoveVariablesNullTaskId() {
-        try {
-            taskService.removeVariables(null, Collections.EMPTY_LIST);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.removeVariables(null, new HashSet<>()))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
@@ -1791,13 +1660,13 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task currentTask = taskService.createTaskQuery().singleResult();
 
         taskService.setVariableLocal(currentTask.getId(), "variable1", "value1");
-        assertEquals("value1", taskService.getVariable(currentTask.getId(), "variable1"));
-        assertEquals("value1", taskService.getVariableLocal(currentTask.getId(), "variable1"));
+        assertThat(taskService.getVariable(currentTask.getId(), "variable1")).isEqualTo("value1");
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable1")).isEqualTo("value1");
 
         taskService.removeVariableLocal(currentTask.getId(), "variable1");
 
-        assertNull(taskService.getVariable(currentTask.getId(), "variable1"));
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable1"));
+        assertThat(taskService.getVariable(currentTask.getId(), "variable1")).isNull();
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable1")).isNull();
 
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
     }
@@ -1812,18 +1681,18 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         org.flowable.task.api.Task currentTask = taskService.createTaskQuery().singleResult();
 
-        assertEquals(0, ((CountingTaskEntity) currentTask).getVariableCount());
+        assertThat(((CountingTaskEntity) currentTask).getVariableCount()).isZero();
 
         taskService.setVariableLocal(currentTask.getId(), "variable1", "value1");
         currentTask = taskService.createTaskQuery().singleResult();
 
-        assertEquals(1, ((CountingTaskEntity) currentTask).getVariableCount());
+        assertThat(((CountingTaskEntity) currentTask).getVariableCount()).isEqualTo(1);
 
         // process variables should have no effect
         taskService.setVariable(currentTask.getId(), "processVariable1", "procValue1");
         currentTask = taskService.createTaskQuery().singleResult();
 
-        assertEquals(1, ((CountingTaskEntity) currentTask).getVariableCount());
+        assertThat(((CountingTaskEntity) currentTask).getVariableCount()).isEqualTo(1);
 
         Map<String, Object> localVars = new HashMap<>();
         localVars.put("localVar1", "localValue1");
@@ -1833,24 +1702,24 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.setVariablesLocal(currentTask.getId(), localVars);
         currentTask = taskService.createTaskQuery().singleResult();
 
-        assertEquals(4, ((CountingTaskEntity) currentTask).getVariableCount());
+        assertThat(((CountingTaskEntity) currentTask).getVariableCount()).isEqualTo(4);
 
         taskService.removeVariablesLocal(currentTask.getId(), localVars.keySet());
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(1, ((CountingTaskEntity) currentTask).getVariableCount());
+        assertThat(((CountingTaskEntity) currentTask).getVariableCount()).isEqualTo(1);
 
         taskService.removeVariablesLocal(currentTask.getId(), localVars.keySet());
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(1, ((CountingTaskEntity) currentTask).getVariableCount());
+        assertThat(((CountingTaskEntity) currentTask).getVariableCount()).isEqualTo(1);
 
         taskService.removeVariableLocal(currentTask.getId(), "variable1");
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(0, ((CountingTaskEntity) currentTask).getVariableCount());
+        assertThat(((CountingTaskEntity) currentTask).getVariableCount()).isZero();
 
         // make sure it does not get negative
         taskService.removeVariableLocal(currentTask.getId(), "variable1");
         currentTask = taskService.createTaskQuery().singleResult();
-        assertEquals(0, ((CountingTaskEntity) currentTask).getVariableCount());
+        assertThat(((CountingTaskEntity) currentTask).getVariableCount()).isZero();
 
         processEngineConfiguration.setEnableTaskRelationshipCounts(false);
         taskServiceConfiguration.setEnableTaskRelationshipCounts(false);
@@ -1858,12 +1727,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testRemoveVariableLocalNullTaskId() {
-        try {
-            taskService.removeVariableLocal(null, "variable");
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.removeVariableLocal(null, "variable"))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
@@ -1879,22 +1745,22 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.setVariablesLocal(currentTask.getId(), varsToDelete);
         taskService.setVariableLocal(currentTask.getId(), "variable3", "value3");
 
-        assertEquals("value1", taskService.getVariable(currentTask.getId(), "variable1"));
-        assertEquals("value2", taskService.getVariable(currentTask.getId(), "variable2"));
-        assertEquals("value3", taskService.getVariable(currentTask.getId(), "variable3"));
-        assertEquals("value1", taskService.getVariableLocal(currentTask.getId(), "variable1"));
-        assertEquals("value2", taskService.getVariableLocal(currentTask.getId(), "variable2"));
-        assertEquals("value3", taskService.getVariableLocal(currentTask.getId(), "variable3"));
+        assertThat(taskService.getVariable(currentTask.getId(), "variable1")).isEqualTo("value1");
+        assertThat(taskService.getVariable(currentTask.getId(), "variable2")).isEqualTo("value2");
+        assertThat(taskService.getVariable(currentTask.getId(), "variable3")).isEqualTo("value3");
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable1")).isEqualTo("value1");
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable2")).isEqualTo("value2");
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable3")).isEqualTo("value3");
 
         taskService.removeVariables(currentTask.getId(), varsToDelete.keySet());
 
-        assertNull(taskService.getVariable(currentTask.getId(), "variable1"));
-        assertNull(taskService.getVariable(currentTask.getId(), "variable2"));
-        assertEquals("value3", taskService.getVariable(currentTask.getId(), "variable3"));
+        assertThat(taskService.getVariable(currentTask.getId(), "variable1")).isNull();
+        assertThat(taskService.getVariable(currentTask.getId(), "variable2")).isNull();
+        assertThat(taskService.getVariable(currentTask.getId(), "variable3")).isEqualTo("value3");
 
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable1"));
-        assertNull(taskService.getVariableLocal(currentTask.getId(), "variable2"));
-        assertEquals("value3", taskService.getVariableLocal(currentTask.getId(), "variable3"));
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable1")).isNull();
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable2")).isNull();
+        assertThat(taskService.getVariableLocal(currentTask.getId(), "variable3")).isEqualTo("value3");
 
         checkHistoricVariableUpdateEntity("variable1", processInstance.getId());
         checkHistoricVariableUpdateEntity("variable2", processInstance.getId());
@@ -1903,12 +1769,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     @SuppressWarnings("unchecked")
     @Test
     public void testRemoveVariablesLocalNullTaskId() {
-        try {
-            taskService.removeVariablesLocal(null, Collections.EMPTY_LIST);
-            fail("ActivitiException expected");
-        } catch (FlowableIllegalArgumentException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.removeVariablesLocal(null, new HashSet<>()))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
@@ -1916,7 +1779,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     public void testGetVariableByHistoricActivityInstance() throws Exception {
         if (isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
 
             taskService.setVariable(task.getId(), "variable1", "value1");
@@ -1928,18 +1791,18 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             HistoricActivityInstance historicActivitiInstance = historyService.createHistoricActivityInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .activityId("theTask").singleResult();
-            assertNotNull(historicActivitiInstance);
+            assertThat(historicActivitiInstance).isNotNull();
 
             List<HistoricDetail> resultSet = historyService.createHistoricDetailQuery().variableUpdates()
                     .orderByTime()
                     .asc()
                     .list();
 
-            assertEquals(2, resultSet.size());
-            assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(0)).getVariableName());
-            assertEquals("value1", ((HistoricVariableUpdate) resultSet.get(0)).getValue());
-            assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(1)).getVariableName());
-            assertEquals("value2", ((HistoricVariableUpdate) resultSet.get(1)).getValue());
+            assertThat(resultSet).hasSize(2);
+            assertThat(((HistoricVariableUpdate) resultSet.get(0)).getVariableName()).isEqualTo("variable1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(0)).getValue()).isEqualTo("value1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(1)).getVariableName()).isEqualTo("variable1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(1)).getValue()).isEqualTo("value2");
 
             resultSet = historyService.createHistoricDetailQuery().variableUpdates()
                     .activityInstanceId(historicActivitiInstance.getId())
@@ -1947,11 +1810,11 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
                     .asc()
                     .list();
 
-            assertEquals(2, resultSet.size());
-            assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(0)).getVariableName());
-            assertEquals("value1", ((HistoricVariableUpdate) resultSet.get(0)).getValue());
-            assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(1)).getVariableName());
-            assertEquals("value2", ((HistoricVariableUpdate) resultSet.get(1)).getValue());
+            assertThat(resultSet).hasSize(2);
+            assertThat(((HistoricVariableUpdate) resultSet.get(0)).getVariableName()).isEqualTo("variable1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(0)).getValue()).isEqualTo("value1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(1)).getVariableName()).isEqualTo("variable1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(1)).getValue()).isEqualTo("value2");
         }
     }
 
@@ -1960,7 +1823,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     public void testGetVariableByActivityInstance() throws Exception {
         if (isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
 
             taskService.setVariable(task.getId(), "variable1", "value1");
@@ -1972,18 +1835,18 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             ActivityInstance activityInstance = runtimeService.createActivityInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .activityId("theTask").singleResult();
-            assertNotNull(activityInstance);
+            assertThat(activityInstance).isNotNull();
 
             List<HistoricDetail> resultSet = historyService.createHistoricDetailQuery().variableUpdates()
                     .orderByTime()
                     .asc()
                     .list();
 
-            assertEquals(2, resultSet.size());
-            assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(0)).getVariableName());
-            assertEquals("value1", ((HistoricVariableUpdate) resultSet.get(0)).getValue());
-            assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(1)).getVariableName());
-            assertEquals("value2", ((HistoricVariableUpdate) resultSet.get(1)).getValue());
+            assertThat(resultSet).hasSize(2);
+            assertThat(((HistoricVariableUpdate) resultSet.get(0)).getVariableName()).isEqualTo("variable1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(0)).getValue()).isEqualTo("value1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(1)).getVariableName()).isEqualTo("variable1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(1)).getValue()).isEqualTo("value2");
 
             resultSet = historyService.createHistoricDetailQuery().variableUpdates()
                     .activityInstanceId(activityInstance.getId())
@@ -1991,11 +1854,11 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
                     .asc()
                     .list();
 
-            assertEquals(2, resultSet.size());
-            assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(0)).getVariableName());
-            assertEquals("value1", ((HistoricVariableUpdate) resultSet.get(0)).getValue());
-            assertEquals("variable1", ((HistoricVariableUpdate) resultSet.get(1)).getVariableName());
-            assertEquals("value2", ((HistoricVariableUpdate) resultSet.get(1)).getValue());
+            assertThat(resultSet).hasSize(2);
+            assertThat(((HistoricVariableUpdate) resultSet.get(0)).getVariableName()).isEqualTo("variable1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(0)).getValue()).isEqualTo("value1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(1)).getVariableName()).isEqualTo("variable1");
+            assertThat(((HistoricVariableUpdate) resultSet.get(1)).getValue()).isEqualTo("value2");
         }
     }
 
@@ -2010,14 +1873,11 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         task1.setDescription("test description one");
         taskService.saveTask(task1);
 
-        try {
+        assertThatThrownBy(() -> {
             task2.setDescription("test description two");
             taskService.saveTask(task2);
-
-            fail("Expecting exception");
-        } catch (FlowableOptimisticLockingException e) {
-            // Expected exception
-        }
+        })
+                .isExactlyInstanceOf(FlowableOptimisticLockingException.class);
     }
 
     @Test
@@ -2030,42 +1890,35 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
             task.setName("test task");
             taskService.saveTask(task);
 
-            assertNotNull(task.getId());
+            assertThat(task.getId()).isNotNull();
 
             taskService.deleteTask(task.getId(), "deleted for testing purposes");
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
 
-            assertNotNull(historicTaskInstance);
-            assertEquals("deleted for testing purposes", historicTaskInstance.getDeleteReason());
+            assertThat(historicTaskInstance).isNotNull();
+            assertThat(historicTaskInstance.getDeleteReason()).isEqualTo("deleted for testing purposes");
 
             // Delete historic task that is left behind, will not be cleaned up
             // because this is not part of a process
             taskService.deleteTask(task.getId(), true);
-
         }
     }
 
     @Test
     public void testResolveTaskNullTaskId() {
-        try {
-            taskService.resolveTask(null);
-            fail();
-        } catch (FlowableException ae) {
-            assertTextPresent("taskId is null", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.resolveTask(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("taskId is null");
     }
 
     @Test
     public void testResolveTaskUnexistingTaskId() {
-        try {
-            taskService.resolveTask("blergh");
-            fail();
-        } catch (FlowableException ae) {
-            assertTextPresent("Cannot find task with id", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.resolveTask("blergh"))
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
+                .hasMessage("Cannot find task with id blergh");
     }
 
     @Test
@@ -2083,7 +1936,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch the task again
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals(DelegationState.RESOLVED, task.getDelegationState());
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
 
         taskService.deleteTask(taskId, true);
     }
@@ -2104,7 +1957,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch the task again
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertEquals(DelegationState.RESOLVED, task.getDelegationState());
+        assertThat(task.getDelegationState()).isEqualTo(DelegationState.RESOLVED);
 
         taskService.deleteTask(taskId, true);
     }
@@ -2116,7 +1969,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Fetch first task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         taskService.delegateTask(task.getId(), "johndoe");
 
@@ -2127,12 +1980,12 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Verify that task is resolved
         task = taskService.createTaskQuery().taskDelegationState(DelegationState.RESOLVED).singleResult();
-        assertEquals("First task", task.getName());
+        assertThat(task.getName()).isEqualTo("First task");
 
         // Verify task parameters set on execution
         Map<String, Object> variables = runtimeService.getVariables(processInstance.getId());
-        assertEquals(1, variables.size());
-        assertEquals("myValue", variables.get("myParam"));
+        assertThat(variables)
+                .containsOnly(entry("myParam", "myValue"));
     }
 
     @Test
@@ -2140,44 +1993,32 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
     public void testDeleteTaskPartOfProcess() {
         runtimeService.startProcessInstanceByKey("oneTaskProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
-        try {
-            taskService.deleteTask(task.getId());
-        } catch (FlowableException ae) {
-            assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.deleteTask(task.getId()))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("The task cannot be deleted because is part of a running process");
 
-        try {
-            taskService.deleteTask(task.getId(), true);
-        } catch (FlowableException ae) {
-            assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.deleteTask(task.getId(), true))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("The task cannot be deleted because is part of a running process");
 
-        try {
-            taskService.deleteTask(task.getId(), "test");
-        } catch (FlowableException ae) {
-            assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.deleteTask(task.getId(), "test"))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("The task cannot be deleted because is part of a running process");
 
-        try {
-            taskService.deleteTasks(Collections.singletonList(task.getId()));
-        } catch (FlowableException ae) {
-            assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
-        }
+        String idLists[] = { task.getId() };
+        assertThatThrownBy(() -> taskService.deleteTasks(Arrays.asList(idLists)))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("The task cannot be deleted because is part of a running process");
 
-        try {
-            taskService.deleteTasks(Collections.singletonList(task.getId()), true);
-        } catch (FlowableException ae) {
-            assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
-        }
+        assertThatThrownBy(() -> taskService.deleteTasks(Arrays.asList(idLists), true))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("The task cannot be deleted because is part of a running process");
 
-        try {
-            taskService.deleteTasks(Collections.singletonList(task.getId()), "test");
-        } catch (FlowableException ae) {
-            assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
-        }
-
+        assertThatThrownBy(() -> taskService.deleteTasks(Arrays.asList(idLists), "test"))
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("The task cannot be deleted because is part of a running process");
     }
 
     @Test
@@ -2186,20 +2027,20 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("testFormExpression", CollectionUtil.singletonMap("var", "abc"));
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("first-form.json", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("first-form.json");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("form-abc.json", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("form-abc.json");
 
         task.setFormKey("form-changed.json");
         taskService.saveTask(task);
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("form-changed.json", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("form-changed.json");
 
         if (isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
-            assertEquals("form-changed.json", historicTaskInstance.getFormKey());
+            assertThat(historicTaskInstance.getFormKey()).isEqualTo("form-changed.json");
         }
     }
 
@@ -2214,7 +2055,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         String variable = taskService.getVariableLocal(currentTask.getId(), "variable1", String.class);
 
-        assertEquals("value1", variable);
+        assertThat(variable).isEqualTo("value1");
     }
 
     @Test
@@ -2226,7 +2067,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         String variable = taskService.getVariableLocal(currentTask.getId(), "variable1", String.class);
 
-        assertNull(variable);
+        assertThat(variable).isNull();
     }
 
     @Test
@@ -2253,7 +2094,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         String variable = taskService.getVariable(currentTask.getId(), "variable1", String.class);
 
-        assertEquals("value1", variable);
+        assertThat(variable).isEqualTo("value1");
     }
 
     @Test
@@ -2265,7 +2106,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         String variable = taskService.getVariable(currentTask.getId(), "variable1", String.class);
 
-        assertNull(variable);
+        assertThat(variable).isNull();
     }
 
     @Test
@@ -2288,19 +2129,19 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         User user = identityService.newUser("user");
         identityService.saveUser(user);
 
-        assertNull(task.getClaimTime());
+        assertThat(task.getClaimTime()).isNull();
 
         // Claim task
         taskService.claim(task.getId(), user.getId());
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
 
-        assertNotNull(task.getClaimTime());
+        assertThat(task.getClaimTime()).isNotNull();
 
         // Unclaim task
         taskService.unclaim(task.getId());
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
 
-        assertNull(task.getClaimTime());
+        assertThat(task.getClaimTime()).isNull();
 
         taskService.deleteTask(task.getId(), true);
         identityService.deleteUser(user.getId());


### PR DESCRIPTION
I have started to work on files that are a mix of assertion styles in the same file. There were 4 such files in the `org.flowable.engine.test.api.task` package.

I need to find files that are not 3600+ lines long :)

