### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
@@ -13,8 +13,8 @@
 
 package org.flowable.engine.test.history;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -51,13 +51,13 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("noop").singleResult();
 
-        assertEquals("noop", historicActivityInstance.getActivityId());
-        assertEquals("serviceTask", historicActivityInstance.getActivityType());
-        assertNotNull(historicActivityInstance.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), historicActivityInstance.getProcessInstanceId());
-        assertNotNull(historicActivityInstance.getStartTime());
-        assertNotNull(historicActivityInstance.getEndTime());
-        assertTrue(historicActivityInstance.getDurationInMillis() >= 0);
+        assertThat(historicActivityInstance.getActivityId()).isEqualTo("noop");
+        assertThat(historicActivityInstance.getActivityType()).isEqualTo("serviceTask");
+        assertThat(historicActivityInstance.getProcessDefinitionId()).isNotNull();
+        assertThat(historicActivityInstance.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(historicActivityInstance.getStartTime()).isNotNull();
+        assertThat(historicActivityInstance.getEndTime()).isNotNull();
+        assertThat(historicActivityInstance.getDurationInMillis() >= 0).isTrue();
     }
     
     @Test
@@ -73,11 +73,11 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivityInstance = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).activityTypes(activityTypes).list();
-            assertEquals(1, historicActivityInstance.size());
+            assertThat(historicActivityInstance).hasSize(1);
     
             activityTypes.add("userTask");
             List<HistoricActivityInstance> historicActivityInstance2 = historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).activityTypes(activityTypes).list();
-            assertEquals(2, historicActivityInstance2.size());
+            assertThat(historicActivityInstance2).hasSize(2);
 
             Calendar hourAgo = Calendar.getInstance();
             hourAgo.add(Calendar.HOUR_OF_DAY, -1);
@@ -85,27 +85,27 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
             hourFromNow.add(Calendar.HOUR_OF_DAY, 1);
     
             // Start/end dates
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourAgo.getTime()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourFromNow.getTime()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourAgo.getTime()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourFromNow.getTime()).count());
-            assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedBefore(hourFromNow.getTime()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedBefore(hourAgo.getTime()).count());
-            assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourAgo.getTime()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourFromNow.getTime()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourFromNow.getTime()).startedBefore(hourAgo.getTime()).count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourAgo.getTime()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourFromNow.getTime()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourAgo.getTime()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourFromNow.getTime()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedBefore(hourFromNow.getTime()).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedBefore(hourAgo.getTime()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourAgo.getTime()).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourFromNow.getTime()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourFromNow.getTime()).startedBefore(hourAgo.getTime()).count()).isZero();
             
             // After finishing process
             taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
             
             HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 5000, 200);
             
-            assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourAgo.getTime()).count());
-            assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourFromNow.getTime()).count());
-            assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourAgo.getTime()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourFromNow.getTime()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourAgo.getTime()).finishedAfter(hourFromNow.getTime()).count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourAgo.getTime()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourFromNow.getTime()).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourAgo.getTime()).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourFromNow.getTime()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourAgo.getTime()).finishedAfter(hourFromNow.getTime()).count()).isZero();
         }
     
         ProcessInstance processInstance2 = runtimeService.createProcessInstanceBuilder()
@@ -123,18 +123,18 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(otherTenantProcessInstance.getId()).singleResult().getId());
         
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(3, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().count()).isEqualTo(3);
             
             List<String> tenantIds = new ArrayList<>();
             tenantIds.add("tenant1");
             tenantIds.add("tenant2");
-            assertEquals(3, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().tenantIdIn(tenantIds).count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().tenantIdIn(tenantIds).count()).isEqualTo(3);
             
-            assertEquals(2, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().tenantIdIn(Collections.singletonList("tenant1")).count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().tenantIdIn(Collections.singletonList("tenant1")).count()).isEqualTo(2);
             
-            assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().tenantIdIn(Collections.singletonList("tenant2")).count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().tenantIdIn(Collections.singletonList("tenant2")).count()).isEqualTo(1);
             
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().tenantIdIn(Collections.singletonList("unexisting")).count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("theTask").finished().tenantIdIn(Collections.singletonList("unexisting")).count()).isZero();
         }
     }
 
@@ -148,13 +148,13 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("receive").singleResult();
         assertActivityInstancesAreSame(historicActivityInstance, runtimeService.createActivityInstanceQuery().activityInstanceId(historicActivityInstance.getId()).singleResult());
 
-        assertEquals("receive", historicActivityInstance.getActivityId());
-        assertEquals("receiveTask", historicActivityInstance.getActivityType());
-        assertNull(historicActivityInstance.getEndTime());
-        assertNull(historicActivityInstance.getDurationInMillis());
-        assertNotNull(historicActivityInstance.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), historicActivityInstance.getProcessInstanceId());
-        assertNotNull(historicActivityInstance.getStartTime());
+        assertThat(historicActivityInstance.getActivityId()).isEqualTo("receive");
+        assertThat(historicActivityInstance.getActivityType()).isEqualTo("receiveTask");
+        assertThat(historicActivityInstance.getEndTime()).isNull();
+        assertThat(historicActivityInstance.getDurationInMillis()).isNull();
+        assertThat(historicActivityInstance.getProcessDefinitionId()).isNotNull();
+        assertThat(historicActivityInstance.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(historicActivityInstance.getStartTime()).isNotNull();
 
         Execution execution = runtimeService.createExecutionQuery().onlyChildExecutions().processInstanceId(processInstance.getId()).singleResult();
         runtimeService.trigger(execution.getId());
@@ -163,30 +163,30 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("receive").singleResult();
 
-        assertEquals("receive", historicActivityInstance.getActivityId());
-        assertEquals("receiveTask", historicActivityInstance.getActivityType());
-        assertNotNull(historicActivityInstance.getEndTime());
-        assertTrue(historicActivityInstance.getDurationInMillis() >= 0);
-        assertNotNull(historicActivityInstance.getProcessDefinitionId());
-        assertEquals(processInstance.getId(), historicActivityInstance.getProcessInstanceId());
-        assertNotNull(historicActivityInstance.getStartTime());
+        assertThat(historicActivityInstance.getActivityId()).isEqualTo("receive");
+        assertThat(historicActivityInstance.getActivityType()).isEqualTo("receiveTask");
+        assertThat(historicActivityInstance.getEndTime()).isNotNull();
+        assertThat(historicActivityInstance.getDurationInMillis() >= 0).isTrue();
+        assertThat(historicActivityInstance.getProcessDefinitionId()).isNotNull();
+        assertThat(historicActivityInstance.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(historicActivityInstance.getStartTime()).isNotNull();
     }
 
     @Test
     @Deployment(resources = "org/flowable/engine/test/history/oneTaskProcess.bpmn20.xml")
     public void testHistoricActivityInstanceUnfinished() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricActivityInstanceQuery historicActivityInstanceQuery = historyService.createHistoricActivityInstanceQuery();
 
         long finishedActivityInstanceCount = historicActivityInstanceQuery.finished().count();
-        assertEquals("The Start event and sequence flow are completed", 2, finishedActivityInstanceCount);
+        assertThat(finishedActivityInstanceCount).as("The Start event and sequence flow are completed").isEqualTo(2);
 
         long unfinishedActivityInstanceCount = historicActivityInstanceQuery.unfinished().count();
-        assertEquals("One active (unfinished) User org.flowable.task.service.Task", 1, unfinishedActivityInstanceCount);
+        assertThat(unfinishedActivityInstanceCount).as("One active (unfinished) User org.flowable.task.service.Task").isEqualTo(1);
     }
 
     @Test
@@ -196,52 +196,52 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("nonExistingActivityId").list().size());
-        assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("noop").list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityId("nonExistingActivityId").list()).isEmpty();
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityId("noop").list()).hasSize(1);
 
-        assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityType("nonExistingActivityType").list().size());
-        assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityType("serviceTask").list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityType("nonExistingActivityType").list()).isEmpty();
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityType("serviceTask").list()).hasSize(1);
 
-        assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityName("nonExistingActivityName").list().size());
-        assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityName("No operation").list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityName("nonExistingActivityName").list()).isEmpty();
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityName("No operation").list()).hasSize(1);
 
-        assertEquals(0, historyService.createHistoricActivityInstanceQuery().taskAssignee("nonExistingAssignee").list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().taskAssignee("nonExistingAssignee").list()).isEmpty();
 
-        assertEquals(0, historyService.createHistoricActivityInstanceQuery().executionId("nonExistingExecutionId").list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().executionId("nonExistingExecutionId").list()).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(5, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(5);
         } else {
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().executionId(processInstance.getId()).list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().executionId(processInstance.getId()).list()).isEmpty();
         }
 
-        assertEquals(0, historyService.createHistoricActivityInstanceQuery().processInstanceId("nonExistingProcessInstanceId").list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId("nonExistingProcessInstanceId").list()).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(5, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(5);
         } else {
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).list()).isEmpty();
         }
 
-        assertEquals(0, historyService.createHistoricActivityInstanceQuery().processDefinitionId("nonExistingProcessDefinitionId").list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().processDefinitionId("nonExistingProcessDefinitionId").list()).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(5, historyService.createHistoricActivityInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list()).hasSize(5);
         } else {
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list()).isEmpty();
         }
 
-        assertEquals(0, historyService.createHistoricActivityInstanceQuery().unfinished().list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().unfinished().list()).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(5, historyService.createHistoricActivityInstanceQuery().finished().list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().finished().list()).hasSize(5);
         } else {
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().finished().list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().finished().list()).isEmpty();
         }
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().list().get(0);
-            assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityInstanceId(historicActivityInstance.getId()).list().size());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityInstanceId(historicActivityInstance.getId()).list()).hasSize(1);
         }
     }
 
@@ -249,33 +249,33 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     @Deployment
     public void testHistoricActivityInstanceForEventsQuery() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("eventProcess");
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         runtimeService.signalEventReceived("signal");
         assertProcessEnded(pi.getId());
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("noop").list().size());
-        assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("userTask").list().size());
-        assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("intermediate-event").list().size());
-        assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("start").list().size());
-        assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("end").list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityId("noop").list()).hasSize(1);
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityId("userTask").list()).hasSize(1);
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityId("intermediate-event").list()).hasSize(1);
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityId("start").list()).hasSize(1);
+        assertThat(historyService.createHistoricActivityInstanceQuery().activityId("end").list()).hasSize(1);
 
         // TODO: Discuss if boundary events will occur in the log! 
-        // assertEquals(1,
-        // historyService.createHistoricActivityInstanceQuery().activityId("boundaryEvent").list().size());
+        // assertThat(
+        // historyService.createHistoricActivityInstanceQuery().activityId("boundaryEvent").list()).hasSize(1);
 
         HistoricActivityInstance intermediateEvent = historyService.createHistoricActivityInstanceQuery().activityId("intermediate-event").singleResult();
-        assertNotNull(intermediateEvent.getStartTime());
-        assertNotNull(intermediateEvent.getEndTime());
+        assertThat(intermediateEvent.getStartTime()).isNotNull();
+        assertThat(intermediateEvent.getEndTime()).isNotNull();
 
         HistoricActivityInstance startEvent = historyService.createHistoricActivityInstanceQuery().activityId("start").singleResult();
