### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/ExpressionManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/ExpressionManagerTest.java
@@ -98,16 +98,13 @@ public class ExpressionManagerTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testMethodExpressions() {
-        // Process contains 2 service tasks. one containing a method with no
-        // params, the other
-        // contains a method with 2 params. When the process completes without
-        // exception,
-        // test passed.
+        // Process contains 2 service tasks. One containing a method with no params, the other
+        // contains a method with 2 params. When the process completes without exception, test passed.
         Map<String, Object> vars = new HashMap<>();
         vars.put("aString", "abcdefgh");
         runtimeService.startProcessInstanceByKey("methodExpressionProcess", vars);
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("methodExpressionProcess").count());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("methodExpressionProcess").count()).isZero();
     }
 
     @Test
@@ -120,8 +117,8 @@ public class ExpressionManagerTest extends PluggableFlowableTestCase {
 
         // Check of the testMethod has been called with the current execution
         String value = (String) runtimeService.getVariable(processInstance.getId(), "testVar");
-        assertNotNull(value);
-        assertEquals("myValue", value);
+        assertThat(value).isNotNull();
+        assertThat(value).isEqualTo("myValue");
     }
 
     @Test
@@ -135,8 +132,8 @@ public class ExpressionManagerTest extends PluggableFlowableTestCase {
             // Check if the variable that has been set in service-task is the
             // authenticated user
             String value = (String) runtimeService.getVariable(processInstance.getId(), "theUser");
-            assertNotNull(value);
-            assertEquals("frederik", value);
+            assertThat(value).isNotNull();
+            assertThat(value).isEqualTo("frederik");
         } finally {
             // Cleanup
             Authentication.setAuthenticatedUserId(null);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/function/VariableExpressionFunctionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/function/VariableExpressionFunctionsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.el.function;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 
 import org.apache.commons.codec.binary.Base64;
@@ -32,114 +34,114 @@ public class VariableExpressionFunctionsTest extends PluggableFlowableTestCase{
     @Deployment
     public void testGetVariable() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "go to A")
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testGetVariableOrDefault() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()); // Default is 123
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A"); // Default is 123
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 1)
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 999)
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testGetVariableContains() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", Arrays.asList(2, 3, 4))
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", Arrays.asList(1, 2, 3, 4))
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testGetVariableContainsAny() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", Arrays.asList(3, 4))
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", Arrays.asList(2, 3, 4))
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", Arrays.asList(1, 2, 3, 4))
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testGetVariableEquals() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 12)
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 123)
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testGetVariableNotEquals() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "hello")
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "test")
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     
@@ -147,170 +149,170 @@ public class VariableExpressionFunctionsTest extends PluggableFlowableTestCase{
     @Deployment
     public void testGetVariableExists() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "hello")
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testGetVariableIsEmpty() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "")
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "abc")
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
     }
     
     @Test
     @Deployment
     public void testGetVariableIsNotEmpty() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "")
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "abc")
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testGetVariableLowerThan() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 1)
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 10)
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 11)
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
     }
     
     @Test
     @Deployment
     public void testGetVariableLowerThanOrEqual() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 1)
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 10)
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 11)
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
     }
     
     @Test
     @Deployment
     public void testGetVariableGreaterThan() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 1)
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 10)
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 11)
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testGetVariableGreaterThanOrEqual() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 1)
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 10)
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", 11)
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
     }
     
     @Test
     @Deployment
     public void testVariableBase64() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "test")
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", "hello")
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
 
     }
 
@@ -318,19 +320,19 @@ public class VariableExpressionFunctionsTest extends PluggableFlowableTestCase{
     @Deployment
     public void testVariableBase64Binary() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testExpressionFunction");
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", Base64.decodeBase64("SGFsbG8sIGhhbGxvIC0gVGVzdCBXUk9ORyE="))
                 .start();
-        assertEquals("B", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("B");
         
         processInstance = runtimeService.createProcessInstanceBuilder()
                 .processDefinitionKey("testExpressionFunction")
                 .variable("myVar", Base64.decodeBase64("SGFsbG8sIGhhbGxvIC0gVGVzdA=="))
                 .start();
-        assertEquals("A", taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getName()).isEqualTo("A");
 
     }
 }


### PR DESCRIPTION
This is for the `org.flowable.engine.test.el` package.  There was one file that was using a mix of assertion types and one that only used `assertEquals()` so I updated both of them.
