### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/DurationHelperTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/DurationHelperTest.java
@@ -116,7 +116,7 @@ public class DurationHelperTest {
         DurationHelper dh = new DurationHelper("R2/2013-11-03T00:45:00-04:00/PT1H", testingClock);
         Calendar expected = parseCalendarWithOffset("20131103-01:45:00-04:00", TimeZone.getTimeZone("US/Eastern"));
 
-        assertThat(expected.compareTo(dh.getCalendarAfter())).isEqualTo(0);
+        assertThat(expected.compareTo(dh.getCalendarAfter())).isZero();
     }
 
     @Test
@@ -127,7 +127,7 @@ public class DurationHelperTest {
         DurationHelper dh = new DurationHelper("R2/2013-11-03T00:45:00-04:00/PT2H", testingClock);
         Calendar expected = parseCalendarWithOffset("20131103-01:45:00-05:00", TimeZone.getTimeZone("US/Eastern"));
 
-        assertThat(expected.compareTo(dh.getCalendarAfter())).isEqualTo(0);
+        assertThat(expected.compareTo(dh.getCalendarAfter())).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/el/ExpressionBeanAccessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/el/ExpressionBeanAccessTest.java
@@ -13,6 +13,7 @@
 
 package org.flowable.standalone.el;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.flowable.common.engine.api.FlowableException;
@@ -36,11 +37,12 @@ public class ExpressionBeanAccessTest extends ResourceFlowableTestCase {
         // Exposed bean returns 'I'm exposed' when to-string is called in first
         // service-task
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("expressionBeanAccess");
-        assertEquals("I'm exposed", runtimeService.getVariable(pi.getId(), "exposedBeanResult"));
+        assertThat(runtimeService.getVariable(pi.getId(), "exposedBeanResult")).isEqualTo("I'm exposed");
 
         // After signaling, an expression tries to use a bean that is present in
         // the configuration but is not added to the beans-list
-        assertThatThrownBy(() -> runtimeService.trigger(runtimeService.createExecutionQuery().processInstanceId(pi.getId()).onlyChildExecutions().singleResult().getId()))
+        assertThatThrownBy(
+                () -> runtimeService.trigger(runtimeService.createExecutionQuery().processInstanceId(pi.getId()).onlyChildExecutions().singleResult().getId()))
                 .isExactlyInstanceOf(FlowableException.class)
                 .hasRootCauseMessage("Cannot resolve identifier 'notExposedBean'");
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
@@ -1258,7 +1258,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
          *
          * execution id: On which execution it was set activity id: in which activity was the process instance when setting the variable
          */
-        assertThat(historicActivityInstance2.getExecutionId().equals(update2.getExecutionId())).isFalse();
+        assertThat(historicActivityInstance2.getExecutionId()).isNotEqualTo(update2.getExecutionId());
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryTest.java
@@ -109,7 +109,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
                 expectedNrOfJobs = 2; // 1 job  for start, 1 for complete
             }
 
-            assertThat(jobs.size()).isEqualTo(expectedNrOfJobs);
+            assertThat(jobs).hasSize(expectedNrOfJobs);
             for (HistoryJob job : jobs) {
                 if (processEngineConfiguration.isAsyncHistoryJsonGzipCompressionEnabled()) {
                     assertThat(job.getJobHandlerType()).isEqualTo(HistoryJsonConstants.JOB_HANDLER_TYPE_DEFAULT_ASYNC_HISTORY_ZIPPED);
@@ -123,7 +123,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
 
             waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
 
-            assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceId).count()).isEqualTo(2L);
+            assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceId).count()).isEqualTo(2);
 
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId)
                     .singleResult();
@@ -539,9 +539,9 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
 
         HistoricTaskLogEntry historicTaskLogEntry = null;
         try {
-            assertThat(historyService.createHistoricTaskLogEntryQuery().taskId("1").count()).isEqualTo(0l);
+            assertThat(historyService.createHistoricTaskLogEntryQuery().taskId("1").count()).isZero();
             waitForHistoryJobExecutorToProcessAllJobs(7000, 200);
-            assertThat(historyService.createHistoricTaskLogEntryQuery().taskId("1").count()).isEqualTo(1l);
+            assertThat(historyService.createHistoricTaskLogEntryQuery().taskId("1").count()).isEqualTo(1);
 
             historicTaskLogEntry = historyService.createHistoricTaskLogEntryQuery().taskId("1").singleResult();
             assertThat(historicTaskLogEntry.getLogNumber()).isPositive();
@@ -585,35 +585,35 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         runtimeService.activateProcessInstanceById(oneTaskProcess.getId());
         taskService.complete(task.getId());
 
-        assertThat(historyService.createHistoricTaskLogEntryQuery().count()).isEqualTo(0l);
+        assertThat(historyService.createHistoricTaskLogEntryQuery().count()).isZero();
         assertThat(managementService.createHistoryJobQuery().count()).isEqualTo(12l);
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 200);
 