-        assertNotNull(startEvent.getStartTime());
-        assertNotNull(startEvent.getEndTime());
+        assertThat(startEvent.getStartTime()).isNotNull();
+        assertThat(startEvent.getEndTime()).isNotNull();
 
         HistoricActivityInstance endEvent = historyService.createHistoricActivityInstanceQuery().activityId("end").singleResult();
-        assertNotNull(endEvent.getStartTime());
-        assertNotNull(endEvent.getEndTime());
+        assertThat(endEvent.getStartTime()).isNotNull();
+        assertThat(endEvent.getEndTime()).isNotNull();
     }
 
     @Test
@@ -291,8 +291,8 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertActivityInstancesAreSame(historicActivityInstance, runtimeService.createActivityInstanceQuery().activityInstanceId(historicActivityInstance.getId()).singleResult());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals(task.getId(), historicActivityInstance.getTaskId());
-        assertEquals("kermit", historicActivityInstance.getAssignee());
+        assertThat(historicActivityInstance.getTaskId()).isEqualTo(task.getId());
+        assertThat(historicActivityInstance.getAssignee()).isEqualTo("kermit");
     }
 
     @Test
@@ -306,7 +306,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         HistoricProcessInstance oldInstance = historyService.createHistoricProcessInstanceQuery().processDefinitionKey("calledProcess").singleResult();
 
-        assertEquals(oldInstance.getId(), historicActivityInstance.getCalledProcessInstanceId());
+        assertThat(historicActivityInstance.getCalledProcessInstanceId()).isEqualTo(oldInstance.getId());
     }
 
     @Test
