### PR TITLE
Set SSL SMTP port when SSL is enabled for email server connections (fixes #2343)

### DIFF
--- a/docs/docusaurus/docs/bpmn/ch05a-Spring-Boot.md
+++ b/docs/docusaurus/docs/bpmn/ch05a-Spring-Boot.md
@@ -702,6 +702,7 @@ Here is a list of configuration properties that the Flowable Spring Boot support
     flowable.mail.server.host=localhost # The host of the mail server.
     flowable.mail.server.password= # The password for the mail server authentication.
     flowable.mail.server.port=1025 # The port of the mail server.
+    flowable.mail.server.ssl-port=1465 # The SSL port of the mail server.
     flowable.mail.server.use-ssl=false # Sets whether SSL/TLS encryption should be enabled for the SMTP transport upon connection (SMTPS/POPS).
     flowable.mail.server.use-tls=false # Set or disable the STARTTLS encryption.
     flowable.mail.server.username= # The username that needs to be used for the mail server authentication. If empty no authentication would be used.
@@ -774,25 +775,31 @@ Here is a list of configuration properties that the Flowable Spring Boot support
 <td><p>The port of the mail server.</p></td>
 </tr>
 <tr class="even">
+<td><p>flowable.mail.server.ssl-port</p></td>
+<td><p>flowable.mail-server-ssl-port</p></td>
+<td><p>1465</p></td>
+<td><p>The SSL port of the mail server.</p></td>
+</tr>
+<tr class="odd">
 <td><p>flowable.mail.server.use-ssl</p></td>
 <td><p>flowable.mail-server-use-ssl</p></td>
 <td><p>false</p></td>
 <td><p>Sets whether SSL/TLS encryption should be enabled for the SMTP transport upon connection (SMTPS/POPS).</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p>flowable.mail.server.use-tls</p></td>
 <td><p>flowable.mail-server-use-tls</p></td>
 <td><p>false</p></td>
 <td><p>Set or disable the STARTTLS encryption.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p>flowable.mail.server.username</p></td>
 <td><p>flowable.mail-server-user-name</p></td>
 <td><p>-</p></td>
 <td><p>The username that needs to be used for the mail server authentication.
 If empty no authentication would be used.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p>flowable.process.definition-cache-limit</p></td>
 <td><p>flowable.process-definitions.cache.max</p></td>
 <td><p>-1</p></td>

--- a/docs/docusaurus/docs/bpmn/ch14-Applications.md
+++ b/docs/docusaurus/docs/bpmn/ch14-Applications.md
@@ -417,25 +417,31 @@ If setting the query alone is insufficient for your specific LDAP setup, you can
 <td><p>The port of the mail server.</p></td>
 </tr>
 <tr class="odd">
+<td><p>flowable.mail.server.ssl-port</p></td>
+<td><p>email.ssl-port</p></td>
+<td><p>1465</p></td>
+<td><p>The SSL port of the mail server.</p></td>
+</tr>
+<tr class="even">
 <td><p>flowable.mail.server.use-ssl</p></td>
 <td><p>email.use-ssl</p></td>
 <td><p>false</p></td>
 <td><p>Sets whether SSL/TLS encryption should be enabled for the SMTP transport upon connection (SMTPS/POPS).</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p>flowable.mail.server.use-tls</p></td>
 <td><p>email.use-tls</p></td>
 <td><p>false</p></td>
 <td><p>Set or disable the STARTTLS encryption.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td><p>flowable.mail.server.username</p></td>
 <td><p>email.username</p></td>
 <td><p>-</p></td>
 <td><p>The username that needs to be used for the mail server authentication.
 If empty no authentication would be used.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td><p>flowable.process.definition-cache-limit</p></td>
 <td><p>flowable.process-definitions.cache.max</p></td>
 <td><p>-1</p></td>

--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -771,6 +771,7 @@ flowable.mail.server.force-to= # The force to address(es) that would be used whe
 flowable.mail.server.host=localhost # The host of the mail server.
 flowable.mail.server.password= # The password for the mail server authentication.
 flowable.mail.server.port=1025 # The port of the mail server.
+flowable.mail.server.ssl-port=1465 # The SSL port of the mail server.
 flowable.mail.server.use-ssl=false # Sets whether SSL/TLS encryption should be enabled for the SMTP transport upon connection (SMTPS/POPS).
 flowable.mail.server.use-tls=false # Set or disable the STARTTLS encryption.
 flowable.mail.server.username= # The username that needs to be used for the mail server authentication. If empty no authentication would be used.
@@ -829,6 +830,11 @@ management.endpoint.flowable.enabled=true # Whether to enable the flowable endpo
 |flowable.mail-server-port
 |1025
 |The port of the mail server.
+
+|flowable.mail.server.ssl-port
+|flowable.mail-server-ssl-port
+|1465
+|The SSL port of the mail server.
 
 |flowable.mail.server.use-ssl
 |flowable.mail-server-use-ssl

--- a/docs/userguide/src/en/bpmn/ch14-Applications.adoc
+++ b/docs/userguide/src/en/bpmn/ch14-Applications.adoc
@@ -360,6 +360,11 @@ As such, if you have a custom implementation of the 'org.flowable.ldap.LDAPIdent
 |1025
 |The port of the mail server.
 
+|flowable.mail.server.ssl-port
+|email.ssl-port
+|1465
+|The SSL port of the mail server.
+
 |flowable.mail.server.use-ssl
 |email.use-ssl
 |false

--- a/docs/userguide/src/zh_CN/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch05a-Spring-Boot.adoc
@@ -773,6 +773,7 @@ flowable.mail.server.default-from=flowable@localhost # 发送邮件时使用的�
 flowable.mail.server.host=localhost # 邮件服务器。
 flowable.mail.server.password= # 邮件服务器的登录密码。
 flowable.mail.server.port=1025 # 邮件服务器的端口号。
+flowable.mail.server.ssl-port=1465 # SSL邮件服务器的端口号。
 flowable.mail.server.use-ssl=false # 是否使用SSL/TLS加密SMTP传输连接（即SMTPS/POPS)。
 flowable.mail.server.use-tls=false # 使用或禁用STARTTLS加密。
 flowable.mail.server.username= # 邮件服务器的登录用户名。如果为空，则不需要登录。
@@ -832,6 +833,11 @@ management.endpoint.flowable.enabled=true # 是否启用flowable端点。
 |flowable.mail-server-port
 |1025
 |邮件服务器的端口号。
+
+|flowable.mail.server.ssl-port
+|flowable.mail-server-ssl-port
+|1465
+|SSL邮件服务器的端口号。
 
 |flowable.mail.server.use-ssl
 |flowable.mail-server-use-ssl

--- a/docs/userguide/src/zh_CN/bpmn/ch13-UI.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch13-UI.adoc
@@ -345,6 +345,11 @@ java -Dloader.path=/location/to/your/driverfolder -jar flowable-idm.war
 |1025
 |邮件服务器的端口号。
 
+|flowable.mail.server.ssl-port
+|email.ssl-port
+|1465
+|SSL邮件服务器的端口号。
+
 |flowable.mail.server.use-ssl
 |email.use-ssl
 |false

--- a/docs/userguide/src/zh_CN/bpmn/ch14-Applications.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch14-Applications.adoc
@@ -360,6 +360,11 @@ As such, if you have a custom implementation of the 'org.flowable.ldap.LDAPIdent
 |1025
 |The port of the mail server.
 
+|flowable.mail.server.ssl-port
+|email.ssl-port
+|1465
+|The SSL port of the mail server.
+
 |flowable.mail.server.use-ssl
 |email.use-ssl
 |false

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -487,6 +487,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
     protected String mailServerUsername; // by default no name and password are provided, which
     protected String mailServerPassword; // means no authentication for mail server
     protected int mailServerPort = 25;
+    protected int mailServerSSLPort = 465;
     protected boolean useSSL;
     protected boolean useTLS;
     protected String mailServerDefaultFrom = "flowable@localhost";
@@ -3625,6 +3626,15 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     public CmmnEngineConfiguration setMailServerPort(int mailServerPort) {
         this.mailServerPort = mailServerPort;
+        return this;
+    }
+
+    public int getMailServerSSLPort() {
+        return mailServerSSLPort;
+    }
+
+    public CmmnEngineConfiguration setMailServerSSLPort(int mailServerSSLPort) {
+        this.mailServerSSLPort = mailServerSSLPort;
         return this;
     }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
@@ -311,6 +311,7 @@ public class MailActivityBehavior extends CoreCmmnActivityBehavior {
                 email.setHostName(host);
 
                 email.setSmtpPort(mailServerInfo.getMailServerPort());
+                email.setSslSmtpPort(Integer.toString(mailServerInfo.getMailServerSSLPort()));
 
                 email.setSSLOnConnect(mailServerInfo.isMailServerUseSSL());
                 email.setStartTLSEnabled(mailServerInfo.isMailServerUseTLS());
@@ -339,6 +340,7 @@ public class MailActivityBehavior extends CoreCmmnActivityBehavior {
 
                 int port = engineConfiguration.getMailServerPort();
                 email.setSmtpPort(port);
+                email.setSslSmtpPort(Integer.toString(engineConfiguration.getMailServerSSLPort()));
 
                 email.setSSLOnConnect(engineConfiguration.getMailServerUseSSL());
                 email.setStartTLSEnabled(engineConfiguration.getMailServerUseTLS());

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/cfg/mail/MailServerInfo.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/cfg/mail/MailServerInfo.java
@@ -21,7 +21,8 @@ public class MailServerInfo {
     protected String mailServerDefaultFrom;
     protected String mailServerForceTo;
     protected String mailServerHost;
-    protected int mailServerPort;
+    protected int mailServerPort = 25;
+    protected int mailServerSSLPort = 465;
     protected String mailServerUsername;
     protected String mailServerPassword;
     protected boolean mailServerUseSSL;
@@ -57,6 +58,14 @@ public class MailServerInfo {
 
     public void setMailServerPort(int mailServerPort) {
         this.mailServerPort = mailServerPort;
+    }
+
+    public int getMailServerSSLPort() {
+        return mailServerSSLPort;
+    }
+
+    public void setMailServerSSLPort(int mailServerSSLPort) {
+        this.mailServerSSLPort = mailServerSSLPort;
     }
 
     public String getMailServerUsername() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngineConfiguration.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngineConfiguration.java
@@ -93,6 +93,7 @@ public abstract class ProcessEngineConfiguration extends AbstractEngineConfigura
     protected String mailServerUsername; // by default no name and password are provided, which
     protected String mailServerPassword; // means no authentication for mail server
     protected int mailServerPort = 25;
+    protected int mailServerSSLPort = 465;
     protected boolean useSSL;
     protected boolean useTLS;
     protected String mailServerDefaultFrom = "flowable@localhost";
@@ -285,6 +286,15 @@ public abstract class ProcessEngineConfiguration extends AbstractEngineConfigura
 
     public ProcessEngineConfiguration setMailServerPort(int mailServerPort) {
         this.mailServerPort = mailServerPort;
+        return this;
+    }
+
+    public int getMailServerSSLPort() {
+        return mailServerSSLPort;
+    }
+
+    public ProcessEngineConfiguration setMailServerSSLPort(int mailServerSSLPort) {
+        this.mailServerSSLPort = mailServerSSLPort;
         return this;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -321,6 +321,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
                 email.setHostName(host);
 
                 email.setSmtpPort(mailServerInfo.getMailServerPort());
+                email.setSslSmtpPort(Integer.toString(mailServerInfo.getMailServerSSLPort()));
 
                 email.setSSLOnConnect(mailServerInfo.isMailServerUseSSL());
                 email.setStartTLSEnabled(mailServerInfo.isMailServerUseTLS());
@@ -349,6 +350,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
 
                 int port = processEngineConfiguration.getMailServerPort();
                 email.setSmtpPort(port);
+                email.setSslSmtpPort(Integer.toString(processEngineConfiguration.getMailServerSSLPort()));
 
                 email.setSSLOnConnect(processEngineConfiguration.getMailServerUseSSL());
                 email.setStartTLSEnabled(processEngineConfiguration.getMailServerUseTLS());

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableMailProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableMailProperties.java
@@ -33,6 +33,11 @@ public class FlowableMailProperties {
     private int port = 1025;
 
     /**
+     * The SSL port of the mail server.
+     */
+    private int sslPort = 1465;
+
+    /**
      * The username that needs to be used for the mail server authentication.
      * If empty no authentication would be used.
      */
@@ -79,6 +84,14 @@ public class FlowableMailProperties {
 
     public void setPort(int port) {
         this.port = port;
+    }
+
+    public int getSSLPort() {
+        return sslPort;
+    }
+
+    public void setSSLPort(int sslPort) {
+        this.sslPort = sslPort;
     }
 
     public String getUsername() {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
@@ -200,6 +200,7 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
 
         conf.setMailServerHost(mailProperties.getHost());
         conf.setMailServerPort(mailProperties.getPort());
+        conf.setMailServerSSLPort(mailProperties.getSSLPort());
         conf.setMailServerUsername(mailProperties.getUsername());
         conf.setMailServerPassword(mailProperties.getPassword());
         conf.setMailServerDefaultFrom(mailProperties.getDefaultFrom());

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -350,6 +350,15 @@
       }
     },
     {
+      "name": "email.ssl-port",
+      "type": "java.lang.Integer",
+      "deprecation": {
+        "level": "error",
+        "reason": "Using improved setup for Spring Boot.",
+        "replacement": "flowable.mail.server.ssl-port"
+      }
+    },
+    {
       "name": "email.use-credentials",
       "type": "java.lang.Boolean",
       "deprecation": {
@@ -409,6 +418,15 @@
         "level": "error",
         "reason": "Moved properties to new group.",
         "replacement": "flowable.mail.server.port"
+      }
+    },
+    {
+      "name": "flowable.mail-server-ssl-port",
+      "type": "java.lang.Integer",
+      "deprecation": {
+        "level": "error",
+        "reason": "Moved properties to new group.",
+        "replacement": "flowable.mail.server.ssl-port"
       }
     },
     {

--- a/modules/flowable5-compatibility/src/main/java/org/flowable/compatibility/DefaultProcessEngineFactory.java
+++ b/modules/flowable5-compatibility/src/main/java/org/flowable/compatibility/DefaultProcessEngineFactory.java
@@ -116,6 +116,7 @@ public class DefaultProcessEngineFactory {
         flowable5Configuration.setMailServerHost(flowable6Configuration.getMailServerHost());
         flowable5Configuration.setMailServerPassword(flowable6Configuration.getMailServerPassword());
         flowable5Configuration.setMailServerPort(flowable6Configuration.getMailServerPort());
+        flowable5Configuration.setMailServerSSLPort(flowable6Configuration.getMailServerSSLPort());
         flowable5Configuration.setMailServerUsername(flowable6Configuration.getMailServerUsername());
         flowable5Configuration.setMailServerUseSSL(flowable6Configuration.getMailServerUseSSL());
         flowable5Configuration.setMailServerUseTLS(flowable6Configuration.getMailServerUseTLS());

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
@@ -117,6 +117,7 @@ public abstract class ProcessEngineConfiguration {
     protected String mailServerUsername; // by default no name and password are provided, which
     protected String mailServerPassword; // means no authentication for mail server
     protected int mailServerPort = 25;
+    protected int mailServerSSLPort = 465;
     protected boolean useSSL;
     protected boolean useTLS;
     protected String mailServerDefaultFrom = "activiti@localhost";
@@ -363,6 +364,15 @@ public abstract class ProcessEngineConfiguration {
 
     public ProcessEngineConfiguration setMailServerPort(int mailServerPort) {
         this.mailServerPort = mailServerPort;
+        return this;
+    }
+
+    public int getMailServerSSLPort() {
+        return mailServerSSLPort;
+    }
+
+    public ProcessEngineConfiguration setMailServerSSLPort(int mailServerSSLPort) {
+        this.mailServerSSLPort = mailServerSSLPort;
         return this;
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -265,6 +265,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
                 email.setHostName(host);
 
                 email.setSmtpPort(mailServerInfo.getMailServerPort());
+                email.setSslSmtpPort(Integer.toString(mailServerInfo.getMailServerSSLPort()));
 
                 email.setSSLOnConnect(processEngineConfiguration.getMailServerUseSSL());
                 email.setStartTLSEnabled(processEngineConfiguration.getMailServerUseTLS());
@@ -293,6 +294,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
 
                 int port = processEngineConfiguration.getMailServerPort();
                 email.setSmtpPort(port);
+                email.setSslSmtpPort(Integer.toString(processEngineConfiguration.getMailServerSSLPort()));
 
                 email.setSSLOnConnect(processEngineConfiguration.getMailServerUseSSL());
                 email.setStartTLSEnabled(processEngineConfiguration.getMailServerUseTLS());


### PR DESCRIPTION
Set SSL SMTP port when SSL is enabled for email server connections (fixes #2343)

I was able to manually test this fix as it applies to a Flowable 6.5.x BPMN XML use-case with an Email Task. The SSL SMTP port could be customized as needed.

#### Check List:
* Unit tests: NO
* Documentation: YES