-        assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(13l);
+        assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(13);
         assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_CREATED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_NAME_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_PRIORITY_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_ASSIGNEE_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_OWNER_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_DUEDATE_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_SUSPENSIONSTATE_CHANGED.name())
-                .count()).isEqualTo(2l);
+                .count()).isEqualTo(2);
         assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_ADDED.name())
-                .count()).isEqualTo(2l);
+                .count()).isEqualTo(2);
         assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_REMOVED.name())
-                .count()).isEqualTo(2l);
+                .count()).isEqualTo(2);
         assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_COMPLETED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
     }
 
     @Test
@@ -622,17 +622,17 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         ProcessInstance oneTaskProcess = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         Task task = taskService.createTaskQuery().processInstanceId(oneTaskProcess.getId()).singleResult();
-        assertThat(historyService.createHistoricTaskLogEntryQuery().count()).isEqualTo(0l);
-        assertThat(managementService.createHistoryJobQuery().count()).isEqualTo(1l);
+        assertThat(historyService.createHistoricTaskLogEntryQuery().count()).isZero();
+        assertThat(managementService.createHistoryJobQuery().count()).isEqualTo(1);
         waitForHistoryJobExecutorToProcessAllJobs(7000, 200);
         List<HistoricTaskLogEntry> historicTaskLogEntries = historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
-        assertThat(historicTaskLogEntries.size()).isEqualTo(1l);
+        assertThat(historicTaskLogEntries).hasSize(1);
 
         historyService.deleteHistoricTaskLogEntry(historicTaskLogEntries.get(0).getLogNumber());
 
-        assertThat(managementService.createHistoryJobQuery().count()).isEqualTo(1l);
+        assertThat(managementService.createHistoryJobQuery().count()).isEqualTo(1);
         waitForHistoryJobExecutorToProcessAllJobs(7000, 200);
-        assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(0l);
+        assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isZero();
     }
 
     @Test
@@ -660,14 +660,15 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("signal-wait");
         waitForHistoryJobExecutorToProcessAllJobs(10000, 200);
 
-        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).signalEventSubscriptionName("waitsig").singleResult();
-        assertNotNull(execution);
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).signalEventSubscriptionName("waitsig")
+                .singleResult();
+        assertThat(execution).isNotNull();
         runtimeService.signalEventReceived("waitsig", execution.getId());
         execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).signalEventSubscriptionName("waitsig").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals("Wait2", task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("Wait2");
     }
 
     protected Task startOneTaskprocess() {

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAVariableTest.java
@@ -348,7 +348,7 @@ public class JPAVariableTest extends ResourceFlowableTestCase {
         Object fieldAccessResult = runtimeService.getVariable(processInstance.getId(), "simpleEntityFieldAccess");
         assertThat(fieldAccessResult).isInstanceOf(List.class);
         List<?> list = (List<?>) fieldAccessResult;
-        assertThat(list.size()).isEqualTo(3L);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0)).isInstanceOf(FieldAccessJPAEntity.class);
         assertThat(simpleEntityFieldAccess.getId()).isEqualTo(((FieldAccessJPAEntity) list.get(0)).getId());
 
@@ -356,7 +356,7 @@ public class JPAVariableTest extends ResourceFlowableTestCase {
         Object propertyAccessResult = runtimeService.getVariable(processInstance.getId(), "simpleEntityPropertyAccess");
         assertThat(propertyAccessResult).isInstanceOf(List.class);
         list = (List<?>) propertyAccessResult;
-        assertThat(list.size()).isEqualTo(3L);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0)).isInstanceOf(PropertyAccessJPAEntity.class);
         assertThat(simpleEntityPropertyAccess.getId()).isEqualTo(((PropertyAccessJPAEntity) list.get(0)).getId());
 