@@ -321,61 +321,49 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
             expectedActivityInstances = 0;
         }
 
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().asc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceStartTime().asc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceEndTime().asc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().asc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessDefinitionId().asc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().asc().list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().asc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceStartTime().asc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceEndTime().asc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().asc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByProcessDefinitionId().asc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().asc().list()).hasSize(expectedActivityInstances);
 
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().desc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceStartTime().desc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceEndTime().desc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().desc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByExecutionId().desc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessDefinitionId().desc().list().size());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().desc().list().size());
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().desc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceStartTime().desc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceEndTime().desc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().desc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByExecutionId().desc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByProcessDefinitionId().desc().list()).hasSize(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().desc().list()).hasSize(expectedActivityInstances);
 
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().asc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceStartTime().asc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceEndTime().asc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().asc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessDefinitionId().asc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().asc().count());
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().asc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceStartTime().asc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceEndTime().asc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().asc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByProcessDefinitionId().asc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().asc().count()).isEqualTo(expectedActivityInstances);
 
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().desc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceStartTime().desc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceEndTime().desc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().desc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByExecutionId().desc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessDefinitionId().desc().count());
-        assertEquals(expectedActivityInstances, historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().desc().count());
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceId().desc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceStartTime().desc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceEndTime().desc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().desc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByExecutionId().desc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByProcessDefinitionId().desc().count()).isEqualTo(expectedActivityInstances);
+        assertThat(historyService.createHistoricActivityInstanceQuery().orderByProcessInstanceId().desc().count()).isEqualTo(expectedActivityInstances);
     }
 
     @Test
     public void testInvalidSorting() {
-        try {
-            historyService.createHistoricActivityInstanceQuery().asc().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
+        assertThatThrownBy(() -> historyService.createHistoricActivityInstanceQuery().asc().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
 
-        }
+        assertThatThrownBy(() -> historyService.createHistoricActivityInstanceQuery().desc().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
 
-        try {
-            historyService.createHistoricActivityInstanceQuery().desc().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-
-        }
-
-        try {
-            historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-
-        }
+        assertThatThrownBy(() -> historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     /**
@@ -387,15 +375,15 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("boundaryEventProcess");
         // Complete the task with the boundary-event on it
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0L);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("boundary").processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(historicActivityInstance);
+        assertThat(historicActivityInstance).isNotNull();
 
         // Now check the history when the boundary-event is fired
         processInstance = runtimeService.startProcessInstanceByKey("boundaryEventProcess");
@@ -404,15 +392,15 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         Execution signalExecution = runtimeService.createExecutionQuery().signalEventSubscriptionName("alert").singleResult();
         runtimeService.signalEventReceived("alert", signalExecution.getId());
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0L);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("boundary").processInstanceId(processInstance.getId()).singleResult();
 
-        assertNotNull(historicActivityInstance);
-        assertNotNull(historicActivityInstance.getStartTime());
-        assertNotNull(historicActivityInstance.getEndTime());
+        assertThat(historicActivityInstance).isNotNull();
+        assertThat(historicActivityInstance.getStartTime()).isNotNull();
+        assertThat(historicActivityInstance.getEndTime()).isNotNull();
     }
 
     /**
@@ -423,16 +411,16 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
     public void testEventBasedGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("catchSignal");
         Execution waitingExecution = runtimeService.createExecutionQuery().signalEventSubscriptionName("alert").singleResult();
-        assertNotNull(waitingExecution);
+        assertThat(waitingExecution).isNotNull();
         runtimeService.signalEventReceived("alert", waitingExecution.getId());
 
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0L);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("eventBasedgateway").processInstanceId(processInstance.getId()).singleResult();
 
-        assertNotNull(historicActivityInstance);
+        assertThat(historicActivityInstance).isNotNull();
     }
 
     /**
@@ -444,7 +432,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("forkJoin");
 
         List<org.flowable.task.api.Task> tasksToComplete = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasksToComplete.size());
+        assertThat(tasksToComplete).hasSize(2);
 
         // Complete both tasks, second task-complete should end the fork-gateway and set time
         taskService.complete(tasksToComplete.get(0).getId());
@@ -454,13 +442,13 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         List<HistoricActivityInstance> historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("join").processInstanceId(processInstance.getId()).list();
 
-        assertNotNull(historicActivityInstance);
+        assertThat(historicActivityInstance).isNotNull();
 
         // History contains 2 entries for parallel join (one for each path
         // arriving in the join), should contain end-time
-        assertEquals(2, historicActivityInstance.size());
-        assertNotNull(historicActivityInstance.get(0).getEndTime());
-        assertNotNull(historicActivityInstance.get(1).getEndTime());
+        assertThat(historicActivityInstance).hasSize(2);
+        assertThat(historicActivityInstance.get(0).getEndTime()).isNotNull();
+        assertThat(historicActivityInstance.get(1).getEndTime()).isNotNull();
     }
 
     @Test
@@ -475,7 +463,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             Number inputNumber = (Number) taskService.getVariable(task.getId(), "input");
             int input = inputNumber.intValue();
-            assertEquals(i, input);
+            assertThat(input).isEqualTo(i);
             taskService.complete(task.getId(), CollectionUtil.singletonMap("input", input + 1));
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         }
@@ -484,17 +472,17 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         // Verify history
         List<HistoricActivityInstance> taskActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("userTask").list();
-        assertEquals(10, taskActivityInstances.size());
+        assertThat(taskActivityInstances).hasSize(10);
         for (HistoricActivityInstance historicActivityInstance : taskActivityInstances) {
-            assertNotNull(historicActivityInstance.getStartTime());
-            assertNotNull(historicActivityInstance.getEndTime());
+            assertThat(historicActivityInstance.getStartTime()).isNotNull();
+            assertThat(historicActivityInstance.getEndTime()).isNotNull();
         }
 
         List<HistoricActivityInstance> serviceTaskInstances = historyService.createHistoricActivityInstanceQuery().activityType("serviceTask").list();
-        assertEquals(15, serviceTaskInstances.size());
+        assertThat(serviceTaskInstances).hasSize(15);
         for (HistoricActivityInstance historicActivityInstance : serviceTaskInstances) {
-            assertNotNull(historicActivityInstance.getStartTime());
-            assertNotNull(historicActivityInstance.getEndTime());
+            assertThat(historicActivityInstance.getStartTime()).isNotNull();
+            assertThat(historicActivityInstance.getEndTime()).isNotNull();
         }
     }
 
@@ -511,10 +499,9 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricActivityInstance callSubProcessActivityInstance = historyService.createHistoricActivityInstanceQuery().processInstanceId(pi.getId())
                 .activityId("callSubProcess").singleResult();
-            assertThat(callSubProcessActivityInstance.getCalledProcessInstanceId(), is(
-                runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult().getId()));
+            assertThat(callSubProcessActivityInstance.getCalledProcessInstanceId()).isEqualTo(
+                runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult().getId());
         }
     }
-
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.text.SimpleDateFormat;
@@ -68,19 +69,19 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         String taskId = runtimeTask.getId();
         String taskDefinitionKey = runtimeTask.getTaskDefinitionKey();
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(1);
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
-        assertEquals(taskId, historicTaskInstance.getId());
-        assertEquals(1234, historicTaskInstance.getPriority());
-        assertEquals("Clean up", historicTaskInstance.getName());
-        assertEquals("Schedule an engineering meeting for next week with the new hire.", historicTaskInstance.getDescription());
-        assertEquals(dueDate, historicTaskInstance.getDueDate());
-        assertEquals("kermit", historicTaskInstance.getAssignee());
-        assertEquals(taskDefinitionKey, historicTaskInstance.getTaskDefinitionKey());
-        assertEquals("expressionFormKey", historicTaskInstance.getFormKey());
-        assertNull(historicTaskInstance.getEndTime());
-        assertNull(historicTaskInstance.getDurationInMillis());
-        assertNull(historicTaskInstance.getWorkTimeInMillis());
+        assertThat(historicTaskInstance.getId()).isEqualTo(taskId);
+        assertThat(historicTaskInstance.getPriority()).isEqualTo(1234);
+        assertThat(historicTaskInstance.getName()).isEqualTo("Clean up");
+        assertThat(historicTaskInstance.getDescription()).isEqualTo("Schedule an engineering meeting for next week with the new hire.");
+        assertThat(historicTaskInstance.getDueDate()).isEqualTo(dueDate);
+        assertThat(historicTaskInstance.getAssignee()).isEqualTo("kermit");
+        assertThat(historicTaskInstance.getTaskDefinitionKey()).isEqualTo(taskDefinitionKey);
+        assertThat(historicTaskInstance.getFormKey()).isEqualTo("expressionFormKey");
+        assertThat(historicTaskInstance.getEndTime()).isNull();
+        assertThat(historicTaskInstance.getDurationInMillis()).isNull();
+        assertThat(historicTaskInstance.getWorkTimeInMillis()).isNull();
 
         runtimeService.setVariable(processInstanceId, "deadline", "yesterday");
 
@@ -88,32 +89,32 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(1);
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
-        assertNotNull(historicTaskInstance.getClaimTime());
-        assertNull(historicTaskInstance.getWorkTimeInMillis());
-        assertEquals("expressionFormKey", historicTaskInstance.getFormKey());
+        assertThat(historicTaskInstance.getClaimTime()).isNotNull();
+        assertThat(historicTaskInstance.getWorkTimeInMillis()).isNull();
+        assertThat(historicTaskInstance.getFormKey()).isEqualTo("expressionFormKey");
 
         taskService.complete(taskId);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(1);
 
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
-        assertEquals(taskId, historicTaskInstance.getId());
-        assertEquals(1234, historicTaskInstance.getPriority());
-        assertEquals("Clean up", historicTaskInstance.getName());
-        assertEquals("Schedule an engineering meeting for next week with the new hire.", historicTaskInstance.getDescription());
-        assertEquals(dueDate, historicTaskInstance.getDueDate());
-        assertEquals("kermit", historicTaskInstance.getAssignee());
-        assertNull(historicTaskInstance.getDeleteReason());
-        assertEquals(taskDefinitionKey, historicTaskInstance.getTaskDefinitionKey());
-        assertEquals("expressionFormKey", historicTaskInstance.getFormKey());
-        assertNotNull(historicTaskInstance.getEndTime());
-        assertNotNull(historicTaskInstance.getDurationInMillis());
-        assertNotNull(historicTaskInstance.getClaimTime());
-        assertNotNull(historicTaskInstance.getWorkTimeInMillis());
+        assertThat(historicTaskInstance.getId()).isEqualTo(taskId);
+        assertThat(historicTaskInstance.getPriority()).isEqualTo(1234);
+        assertThat(historicTaskInstance.getName()).isEqualTo("Clean up");
+        assertThat(historicTaskInstance.getDescription()).isEqualTo("Schedule an engineering meeting for next week with the new hire.");
+        assertThat(historicTaskInstance.getDueDate()).isEqualTo(dueDate);
+        assertThat(historicTaskInstance.getAssignee()).isEqualTo("kermit");
+        assertThat(historicTaskInstance.getDeleteReason()).isNull();
+        assertThat(historicTaskInstance.getTaskDefinitionKey()).isEqualTo(taskDefinitionKey);
+        assertThat(historicTaskInstance.getFormKey()).isEqualTo("expressionFormKey");
+        assertThat(historicTaskInstance.getEndTime()).isNotNull();
+        assertThat(historicTaskInstance.getDurationInMillis()).isNotNull();
+        assertThat(historicTaskInstance.getClaimTime()).isNotNull();
+        assertThat(historicTaskInstance.getWorkTimeInMillis()).isNotNull();
 
         historyService.deleteHistoricTaskInstance(taskId);
         managementService.executeCommand(commandContext -> {
@@ -123,7 +124,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -161,87 +162,87 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // org.flowable.task.service.Task id
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(taskId).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskId("unexistingtaskid").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskId(taskId).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskId("unexistingtaskid").count()).isZero();
 
         // Name
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskName("Clean up").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskName("unexistingname").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskNameLike("Clean u%").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskNameLike("%lean up").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskNameLike("%lean u%").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskNameLike("%unexistingname%").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskName("Clean up").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskName("unexistingname").count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLike("Clean u%").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLike("%lean up").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLike("%lean u%").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLike("%unexistingname%").count()).isZero();
 
         // Description
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDescription("Historic task description").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDescription("unexistingdescription").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("%task description").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("Historic task %").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("%task%").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("%unexistingdescripton%").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDescription("Historic task description").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDescription("unexistingdescription").count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("%task description").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("Historic task %").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("%task%").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("%unexistingdescripton%").count()).isZero();
 
         // Execution id
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processInstanceId(finishedInstance.getId()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().executionId("unexistingexecution").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(finishedInstance.getId()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().executionId("unexistingexecution").count()).isZero();
 
         // Process instance id
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processInstanceId(finishedInstance.getId()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processInstanceId("unexistingid").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(finishedInstance.getId()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId("unexistingid").count()).isZero();
 
         // Process instance business key
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKey("myBusinessKey").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKey("unexistingKey").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKey("myBusinessKey").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKey("unexistingKey").count()).isZero();
 
         // Process definition id
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processDefinitionId(finishedInstance.getProcessDefinitionId()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processDefinitionId("unexistingdefinitionid").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionId(finishedInstance.getProcessDefinitionId()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionId("unexistingdefinitionid").count()).isZero();
 
         // Process definition name
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processDefinitionName("Historic task query test process").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processDefinitionName("unexistingdefinitionname").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionName("Historic task query test process").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionName("unexistingdefinitionname").count()).isZero();
 
         // Process definition key
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processDefinitionKey("HistoricTaskQueryTest").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processDefinitionKey("unexistingdefinitionkey").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKey("HistoricTaskQueryTest").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKey("unexistingdefinitionkey").count()).isZero();
 
         // Process definition key in
         List<String> includeIds = new ArrayList<>();
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processDefinitionKeyIn(includeIds).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKeyIn(includeIds).count()).isEqualTo(1);
         includeIds.add("unexistingProcessDefinition");
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processDefinitionKeyIn(includeIds).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKeyIn(includeIds).count()).isZero();
         includeIds.add("HistoricTaskQueryTest");
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyIn(includeIds).count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKeyIn(includeIds).count()).isEqualTo(1);
 
         // Form key
         HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(finishedInstance.getId()).singleResult();
-        assertEquals("testFormKey", historicTask.getFormKey());
+        assertThat(historicTask.getFormKey()).isEqualTo("testFormKey");
 
         // Assignee
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssignee("kermit").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskAssignee("johndoe").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("%ermit").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("kermi%").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("%ermi%").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("%johndoe%").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskAssignee("kermit").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskAssignee("johndoe").count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("%ermit").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("kermi%").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("%ermi%").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("%johndoe%").count()).isZero();
 
         // Delete reason
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDeleteReason("deleted").count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskWithoutDeleteReason().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDeleteReason("deleted").count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskWithoutDeleteReason().count()).isEqualTo(1);
 
         // org.flowable.task.service.Task definition ID
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("task").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("unexistingkey").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("task").count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("unexistingkey").count()).isZero();
 
         // org.flowable.task.service.Task priority
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskPriority(1234).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskPriority(5678).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskPriority(1234).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskPriority(5678).count()).isZero();
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskMinPriority(1234).count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskMinPriority(1000).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskMinPriority(1300).count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskMaxPriority(1234).count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskMaxPriority(1300).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskMaxPriority(1000).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskMinPriority(1234).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskMinPriority(1000).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskMinPriority(1300).count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskMaxPriority(1234).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskMaxPriority(1300).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskMaxPriority(1000).count()).isZero();
 
         // Due date
         Calendar anHourAgo = Calendar.getInstance();
@@ -252,17 +253,17 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         anHourLater.setTime(dueDate);
         anHourLater.add(Calendar.HOUR, 1);
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDueDate(dueDate).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueDate(anHourAgo.getTime()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueDate(anHourLater.getTime()).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDueDate(dueDate).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDueDate(anHourAgo.getTime()).count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDueDate(anHourLater.getTime()).count()).isZero();
 
         // Due date before
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDueBefore(anHourLater.getTime()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueBefore(anHourAgo.getTime()).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDueBefore(anHourLater.getTime()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDueBefore(anHourAgo.getTime()).count()).isZero();
 
         // Due date after
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDueAfter(anHourAgo.getTime()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueAfter(anHourLater.getTime()).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDueAfter(anHourAgo.getTime()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDueAfter(anHourLater.getTime()).count()).isZero();
 
         anHourAgo = new GregorianCalendar();
         anHourAgo.setTime(start.getTime());
@@ -274,37 +275,37 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         // Start date
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskCreatedOn(start.getTime()).count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskCreatedOn(anHourAgo.getTime()).count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskCreatedOn(start.getTime()).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskCreatedOn(anHourAgo.getTime()).count()).isZero();
         }
         
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskCreatedAfter(anHourAgo.getTime()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskCreatedAfter(anHourLater.getTime()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskCreatedBefore(anHourAgo.getTime()).count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskCreatedBefore(anHourLater.getTime()).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskCreatedAfter(anHourAgo.getTime()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskCreatedAfter(anHourLater.getTime()).count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskCreatedBefore(anHourAgo.getTime()).count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskCreatedBefore(anHourLater.getTime()).count()).isEqualTo(1);
 
         // Completed date
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskCompletedAfter(anHourAgo.getTime()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskCompletedAfter(anHourLater.getTime()).count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskCompletedBefore(anHourAgo.getTime()).count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskCompletedBefore(anHourLater.getTime()).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskCompletedAfter(anHourAgo.getTime()).count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskCompletedAfter(anHourLater.getTime()).count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskCompletedBefore(anHourAgo.getTime()).count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskCompletedBefore(anHourLater.getTime()).count()).isEqualTo(1);
 
         // Filter based on identity-links Assignee is involved
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskInvolvedUser("kermit").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedUser("kermit").count()).isEqualTo(1);
 
         // Owner is involved
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskInvolvedUser("fozzie").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedUser("fozzie").count()).isEqualTo(1);
 
         // Manually involved person
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskInvolvedUser("gonzo").count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedUser("gonzo").count()).isEqualTo(1);
 
         // Finished and Unfinished - Add anther other instance that has a running task (unfinished)
         runtimeService.startProcessInstanceByKey("HistoricTaskQueryTest");
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().finished().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().unfinished().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().finished().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().unfinished().count()).isEqualTo(1);
     }
 
     @Test
@@ -353,7 +354,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
     public void testHistoricIdentityLinksForTaskOwner() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTaskProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         String taskId = task.getId();
         taskService.setOwner(taskId, "kermit");
@@ -362,41 +363,41 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         // task is still active
         List<HistoricIdentityLink> historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
-        assertEquals(1, historicIdentityLinksForTask.size());
-        assertNotNull(historicIdentityLinksForTask.get(0).getCreateTime());
+        assertThat(historicIdentityLinksForTask).hasSize(1);
+        assertThat(historicIdentityLinksForTask.get(0).getCreateTime()).isNotNull();
 
-        assertEquals("kermit", historicIdentityLinksForTask.get(0).getUserId());
-        assertEquals(IdentityLinkType.OWNER, historicIdentityLinksForTask.get(0).getType());
+        assertThat(historicIdentityLinksForTask.get(0).getUserId()).isEqualTo("kermit");
+        assertThat(historicIdentityLinksForTask.get(0).getType()).isEqualTo(IdentityLinkType.OWNER);
 
         // change owner
         taskService.setOwner(taskId, "gonzo");
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
-        assertEquals(2, historicIdentityLinksForTask.size());
+        assertThat(historicIdentityLinksForTask).hasSize(2);
 
         taskService.setOwner(taskId, null);
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
-        assertEquals(3, historicIdentityLinksForTask.size());
+        assertThat(historicIdentityLinksForTask).hasSize(3);
 
         taskService.complete(taskId);
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
-        assertEquals(3, historicIdentityLinksForTask.size());
+        assertThat(historicIdentityLinksForTask).hasSize(3);
 
         for (HistoricIdentityLink link : historicIdentityLinksForTask) {
-            assertNotNull(link.getCreateTime());
+            assertThat(link.getCreateTime()).isNotNull();
         }
 
         org.flowable.task.api.Task secondTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(secondTask);
+        assertThat(secondTask).isNotNull();
 
         secondTask.setOwner("fozzie");
         taskService.saveTask(secondTask);
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(secondTask.getId());
-        assertEquals(1, historicIdentityLinksForTask.size());
-        assertNotNull(historicIdentityLinksForTask.get(0).getCreateTime());
+        assertThat(historicIdentityLinksForTask).hasSize(1);
+        assertThat(historicIdentityLinksForTask.get(0).getCreateTime()).isNotNull();
     }
 
     @Test
@@ -404,7 +405,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
     public void testHistoricIdentityLinksOnTaskClaim() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTaskProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // over a time period the task can be claimed by multiple users we must keep track of who claimed it
         String taskId = task.getId();
@@ -421,7 +422,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         
         // task is still active
         List<HistoricIdentityLink> historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(task.getId());
-        assertEquals(6, historicIdentityLinksForTask.size());
+        assertThat(historicIdentityLinksForTask).hasSize(6);
 
         int nullCount = 0;
         int kermitCount = 0;
@@ -430,28 +431,28 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         // The order of history identity links is not guaranteed.
         for (HistoricIdentityLink link : historicIdentityLinksForTask) {
-            assertEquals("Expected ASSIGNEE lnk type", IdentityLinkType.ASSIGNEE, link.getType());
+            assertThat(link.getType()).as("Expected ASSIGNEE lnk type").isEqualTo(IdentityLinkType.ASSIGNEE);
             if (link.getUserId() == null) {
                 nullCount++;
             } else if ("kermit".equals(link.getUserId())) {
                 kermitCount++;
-                assertNotNull(link.getCreateTime());
+                assertThat(link.getCreateTime()).isNotNull();
             } else if ("fozzie".equals(link.getUserId())) {
                 fozzieCount++;
-                assertNotNull(link.getCreateTime());
+                assertThat(link.getCreateTime()).isNotNull();
             } else if ("gonzo".equals(link.getUserId())) {
-                assertNotNull(link.getCreateTime());
+                assertThat(link.getCreateTime()).isNotNull();
                 gonzoCount++;
             }
         }
 
-        assertEquals(3, nullCount);
-        assertEquals(1, kermitCount);
-        assertEquals(1, fozzieCount);
-        assertEquals(1, gonzoCount);
+        assertThat(nullCount).isEqualTo(3);
+        assertThat(kermitCount).isEqualTo(1);
+        assertThat(fozzieCount).isEqualTo(1);
+        assertThat(gonzoCount).isEqualTo(1);
 
         List<HistoricIdentityLink> historicIdentityLinksForProcess = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
-        assertEquals(3, historicIdentityLinksForProcess.size());
+        assertThat(historicIdentityLinksForProcess).hasSize(3);
 
         // historic links should be present after the task is completed
         taskService.complete(taskId);
@@ -466,7 +467,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         // The order of history identity links is not guaranteed.
         for (HistoricIdentityLink link : historicIdentityLinksForTask) {
-            assertEquals("Expected ASSIGNEE lnk type", IdentityLinkType.ASSIGNEE, link.getType());
+            assertThat(link.getType()).as("Expected ASSIGNEE lnk type").isEqualTo(IdentityLinkType.ASSIGNEE);
             if (link.getUserId() == null) {
                 nullCount++;
             } else if ("kermit".equals(link.getUserId())) {
@@ -478,16 +479,16 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertEquals(3, nullCount);
-        assertEquals(1, kermitCount);
-        assertEquals(1, fozzieCount);
-        assertEquals(1, gonzoCount);
+        assertThat(nullCount).isEqualTo(3);
+        assertThat(kermitCount).isEqualTo(1);
+        assertThat(fozzieCount).isEqualTo(1);
+        assertThat(gonzoCount).isEqualTo(1);
 
         historicIdentityLinksForProcess = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
-        assertEquals(3, historicIdentityLinksForProcess.size());
+        assertThat(historicIdentityLinksForProcess).hasSize(3);
 
         org.flowable.task.api.Task secondTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(secondTask);
+        assertThat(secondTask).isNotNull();
 
         String secondTaskId = secondTask.getId();
         taskService.setAssignee(secondTaskId, "newKid");
@@ -496,7 +497,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         // 4 users now participated to the process
         historicIdentityLinksForProcess = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
-        assertEquals(4, historicIdentityLinksForProcess.size());
+        assertThat(historicIdentityLinksForProcess).hasSize(4);
 
         // 4 users participated after the last task (and the process) is completed
         taskService.complete(secondTaskId);
@@ -504,11 +505,11 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         historicIdentityLinksForProcess = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
-        assertEquals(4, historicIdentityLinksForProcess.size());
+        assertThat(historicIdentityLinksForProcess).hasSize(4);
 
         historicIdentityLinksForTask = historyService.getHistoricIdentityLinksForTask(secondTaskId);
-        assertEquals(1, historicIdentityLinksForTask.size());
-        assertEquals("newKid", historicIdentityLinksForTask.get(0).getUserId());
+        assertThat(historicIdentityLinksForTask).hasSize(1);
+        assertThat(historicIdentityLinksForTask.get(0).getUserId()).isEqualTo("newKid");
     }
 
     @Test
@@ -539,73 +540,73 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // org.flowable.task.service.Task id
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskId(taskId).endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskId(taskId).or().taskId(taskId).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskId("unexistingtaskid").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskId("unexistingtaskid").endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskId(taskId).taskName("Clean up").endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskId("unexistingtaskid").taskName("Clean up").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskId("unexistingtaskid").taskName("unexistingname").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId(taskId).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskId(taskId).or().taskId(taskId).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskId("unexistingtaskid").count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("unexistingtaskid").endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId(taskId).taskName("Clean up").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("unexistingtaskid").taskName("Clean up").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("unexistingtaskid").taskName("unexistingname").endOr().count()).isZero();
 
         // Name
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskName("Clean up").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskName("unexistingname").endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskNameLike("Clean u%").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskNameLike("%unexistingname%").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskName("Clean up").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskName("unexistingname").endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameLike("Clean u%").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameLike("%unexistingname%").endOr().count()).isZero();
         final List<String> taskNameList = new ArrayList<>(1);
         taskNameList.add("Clean up");
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskNameIn(taskNameList).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameIn(taskNameList).endOr().count()).isEqualTo(1);
         taskNameList.clear();
         taskNameList.add("unexistingname");
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskNameIn(taskNameList).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameIn(taskNameList).endOr().count()).isZero();
         taskNameList.clear();
         taskNameList.add("clean up");
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskNameInIgnoreCase(taskNameList).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameInIgnoreCase(taskNameList).endOr().count()).isEqualTo(1);
         taskNameList.clear();
         taskNameList.add("unexistingname");
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskNameInIgnoreCase(taskNameList).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameInIgnoreCase(taskNameList).endOr().count()).isZero();
 
         taskNameList.clear();
         taskNameList.add("clean up");
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskName("Clean up").endOr().or().taskNameInIgnoreCase(taskNameList).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskName("Clean up").endOr().or().taskNameInIgnoreCase(taskNameList).endOr().count()).isEqualTo(1);
         taskNameList.clear();
         taskNameList.add("unexistingname");
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskName("Clean up").endOr().or().taskNameInIgnoreCase(taskNameList).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskName("Clean up").endOr().or().taskNameInIgnoreCase(taskNameList).endOr().count()).isZero();
 
         // Description
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskDescription("Historic task description").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDescription("unexistingdescription").endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskDescriptionLike("%task description").endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskDescriptionLike("%task description").taskDescription("unexistingdescription").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("%unexistingdescripton%").count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDescriptionLike("%unexistingdescripton%").taskDescription("unexistingdescription").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDescription("Historic task description").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDescription("unexistingdescription").endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDescriptionLike("%task description").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDescriptionLike("%task description").taskDescription("unexistingdescription").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLike("%unexistingdescripton%").count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDescriptionLike("%unexistingdescripton%").taskDescription("unexistingdescription").endOr().count()).isZero();
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskDescription("Historic task description").endOr().or().taskDescriptionLike("%task description").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDescription("Historic task description").endOr().or().taskDescriptionLike("%task description2").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDescription("Historic task description").endOr().or().taskDescriptionLike("%task description").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDescription("Historic task description").endOr().or().taskDescriptionLike("%task description2").endOr().count()).isZero();
 
         // Execution id
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processInstanceId(finishedInstance.getId()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().executionId("unexistingexecution").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processInstanceId(finishedInstance.getId()).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().executionId("unexistingexecution").endOr().count()).isZero();
 
         // Process instance id
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processInstanceId(finishedInstance.getId()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processInstanceId("unexistingid").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processInstanceId(finishedInstance.getId()).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processInstanceId("unexistingid").endOr().count()).isZero();
 
         // Process instance business key
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processInstanceBusinessKey("myBusinessKey").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processInstanceBusinessKey("unexistingKey").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processInstanceBusinessKey("myBusinessKey").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processInstanceBusinessKey("unexistingKey").endOr().count()).isZero();
 
         // Process definition id
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processDefinitionId(finishedInstance.getProcessDefinitionId()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processDefinitionId("unexistingdefinitionid").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionId(finishedInstance.getProcessDefinitionId()).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionId("unexistingdefinitionid").endOr().count()).isZero();
 
         // Process definition name
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processDefinitionName("Historic task query test process").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processDefinitionName("unexistingdefinitionname").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionName("Historic task query test process").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionName("unexistingdefinitionname").endOr().count()).isZero();
 
         // Process definition key
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("HistoricTaskQueryTest").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("HistoricTaskQueryTest").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").endOr().count()).isZero();
 
         // Process definition key and ad hoc task
         org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -613,51 +614,51 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskId(adhocTask.getId()).processDefinitionKey("unexistingdefinitionkey").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId(adhocTask.getId()).processDefinitionKey("unexistingdefinitionkey").endOr().count()).isEqualTo(1);
         taskService.deleteTask(adhocTask.getId(), true);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Process definition key in
         List<String> includeIds = new ArrayList<>();
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count()).isZero();
         includeIds.add("unexistingProcessDefinition");
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count()).isZero();
         includeIds.add("unexistingProcessDefinition");
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("HistoricTaskQueryTest").processDefinitionKeyIn(includeIds).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("HistoricTaskQueryTest").processDefinitionKeyIn(includeIds).endOr().count()).isEqualTo(1);
         includeIds.add("HistoricTaskQueryTest");
-        assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count());
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count()).isEqualTo(1);
 
         // Assignee
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskAssignee("johndoe").endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskAssigneeLike("%ermit").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskAssigneeLike("%johndoe%").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssignee("johndoe").endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssigneeLike("%ermit").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssigneeLike("%johndoe%").endOr().count()).isZero();
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().or().taskAssigneeLike("%ermit").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().or().taskAssigneeLike("%johndoe%").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().or().taskAssigneeLike("%ermit").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().or().taskAssigneeLike("%johndoe%").endOr().count()).isZero();
 
         // Delete reason
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDeleteReason("deleted").endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskWithoutDeleteReason().endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDeleteReason("deleted").endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskWithoutDeleteReason().endOr().count()).isEqualTo(1);
 
         // org.flowable.task.service.Task definition ID
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskDefinitionKey("task").endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDefinitionKey("unexistingkey").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDefinitionKey("task").endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDefinitionKey("unexistingkey").endOr().count()).isZero();
 
         // org.flowable.task.service.Task priority
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskPriority(1234).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskPriority(5678).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskPriority(1234).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskPriority(5678).endOr().count()).isZero();
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskMinPriority(1234).endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskMinPriority(1000).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskMinPriority(1300).endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskMaxPriority(1234).endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskMaxPriority(1300).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskMaxPriority(1000).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskMinPriority(1234).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskMinPriority(1000).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskMinPriority(1300).endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskMaxPriority(1234).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskMaxPriority(1300).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskMaxPriority(1000).endOr().count()).isZero();
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskPriority(1234).endOr().or().taskMinPriority(1234).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskPriority(1234).endOr().or().taskMinPriority(1300).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskPriority(1234).endOr().or().taskMinPriority(1234).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskPriority(1234).endOr().or().taskMinPriority(1300).endOr().count()).isZero();
 
         // Due date
         Calendar anHourAgo = Calendar.getInstance();
@@ -668,17 +669,17 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         anHourLater.setTime(dueDate);
         anHourLater.add(Calendar.HOUR, 1);
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskDueDate(dueDate).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDueDate(anHourAgo.getTime()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDueDate(anHourLater.getTime()).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDueDate(dueDate).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDueDate(anHourAgo.getTime()).endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDueDate(anHourLater.getTime()).endOr().count()).isZero();
 
         // Due date before
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskDueBefore(anHourLater.getTime()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDueBefore(anHourAgo.getTime()).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDueBefore(anHourLater.getTime()).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDueBefore(anHourAgo.getTime()).endOr().count()).isZero();
 
         // Due date after
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskDueAfter(anHourAgo.getTime()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskDueAfter(anHourLater.getTime()).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDueAfter(anHourAgo.getTime()).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskDueAfter(anHourLater.getTime()).endOr().count()).isZero();
 
         anHourAgo = new GregorianCalendar();
         anHourAgo.setTime(start.getTime());
@@ -690,37 +691,37 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         // Start date
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
-            assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskCreatedOn(start.getTime()).endOr().count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskCreatedOn(anHourAgo.getTime()).endOr().count());
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCreatedOn(start.getTime()).endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCreatedOn(anHourAgo.getTime()).endOr().count()).isZero();
         }
         
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskCreatedAfter(anHourAgo.getTime()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskCreatedAfter(anHourLater.getTime()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskCreatedBefore(anHourAgo.getTime()).endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskCreatedBefore(anHourLater.getTime()).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCreatedAfter(anHourAgo.getTime()).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCreatedAfter(anHourLater.getTime()).endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCreatedBefore(anHourAgo.getTime()).endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCreatedBefore(anHourLater.getTime()).endOr().count()).isEqualTo(1);
 
         // Completed date
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskCompletedAfter(anHourAgo.getTime()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskCompletedAfter(anHourLater.getTime()).endOr().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskCompletedBefore(anHourAgo.getTime()).endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskCompletedBefore(anHourLater.getTime()).endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCompletedAfter(anHourAgo.getTime()).endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCompletedAfter(anHourLater.getTime()).endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCompletedBefore(anHourAgo.getTime()).endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskCompletedBefore(anHourLater.getTime()).endOr().count()).isEqualTo(1);
 
         // Filter based on identity-links Assignee is involved
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskInvolvedUser("kermit").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskInvolvedUser("kermit").endOr().count()).isEqualTo(1);
 
         // Owner is involved
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskInvolvedUser("fozzie").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskInvolvedUser("fozzie").endOr().count()).isEqualTo(1);
 
         // Manually involved person
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskInvolvedUser("gonzo").endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskInvolvedUser("gonzo").endOr().count()).isEqualTo(1);
 
         // Finished and Unfinished - Add anther other instance that has a running task (unfinished)
         runtimeService.startProcessInstanceByKey("HistoricTaskQueryTest");
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().finished().endOr().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().unfinished().endOr().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().finished().endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().unfinished().endOr().count()).isEqualTo(1);
     }
 
     @Test
@@ -732,16 +733,16 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Running task on running process should be available
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processUnfinished().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processFinished().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processUnfinished().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processFinished().count()).isZero();
 
         // Finished and running task on running process should be available
         taskService.complete(task.getId());
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
-        assertEquals(2, historyService.createHistoricTaskInstanceQuery().processUnfinished().count());
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processFinished().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processUnfinished().count()).isEqualTo(2);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processFinished().count()).isZero();
 
         // 2 finished tasks are found for finished process after completing last task of process
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -749,8 +750,8 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
-        assertEquals(0, historyService.createHistoricTaskInstanceQuery().processUnfinished().count());
-        assertEquals(2, historyService.createHistoricTaskInstanceQuery().processFinished().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processUnfinished().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().processFinished().count()).isEqualTo(2);
     }
 
     @Test
@@ -763,33 +764,33 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByDeleteReason().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByHistoricActivityInstanceId().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskCreateTime().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByProcessDefinitionId().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByProcessInstanceId().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskDescription().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskName().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskDefinitionKey().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskPriority().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskAssignee().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskId().asc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByCategory().asc().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByDeleteReason().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByHistoricActivityInstanceId().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskCreateTime().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByProcessDefinitionId().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByProcessInstanceId().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskDescription().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskName().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskDefinitionKey().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskPriority().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskAssignee().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskId().asc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByCategory().asc().count()).isEqualTo(1);
 
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByDeleteReason().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByExecutionId().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByHistoricActivityInstanceId().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskCreateTime().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByProcessDefinitionId().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByProcessInstanceId().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskDescription().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskName().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskDefinitionKey().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskPriority().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskAssignee().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByTaskId().desc().count());
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().orderByCategory().desc().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByDeleteReason().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByExecutionId().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByHistoricActivityInstanceId().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskCreateTime().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByProcessDefinitionId().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByProcessInstanceId().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskDescription().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskName().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskDefinitionKey().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskPriority().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskAssignee().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByTaskId().desc().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().orderByCategory().desc().count()).isEqualTo(1);
     }
 
     @Test
@@ -797,17 +798,17 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
     public void testHistoricIdentityLinksOnTask() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("historicIdentityLinks");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Set additional identity-link not coming from process
         taskService.addUserIdentityLink(task.getId(), "gonzo", "customUseridentityLink");
-        assertEquals(4, taskService.getIdentityLinksForTask(task.getId()).size());
+        assertThat(taskService.getIdentityLinksForTask(task.getId())).hasSize(4);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // Check historic identity-links when task is still active
         List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForTask(task.getId());
-        assertEquals(4, historicIdentityLinks.size());
+        assertThat(historicIdentityLinks).hasSize(4);
 
         // Validate all links
         boolean foundCandidateUser = false;
@@ -815,47 +816,44 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         boolean foundAssignee = false;
         boolean foundCustom = false;
         for (HistoricIdentityLink link : historicIdentityLinks) {
-            assertEquals(task.getId(), link.getTaskId());
+            assertThat(link.getTaskId()).isEqualTo(task.getId());
             if (link.getGroupId() != null) {
-                assertEquals("sales", link.getGroupId());
+                assertThat(link.getGroupId()).isEqualTo("sales");
                 foundCandidateGroup = true;
             } else {
                 if (link.getType().equals("candidate")) {
-                    assertEquals("fozzie", link.getUserId());
+                    assertThat(link.getUserId()).isEqualTo("fozzie");
                     foundCandidateUser = true;
                 } else if (link.getType().equals("assignee")) {
-                    assertEquals("kermit", link.getUserId());
+                    assertThat(link.getUserId()).isEqualTo("kermit");
                     foundAssignee = true;
                 } else if (link.getType().equals("customUseridentityLink")) {
-                    assertEquals("gonzo", link.getUserId());
+                    assertThat(link.getUserId()).isEqualTo("gonzo");
                     foundCustom = true;
                 }
             }
         }
 
-        assertTrue(foundAssignee);
-        assertTrue(foundCandidateGroup);
-        assertTrue(foundCandidateUser);
-        assertTrue(foundCustom);
+        assertThat(foundAssignee).isTrue();
+        assertThat(foundCandidateGroup).isTrue();
+        assertThat(foundCandidateUser).isTrue();
+        assertThat(foundCustom).isTrue();
 
         // Now complete the task and check if links are still there
         taskService.complete(task.getId());
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
-        assertEquals(4, historyService.getHistoricIdentityLinksForTask(task.getId()).size());
+        assertThat(historyService.getHistoricIdentityLinksForTask(task.getId())).hasSize(4);
 
         // After deleting historic task, exception should be thrown when trying to get links
         historyService.deleteHistoricTaskInstance(task.getId());
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        try {
-            historyService.getHistoricIdentityLinksForTask(task.getId()).size();
-            fail("Exception expected");
-        } catch (FlowableObjectNotFoundException aonfe) {
-            assertEquals(HistoricTaskInstance.class, aonfe.getObjectClass());
-        }
+        assertThatThrownBy(() -> historyService.getHistoricIdentityLinksForTask(task.getId()).size())
+                .isExactlyInstanceOf(FlowableObjectNotFoundException.class);
+
         managementService.executeCommand(commandContext -> {
             CommandContextUtil.getHistoricTaskService(commandContext).deleteHistoricTaskLogEntriesForTaskId(task.getId());
             return null;
@@ -864,26 +862,14 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
     @Test
     public void testInvalidSorting() {
-        try {
-            historyService.createHistoricTaskInstanceQuery().asc();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
+        assertThatThrownBy(() -> historyService.createHistoricTaskInstanceQuery().asc())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
 
-        }
+        assertThatThrownBy(() -> historyService.createHistoricTaskInstanceQuery().desc())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
 
-        try {
-            historyService.createHistoricTaskInstanceQuery().desc();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-
-        }
-
-        try {
-            historyService.createHistoricTaskInstanceQuery().orderByProcessInstanceId().list();
-            fail();
-        } catch (FlowableIllegalArgumentException e) {
-
-        }
+        assertThatThrownBy(() -> historyService.createHistoricTaskInstanceQuery().orderByProcessInstanceId().list())
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
     }
 
     /**
@@ -894,7 +880,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
     public void testVariableUpdateOrderHistoricTaskInstance() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("historicTask");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Update task and process-variable 10 times
         for (int i = 0; i < 10; i++) {
@@ -910,12 +896,12 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         HistoricTaskInstance taskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeProcessVariables().singleResult();
 
         Object varValue = taskInstance.getProcessVariables().get("procVar");
-        assertEquals(9, varValue);
+        assertThat(varValue).isEqualTo(9);
 
         taskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeTaskLocalVariables().singleResult();
 
         varValue = taskInstance.getTaskLocalVariables().get("taskVar");
-        assertEquals(9, varValue);
+        assertThat(varValue).isEqualTo(9);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceUpdateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceUpdateTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
@@ -42,13 +44,13 @@ public class HistoricTaskInstanceUpdateTest extends PluggableFlowableTestCase {
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(1);
 
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
-        assertEquals("Updated name", historicTaskInstance.getName());
-        assertEquals("Updated description", historicTaskInstance.getDescription());
-        assertEquals("gonzo", historicTaskInstance.getAssignee());
-        assertEquals("task", historicTaskInstance.getTaskDefinitionKey());
+        assertThat(historicTaskInstance.getName()).isEqualTo("Updated name");
+        assertThat(historicTaskInstance.getDescription()).isEqualTo("Updated description");
+        assertThat(historicTaskInstance.getAssignee()).isEqualTo("gonzo");
+        assertThat(historicTaskInstance.getTaskDefinitionKey()).isEqualTo("task");
 
         // Validate fix of ACT-1923: updating assignee to null should be reflected in history
         ProcessInstance secondInstance = runtimeService.startProcessInstanceByKey("HistoricTaskInstanceTest");
@@ -64,11 +66,11 @@ public class HistoricTaskInstanceUpdateTest extends PluggableFlowableTestCase {
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
-        assertEquals(1, historyService.createHistoricTaskInstanceQuery().processInstanceId(secondInstance.getId()).count());
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(secondInstance.getId()).count()).isEqualTo(1);
 
         historicTaskInstance = historyService.createHistoricTaskInstanceQuery().processInstanceId(secondInstance.getId()).singleResult();
-        assertNull(historicTaskInstance.getName());
-        assertNull(historicTaskInstance.getDescription());
-        assertNull(historicTaskInstance.getAssignee());
+        assertThat(historicTaskInstance.getName()).isNull();
+        assertThat(historicTaskInstance.getDescription()).isNull();
+        assertThat(historicTaskInstance.getAssignee()).isNull();
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,17 +50,17 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("orderProcess");
             TaskQuery taskQuery = taskService.createTaskQuery();
             org.flowable.task.api.Task verifyCreditTask = taskQuery.singleResult();
-            assertEquals("Verify credit history", verifyCreditTask.getName());
+            assertThat(verifyCreditTask.getName()).isEqualTo("Verify credit history");
 
             // Verify with Query API
             ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-            assertNotNull(subProcessInstance);
-            assertEquals(pi.getId(), runtimeService.createProcessInstanceQuery().subProcessInstanceId(subProcessInstance.getId()).singleResult().getId());
+            assertThat(subProcessInstance).isNotNull();
+            assertThat(runtimeService.createProcessInstanceQuery().subProcessInstanceId(subProcessInstance.getId()).singleResult().getId()).isEqualTo(pi.getId());
 
             // Completing the task with approval, will end the subprocess and continue the original process
             taskService.complete(verifyCreditTask.getId(), CollectionUtil.singletonMap("creditApproved", true));
             org.flowable.task.api.Task prepareAndShipTask = taskQuery.singleResult();
-            assertEquals("Prepare and Ship", prepareAndShipTask.getName());
+            assertThat(prepareAndShipTask.getName()).isEqualTo("Prepare and Ship");
         }
     }
 
@@ -69,7 +71,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc");
             TaskQuery taskQuery = taskService.createTaskQuery();
             org.flowable.task.api.Task userTask = taskQuery.singleResult();
-            assertEquals("userTask1", userTask.getName());
+            assertThat(userTask.getName()).isEqualTo("userTask1");
 
             taskService.complete(userTask.getId(), CollectionUtil.singletonMap("myVar", "test789"));
 
@@ -78,13 +80,13 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().list();
-            assertEquals(1, variables.size());
+            assertThat(variables).hasSize(1);
 
             HistoricVariableInstanceEntity historicVariable = (HistoricVariableInstanceEntity) variables.get(0);
-            assertEquals("test456", historicVariable.getTextValue());
+            assertThat(historicVariable.getTextValue()).isEqualTo("test456");
 
-            assertEquals(9, historyService.createHistoricActivityInstanceQuery().count());
-            assertEquals(3, historyService.createHistoricDetailQuery().count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(9);
+            assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(3);
         }
     }
 
@@ -98,13 +100,13 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().list();
-            assertEquals(1, variables.size());
+            assertThat(variables).hasSize(1);
 
             HistoricVariableInstanceEntity historicVariable = (HistoricVariableInstanceEntity) variables.get(0);
-            assertEquals("test456", historicVariable.getTextValue());
+            assertThat(historicVariable.getTextValue()).isEqualTo("test456");
 
-            assertEquals(7, historyService.createHistoricActivityInstanceQuery().count());
-            assertEquals(2, historyService.createHistoricDetailQuery().count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(7);
+            assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2);
         }
     }
 
@@ -115,7 +117,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc");
             TaskQuery taskQuery = taskService.createTaskQuery();
             org.flowable.task.api.Task userTask = taskQuery.singleResult();
-            assertEquals("userTask1", userTask.getName());
+            assertThat(userTask.getName()).isEqualTo("userTask1");
 
             taskService.complete(userTask.getId(), CollectionUtil.singletonMap("myVar", "test789"));
 
@@ -127,18 +129,18 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
                     .processInstanceId(processInstance.getId())
                     .orderByVariableName().asc()
                     .list();
-            assertEquals(2, variables.size());
+            assertThat(variables).hasSize(2);
 
             HistoricVariableInstanceEntity historicVariable = (HistoricVariableInstanceEntity) variables.get(0);
-            assertEquals("myVar", historicVariable.getName());
-            assertEquals("test789", historicVariable.getTextValue());
+            assertThat(historicVariable.getName()).isEqualTo("myVar");
+            assertThat(historicVariable.getTextValue()).isEqualTo("test789");
 
             HistoricVariableInstanceEntity historicVariable1 = (HistoricVariableInstanceEntity) variables.get(1);
-            assertEquals("myVar1", historicVariable1.getName());
-            assertEquals("test456", historicVariable1.getTextValue());
+            assertThat(historicVariable1.getName()).isEqualTo("myVar1");
+            assertThat(historicVariable1.getTextValue()).isEqualTo("test456");
 
-            assertEquals(15, historyService.createHistoricActivityInstanceQuery().count());
-            assertEquals(5, historyService.createHistoricDetailQuery().count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(15);
+            assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(5);
         }
     }
 
@@ -154,13 +156,13 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .list();
-            assertEquals(1, variables.size());
+            assertThat(variables).hasSize(1);
 
             HistoricVariableInstanceEntity historicVariable = (HistoricVariableInstanceEntity) variables.get(0);
-            assertEquals("test456", historicVariable.getTextValue());
+            assertThat(historicVariable.getTextValue()).isEqualTo("test456");
 
-            assertEquals(13, historyService.createHistoricActivityInstanceQuery().count());
-            assertEquals(2, historyService.createHistoricDetailQuery().count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(13);
+            assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2);
         }
     }
 
@@ -176,18 +178,18 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .orderByVariableName().asc().list();
-            assertEquals(2, variables.size());
+            assertThat(variables).hasSize(2);
 
             HistoricVariableInstanceEntity historicVariable = (HistoricVariableInstanceEntity) variables.get(0);
-            assertEquals("myVar", historicVariable.getName());
-            assertEquals("test101112", historicVariable.getTextValue());
+            assertThat(historicVariable.getName()).isEqualTo("myVar");
+            assertThat(historicVariable.getTextValue()).isEqualTo("test101112");
 
             HistoricVariableInstanceEntity historicVariable1 = (HistoricVariableInstanceEntity) variables.get(1);
-            assertEquals("myVar1", historicVariable1.getName());
-            assertEquals("test789", historicVariable1.getTextValue());
+            assertThat(historicVariable1.getName()).isEqualTo("myVar1");
+            assertThat(historicVariable1.getTextValue()).isEqualTo("test789");
 
-            assertEquals(32, historyService.createHistoricActivityInstanceQuery().count());
-            assertEquals(7, historyService.createHistoricDetailQuery().count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(32);
+            assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(7);
         }
     }
 
@@ -200,34 +202,34 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            assertEquals(4, historyService.createHistoricVariableInstanceQuery().count());
-            assertEquals(4, historyService.createHistoricVariableInstanceQuery().list().size());
-            assertEquals(4, historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().count());
-            assertEquals(4, historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().list().size());
-            assertEquals(4, historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().count());
-            assertEquals(4, historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().list().size());
+            assertThat(historyService.createHistoricVariableInstanceQuery().count()).isEqualTo(4);
+            assertThat(historyService.createHistoricVariableInstanceQuery().list()).hasSize(4);
+            assertThat(historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().count()).isEqualTo(4);
+            assertThat(historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().list()).hasSize(4);
+            assertThat(historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().count()).isEqualTo(4);
+            assertThat(historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().list()).hasSize(4);
 
-            assertEquals(2, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(2, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list().size());
-            assertEquals(2, historyService.createHistoricVariableInstanceQuery().variableName("myVar").count());
-            assertEquals(2, historyService.createHistoricVariableInstanceQuery().variableName("myVar").list().size());
-            assertEquals(2, historyService.createHistoricVariableInstanceQuery().variableNameLike("myVar1").count());
-            assertEquals(2, historyService.createHistoricVariableInstanceQuery().variableNameLike("myVar1").list().size());
+            assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
+            assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(2);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableName("myVar").count()).isEqualTo(2);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableName("myVar").list()).hasSize(2);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableNameLike("myVar1").count()).isEqualTo(2);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableNameLike("myVar1").list()).hasSize(2);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().list();
-            assertEquals(4, variables.size());
+            assertThat(variables).hasSize(4);
 
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test123").count());
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test123").list().size());
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar1", "test456").count());
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar1", "test456").list().size());
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test666").count());
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test666").list().size());
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar1", "test666").count());
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar1", "test666").list().size());
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test123").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test123").list()).hasSize(1);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar1", "test456").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar1", "test456").list()).hasSize(1);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test666").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test666").list()).hasSize(1);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar1", "test666").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar1", "test666").list()).hasSize(1);
 
-            assertEquals(14, historyService.createHistoricActivityInstanceQuery().count());
-            assertEquals(5, historyService.createHistoricDetailQuery().count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(14);
+            assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(5);
         }
     }
 
@@ -250,56 +252,56 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         // Verify historic variable instance queries
         List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .processInstanceId(processInstanceId).orderByVariableName().asc().list();
-        assertEquals(5, historicVariableInstances.size());
+        assertThat(historicVariableInstances).hasSize(5);
 
         List<String> expectedVariableNames = Arrays.asList("executionVar0", "executionVar1", "startVar", "taskVar0", "taskVar1");
         for (int i = 0; i < expectedVariableNames.size(); i++) {
-            assertEquals(expectedVariableNames.get(i), historicVariableInstances.get(i).getVariableName());
+            assertThat(historicVariableInstances.get(i).getVariableName()).isEqualTo(expectedVariableNames.get(i));
         }
 
         // by execution id
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .executionId(tasks.get(0).getExecutionId()).orderByVariableName().asc().list();
-        assertEquals(2, historicVariableInstances.size());
-        assertEquals("executionVar0", historicVariableInstances.get(0).getVariableName());
-        assertEquals("taskVar0", historicVariableInstances.get(1).getVariableName());
+        assertThat(historicVariableInstances).hasSize(2);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("executionVar0");
+        assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo("taskVar0");
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .executionId(tasks.get(1).getExecutionId()).orderByVariableName().asc().list();
-        assertEquals(2, historicVariableInstances.size());
-        assertEquals("executionVar1", historicVariableInstances.get(0).getVariableName());
-        assertEquals("taskVar1", historicVariableInstances.get(1).getVariableName());
+        assertThat(historicVariableInstances).hasSize(2);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("executionVar1");
+        assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo("taskVar1");
 
         // By process instance id and execution id
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .processInstanceId(processInstanceId).executionId(tasks.get(0).getExecutionId()).orderByVariableName().asc().list();
-        assertEquals(2, historicVariableInstances.size());
-        assertEquals("executionVar0", historicVariableInstances.get(0).getVariableName());
-        assertEquals("taskVar0", historicVariableInstances.get(1).getVariableName());
+        assertThat(historicVariableInstances).hasSize(2);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("executionVar0");
+        assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo("taskVar0");
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .processInstanceId(processInstanceId).executionId(tasks.get(1).getExecutionId()).orderByVariableName().asc().list();
-        assertEquals(2, historicVariableInstances.size());
-        assertEquals("executionVar1", historicVariableInstances.get(0).getVariableName());
-        assertEquals("taskVar1", historicVariableInstances.get(1).getVariableName());
+        assertThat(historicVariableInstances).hasSize(2);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("executionVar1");
+        assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo("taskVar1");
 
         // By task id
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .taskId(tasks.get(0).getId()).list();
-        assertEquals(1, historicVariableInstances.size());
-        assertEquals("taskVar0", historicVariableInstances.get(0).getVariableName());
+        assertThat(historicVariableInstances).hasSize(1);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("taskVar0");
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .taskId(tasks.get(1).getId()).list();
-        assertEquals(1, historicVariableInstances.size());
-        assertEquals("taskVar1", historicVariableInstances.get(0).getVariableName());
+        assertThat(historicVariableInstances).hasSize(1);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("taskVar1");
 
         // By task id and process instance id
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .processInstanceId(processInstanceId).taskId(tasks.get(0).getId()).list();
-        assertEquals(1, historicVariableInstances.size());
-        assertEquals("taskVar0", historicVariableInstances.get(0).getVariableName());
+        assertThat(historicVariableInstances).hasSize(1);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("taskVar0");
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery()
                 .processInstanceId(processInstanceId).taskId(tasks.get(1).getId()).list();
-        assertEquals(1, historicVariableInstances.size());
-        assertEquals("taskVar1", historicVariableInstances.get(0).getVariableName());
+        assertThat(historicVariableInstances).hasSize(1);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("taskVar1");
 
     }
 
@@ -326,12 +328,12 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-        assertEquals(2, historyService.createHistoricVariableInstanceQuery().executionIds(testProcessInstanceIds).count());
-        assertEquals(2, historyService.createHistoricVariableInstanceQuery().executionIds(testProcessInstanceIds).list().size());
+        assertThat(historyService.createHistoricVariableInstanceQuery().executionIds(testProcessInstanceIds).count()).isEqualTo(2);
+        assertThat(historyService.createHistoricVariableInstanceQuery().executionIds(testProcessInstanceIds).list()).hasSize(2);
 
         List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().executionIds(testProcessInstanceIds).list();
-        assertEquals("startVar", historicVariableInstances.get(0).getVariableName());
-        assertEquals("hello", historicVariableInstances.get(0).getValue());
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("startVar");
+        assertThat(historicVariableInstances.get(0).getValue()).isEqualTo("hello");
 
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery().executionIds(processInstanceIds).list();
         int startVarCount = 0;
@@ -339,16 +341,16 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         for (HistoricVariableInstance historicVariableInstance : historicVariableInstances) {
             if ("startVar".equals(historicVariableInstance.getVariableName())) {
                 startVarCount++;
-                assertEquals("hello", historicVariableInstance.getValue());
+                assertThat(historicVariableInstance.getValue()).isEqualTo("hello");
             
             } else if ("startVar2".equals(historicVariableInstance.getVariableName())) {
                 startVar2Count++;
-                assertEquals("hello2", historicVariableInstance.getValue());
+                assertThat(historicVariableInstance.getValue()).isEqualTo("hello2");
             }
         }
         
-        assertEquals(2, startVarCount);
-        assertEquals(1, startVar2Count);
+        assertThat(startVarCount).isEqualTo(2);
+        assertThat(startVar2Count).isEqualTo(1);
     }
 
     @Test
@@ -379,16 +381,16 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         Set<String> processInstanceIds = new HashSet<>();
         processInstanceIds.add(processInstance.getId());
         List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().executionIds(processInstanceIds).list();
-        assertEquals(1, historicVariableInstances.size());
-        assertEquals("processVar", historicVariableInstances.get(0).getVariableName());
-        assertEquals("processVar", historicVariableInstances.get(0).getValue());
+        assertThat(historicVariableInstances).hasSize(1);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("processVar");
+        assertThat(historicVariableInstances.get(0).getValue()).isEqualTo("processVar");
 
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery().executionIds(executionIds).excludeTaskVariables().list();
-        assertEquals(2, historicVariableInstances.size());
-        assertEquals("executionVar", historicVariableInstances.get(0).getVariableName());
-        assertEquals("executionVar", historicVariableInstances.get(0).getValue());
-        assertEquals("executionVar", historicVariableInstances.get(1).getVariableName());
-        assertEquals("executionVar", historicVariableInstances.get(1).getValue());
+        assertThat(historicVariableInstances).hasSize(2);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("executionVar");
+        assertThat(historicVariableInstances.get(0).getValue()).isEqualTo("executionVar");
+        assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo("executionVar");
+        assertThat(historicVariableInstances.get(1).getValue()).isEqualTo("executionVar");
     }
 
     @Test
@@ -406,20 +408,20 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         taskIds.add(tasks.get(0).getId());
         taskIds.add(tasks.get(1).getId());
         List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).list();
-        assertEquals(2, historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).count());
-        assertEquals(2, historicVariableInstances.size());
-        assertEquals("taskVar1", historicVariableInstances.get(0).getVariableName());
-        assertEquals("hello1", historicVariableInstances.get(0).getValue());
-        assertEquals("taskVar2", historicVariableInstances.get(1).getVariableName());
-        assertEquals("hello2", historicVariableInstances.get(1).getValue());
+        assertThat(historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).count()).isEqualTo(2);
+        assertThat(historicVariableInstances).hasSize(2);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("taskVar1");
+        assertThat(historicVariableInstances.get(0).getValue()).isEqualTo("hello1");
+        assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo("taskVar2");
+        assertThat(historicVariableInstances.get(1).getValue()).isEqualTo("hello2");
 
         taskIds = new HashSet<>();
         taskIds.add(tasks.get(0).getId());
         historicVariableInstances = historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).list();
-        assertEquals(1, historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).count());
-        assertEquals(1, historicVariableInstances.size());
-        assertEquals("taskVar1", historicVariableInstances.get(0).getVariableName());
-        assertEquals("hello1", historicVariableInstances.get(0).getValue());
+        assertThat(historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).count()).isEqualTo(1);
+        assertThat(historicVariableInstances).hasSize(1);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("taskVar1");
+        assertThat(historicVariableInstances.get(0).getValue()).isEqualTo("hello1");
     }
 
     @Test
@@ -448,11 +450,11 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().taskIds(taskIds).list();
-        assertEquals(2, historicVariableInstances.size());
-        assertEquals("taskVar", historicVariableInstances.get(0).getVariableName());
-        assertEquals("taskVar", historicVariableInstances.get(0).getValue());
-        assertEquals("taskVar", historicVariableInstances.get(1).getVariableName());
-        assertEquals("taskVar", historicVariableInstances.get(1).getValue());
+        assertThat(historicVariableInstances).hasSize(2);
+        assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo("taskVar");
+        assertThat(historicVariableInstances.get(0).getValue()).isEqualTo("taskVar");
+        assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo("taskVar");
+        assertThat(historicVariableInstances.get(1).getValue()).isEqualTo("taskVar");
     }
 
     @Test
@@ -466,7 +468,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             assertProcessEnded(processInstance.getId());
 
             // check that process variable is set even if the process is canceled and not ended normally
-            assertEquals(1, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).variableValueEquals("testVar", "Hallo Christian").count());
+            assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).variableValueEquals("testVar", "Hallo Christian").count()).isEqualTo(1);
         }
     }
 
@@ -494,7 +496,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
             // check history
             List<HistoricDetail> updates = historyService.createHistoricDetailQuery().processInstanceId(pi.getId()).variableUpdates().list();
-            assertEquals(2, updates.size());
+            assertThat(updates).hasSize(2);
 
             Map<String, HistoricVariableUpdate> updatesMap = new HashMap<>();
             HistoricVariableUpdate update = (HistoricVariableUpdate) updates.get(0);
@@ -505,15 +507,15 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             HistoricVariableUpdate update1 = updatesMap.get("1");
             HistoricVariableUpdate update2 = updatesMap.get("2");
 
-            assertNotNull(update1.getActivityInstanceId());
-            assertNotNull(update1.getExecutionId());
+            assertThat(update1.getActivityInstanceId()).isNotNull();
+            assertThat(update1.getExecutionId()).isNotNull();
             HistoricActivityInstance historicActivityInstance1 = historyService.createHistoricActivityInstanceQuery().activityInstanceId(update1.getActivityInstanceId()).singleResult();
-            assertEquals("usertask1", historicActivityInstance1.getActivityId());
+            assertThat(historicActivityInstance1.getActivityId()).isEqualTo("usertask1");
 
             // TODO https://activiti.atlassian.net/browse/ACT-1083
-            assertNotNull(update2.getActivityInstanceId());
+            assertThat(update2.getActivityInstanceId()).isNotNull();
             HistoricActivityInstance historicActivityInstance2 = historyService.createHistoricActivityInstanceQuery().activityInstanceId(update2.getActivityInstanceId()).singleResult();
-            assertEquals("usertask2", historicActivityInstance2.getActivityId());
+            assertThat(historicActivityInstance2.getActivityId()).isEqualTo("usertask2");
 
             /*
              * This is OK! The variable is set on the root execution, on a execution never run through the activity, where the process instances stands when calling the set Variable. But the
@@ -521,7 +523,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
              * 
              * execution id: On which execution it was set activity id: in which activity was the process instance when setting the variable
              */
-            assertFalse(historicActivityInstance2.getExecutionId().equals(update2.getExecutionId()));
+            assertThat(historicActivityInstance2.getExecutionId().equals(update2.getExecutionId())).isFalse();
         }
     }
 
@@ -538,19 +540,19 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             variables.put("var1", "value1");
             variables.put("var2", "value2");
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProcess", variables);
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
             variables = new HashMap<>();
             variables.put("var3", "value3");
             variables.put("var4", "value4");
             ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("myProcess", variables);
-            assertNotNull(processInstance2);
+            assertThat(processInstance2).isNotNull();
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // check variables
             long count = historyService.createHistoricVariableInstanceQuery().count();
-            assertEquals(4, count);
+            assertThat(count).isEqualTo(4);
 
             // delete runtime execution of ONE process instance
             runtimeService.deleteProcessInstance(processInstance.getId(), "reason 1");
@@ -566,12 +568,12 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             count = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstance2.getId())
                     .count();
-            assertEquals(2, count);
+            assertThat(count).isEqualTo(2);
             
             count = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .count();
-            assertEquals(0, count);
+            assertThat(count).isZero();
         }
 
     }
