### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/ServiceTaskLoggingTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/ServiceTaskLoggingTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@ package org.flowable.engine.test.logging;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,260 +45,262 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class ServiceTaskLoggingTest extends ResourceFlowableTestCase {
-    
+
     public ServiceTaskLoggingTest() {
         super("org/flowable/engine/test/logging/logging.test.flowable.cfg.xml");
     }
-    
+
     @AfterEach
     void tearDown() {
         FlowableLoggingListener.clear();
     }
 
     @Test
-    @Deployment(resources="org/flowable/engine/test/bpmn/serviceTask.bpmn20.xml")
+    @Deployment(resources = "org/flowable/engine/test/bpmn/serviceTask.bpmn20.xml")
     public void testServiceTaskException() {
         FlowableLoggingListener.clear();
-        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("startToEnd").latestVersion().singleResult();
-            
-        try {
-            runtimeService.startProcessInstanceByKey("startToEnd");
-            fail("expected exception");
-            
-        } catch (Exception e) {
-            // expected
-        }
-            
-        assertEquals(7, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("startToEnd").latestVersion()
+                .singleResult();
+
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("startToEnd"))
+                .isInstanceOf(Exception.class);
+
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(7);
+
         ObjectNode loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.ID).asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText());
-        assertEquals(LoggingSessionConstants.TYPE_PROCESS_STARTED, loggingNode.get("type").asText());
-        assertTrue(loggingNode.get("message").asText().contains("Started process instance with id "));
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.ID).asText()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText()).isNotNull();
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_PROCESS_STARTED);
+        assertThat(loggingNode.get("message").asText()).contains("Started process instance with id ");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(1);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.ID).asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText());
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In StartEvent, executing NoneStartEventActivityBehavior", loggingNode.get("message").asText());
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertNotNull(loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("theStart", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("StartEvent", loggingNode.get("elementType").asText());
-        assertEquals("NoneStartEventActivityBehavior", loggingNode.get("activityBehavior").asText());
-        assertEquals(2, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.ID).asText()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText()).isNotNull();
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In StartEvent, executing NoneStartEventActivityBehavior");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("theStart");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("StartEvent");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("NoneStartEventActivityBehavior");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(2);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(2);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.ID).asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText());
-        assertEquals(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE, loggingNode.get("type").asText());
-        assertEquals("Sequence flow will be taken for flow1, theStart --> task", loggingNode.get("message").asText());
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertNotNull(loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("flow1", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("SequenceFlow", loggingNode.get("elementType").asText());
-        assertEquals("theStart", loggingNode.get("sourceRef").asText());
-        assertEquals("task", loggingNode.get("targetRef").asText());
-        assertEquals(3, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.ID).asText()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText()).isNotNull();
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Sequence flow will be taken for flow1, theStart --> task");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("flow1");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("SequenceFlow");
+        assertThat(loggingNode.get("sourceRef").asText()).isEqualTo("theStart");
+        assertThat(loggingNode.get("targetRef").asText()).isEqualTo("task");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(3);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(3);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.ID).asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText());
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In ServiceTask, executing ClassDelegate", loggingNode.get("message").asText());
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertNotNull(loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate", loggingNode.get("elementSubType").asText());
-        assertEquals("ClassDelegate", loggingNode.get("activityBehavior").asText());
-        assertEquals(4, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.ID).asText()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText()).isNotNull();
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In ServiceTask, executing ClassDelegate");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementSubType").asText())
+                .isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("ClassDelegate");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(4);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(4);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.ID).asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText());
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_ENTER, loggingNode.get("type").asText());
-        assertEquals("Executing service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate", loggingNode.get("message").asText());
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertNotNull(loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate", loggingNode.get("elementSubType").asText());
-        assertEquals(5, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.ID).asText()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText()).isNotNull();
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_ENTER);
+        assertThat(loggingNode.get("message").asText())
+                .isEqualTo("Executing service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementSubType").asText())
+                .isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(5);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(5);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.ID).asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText());
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_EXCEPTION, loggingNode.get("type").asText());
-        assertEquals("Service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate threw exception Test exception", loggingNode.get("message").asText());
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertNotNull(loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate", loggingNode.get("elementSubType").asText());
-        assertEquals("Test exception", loggingNode.get("exception").get("message").asText());
-        assertNotNull(loggingNode.get("exception").get("stackTrace").asText());
-        assertEquals(6, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.ID).asText()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText()).isNotNull();
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_EXCEPTION);
+        assertThat(loggingNode.get("message").asText()).isEqualTo(
+                "Service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate threw exception Test exception");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementSubType").asText())
+                .isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$ExceptionServiceTaskDelegate");
+        assertThat(loggingNode.get("exception").get("message").asText()).isEqualTo("Test exception");
+        assertThat(loggingNode.get("exception").get("stackTrace").asText()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(6);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(6);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.ID).asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText());
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE_FAILURE, loggingNode.get("type").asText());
-        assertEquals("Exception at closing command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(7, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.ID).asText()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TRANSACTION_ID).asText()).isNotNull();
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE_FAILURE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Exception at closing command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(7);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         LoggingSessionLoggerOutput.printLogNodes(FlowableLoggingListener.TEST_LOGGING_NODES);
         FlowableLoggingListener.clear();
     }
-    
+
     @Test