@@ -364,7 +364,7 @@ public class JPAVariableTest extends ResourceFlowableTestCase {
         Object subclassFieldResult = runtimeService.getVariable(processInstance.getId(), "subclassFieldAccess");
         assertThat(subclassFieldResult).isInstanceOf(List.class);
         list = (List<?>) subclassFieldResult;
-        assertThat(list.size()).isEqualTo(3L);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0)).isInstanceOf(SubclassFieldAccessJPAEntity.class);
         assertThat(simpleEntityPropertyAccess.getId()).isEqualTo(((SubclassFieldAccessJPAEntity) list.get(0)).getId());
 
@@ -372,7 +372,7 @@ public class JPAVariableTest extends ResourceFlowableTestCase {
         Object subclassPropertyResult = runtimeService.getVariable(processInstance.getId(), "subclassPropertyAccess");
         assertThat(subclassPropertyResult).isInstanceOf(List.class);
         list = (List<?>) subclassPropertyResult;
-        assertThat(list.size()).isEqualTo(3L);
+        assertThat(list).hasSize(3);
         assertThat(list.get(0)).isInstanceOf(SubclassPropertyAccessJPAEntity.class);
         assertThat(simpleEntityPropertyAccess.getId()).isEqualTo(((SubclassPropertyAccessJPAEntity) list.get(0)).getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableJupiterTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableJupiterTest.java
@@ -48,7 +48,7 @@ class FlowableJupiterTest {
         assertThat(task.getName()).isEqualTo("My Task");
 
         taskService.complete(task.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
         assertThat(processEngine.getName()).as("process engine  name").isEqualTo(ProcessEngines.NAME_DEFAULT);
     }
 
@@ -75,6 +75,6 @@ class FlowableJupiterTest {
         testHelper.waitForJobExecutorToProcessAllJobs(7000L, 500L);
 
         // the job is done
-        assertThat(managementService.createJobQuery().count()).isEqualTo(0);
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableRuleJunit4Test.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableRuleJunit4Test.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,7 @@
 
 package org.flowable.standalone.testing;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.engine.ManagementService;
 import org.flowable.engine.RuntimeService;
@@ -26,9 +26,9 @@ import org.junit.Test;
 
 /**
  * Test runners follow the this rule: - if the class extends Testcase, run as Junit 3 - otherwise use Junit 4
- * 
+ * <p>
  * So this test can be included in the regular test suite without problems.
- * 
+ *
  * @author Joram Barrez
  */
 public class FlowableRuleJunit4Test {
@@ -44,10 +44,10 @@ public class FlowableRuleJunit4Test {
 
         TaskService taskService = activitiRule.getTaskService();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("My Task", task.getName());
+        assertThat(task.getName()).isEqualTo("My Task");
 
         taskService.complete(task.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     // this is to show how JobTestHelper could be used to wait for jobs to be all processed
@@ -61,11 +61,11 @@ public class FlowableRuleJunit4Test {
         runtimeService.startProcessInstanceByKey("asyncTask");
 
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
 
         JobTestHelper.waitForJobExecutorToProcessAllJobs(activitiRule, 7000L, 500L);
 
         // the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableTestCaseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/FlowableTestCaseTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,8 @@
  */
 
 package org.flowable.standalone.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.FlowableTestCase;
@@ -26,9 +28,9 @@ public class FlowableTestCaseTest extends FlowableTestCase {
         runtimeService.startProcessInstanceByKey("simpleProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("My Task", task.getName());
+        assertThat(task.getName()).isEqualTo("My Task");
 
         taskService.complete(task.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.java
@@ -88,36 +88,36 @@ class MockSupportWithFlowableJupiterTest {
     @Deployment
     @NoOpServiceTasks
     void testNoOpServiceTasksAnnotation(FlowableMockSupport mockSupport) {
-        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(0);
+        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isZero();
         processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
         assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(5);
 
         assertThat(mockSupport.getExecutedNoOpServiceTaskDelegateClassNames())
-            .containsExactly(
-                "com.yourcompany.delegate1",
-                "com.yourcompany.delegate2",
-                "com.yourcompany.delegate3",
-                "com.yourcompany.delegate4",
-                "com.yourcompany.delegate5"
-            );
+                .containsExactly(
+                        "com.yourcompany.delegate1",
+                        "com.yourcompany.delegate2",
+                        "com.yourcompany.delegate3",
+                        "com.yourcompany.delegate4",
+                        "com.yourcompany.delegate5"
+                );
     }
 
     @Test
     @Deployment(resources = { "org/flowable/standalone/testing/MockSupportWithFlowableJupiterTest.testNoOpServiceTasksAnnotation.bpmn20.xml" })
     @NoOpServiceTasks(ids = { "serviceTask1", "serviceTask3", "serviceTask5" }, classNames = { "com.yourcompany.delegate2", "com.yourcompany.delegate4" })
     void testNoOpServiceTasksWithIdsAnnotation(FlowableMockSupport mockSupport) {
-        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(0);
+        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isZero();
         processEngine.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
         assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(5);
 
         assertThat(mockSupport.getExecutedNoOpServiceTaskDelegateClassNames())
-            .containsExactly(
-                "com.yourcompany.delegate1",
-                "com.yourcompany.delegate2",
-                "com.yourcompany.delegate3",
-                "com.yourcompany.delegate4",
-                "com.yourcompany.delegate5"
-            );
+                .containsExactly(
+                        "com.yourcompany.delegate1",
+                        "com.yourcompany.delegate2",
+                        "com.yourcompany.delegate3",
+                        "com.yourcompany.delegate4",
+                        "com.yourcompany.delegate5"
+                );
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/MockSupportWithFlowableRuleTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/MockSupportWithFlowableRuleTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,8 @@
  */
 package org.flowable.standalone.testing;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.FlowableRule;
 import org.flowable.engine.test.mock.FlowableMockSupport;
@@ -19,7 +21,6 @@ import org.flowable.engine.test.mock.MockServiceTask;
 import org.flowable.engine.test.mock.MockServiceTasks;
 import org.flowable.engine.test.mock.NoOpServiceTasks;
 import org.flowable.standalone.testing.helpers.ServiceTaskTestMock;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -36,7 +37,8 @@ public class MockSupportWithFlowableRuleTest {
             ServiceTaskTestMock.CALL_COUNT.set(0);
 
             flowableRule.mockSupport().mockServiceTaskWithClassDelegate("com.yourcompany.delegate", ServiceTaskTestMock.class);
-            flowableRule.mockSupport().mockServiceTaskWithClassDelegate("com.yourcompany.anotherDelegate", "org.flowable.standalone.testing.helpers.ServiceTaskTestMock");
+            flowableRule.mockSupport()
+                    .mockServiceTaskWithClassDelegate("com.yourcompany.anotherDelegate", "org.flowable.standalone.testing.helpers.ServiceTaskTestMock");
         }
 
     };
@@ -44,57 +46,58 @@ public class MockSupportWithFlowableRuleTest {
     @Test
     @Deployment
     public void testClassDelegateMockSupport() {
-        Assert.assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         flowableRule.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
-        Assert.assertEquals(1, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(1);
     }
 
     @Test
     @Deployment
     public void testClassDelegateStringMockSupport() {
-        Assert.assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         flowableRule.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
-        Assert.assertEquals(1, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(1);
     }
 
     @Test
     @Deployment
     @MockServiceTask(originalClassName = "com.yourcompany.delegate", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock")
     public void testMockedServiceTaskAnnotation() {
-        Assert.assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         flowableRule.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
-        Assert.assertEquals(1, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(1);
     }
 
     @Test
     @Deployment(resources = { "org/flowable/standalone/testing/MockSupportWithFlowableRuleTest.testMockedServiceTaskAnnotation.bpmn20.xml" })
     @MockServiceTask(id = "serviceTask", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock")
     public void testMockedServiceTaskByIdAnnotation() {
-        Assert.assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         flowableRule.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
-        Assert.assertEquals(1, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(1);
     }
 
     @Test
     @Deployment
-    @MockServiceTasks({ @MockServiceTask(originalClassName = "com.yourcompany.delegate1", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock"),
+    @MockServiceTasks({
+            @MockServiceTask(originalClassName = "com.yourcompany.delegate1", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock"),
             @MockServiceTask(originalClassName = "com.yourcompany.delegate2", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock") })
     public void testMockedServiceTasksAnnotation() {
-        Assert.assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         flowableRule.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
-        Assert.assertEquals(2, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(2);
     }
 
     @Test
     @Deployment
     @NoOpServiceTasks
     public void testNoOpServiceTasksAnnotation() {
-        Assert.assertEquals(0, flowableRule.mockSupport().getNrOfNoOpServiceTaskExecutions());
+        assertThat(flowableRule.mockSupport().getNrOfNoOpServiceTaskExecutions()).isZero();
         flowableRule.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
-        Assert.assertEquals(5, flowableRule.mockSupport().getNrOfNoOpServiceTaskExecutions());
+        assertThat(flowableRule.mockSupport().getNrOfNoOpServiceTaskExecutions()).isEqualTo(5);
 
         for (int i = 1; i <= 5; i++) {
-            Assert.assertEquals("com.yourcompany.delegate" + i, flowableRule.mockSupport().getExecutedNoOpServiceTaskDelegateClassNames().get(i - 1));
+            assertThat(flowableRule.mockSupport().getExecutedNoOpServiceTaskDelegateClassNames().get(i - 1)).isEqualTo("com.yourcompany.delegate" + i);
         }
     }
 
@@ -103,12 +106,12 @@ public class MockSupportWithFlowableRuleTest {
     @NoOpServiceTasks(ids = { "serviceTask1", "serviceTask3", "serviceTask5" }, classNames = { "com.yourcompany.delegate2", "com.yourcompany.delegate4" })
     public void testNoOpServiceTasksWithIdsAnnotation() {
         FlowableMockSupport mockSupport = flowableRule.getMockSupport();
-        Assert.assertEquals(0, mockSupport.getNrOfNoOpServiceTaskExecutions());
+        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isZero();
         flowableRule.getRuntimeService().startProcessInstanceByKey("mockSupportTest");
-        Assert.assertEquals(5, mockSupport.getNrOfNoOpServiceTaskExecutions());
+        assertThat(mockSupport.getNrOfNoOpServiceTaskExecutions()).isEqualTo(5);
 
         for (int i = 1; i <= 5; i++) {
-            Assert.assertEquals("com.yourcompany.delegate" + i, mockSupport.getExecutedNoOpServiceTaskDelegateClassNames().get(i - 1));
+            assertThat(mockSupport.getExecutedNoOpServiceTaskDelegateClassNames().get(i - 1)).isEqualTo("com.yourcompany.delegate" + i);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/MockSupportWithFlowableTestCaseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/testing/MockSupportWithFlowableTestCaseTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 package org.flowable.standalone.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.FlowableTestCase;
@@ -36,64 +38,65 @@ public class MockSupportWithFlowableTestCaseTest extends FlowableTestCase {
 
     @Deployment
     public void testClassDelegateMockSupport() {
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         runtimeService.startProcessInstanceByKey("mockSupportTest");
-        assertEquals(1, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(1);
     }
 
     @Deployment
     public void testClassDelegateStringMockSupport() {
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         runtimeService.startProcessInstanceByKey("mockSupportTest");
-        assertEquals(1, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(1);
     }
 
     @Deployment
     @MockServiceTask(originalClassName = "com.yourcompany.delegate", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock")
     public void testMockedServiceTaskAnnotation() {
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         runtimeService.startProcessInstanceByKey("mockSupportTest");
-        assertEquals(1, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(1);
     }
 
     @Deployment(resources = { "org/flowable/standalone/testing/MockSupportWithFlowableTestCaseTest.testMockedServiceTaskAnnotation.bpmn20.xml" })
     @MockServiceTask(id = "serviceTask", mockedClassName = "org.activiti.standalone.testing.helpers.ServiceTaskTestMock")
     public void testMockedServiceTaskByIdAnnotation() {
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         runtimeService.startProcessInstanceByKey("mockSupportTest");
-        assertEquals(1, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(1);
     }
 
     @Deployment
-    @MockServiceTasks({ @MockServiceTask(originalClassName = "com.yourcompany.delegate1", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock"),
+    @MockServiceTasks({
+            @MockServiceTask(originalClassName = "com.yourcompany.delegate1", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock"),
             @MockServiceTask(originalClassName = "com.yourcompany.delegate2", mockedClassName = "org.flowable.standalone.testing.helpers.ServiceTaskTestMock") })
     public void testMockedServiceTasksAnnotation() {
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
         runtimeService.startProcessInstanceByKey("mockSupportTest");
-        assertEquals(2, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isEqualTo(2);
     }
 
     @Deployment
     @NoOpServiceTasks
     public void testNoOpServiceTasksAnnotation() {
-        assertEquals(0, mockSupport().getNrOfNoOpServiceTaskExecutions());
+        assertThat(mockSupport().getNrOfNoOpServiceTaskExecutions()).isZero();
         runtimeService.startProcessInstanceByKey("mockSupportTest");
-        assertEquals(5, mockSupport().getNrOfNoOpServiceTaskExecutions());
+        assertThat(mockSupport().getNrOfNoOpServiceTaskExecutions()).isEqualTo(5);
 
         for (int i = 1; i <= 5; i++) {
-            assertEquals("com.yourcompany.delegate" + i, mockSupport().getExecutedNoOpServiceTaskDelegateClassNames().get(i - 1));
+            assertThat(mockSupport().getExecutedNoOpServiceTaskDelegateClassNames().get(i - 1)).isEqualTo("com.yourcompany.delegate" + i);
         }
     }
 
     @Deployment(resources = { "org/flowable/standalone/testing/MockSupportWithFlowableTestCaseTest.testNoOpServiceTasksAnnotation.bpmn20.xml" })
     @NoOpServiceTasks(ids = { "serviceTask1", "serviceTask3", "serviceTask5" }, classNames = { "com.yourcompany.delegate2", "com.yourcompany.delegate4" })
     public void testNoOpServiceTasksWithIdsAnnotation() {
-        assertEquals(0, mockSupport().getNrOfNoOpServiceTaskExecutions());
+        assertThat(mockSupport().getNrOfNoOpServiceTaskExecutions()).isZero();
         runtimeService.startProcessInstanceByKey("mockSupportTest");
-        assertEquals(5, mockSupport().getNrOfNoOpServiceTaskExecutions());
+        assertThat(mockSupport().getNrOfNoOpServiceTaskExecutions()).isEqualTo(5);
 
         for (int i = 1; i <= 5; i++) {
-            assertEquals("com.yourcompany.delegate" + i, mockSupport().getExecutedNoOpServiceTaskDelegateClassNames().get(i - 1));
+            assertThat(mockSupport().getExecutedNoOpServiceTaskDelegateClassNames().get(i - 1)).isEqualTo("com.yourcompany.delegate" + i);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DefaultProcessValidatorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DefaultProcessValidatorTest.java
@@ -63,7 +63,7 @@ public class DefaultProcessValidatorTest {
         assertThat(bpmnModel).isNotNull();
 
         List<ValidationError> allErrors = processValidator.validate(bpmnModel);
-        assertThat(allErrors.size()).isEqualTo(71);
+        assertThat(allErrors).hasSize(71);
 
         String setName = ValidatorSetNames.FLOWABLE_EXECUTABLE_PROCESS; // shortening it a bit
 
@@ -273,7 +273,7 @@ public class DefaultProcessValidatorTest {
         BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(xtr);
         assertThat(bpmnModel).isNotNull();
         List<ValidationError> allErrors = processValidator.validate(bpmnModel);
-        assertThat(allErrors.size()).isEqualTo(1);
+        assertThat(allErrors).hasSize(1);
         assertThat(allErrors.get(0).isWarning()).isTrue();
     }
 
@@ -292,7 +292,7 @@ public class DefaultProcessValidatorTest {
         }
 
         List<ValidationError> errors = processValidator.validate(bpmnModel);
-        assertThat(errors.size()).isEqualTo(1);
+        assertThat(errors).hasSize(1);
     }
 
     /*
@@ -318,7 +318,7 @@ public class DefaultProcessValidatorTest {
         bpmnModel.addProcess(process);
 
         List<ValidationError> errors = processValidator.validate(bpmnModel);
-        assertThat(errors.size()).isEqualTo(3);
+        assertThat(errors).hasSize(3);
         for (ValidationError error : errors) {
             assertThat(error.isWarning()).isTrue();
             assertThat(error.getValidatorSetName()).isNotNull();
@@ -380,7 +380,7 @@ public class DefaultProcessValidatorTest {
 
     protected List<ValidationError> findErrors(List<ValidationError> errors, String validatorSetName, String problemName, int expectedNrOfProblems) {
         List<ValidationError> results = findErrors(errors, validatorSetName, problemName);
-        assertThat(results.size()).isEqualTo(expectedNrOfProblems);
+        assertThat(results).hasSize(expectedNrOfProblems);
         for (ValidationError result : results) {
             assertThat(result.getValidatorSetName()).isEqualTo(validatorSetName);
             assertThat(result.getProblem()).isEqualTo(problemName);


### PR DESCRIPTION
This is a second (and final) pass through the `org.flowable.standalone` package including updating a recently updated file that used non assertj style assertions in a file that was all assertj.