@@ -582,8 +584,8 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
 
-            assertEquals("ACT_HI_VARINST", managementService.getTableName(HistoricVariableInstance.class, false));
-            assertEquals("ACT_HI_VARINST", managementService.getTableName(HistoricVariableInstanceEntity.class, false));
+            assertThat(managementService.getTableName(HistoricVariableInstance.class, false)).isEqualTo("ACT_HI_VARINST");
+            assertThat(managementService.getTableName(HistoricVariableInstanceEntity.class, false)).isEqualTo("ACT_HI_VARINST");
 
             String tableName = managementService.getTableName(HistoricVariableInstance.class);
             String baseQuerySql = "SELECT * FROM " + tableName;
@@ -592,22 +594,22 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             variables.put("var1", "value1");
             variables.put("var2", "value2");
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc", variables);
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            assertEquals(3, historyService.createNativeHistoricVariableInstanceQuery().sql(baseQuerySql).list().size());
+            assertThat(historyService.createNativeHistoricVariableInstanceQuery().sql(baseQuerySql).list()).hasSize(3);
 
             String sqlWithConditions = baseQuerySql + " where NAME_ = #{name}";
-            assertEquals("test123", historyService.createNativeHistoricVariableInstanceQuery().sql(sqlWithConditions).parameter("name", "myVar").singleResult().getValue());
+            assertThat(historyService.createNativeHistoricVariableInstanceQuery().sql(sqlWithConditions).parameter("name", "myVar").singleResult().getValue()).isEqualTo("test123");
 
             sqlWithConditions = baseQuerySql + " where NAME_ like #{name}";