-    @Deployment(resources="org/flowable/engine/test/logging/failingAsyncServiceTask.bpmn20.xml")
+    @Deployment(resources = "org/flowable/engine/test/logging/failingAsyncServiceTask.bpmn20.xml")
     public void testFailingServiceTaskException() {
         FlowableLoggingListener.clear();
-        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("failingServiceTask").latestVersion().singleResult();
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("failingServiceTask").latestVersion()
+                .singleResult();
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("failingServiceTask");
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-            
-        assertEquals(5, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(5);
+
         ObjectNode loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertEquals(LoggingSessionConstants.TYPE_PROCESS_STARTED, loggingNode.get("type").asText());
-        assertTrue(loggingNode.get("message").asText().contains("Started process instance with id "));
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_PROCESS_STARTED);
+        assertThat(loggingNode.get("message").asText().contains("Started process instance with id ")).isTrue();
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(1);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In StartEvent, executing NoneStartEventActivityBehavior", loggingNode.get("message").asText());
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertNotNull(loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("theStart", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("StartEvent", loggingNode.get("elementType").asText());
-        assertEquals("NoneStartEventActivityBehavior", loggingNode.get("activityBehavior").asText());
-        assertEquals(2, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In StartEvent, executing NoneStartEventActivityBehavior");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("theStart");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("StartEvent");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("NoneStartEventActivityBehavior");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(2);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(2);
-        assertEquals(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE, loggingNode.get("type").asText());
-        assertEquals("Sequence flow will be taken for flow1, theStart --> task", loggingNode.get("message").asText());
-        assertNotNull(loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertNotNull(loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("flow1", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("SequenceFlow", loggingNode.get("elementType").asText());
-        assertEquals("theStart", loggingNode.get("sourceRef").asText());
-        assertEquals("task", loggingNode.get("targetRef").asText());
-        assertEquals(3, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Sequence flow will be taken for flow1, theStart --> task");
+        assertThat(loggingNode.get("scopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isNotNull();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("flow1");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("SequenceFlow");
+        assertThat(loggingNode.get("sourceRef").asText()).isEqualTo("theStart");
+        assertThat(loggingNode.get("targetRef").asText()).isEqualTo("task");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(3);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(3);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_ASYNC_JOB, loggingNode.get("type").asText());
-        assertEquals("Created async job for task, with job id " + job.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals(job.getId(), loggingNode.get("jobId").asText());
-        assertEquals(4, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_ASYNC_JOB);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Created async job for task, with job id " + job.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("jobId").asText()).isEqualTo(job.getId());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(4);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(4);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(5, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(5);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         FlowableLoggingListener.clear();
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
-        assertEquals(8, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(8);
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_LOCK_JOB, loggingNode.get("type").asText());
-        assertEquals("Locking job for task, with job id " + job.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals(job.getId(), loggingNode.get("jobId").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_LOCK_JOB);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Locking job for task, with job id " + job.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("jobId").asText()).isEqualTo(job.getId());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         Map<String, ObjectNode> loggingMap = new HashMap<>();
         int commandContextCounter = 1;
         for (ObjectNode logObjectNode : FlowableLoggingListener.TEST_LOGGING_NODES) {
@@ -310,842 +313,849 @@ public class ServiceTaskLoggingTest extends ResourceFlowableTestCase {
             }
             loggingMap.put(logType, logObjectNode);
         }
-        
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_SERVICE_TASK_EXECUTE_ASYNC_JOB);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_EXECUTE_ASYNC_JOB, loggingNode.get("type").asText());
-        assertEquals("Executing async job for task, with job id " + job.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals(job.getId(), loggingNode.get("jobId").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_EXECUTE_ASYNC_JOB);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Executing async job for task, with job id " + job.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("jobId").asText()).isEqualTo(job.getId());
         int beforeJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(beforeJobNumber > 0);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(beforeJobNumber).isGreaterThan(0);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("ServiceTask" + LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In ServiceTask, executing ServiceTaskExpressionActivityBehavior", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("${failureExpressionValue}", loggingNode.get("elementSubType").asText());
-        assertEquals("ServiceTaskExpressionActivityBehavior", loggingNode.get("activityBehavior").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In ServiceTask, executing ServiceTaskExpressionActivityBehavior");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementSubType").asText()).isEqualTo("${failureExpressionValue}");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("ServiceTaskExpressionActivityBehavior");
         int newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE_FAILURE);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE_FAILURE, loggingNode.get("type").asText());
-        assertEquals("Exception at closing command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE_FAILURE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Exception at closing command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
-        assertEquals(8, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(8);
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_LOCK_JOB, loggingNode.get("type").asText());
-        assertEquals("Locking job for task, with job id " + job.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals(job.getId(), loggingNode.get("jobId").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_LOCK_JOB);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Locking job for task, with job id " + job.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("jobId").asText()).isEqualTo(job.getId());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
     }
-    
+
     @Test
-    @Deployment(resources="org/flowable/engine/test/logging/serviceAndUserTask.bpmn20.xml")
+    @Deployment(resources = "org/flowable/engine/test/logging/serviceAndUserTask.bpmn20.xml")
     public void testVariableCreateLogging() {
         FlowableLoggingListener.clear();
-        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion().singleResult();
-            
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion()
+                .singleResult();
+
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("serviceAndUserTask");
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-            
-        assertEquals(17, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(17);
+
         int loggingItemCounter = 0;
         int loggingNumberCounter = 1;
-        
+
         ObjectNode loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_PROCESS_STARTED, loggingNode.get("type").asText());
-        assertEquals("Started process instance with id " + processInstance.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertFalse(loggingNode.has("elementId"));
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_PROCESS_STARTED);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Started process instance with id " + processInstance.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.has("elementId")).isFalse();
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In StartEvent, executing NoneStartEventActivityBehavior", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("theStart", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("StartEvent", loggingNode.get("elementType").asText());
-        assertEquals("NoneStartEventActivityBehavior", loggingNode.get("activityBehavior").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In StartEvent, executing NoneStartEventActivityBehavior");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("theStart");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("StartEvent");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("NoneStartEventActivityBehavior");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE, loggingNode.get("type").asText());
-        assertEquals("Sequence flow will be taken for flow1, theStart --> task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("flow1", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("SequenceFlow", loggingNode.get("elementType").asText());
-        assertEquals("theStart", loggingNode.get("sourceRef").asText());
-        assertEquals("task", loggingNode.get("targetRef").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Sequence flow will be taken for flow1, theStart --> task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("flow1");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("SequenceFlow");
+        assertThat(loggingNode.get("sourceRef").asText()).isEqualTo("theStart");
+        assertThat(loggingNode.get("targetRef").asText()).isEqualTo("task");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In ServiceTask, executing ClassDelegate", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("elementSubType").asText());
-        assertEquals("ClassDelegate", loggingNode.get("activityBehavior").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In ServiceTask, executing ClassDelegate");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementSubType").asText()).isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("ClassDelegate");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_ENTER, loggingNode.get("type").asText());
-        assertEquals("Executing service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("elementSubType").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_ENTER);
+        assertThat(loggingNode.get("message").asText())
+                .isEqualTo("Executing service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementSubType").asText()).isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_VARIABLE_CREATE, loggingNode.get("type").asText());
-        assertEquals("Variable 'newVariable' created", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertFalse(loggingNode.has("subScopeId"));
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("newVariable", loggingNode.get("variableName").asText());
-        assertEquals("string", loggingNode.get("variableType").asText());
-        assertEquals("test", loggingNode.get("variableValue").asText());
-        assertEquals("test", loggingNode.get("variableRawValue").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_VARIABLE_CREATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Variable 'newVariable' created");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.has("subScopeId")).isFalse();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("variableName").asText()).isEqualTo("newVariable");
+        assertThat(loggingNode.get("variableType").asText()).isEqualTo("string");
+        assertThat(loggingNode.get("variableValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get("variableRawValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_EXIT, loggingNode.get("type").asText());
-        assertEquals("Executed service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("elementSubType").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_EXIT);
+        assertThat(loggingNode.get("message").asText())
+                .isEqualTo("Executed service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementSubType").asText()).isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE, loggingNode.get("type").asText());
-        assertEquals("Sequence flow will be taken for flow2, task --> userTask", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("flow2", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("SequenceFlow", loggingNode.get("elementType").asText());
-        assertEquals("task", loggingNode.get("sourceRef").asText());
-        assertEquals("userTask", loggingNode.get("targetRef").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Sequence flow will be taken for flow2, task --> userTask");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("flow2");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("SequenceFlow");
+        assertThat(loggingNode.get("sourceRef").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("targetRef").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In UserTask, executing UserTaskActivityBehavior", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("UserTaskActivityBehavior", loggingNode.get("activityBehavior").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In UserTask, executing UserTaskActivityBehavior");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("UserTaskActivityBehavior");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_CREATE, loggingNode.get("type").asText());
-        assertEquals("User task 'Some user task' created", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertFalse(loggingNode.has("taskCategory"));
-        assertFalse(loggingNode.has("taskDescription"));
-        assertEquals("someKey", loggingNode.get("taskFormKey").asText());
-        assertEquals(50, loggingNode.get("taskPriority").asInt());
-        assertFalse(loggingNode.has("taskDueDate"));
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_CREATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("User task 'Some user task' created");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.has("taskCategory")).isFalse();
+        assertThat(loggingNode.has("taskDescription")).isFalse();
+        assertThat(loggingNode.get("taskFormKey").asText()).isEqualTo("someKey");
+        assertThat(loggingNode.get("taskPriority").asInt()).isEqualTo(50);
+        assertThat(loggingNode.has("taskDueDate")).isFalse();
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_ASSIGNEE, loggingNode.get("type").asText());
-        assertEquals("Set task assignee value to johndoe", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals("johndoe", loggingNode.get("taskAssignee").asText());
-        assertFalse(loggingNode.has("taskCategory"));
-        assertFalse(loggingNode.has("taskDescription"));
-        assertFalse(loggingNode.has("taskFormKey"));
-        assertFalse(loggingNode.has("taskPriority"));
-        assertFalse(loggingNode.has("taskDueDate"));
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_ASSIGNEE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Set task assignee value to johndoe");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskAssignee").asText()).isEqualTo("johndoe");
+        assertThat(loggingNode.has("taskCategory")).isFalse();
+        assertThat(loggingNode.has("taskDescription")).isFalse();
+        assertThat(loggingNode.has("taskFormKey")).isFalse();
+        assertThat(loggingNode.has("taskPriority")).isFalse();
+        assertThat(loggingNode.has("taskDueDate")).isFalse();
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_OWNER, loggingNode.get("type").asText());
-        assertEquals("Set task owner value to janedoe", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals("janedoe", loggingNode.get("taskOwner").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_OWNER);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Set task owner value to janedoe");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskOwner").asText()).isEqualTo("janedoe");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS, loggingNode.get("type").asText());
-        assertEquals("Added 2 candidate group identity links to task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals(2, loggingNode.get("taskGroupIdentityLinks").size());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Added 2 candidate group identity links to task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskGroupIdentityLinks")).hasSize(2);
         JsonNode identityLinksArray = loggingNode.get("taskGroupIdentityLinks");
         JsonNode identityLinkNode = identityLinksArray.get(0);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("candidate", identityLinkNode.get("type").asText());
-        assertEquals("group1", identityLinkNode.get("groupId").asText());
+        assertThat(identityLinkNode.get("id").asText()).isNotNull();
+        assertThat(identityLinkNode.get("type").asText()).isEqualTo("candidate");
+        assertThat(identityLinkNode.get("groupId").asText()).isEqualTo("group1");
         identityLinkNode = identityLinksArray.get(1);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("candidate", identityLinkNode.get("type").asText());
-        assertEquals("group2", identityLinkNode.get("groupId").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(identityLinkNode.get("id").asText()).isNotNull();
+        assertThat(identityLinkNode.get("type").asText()).isEqualTo("candidate");
+        assertThat(identityLinkNode.get("groupId").asText()).isEqualTo("group2");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS, loggingNode.get("type").asText());
-        assertEquals("Added 2 candidate user identity links to task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals(2, loggingNode.get("taskUserIdentityLinks").size());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Added 2 candidate user identity links to task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskUserIdentityLinks")).hasSize(2);
         identityLinksArray = loggingNode.get("taskUserIdentityLinks");
         identityLinkNode = identityLinksArray.get(0);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("candidate", identityLinkNode.get("type").asText());
-        assertEquals("johndoe", identityLinkNode.get("userId").asText());
+        assertThat(identityLinkNode.get("id").asText()).isNotNull();
+        assertThat(identityLinkNode.get("type").asText()).isEqualTo("candidate");
+        assertThat(identityLinkNode.get("userId").asText()).isEqualTo("johndoe");
         identityLinkNode = identityLinksArray.get(1);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("candidate", identityLinkNode.get("type").asText());
-        assertEquals("janedoe", identityLinkNode.get("userId").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(identityLinkNode.get("id").asText()).isNotNull();
+        assertThat(identityLinkNode.get("type").asText()).isEqualTo("candidate");
+        assertThat(identityLinkNode.get("userId").asText()).isEqualTo("janedoe");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS, loggingNode.get("type").asText());
-        assertEquals("Added 2 custom user identity links to task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals(2, loggingNode.get("taskUserIdentityLinks").size());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Added 2 custom user identity links to task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskUserIdentityLinks")).hasSize(2);
         identityLinksArray = loggingNode.get("taskUserIdentityLinks");
         identityLinkNode = identityLinksArray.get(0);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("businessAdministrator", identityLinkNode.get("type").asText());
-        assertEquals("johndoe", identityLinkNode.get("userId").asText());
+        assertThat(identityLinkNode.get("id").asText()).isNotNull();
+        assertThat(identityLinkNode.get("type").asText()).isEqualTo("businessAdministrator");
+        assertThat(identityLinkNode.get("userId").asText()).isEqualTo("johndoe");
         identityLinkNode = identityLinksArray.get(1);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("someAdmin", identityLinkNode.get("type").asText());
-        assertEquals("janedoe", identityLinkNode.get("userId").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(identityLinkNode.get("id").asText()).isNotNull();
+        assertThat(identityLinkNode.get("type").asText()).isEqualTo("someAdmin");
+        assertThat(identityLinkNode.get("userId").asText()).isEqualTo("janedoe");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS, loggingNode.get("type").asText());
-        assertEquals("Added 2 custom group identity links to task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals(2, loggingNode.get("taskGroupIdentityLinks").size());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Added 2 custom group identity links to task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskGroupIdentityLinks")).hasSize(2);
         identityLinksArray = loggingNode.get("taskGroupIdentityLinks");
         identityLinkNode = identityLinksArray.get(0);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("businessAdministrator", identityLinkNode.get("type").asText());
-        assertEquals("group3", identityLinkNode.get("groupId").asText());
+        assertThat(identityLinkNode.get("id").asText()).isNotNull();
+        assertThat(identityLinkNode.get("type").asText()).isEqualTo("businessAdministrator");
+        assertThat(identityLinkNode.get("groupId").asText()).isEqualTo("group3");
         identityLinkNode = identityLinksArray.get(1);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("someAdmin", identityLinkNode.get("type").asText());
-        assertEquals("group4", identityLinkNode.get("groupId").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(identityLinkNode.get("id").asText()).isNotNull();
+        assertThat(identityLinkNode.get("type").asText()).isEqualTo("someAdmin");
+        assertThat(identityLinkNode.get("groupId").asText()).isEqualTo("group4");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         LoggingSessionLoggerOutput.printLogNodes(FlowableLoggingListener.TEST_LOGGING_NODES);
-        
+
         FlowableLoggingListener.clear();
         loggingItemCounter = 0;
         loggingNumberCounter = 1;
-        
+
         runtimeService.setVariable(processInstance.getId(), "numVar", 123);
-        assertEquals(2, FlowableLoggingListener.TEST_LOGGING_NODES.size());
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(2);
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_VARIABLE_CREATE, loggingNode.get("type").asText());
-        assertEquals("Variable 'numVar' created", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertFalse(loggingNode.has("subScopeId"));
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertFalse(loggingNode.has("elementId"));
-        assertFalse(loggingNode.has("elementType"));
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("numVar", loggingNode.get("variableName").asText());
-        assertEquals("integer", loggingNode.get("variableType").asText());
-        assertEquals("123", loggingNode.get("variableValue").asText());
-        assertEquals(123, loggingNode.get("variableRawValue").asInt());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_VARIABLE_CREATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Variable 'numVar' created");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.has("subScopeId")).isFalse();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.has("elementId")).isFalse();
+        assertThat(loggingNode.has("elementType")).isFalse();
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("variableName").asText()).isEqualTo("numVar");
+        assertThat(loggingNode.get("variableType").asText()).isEqualTo("integer");
+        assertThat(loggingNode.get("variableValue").asText()).isEqualTo("123");
+        assertThat(loggingNode.get("variableRawValue").asInt()).isEqualTo(123);
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         FlowableLoggingListener.clear();
         loggingItemCounter = 0;
         loggingNumberCounter = 1;
-        
+
         runtimeService.setVariable(processInstance.getId(), "boolVar", true);
-        assertEquals(2, FlowableLoggingListener.TEST_LOGGING_NODES.size());
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(2);
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_VARIABLE_CREATE, loggingNode.get("type").asText());
-        assertEquals("Variable 'boolVar' created", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertFalse(loggingNode.has("subScopeId"));
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertFalse(loggingNode.has("elementId"));
-        assertFalse(loggingNode.has("elementType"));
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("boolVar", loggingNode.get("variableName").asText());
-        assertEquals("boolean", loggingNode.get("variableType").asText());
-        assertEquals("true", loggingNode.get("variableValue").asText());
-        assertTrue(loggingNode.get("variableRawValue").asBoolean());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_VARIABLE_CREATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Variable 'boolVar' created");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.has("subScopeId")).isFalse();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.has("elementId")).isFalse();
+        assertThat(loggingNode.has("elementType")).isFalse();
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("variableName").asText()).isEqualTo("boolVar");
+        assertThat(loggingNode.get("variableType").asText()).isEqualTo("boolean");
+        assertThat(loggingNode.get("variableValue").asText()).isEqualTo("true");
+        assertThat(loggingNode.get("variableRawValue").asBoolean()).isTrue();
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(loggingItemCounter++);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(loggingNumberCounter++, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(loggingNumberCounter++);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         FlowableLoggingListener.clear();
     }
-    
+
     @Test
-    @Deployment(resources="org/flowable/engine/test/logging/serviceAndUserTask.bpmn20.xml")
+    @Deployment(resources = "org/flowable/engine/test/logging/serviceAndUserTask.bpmn20.xml")
     public void testVariableUpdateLogging() {
         FlowableLoggingListener.clear();
-        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion().singleResult();
-            
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion()
+                .singleResult();
+
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("serviceAndUserTask");
-            
-        assertEquals(17, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(17);
+
         FlowableLoggingListener.clear();
         runtimeService.setVariable(processInstance.getId(), "newVariable", "updatedValue");
-        assertEquals(2, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(2);
+
         ObjectNode loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertEquals(LoggingSessionConstants.TYPE_VARIABLE_UPDATE, loggingNode.get("type").asText());
-        assertEquals("Variable 'newVariable' updated", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertFalse(loggingNode.has("subScopeId"));
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertFalse(loggingNode.has("elementId"));
-        assertFalse(loggingNode.has("elementType"));
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("newVariable", loggingNode.get("variableName").asText());
-        assertEquals("string", loggingNode.get("variableType").asText());
-        assertEquals("updatedValue", loggingNode.get("variableValue").asText());
-        assertEquals("updatedValue", loggingNode.get("variableRawValue").asText());
-        assertEquals("string", loggingNode.get("oldVariableType").asText());
-        assertEquals("test", loggingNode.get("oldVariableValue").asText());
-        assertEquals("test", loggingNode.get("oldVariableRawValue").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_VARIABLE_UPDATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Variable 'newVariable' updated");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.has("subScopeId")).isFalse();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.has("elementId")).isFalse();
+        assertThat(loggingNode.has("elementType")).isFalse();
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("variableName").asText()).isEqualTo("newVariable");
+        assertThat(loggingNode.get("variableType").asText()).isEqualTo("string");
+        assertThat(loggingNode.get("variableValue").asText()).isEqualTo("updatedValue");
+        assertThat(loggingNode.get("variableRawValue").asText()).isEqualTo("updatedValue");
+        assertThat(loggingNode.get("oldVariableType").asText()).isEqualTo("string");
+        assertThat(loggingNode.get("oldVariableValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get("oldVariableRawValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(1);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(2, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(2);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         FlowableLoggingListener.clear();
     }
-    
+
     @Test
-    @Deployment(resources="org/flowable/engine/test/logging/serviceAndUserTask.bpmn20.xml")
+    @Deployment(resources = "org/flowable/engine/test/logging/serviceAndUserTask.bpmn20.xml")
     public void testVariableDeleteLogging() {
         FlowableLoggingListener.clear();
-        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion().singleResult();
-            
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion()
+                .singleResult();
+
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("serviceAndUserTask");
-            
-        assertEquals(17, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(17);
+
         FlowableLoggingListener.clear();
         runtimeService.removeVariable(processInstance.getId(), "newVariable");
-        assertEquals(2, FlowableLoggingListener.TEST_LOGGING_NODES.size());
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(2);
         ObjectNode loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertEquals(LoggingSessionConstants.TYPE_VARIABLE_DELETE, loggingNode.get("type").asText());
-        assertEquals("Variable 'newVariable' deleted", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertFalse(loggingNode.has("subScopeId"));
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertFalse(loggingNode.has("elementId"));
-        assertFalse(loggingNode.has("elementType"));
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("newVariable", loggingNode.get("variableName").asText());
-        assertEquals("string", loggingNode.get("variableType").asText());
-        assertEquals("test", loggingNode.get("variableValue").asText());
-        assertEquals("test", loggingNode.get("variableRawValue").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_VARIABLE_DELETE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Variable 'newVariable' deleted");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.has("subScopeId")).isFalse();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.has("elementId")).isFalse();
+        assertThat(loggingNode.has("elementType")).isFalse();
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("variableName").asText()).isEqualTo("newVariable");
+        assertThat(loggingNode.get("variableType").asText()).isEqualTo("string");
+        assertThat(loggingNode.get("variableValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get("variableRawValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(1);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(2, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(2);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         FlowableLoggingListener.clear();
     }
-    
+
     @Test
-    @Deployment(resources="org/flowable/engine/test/logging/serviceAndUserTask.bpmn20.xml")
+    @Deployment(resources = "org/flowable/engine/test/logging/serviceAndUserTask.bpmn20.xml")
     public void testCompleteTaskLogging() {
         FlowableLoggingListener.clear();
-        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion().singleResult();
-            
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion()
+                .singleResult();
+
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("serviceAndUserTask");
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-            
-        assertEquals(17, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(17);
+
         FlowableLoggingListener.clear();
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("newVariable", "newValue");
         variableMap.put("numVar", 123);
         taskService.complete(task.getId(), variableMap);
-        
-        assertEquals(7, FlowableLoggingListener.TEST_LOGGING_NODES.size());
+
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(7);
         ObjectNode loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertEquals(LoggingSessionConstants.TYPE_VARIABLE_UPDATE, loggingNode.get("type").asText());
-        assertEquals("Variable 'newVariable' updated", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertFalse(loggingNode.has("subScopeId"));
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertEquals("newVariable", loggingNode.get("variableName").asText());
-        assertEquals("string", loggingNode.get("variableType").asText());
-        assertEquals("newValue", loggingNode.get("variableValue").asText());
-        assertEquals("newValue", loggingNode.get("variableRawValue").asText());
-        assertEquals("string", loggingNode.get("oldVariableType").asText());
-        assertEquals("test", loggingNode.get("oldVariableValue").asText());
-        assertEquals("test", loggingNode.get("oldVariableRawValue").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_VARIABLE_UPDATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Variable 'newVariable' updated");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.has("subScopeId")).isFalse();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("variableName").asText()).isEqualTo("newVariable");
+        assertThat(loggingNode.get("variableType").asText()).isEqualTo("string");
+        assertThat(loggingNode.get("variableValue").asText()).isEqualTo("newValue");
+        assertThat(loggingNode.get("variableRawValue").asText()).isEqualTo("newValue");
+        assertThat(loggingNode.get("oldVariableType").asText()).isEqualTo("string");
+        assertThat(loggingNode.get("oldVariableValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get("oldVariableRawValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(1);
-        assertEquals(LoggingSessionConstants.TYPE_VARIABLE_CREATE, loggingNode.get("type").asText());
-        assertEquals("Variable 'numVar' created", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertFalse(loggingNode.has("subScopeId"));
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertEquals("numVar", loggingNode.get("variableName").asText());
-        assertEquals("integer", loggingNode.get("variableType").asText());
-        assertEquals(123, loggingNode.get("variableValue").asInt());
-        assertEquals(2, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertEquals("123", loggingNode.get("variableRawValue").asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_VARIABLE_CREATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Variable 'numVar' created");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.has("subScopeId")).isFalse();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("variableName").asText()).isEqualTo("numVar");
+        assertThat(loggingNode.get("variableType").asText()).isEqualTo("integer");
+        assertThat(loggingNode.get("variableValue").asInt()).isEqualTo(123);
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(2);
+        assertThat(loggingNode.get("variableRawValue").asText()).isEqualTo("123");
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(2);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_COMPLETE, loggingNode.get("type").asText());
-        assertEquals("User task 'Some user task' completed", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertFalse(loggingNode.has("taskCategory"));
-        assertFalse(loggingNode.has("taskDescription"));
-        assertEquals("someKey", loggingNode.get("taskFormKey").asText());
-        assertEquals(50, loggingNode.get("taskPriority").asInt());
-        assertFalse(loggingNode.has("taskDueDate"));
-        assertEquals(3, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_COMPLETE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("User task 'Some user task' completed");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.has("taskCategory")).isFalse();
+        assertThat(loggingNode.has("taskDescription")).isFalse();
+        assertThat(loggingNode.get("taskFormKey").asText()).isEqualTo("someKey");
+        assertThat(loggingNode.get("taskPriority").asInt()).isEqualTo(50);
+        assertThat(loggingNode.has("taskDueDate")).isFalse();
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(3);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(3);
-        assertEquals(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE, loggingNode.get("type").asText());
-        assertEquals("Sequence flow will be taken for flow3, userTask --> theEnd", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("flow3", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("SequenceFlow", loggingNode.get("elementType").asText());
-        assertEquals("userTask", loggingNode.get("sourceRef").asText());
-        assertEquals("theEnd", loggingNode.get("targetRef").asText());
-        assertEquals(4, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Sequence flow will be taken for flow3, userTask --> theEnd");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("flow3");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("SequenceFlow");
+        assertThat(loggingNode.get("sourceRef").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("targetRef").asText()).isEqualTo("theEnd");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(4);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(4);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In EndEvent, executing NoneEndEventActivityBehavior", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("theEnd", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("EndEvent", loggingNode.get("elementType").asText());
-        assertEquals("NoneEndEventActivityBehavior", loggingNode.get("activityBehavior").asText());
-        assertEquals(5, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In EndEvent, executing NoneEndEventActivityBehavior");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("theEnd");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("EndEvent");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("NoneEndEventActivityBehavior");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(5);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(5);
-        assertEquals(LoggingSessionConstants.TYPE_PROCESS_COMPLETED, loggingNode.get("type").asText());
-        assertEquals("Completed process instance with id " + processInstance.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(6, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_PROCESS_COMPLETED);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Completed process instance with id " + processInstance.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(6);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(6);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(7, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(7);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         FlowableLoggingListener.clear();
     }
-    
+
     @Test
-    @Deployment(resources="org/flowable/engine/test/logging/asyncServiceTaskAndUserTask.bpmn20.xml")
+    @Deployment(resources = "org/flowable/engine/test/logging/asyncServiceTaskAndUserTask.bpmn20.xml")
     public void testAsyncServiceTask() {
         FlowableLoggingListener.clear();
-        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion().singleResult();
-            
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("serviceAndUserTask").latestVersion()
+                .singleResult();
+
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("serviceAndUserTask");
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-            
-        assertEquals(5, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(5);
+
         ObjectNode loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertEquals(LoggingSessionConstants.TYPE_PROCESS_STARTED, loggingNode.get("type").asText());
-        assertEquals("Started process instance with id " + processInstance.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_PROCESS_STARTED);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Started process instance with id " + processInstance.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(1);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In StartEvent, executing NoneStartEventActivityBehavior", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("theStart", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("StartEvent", loggingNode.get("elementType").asText());
-        assertEquals("NoneStartEventActivityBehavior", loggingNode.get("activityBehavior").asText());
-        assertEquals(2, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In StartEvent, executing NoneStartEventActivityBehavior");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("theStart");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("StartEvent");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("NoneStartEventActivityBehavior");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(2);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(2);
-        assertEquals(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE, loggingNode.get("type").asText());
-        assertEquals("Sequence flow will be taken for flow1, theStart --> task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("flow1", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("SequenceFlow", loggingNode.get("elementType").asText());
-        assertEquals("theStart", loggingNode.get("sourceRef").asText());
-        assertEquals("task", loggingNode.get("targetRef").asText());
-        assertEquals(3, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Sequence flow will be taken for flow1, theStart --> task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("flow1");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("SequenceFlow");
+        assertThat(loggingNode.get("sourceRef").asText()).isEqualTo("theStart");
+        assertThat(loggingNode.get("targetRef").asText()).isEqualTo("task");
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(3);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(3);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_ASYNC_JOB, loggingNode.get("type").asText());
-        assertEquals("Created async job for task, with job id " + job.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals(job.getId(), loggingNode.get("jobId").asText());
-        assertEquals(4, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_ASYNC_JOB);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Created async job for task, with job id " + job.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("jobId").asText()).isEqualTo(job.getId());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(4);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(4);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals(5, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(5);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         FlowableLoggingListener.clear();
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
-        assertEquals(18, FlowableLoggingListener.TEST_LOGGING_NODES.size());
-        
+        assertThat(FlowableLoggingListener.TEST_LOGGING_NODES).hasSize(18);
+
         loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_LOCK_JOB, loggingNode.get("type").asText());
-        assertEquals("Locking job for task, with job id " + job.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("elementSubType").asText());
-        assertEquals(job.getId(), loggingNode.get("jobId").asText());
-        assertEquals(1, loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_LOCK_JOB);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Locking job for task, with job id " + job.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementSubType").asText()).isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get("jobId").asText()).isEqualTo(job.getId());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isEqualTo(1);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         Map<String, ObjectNode> loggingMap = new HashMap<>();
         int groupCounter = 1;
         int userCounter = 1;
@@ -1166,361 +1176,370 @@ public class ServiceTaskLoggingTest extends ResourceFlowableTestCase {
             }
             loggingMap.put(logType, logObjectNode);
         }
-        
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_SERVICE_TASK_EXECUTE_ASYNC_JOB);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_EXECUTE_ASYNC_JOB, loggingNode.get("type").asText());
-        assertEquals("Executing async job for task, with job id " + job.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals(job.getId(), loggingNode.get("jobId").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_EXECUTE_ASYNC_JOB);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Executing async job for task, with job id " + job.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("jobId").asText()).isEqualTo(job.getId());
         int beforeJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(beforeJobNumber > 0);
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(beforeJobNumber).isGreaterThan(0);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("ServiceTask" + LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In ServiceTask, executing ClassDelegate", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("elementSubType").asText());
-        assertEquals("ClassDelegate", loggingNode.get("activityBehavior").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In ServiceTask, executing ClassDelegate");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementSubType").asText()).isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("ClassDelegate");
         int newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_SERVICE_TASK_ENTER);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_ENTER, loggingNode.get("type").asText());
-        assertEquals("Executing service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("elementSubType").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_ENTER);
+        assertThat(loggingNode.get("message").asText())
+                .isEqualTo("Executing service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementSubType").asText()).isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_VARIABLE_CREATE);
-        assertEquals(LoggingSessionConstants.TYPE_VARIABLE_CREATE, loggingNode.get("type").asText());
-        assertEquals("Variable 'newVariable' created", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertFalse(loggingNode.has("subScopeId"));
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("newVariable", loggingNode.get("variableName").asText());
-        assertEquals("string", loggingNode.get("variableType").asText());
-        assertEquals("test", loggingNode.get("variableValue").asText());
-        assertEquals("test", loggingNode.get("variableRawValue").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_VARIABLE_CREATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Variable 'newVariable' created");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.has("subScopeId")).isFalse();
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("variableName").asText()).isEqualTo("newVariable");
+        assertThat(loggingNode.get("variableType").asText()).isEqualTo("string");
+        assertThat(loggingNode.get("variableValue").asText()).isEqualTo("test");
+        assertThat(loggingNode.get("variableRawValue").asText()).isEqualTo("test");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_SERVICE_TASK_EXIT);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_EXIT, loggingNode.get("type").asText());
-        assertEquals("Executed service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate", loggingNode.get("elementSubType").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_EXIT);
+        assertThat(loggingNode.get("message").asText())
+                .isEqualTo("Executed service task with java class org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementSubType").asText()).isEqualTo("org.flowable.engine.test.logging.ServiceTaskLoggingTest$VariableServiceTaskDelegate");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_SERVICE_TASK_UNLOCK_JOB);
-        assertEquals(LoggingSessionConstants.TYPE_SERVICE_TASK_UNLOCK_JOB, loggingNode.get("type").asText());
-        assertEquals("Unlocking job for task, with job id " + job.getId(), loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("task", loggingNode.get("elementId").asText());
-        assertEquals("Test task", loggingNode.get("elementName").asText());
-        assertEquals("ServiceTask", loggingNode.get("elementType").asText());
-        assertEquals(job.getId(), loggingNode.get("jobId").asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.LOG_NUMBER));
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SERVICE_TASK_UNLOCK_JOB);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Unlocking job for task, with job id " + job.getId());
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Test task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("ServiceTask");
+        assertThat(loggingNode.get("jobId").asText()).isEqualTo(job.getId());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER)).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE);
-        assertEquals(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE, loggingNode.get("type").asText());
-        assertEquals("Sequence flow will be taken for flow2, task --> userTask", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("flow2", loggingNode.get("elementId").asText());
-        assertFalse(loggingNode.has("elementName"));
-        assertEquals("SequenceFlow", loggingNode.get("elementType").asText());
-        assertEquals("task", loggingNode.get("sourceRef").asText());
-        assertEquals("userTask", loggingNode.get("targetRef").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_SEQUENCE_FLOW_TAKE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Sequence flow will be taken for flow2, task --> userTask");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("flow2");
+        assertThat(loggingNode.has("elementName")).isFalse();
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("SequenceFlow");
+        assertThat(loggingNode.get("sourceRef").asText()).isEqualTo("task");
+        assertThat(loggingNode.get("targetRef").asText()).isEqualTo("userTask");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("UserTask" + LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
-        assertEquals(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE, loggingNode.get("type").asText());
-        assertEquals("In UserTask, executing UserTaskActivityBehavior", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("UserTaskActivityBehavior", loggingNode.get("activityBehavior").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_ACTIVITY_BEHAVIOR_EXECUTE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("In UserTask, executing UserTaskActivityBehavior");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("activityBehavior").asText()).isEqualTo("UserTaskActivityBehavior");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_USER_TASK_CREATE);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_CREATE, loggingNode.get("type").asText());
-        assertEquals("User task 'Some user task' created", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertFalse(loggingNode.has("taskCategory"));
-        assertFalse(loggingNode.has("taskDescription"));
-        assertEquals("someKey", loggingNode.get("taskFormKey").asText());
-        assertEquals(50, loggingNode.get("taskPriority").asInt());
-        assertFalse(loggingNode.has("taskDueDate"));
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_CREATE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("User task 'Some user task' created");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.has("taskCategory")).isFalse();
+        assertThat(loggingNode.has("taskDescription")).isFalse();
+        assertThat(loggingNode.get("taskFormKey").asText()).isEqualTo("someKey");
+        assertThat(loggingNode.get("taskPriority").asInt()).isEqualTo(50);
+        assertThat(loggingNode.has("taskDueDate")).isFalse();
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_USER_TASK_SET_ASSIGNEE);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_ASSIGNEE, loggingNode.get("type").asText());
-        assertEquals("Set task assignee value to johndoe", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals("johndoe", loggingNode.get("taskAssignee").asText());
-        assertFalse(loggingNode.has("taskCategory"));
-        assertFalse(loggingNode.has("taskDescription"));
-        assertFalse(loggingNode.has("taskFormKey"));
-        assertFalse(loggingNode.has("taskPriority"));
-        assertFalse(loggingNode.has("taskDueDate"));
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_ASSIGNEE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Set task assignee value to johndoe");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskAssignee").asText()).isEqualTo("johndoe");
+        assertThat(loggingNode.has("taskCategory")).isFalse();
+        assertThat(loggingNode.has("taskDescription")).isFalse();
+        assertThat(loggingNode.has("taskFormKey")).isFalse();
+        assertThat(loggingNode.has("taskPriority")).isFalse();
+        assertThat(loggingNode.has("taskDueDate")).isFalse();
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get(LoggingSessionConstants.TYPE_USER_TASK_SET_OWNER);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_OWNER, loggingNode.get("type").asText());
-        assertEquals("Set task owner value to janedoe", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals("janedoe", loggingNode.get("taskOwner").asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_OWNER);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Set task owner value to janedoe");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskOwner").asText()).isEqualTo("janedoe");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("1" + LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS, loggingNode.get("type").asText());
-        assertEquals("Added 2 candidate group identity links to task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals(2, loggingNode.get("taskGroupIdentityLinks").size());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Added 2 candidate group identity links to task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskGroupIdentityLinks")).hasSize(2);
         JsonNode identityLinksArray = loggingNode.get("taskGroupIdentityLinks");
-        JsonNode identityLinkNode = identityLinksArray.get(0);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("candidate", identityLinkNode.get("type").asText());
-        assertEquals("group1", identityLinkNode.get("groupId").asText());
-        identityLinkNode = identityLinksArray.get(1);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("candidate", identityLinkNode.get("type").asText());
-        assertEquals("group2", identityLinkNode.get("groupId").asText());
+        assertThatJson(identityLinksArray)
+                .isEqualTo("[ {"
+                        + "  id: '${json-unit.any-string}',"
+                        + "  type: 'candidate',"
+                        + "  groupId: 'group1'"
+                        + "}, {"
+                        + "  id: '${json-unit.any-string}',"
+                        + "  type: 'candidate',"
+                        + "  groupId: 'group2'"
+                        + " } ]");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("1" + LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS, loggingNode.get("type").asText());
-        assertEquals("Added 2 candidate user identity links to task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals(2, loggingNode.get("taskUserIdentityLinks").size());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Added 2 candidate user identity links to task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskUserIdentityLinks")).hasSize(2);
         identityLinksArray = loggingNode.get("taskUserIdentityLinks");
-        identityLinkNode = identityLinksArray.get(0);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("candidate", identityLinkNode.get("type").asText());
-        assertEquals("johndoe", identityLinkNode.get("userId").asText());
-        identityLinkNode = identityLinksArray.get(1);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("candidate", identityLinkNode.get("type").asText());
-        assertEquals("janedoe", identityLinkNode.get("userId").asText());
+        assertThatJson(identityLinksArray)
+                .isEqualTo("[ {"
+                        + "  id: '${json-unit.any-string}',"
+                        + "  type: 'candidate',"
+                        + "  userId: 'johndoe'"
+                        + "}, {"
+                        + "  id: '${json-unit.any-string}',"
+                        + "  type: 'candidate',"
+                        + "  userId: 'janedoe'"
+                        + " } ]");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("2" + LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS, loggingNode.get("type").asText());
-        assertEquals("Added 2 custom user identity links to task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals(2, loggingNode.get("taskUserIdentityLinks").size());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_USER_IDENTITY_LINKS);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Added 2 custom user identity links to task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskUserIdentityLinks")).hasSize(2);
         identityLinksArray = loggingNode.get("taskUserIdentityLinks");
-        identityLinkNode = identityLinksArray.get(0);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("businessAdministrator", identityLinkNode.get("type").asText());
-        assertEquals("johndoe", identityLinkNode.get("userId").asText());
-        identityLinkNode = identityLinksArray.get(1);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("someAdmin", identityLinkNode.get("type").asText());
-        assertEquals("janedoe", identityLinkNode.get("userId").asText());
+        assertThatJson(identityLinksArray)
+                .isEqualTo("[ {"
+                        + "  id: '${json-unit.any-string}',"
+                        + "  type: 'businessAdministrator',"
+                        + "  userId: 'johndoe'"
+                        + "}, {"
+                        + "  id: '${json-unit.any-string}',"
+                        + "  type: 'someAdmin',"
+                        + "  userId: 'janedoe'"
+                        + " } ]");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
         beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("2" + LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS);
-        assertEquals(LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS, loggingNode.get("type").asText());
-        assertEquals("Added 2 custom group identity links to task", loggingNode.get("message").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(execution.getId(), loggingNode.get("subScopeId").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertEquals("userTask", loggingNode.get("elementId").asText());
-        assertEquals("UserTask", loggingNode.get("elementType").asText());
-        assertEquals("Some user task", loggingNode.get("elementName").asText());
-        assertNotNull(loggingNode.get("taskId").asText());
-        assertEquals("Some user task", loggingNode.get("taskName").asText());
-        assertEquals(2, loggingNode.get("taskGroupIdentityLinks").size());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_USER_TASK_SET_GROUP_IDENTITY_LINKS);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Added 2 custom group identity links to task");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("subScopeId").asText()).isEqualTo(execution.getId());
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get("elementId").asText()).isEqualTo("userTask");
+        assertThat(loggingNode.get("elementType").asText()).isEqualTo("UserTask");
+        assertThat(loggingNode.get("elementName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskId").asText()).isNotNull();
+        assertThat(loggingNode.get("taskName").asText()).isEqualTo("Some user task");
+        assertThat(loggingNode.get("taskGroupIdentityLinks")).hasSize(2);
         identityLinksArray = loggingNode.get("taskGroupIdentityLinks");
-        identityLinkNode = identityLinksArray.get(0);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("businessAdministrator", identityLinkNode.get("type").asText());
-        assertEquals("group3", identityLinkNode.get("groupId").asText());
-        identityLinkNode = identityLinksArray.get(1);
-        assertNotNull(identityLinkNode.get("id").asText());
-        assertEquals("someAdmin", identityLinkNode.get("type").asText());
-        assertEquals("group4", identityLinkNode.get("groupId").asText());
+        assertThatJson(identityLinksArray)
+                .isEqualTo("[ {"
+                        + "  id: '${json-unit.any-string}',"
+                        + "  type: 'businessAdministrator',"
+                        + "  groupId: 'group3'"
+                        + "}, {"
+                        + "  id: '${json-unit.any-string}',"
+                        + "  type: 'someAdmin',"
+                        + "  groupId: 'group4'"
+                        + " } ]");
         newJobNumber = loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt();
-        assertTrue(newJobNumber > beforeJobNumber);
-        beforeJobNumber = newJobNumber;
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(newJobNumber).isGreaterThan(beforeJobNumber);
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("1" + LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
-        
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
+
         loggingNode = loggingMap.get("2" + LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
-        assertEquals(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE, loggingNode.get("type").asText());
-        assertEquals("Closed command context for bpmn engine", loggingNode.get("message").asText());
-        assertEquals("bpmn", loggingNode.get("engineType").asText());
-        assertEquals(processInstance.getId(), loggingNode.get("scopeId").asText());
-        assertEquals(ScopeTypes.BPMN, loggingNode.get("scopeType").asText());
-        assertEquals(processDefinition.getId(), loggingNode.get("scopeDefinitionId").asText());
-        assertEquals(processDefinition.getKey(), loggingNode.get("scopeDefinitionKey").asText());
-        assertEquals(processDefinition.getName(), loggingNode.get("scopeDefinitionName").asText());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt());
-        assertNotNull(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText());
+        assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_COMMAND_CONTEXT_CLOSE);
+        assertThat(loggingNode.get("message").asText()).isEqualTo("Closed command context for bpmn engine");
+        assertThat(loggingNode.get("engineType").asText()).isEqualTo("bpmn");
+        assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
+        assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
+        assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());
+        assertThat(loggingNode.get("scopeDefinitionKey").asText()).isEqualTo(processDefinition.getKey());
+        assertThat(loggingNode.get("scopeDefinitionName").asText()).isEqualTo(processDefinition.getName());
+        assertThat(loggingNode.get(LoggingSessionUtil.LOG_NUMBER).asInt()).isNotNull();
+        assertThat(loggingNode.get(LoggingSessionUtil.TIMESTAMP).asText()).isNotNull();
 
         FlowableLoggingListener.clear();
     }
@@ -1684,19 +1703,18 @@ public class ServiceTaskLoggingTest extends ResourceFlowableTestCase {
                         + "  __logNumber: 3"
                         + "}");
 
-
     }
 
     public static class ExceptionServiceTaskDelegate implements JavaDelegate {
-        
+
         @Override
         public void execute(DelegateExecution execution) {
             throw new FlowableException("Test exception");
         }
     }
-    
+
     public static class VariableServiceTaskDelegate implements JavaDelegate {
-        
+
         @Override
         public void execute(DelegateExecution execution) {
             execution.setVariable("newVariable", "test");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/mdc/MDCLoggingTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/mdc/MDCLoggingTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.logging.mdc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -73,27 +76,19 @@ public class MDCLoggingTest extends PluggableFlowableTestCase {
     public void testLogger() {
         setCustomLogger();
 
-        try {
-            runtimeService.startProcessInstanceByKey("testLoggerProcess");
-            fail("Expected exception");
-        } catch (Exception e) {
-            // expected exception
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testLoggerProcess"))
+                .isInstanceOf(Exception.class);
         String messages = console.toString();
 
-        assertTrue(messages.contains("ProcessDefinitionId=" + TestService.processDefinitionId));
-        assertTrue(messages.contains("executionId=" + TestService.executionId));
-        assertTrue(messages.contains("mdcProcessInstanceID=" + TestService.processInstanceId));
-        assertTrue(messages.contains("mdcBusinessKey=" + (TestService.businessKey == null ? "" : TestService.businessKey)));
+        assertThat(messages).contains("ProcessDefinitionId=" + TestService.processDefinitionId);
+        assertThat(messages).contains("executionId=" + TestService.executionId);
+        assertThat(messages).contains("mdcProcessInstanceID=" + TestService.processInstanceId);
+        assertThat(messages).contains("mdcBusinessKey=" + (TestService.businessKey == null ? "" : TestService.businessKey));
         console.clear();
         restoreLoggers();
 
-        try {
-            runtimeService.startProcessInstanceByKey("testLoggerProcess");
-            fail("Expected exception");
-        } catch (Exception e) {
-            // expected exception
-        }
-        assertFalse(console.toString().contains("ProcessDefinitionId=" + TestService.processDefinitionId));
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testLoggerProcess"))
+                .isInstanceOf(Exception.class);
+        assertThat(console.toString()).doesNotContain("ProcessDefinitionId=" + TestService.processDefinitionId);
     }
 }


### PR DESCRIPTION
This is for the `org.flowable.engine.test.logging` package.  One file has a mixture of assertions so I fixed that and finished off the other files in the package too.
