### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/impl/calendar/MapBusinessCalendarManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/impl/calendar/MapBusinessCalendarManagerTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,10 +13,8 @@
 
 package org.flowable.engine.test.impl.calendar;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,7 +38,7 @@ public class MapBusinessCalendarManagerTest {
         calendars.put("someKey", calendar);
         MapBusinessCalendarManager businessCalendarManager = new MapBusinessCalendarManager(calendars);
 
-        assertEquals(calendar, businessCalendarManager.getBusinessCalendar("someKey"));
+        assertThat(businessCalendarManager.getBusinessCalendar("someKey")).isEqualTo(calendar);
     }
 
     @Test
@@ -48,21 +46,14 @@ public class MapBusinessCalendarManagerTest {
         @SuppressWarnings("unchecked")
         MapBusinessCalendarManager businessCalendarManager = new MapBusinessCalendarManager(Collections.EMPTY_MAP);
 
-        try {
-            businessCalendarManager.getBusinessCalendar("INVALID");
-            fail("ActivitiException expected");
-        } catch (FlowableException e) {
-            assertThat(e.getMessage(), containsString("INVALID does not exist"));
-        }
+        assertThatThrownBy(() -> businessCalendarManager.getBusinessCalendar("INVALID"))
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessageContaining("INVALID does not exist");
     }
 
     @Test
     public void testNullCalendars() {
-        try {
-            new MapBusinessCalendarManager(null);
-            fail("AssertionError expected");
-        } catch (IllegalArgumentException e) {
-            // Expected error
-        }
+        assertThatThrownBy(() -> new MapBusinessCalendarManager(null))
+                .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
This is for the `org.flowable.engine.test.impl.calendar` package.  There is a single file in this package that had a mixture of assertion styles.