-            assertEquals(2, historyService.createNativeHistoricVariableInstanceQuery().sql(sqlWithConditions).parameter("name", "var%").list().size());
+            assertThat(historyService.createNativeHistoricVariableInstanceQuery().sql(sqlWithConditions).parameter("name", "var%").list()).hasSize(2);
 
             // paging
-            assertEquals(3, historyService.createNativeHistoricVariableInstanceQuery().sql(baseQuerySql).listPage(0, 3).size());
-            assertEquals(2, historyService.createNativeHistoricVariableInstanceQuery().sql(baseQuerySql).listPage(1, 3).size());
-            assertEquals(2, historyService.createNativeHistoricVariableInstanceQuery().sql(sqlWithConditions).parameter("name", "var%").listPage(0, 2).size());
+            assertThat(historyService.createNativeHistoricVariableInstanceQuery().sql(baseQuerySql).listPage(0, 3)).hasSize(3);
+            assertThat(historyService.createNativeHistoricVariableInstanceQuery().sql(baseQuerySql).listPage(1, 3)).hasSize(2);
+            assertThat(historyService.createNativeHistoricVariableInstanceQuery().sql(sqlWithConditions).parameter("name", "var%").listPage(0, 2)).hasSize(2);
         }
 
     }
@@ -616,8 +618,8 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/history/HistoricVariableInstanceTest.testSimple.bpmn20.xml")
     public void testNativeHistoricDetailQuery() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
-            assertEquals("ACT_HI_DETAIL", managementService.getTableName(HistoricDetail.class, false));
-            assertEquals("ACT_HI_DETAIL", managementService.getTableName(HistoricVariableUpdate.class, false));
+            assertThat(managementService.getTableName(HistoricDetail.class, false)).isEqualTo("ACT_HI_DETAIL");
+            assertThat(managementService.getTableName(HistoricVariableUpdate.class, false)).isEqualTo("ACT_HI_DETAIL");
 
             String tableName = managementService.getTableName(HistoricDetail.class);
             String baseQuerySql = "SELECT * FROM " + tableName;
@@ -626,17 +628,17 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             variables.put("var1", "value1");
             variables.put("var2", "value2");
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc", variables);
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            assertEquals(3, historyService.createNativeHistoricDetailQuery().sql(baseQuerySql).list().size());
+            assertThat(historyService.createNativeHistoricDetailQuery().sql(baseQuerySql).list()).hasSize(3);
 
             String sqlWithConditions = baseQuerySql + " where NAME_ = #{name} and TYPE_ = #{type}";
-            assertNotNull(historyService.createNativeHistoricDetailQuery().sql(sqlWithConditions).parameter("name", "myVar").parameter("type", "VariableUpdate").singleResult());
+            assertThat(historyService.createNativeHistoricDetailQuery().sql(sqlWithConditions).parameter("name", "myVar").parameter("type", "VariableUpdate").singleResult()).isNotNull();
 
             sqlWithConditions = baseQuerySql + " where NAME_ like #{name}";
-            assertEquals(2, historyService.createNativeHistoricDetailQuery().sql(sqlWithConditions).parameter("name", "var%").list().size());
+            assertThat(historyService.createNativeHistoricDetailQuery().sql(sqlWithConditions).parameter("name", "var%").list()).hasSize(2);
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
             Map<String, String> formDatas = new HashMap<>();
@@ -647,13 +649,13 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             String countSql = "select count(*) from " + tableName + " where TYPE_ = #{type} and PROC_INST_ID_ = #{pid}";
-            assertEquals(2, historyService.createNativeHistoricDetailQuery().sql(countSql).parameter("type", "FormProperty").parameter("pid", processInstance.getId()).count());
+            assertThat(historyService.createNativeHistoricDetailQuery().sql(countSql).parameter("type", "FormProperty").parameter("pid", processInstance.getId()).count()).isEqualTo(2);
 
             // paging
-            assertEquals(3, historyService.createNativeHistoricDetailQuery().sql(baseQuerySql).listPage(0, 3).size());
-            assertEquals(3, historyService.createNativeHistoricDetailQuery().sql(baseQuerySql).listPage(1, 3).size());
+            assertThat(historyService.createNativeHistoricDetailQuery().sql(baseQuerySql).listPage(0, 3)).hasSize(3);
+            assertThat(historyService.createNativeHistoricDetailQuery().sql(baseQuerySql).listPage(1, 3)).hasSize(3);
             sqlWithConditions = baseQuerySql + " where TYPE_ = #{type} and PROC_INST_ID_ = #{pid}";
-            assertEquals(2, historyService.createNativeHistoricDetailQuery().sql(sqlWithConditions).parameter("type", "FormProperty").parameter("pid", processInstance.getId()).listPage(0, 2).size());
+            assertThat(historyService.createNativeHistoricDetailQuery().sql(sqlWithConditions).parameter("type", "FormProperty").parameter("pid", processInstance.getId()).listPage(0, 2)).hasSize(2);
         }
     }
 
@@ -664,35 +666,35 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
             TaskQuery taskQuery = taskService.createTaskQuery();
             org.flowable.task.api.Task task = taskQuery.singleResult();
-            assertEquals("my task", task.getName());
+            assertThat(task.getName()).isEqualTo("my task");
 
             // no type change
             runtimeService.setVariable(processInstance.getId(), "firstVar", "123");
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals("123", getHistoricVariable("firstVar").getValue());
+            assertThat(getHistoricVariable("firstVar").getValue()).isEqualTo("123");
             
             runtimeService.setVariable(processInstance.getId(), "firstVar", "456");
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals("456", getHistoricVariable("firstVar").getValue());
+            assertThat(getHistoricVariable("firstVar").getValue()).isEqualTo("456");
             
             runtimeService.setVariable(processInstance.getId(), "firstVar", "789");
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals("789", getHistoricVariable("firstVar").getValue());
+            assertThat(getHistoricVariable("firstVar").getValue()).isEqualTo("789");
 
             // type is changed from text to integer and back again. same result expected(?)
             runtimeService.setVariable(processInstance.getId(), "secondVar", "123");
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals("123", getHistoricVariable("secondVar").getValue());
+            assertThat(getHistoricVariable("secondVar").getValue()).isEqualTo("123");
             
             runtimeService.setVariable(processInstance.getId(), "secondVar", 456);
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             // there are now 2 historic variables, so the following does not work
-            assertEquals(456, getHistoricVariable("secondVar").getValue());
+            assertThat(getHistoricVariable("secondVar").getValue()).isEqualTo(456);
             
             runtimeService.setVariable(processInstance.getId(), "secondVar", "789");
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             // there are now 3 historic variables, so the following does not work
-            assertEquals("789", getHistoricVariable("secondVar").getValue());
+            assertThat(getHistoricVariable("secondVar").getValue()).isEqualTo("789");
 
             taskService.complete(task.getId());
 
@@ -711,7 +713,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc");
             TaskQuery taskQuery = taskService.createTaskQuery();
             org.flowable.task.api.Task userTask = taskQuery.singleResult();
-            assertEquals("userTask1", userTask.getName());
+            assertThat(userTask.getName()).isEqualTo("userTask1");
 
             taskService.complete(userTask.getId(), CollectionUtil.singletonMap("myVar", "test789"));
 
@@ -720,13 +722,13 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().executionId(processInstance.getId()).list();
-            assertEquals(1, variables.size());
+            assertThat(variables).hasSize(1);
 
             HistoricVariableInstanceEntity historicVariable = (HistoricVariableInstanceEntity) variables.get(0);
-            assertEquals("test456", historicVariable.getTextValue());
+            assertThat(historicVariable.getTextValue()).isEqualTo("test456");
 
-            assertEquals(9, historyService.createHistoricActivityInstanceQuery().count());
-            assertEquals(3, historyService.createHistoricDetailQuery().count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(9);
+            assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(3);
         }
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
@@ -11,6 +11,8 @@
  */
 package org.flowable.engine.test.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,11 +70,11 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
                     .includeVariables()
                     .singleResult();
             List<HistoricData> events = log.getHistoricData();
-            assertEquals(1, events.size());
+            assertThat(events).hasSize(1);
 
             for (HistoricData event : events) {
-                assertTrue(event instanceof HistoricVariableInstance);
-                assertEquals(LARGE_STRING_VALUE, ((HistoricVariableInstanceEntity) event).getValue());
+                assertThat(event).isInstanceOf(HistoricVariableInstance.class);
+                assertThat(((HistoricVariableInstanceEntity) event).getValue()).isEqualTo(LARGE_STRING_VALUE);
             }
         }
     }
@@ -83,17 +85,17 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
             HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
                     .processInstanceId(processInstanceId).variableName("var").singleResult();
-            assertEquals(LARGE_STRING_VALUE, historicVariableInstance.getValue());
+            assertThat(historicVariableInstance.getValue()).isEqualTo(LARGE_STRING_VALUE);
 
             ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId)
                     .includeVariableUpdates()
                     .singleResult();
             List<HistoricData> events = log.getHistoricData();
-            assertEquals(1, events.size());
+            assertThat(events).hasSize(1);
 
             for (HistoricData event : events) {
-                assertTrue(event instanceof HistoricVariableUpdate);
-                assertEquals(LARGE_STRING_VALUE, ((HistoricDetailVariableInstanceUpdateEntity) event).getValue());
+                assertThat(event).isInstanceOf(HistoricVariableUpdate.class);
+                assertThat(((HistoricDetailVariableInstanceUpdateEntity) event).getValue()).isEqualTo(LARGE_STRING_VALUE);
             }
         }
     }


### PR DESCRIPTION
This is for the `org.flowable.engine.test.history` package.  There was a mixture of assertion styles in 6 files.

