### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncEmailTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncEmailTaskTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.async;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -34,12 +36,12 @@ public class AsyncEmailTaskTest extends EmailTestCase {
         String procId = runtimeService.startProcessInstanceByKey("simpleTextOnly").getId();
 
         List<WiserMessage> messages = wiser.getMessages();
-        assertEquals(0, messages.size());
+        assertThat(messages).isEmpty();
 
         waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         messages = wiser.getMessages();
-        assertEquals(1, messages.size());
+        assertThat(messages).hasSize(1);
 
         WiserMessage message = messages.get(0);
         EmailServiceTaskTest.assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "flowable@localhost", Collections.singletonList("kermit@activiti.org"), null);
@@ -52,12 +54,12 @@ public class AsyncEmailTaskTest extends EmailTestCase {
         runtimeService.startProcessInstanceByKey("simpleTextOnly");
 
         List<WiserMessage> messages = wiser.getMessages();
-        assertEquals(0, messages.size());
+        assertThat(messages).isEmpty();
 
         waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         messages = wiser.getMessages();
-        assertEquals(1, messages.size());
+        assertThat(messages).hasSize(1);
 
         WiserMessage message = messages.get(0);
         EmailServiceTaskTest.assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "flowable@localhost", Collections.singletonList(

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncExclusiveJobsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncExclusiveJobsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.async;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.impl.test.HistoryTestHelper;
@@ -50,7 +52,7 @@ public class AsyncExclusiveJobsTest extends PluggableFlowableTestCase {
             } else {
                 endTimeDifference = endTimeA - endTimeB;
             }
-            assertTrue(endTimeDifference > 6000); // > 6000 -> jobs were executed in parallel
+            assertThat(endTimeDifference).isGreaterThan(6000); // > 6000 -> jobs were executed in parallel
         }
 
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncTaskTest.java
@@ -12,12 +12,15 @@
  */
 package org.flowable.engine.test.bpmn.async;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.impl.context.Context;
@@ -44,29 +47,29 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncService");
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         // the service was not invoked:
-        assertFalse(INVOCATION);
+        assertThat(INVOCATION).isFalse();
 
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // the service was invoked
-        assertTrue(INVOCATION);
+        assertThat(INVOCATION).isTrue();
         // and the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     @Test
     @Deployment
     public void testAsyncServiceListeners() {
         String pid = runtimeService.startProcessInstanceByKey("asyncService").getProcessInstanceId();
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         // the listener was not yet invoked:
-        assertNull(runtimeService.getVariable(pid, "listener"));
+        assertThat(runtimeService.getVariable(pid, "listener")).isNull();
 
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     @Test
@@ -76,16 +79,16 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncService");
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         // the service was not invoked:
-        assertFalse(INVOCATION);
+        assertThat(INVOCATION).isFalse();
 
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // the service was invoked
-        assertTrue(INVOCATION);
+        assertThat(INVOCATION).isTrue();
         // and the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     @Test
@@ -95,16 +98,16 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncService");
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         // the service was not invoked:
-        assertFalse(INVOCATION);
+        assertThat(INVOCATION).isFalse();
 
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // the service was invoked
-        assertTrue(INVOCATION);
+        assertThat(INVOCATION).isTrue();
         // and the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     @Test
@@ -113,10 +116,11 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncService");
         // now there should be one job in the database, and it is a message
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         Job job = managementService.createJobQuery().singleResult();
 
-        assertThatThrownBy(() -> managementService.executeJob(job.getId()));
+        assertThatThrownBy(() -> managementService.executeJob(job.getId()))
+                .isInstanceOf(FlowableException.class);
 
         // the service failed: the execution is still sitting in the service task:
         Execution execution = null;
@@ -125,11 +129,11 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
                 execution = e;
             }
         }
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // there is still a single job because the timer was created in the same
         // transaction as the service was executed (which rolled back)
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         runtimeService.deleteProcessInstance(execution.getId(), "dead");
     }
@@ -140,28 +144,28 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncService");
         // now there are two jobs the message and a timer:
-        assertEquals(2, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(2);
 
         // let 'max-retires' on the message be reached
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // the service failed: the execution is still sitting in the service task:
         Execution execution = runtimeService.createExecutionQuery().singleResult();
-        assertNotNull(execution);
-        assertEquals("service", runtimeService.getActiveActivityIds(execution.getId()).get(0));
+        assertThat(execution).isNotNull();
+        assertThat(runtimeService.getActiveActivityIds(execution.getId()).get(0)).isEqualTo("service");
 
         // there are tow jobs, the message and the timer (the message will not
         // be retried anymore, max retires is reached.)
-        assertEquals(2, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(2);
 
         // now the timer triggers:
         Context.getProcessEngineConfiguration().getClock().setCurrentTime(new Date(System.currentTimeMillis() + 10000));
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // and we are done:
-        assertNull(runtimeService.createExecutionQuery().singleResult());
+        assertThat(runtimeService.createExecutionQuery().singleResult()).isNull();
         // and there are no more jobs left:
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
 
     }
 
@@ -172,18 +176,18 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncService");
         // now there should be two jobs in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
 
         // the service was not invoked:
-        assertFalse(INVOCATION);
+        assertThat(INVOCATION).isFalse();
 
         waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         // the service was invoked
-        assertTrue(INVOCATION);
+        assertThat(INVOCATION).isTrue();
 
         // both the timer and the message are cancelled
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     @Test
@@ -192,12 +196,12 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncService");
 
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
 
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // both the timer and the message are cancelled
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
 
     }
 
@@ -207,16 +211,16 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncTask");
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         
         Job job = managementService.createJobQuery().singleResult();
-        assertEquals("task", job.getElementId());
-        assertEquals("Test task", job.getElementName());
+        assertThat(job.getElementId()).isEqualTo("task");
+        assertThat(job.getElementName()).isEqualTo("Test task");
 
         waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         // the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
     
     @Test
@@ -225,16 +229,16 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncTask");
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         
         Job job = managementService.createJobQuery().singleResult();
-        assertEquals("task", job.getElementId());
-        assertEquals("testCategory", job.getCategory());
+        assertThat(job.getElementId()).isEqualTo("task");
+        assertThat(job.getCategory()).isEqualTo("testCategory");
 
         waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         // the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
     
     @Test
@@ -244,23 +248,19 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory("myCategory");
             // start process
             runtimeService.startProcessInstanceByKey("asyncTask");
-    
-            try {
-                waitForJobExecutorToProcessAllJobs(4000L, 200L);
-                fail("should fail");
-            } catch (Exception e ) {
-                // expected
-            }
+
+            assertThatThrownBy(() -> waitForJobExecutorToProcessAllJobs(4000L, 200L))
+                    .isInstanceOf(FlowableException.class);
             
             // job is not executed because of different job category value
-            assertEquals(1, managementService.createJobQuery().count());
+            assertThat(managementService.createJobQuery().count()).isEqualTo(1);
             
             processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(Collections.singletonList("testCategory"));
     
             waitForJobExecutorToProcessAllJobs(4000L, 200L);
             
             // the job is done
-            assertEquals(0, managementService.createJobQuery().count());
+            assertThat(managementService.createJobQuery().count()).isZero();
             
         } finally {
             processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
@@ -280,17 +280,17 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncTask");
             
             JobEntity job = (JobEntity) managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNull(job.getLockOwner());
-            assertNull(job.getLockExpirationTime());
+            assertThat(job.getLockOwner()).isNull();
+            assertThat(job.getLockExpirationTime()).isNull();
             
             Thread.sleep(4000);
             
             // job is not executed because of different job category value
-            assertEquals(1, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
             
             job = (JobEntity) managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNull(job.getLockOwner());
-            assertNull(job.getLockExpirationTime());
+            assertThat(job.getLockOwner()).isNull();
+            assertThat(job.getLockExpirationTime()).isNull();
             
             processEngineConfiguration.getAsyncExecutor().shutdown();
             
@@ -300,9 +300,9 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
             JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 4000, 300, false);
             
             // the job is done
-            assertEquals(0, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
             
-            assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
             
         } finally {
             processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
@@ -317,15 +317,15 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncTask", Collections.singletonMap("categoryValue", "myCategory"));
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         
         Job job = managementService.createJobQuery().singleResult();
-        assertEquals("myCategory", job.getCategory());
+        assertThat(job.getCategory()).isEqualTo("myCategory");
 
         waitForJobExecutorToProcessAllJobs(5000L, 200L);
 
         // the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
     
     @Test
@@ -339,7 +339,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
             waitForJobExecutorToProcessAllJobs(4000L, 200L);
             
             // the job is done
-            assertEquals(0, managementService.createJobQuery().count());
+            assertThat(managementService.createJobQuery().count()).isZero();
             
         } finally {
             processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
@@ -360,7 +360,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
             waitForJobExecutorToProcessAllJobs(4000L, 200L);
             
             // the job is done
-            assertEquals(0, managementService.createJobQuery().count());
+            assertThat(managementService.createJobQuery().count()).isZero();
             
         } finally {
             processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
@@ -373,33 +373,29 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncEndEvent");
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         
         Job job = managementService.createJobQuery().singleResult();
-        assertEquals("theEnd", job.getElementId());
-        assertEquals("End event", job.getElementName());
+        assertThat(job.getElementId()).isEqualTo("theEnd");
+        assertThat(job.getElementName()).isEqualTo("End event");
 
         Object value = runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
-        assertNull(value);
+        assertThat(value).isNull();
 
         waitForJobExecutorToProcessAllJobs(2000L, 200L);
 
         // the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
 
         assertProcessEnded(processInstance.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-            assertEquals(3, variables.size());
+            assertThat(variables).hasSize(3);
 
-            Object historyValue = null;
-            for (HistoricVariableInstance variable : variables) {
-                if ("variableSetInExecutionListener".equals(variable.getVariableName())) {
-                    historyValue = variable.getValue();
-                }
-            }
-            assertEquals("firstValue", historyValue);
+            assertThat(variables)
+                    .extracting(HistoricVariableInstance::getVariableName, HistoricVariableInstance::getValue)
+                    .contains(tuple("variableSetInExecutionListener", "firstValue"));
         }
     }
 
@@ -409,11 +405,11 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncScript");
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         
         Job job = managementService.createJobQuery().singleResult();
-        assertEquals("script", job.getElementId());
-        assertEquals("Script", job.getElementName());
+        assertThat(job.getElementId()).isEqualTo("script");
+        assertThat(job.getElementName()).isEqualTo("Script");
         
         // the script was not invoked:
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
@@ -423,15 +419,15 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
                 eid = e.getId();
             }
         }
-        assertNull(runtimeService.getVariable(eid, "invoked"));
+        assertThat(runtimeService.getVariable(eid, "invoked")).isNull();
 
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
 
         // and the job is done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
 
         // the script was invoked
-        assertEquals("true", runtimeService.getVariable(eid, "invoked"));
+        assertThat(runtimeService.getVariable(eid, "invoked")).isEqualTo("true");
 
         runtimeService.trigger(eid);
     }
@@ -443,21 +439,21 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("asyncCallactivity");
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
 
         waitForJobExecutorToProcessAllJobs(20000L, 250L);
 
-        assertEquals(0, managementService.createJobQuery().count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testBasicAsyncCallActivity.bpmn20.xml", "org/flowable/engine/test/bpmn/StartToEndTest.testStartToEnd.bpmn20.xml" })
     public void testBasicAsyncCallActivity() {
         runtimeService.startProcessInstanceByKey("myProcess");
-        Assert.assertEquals("There should be one job available.", 1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).as("There should be one job available.").isEqualTo(1);
         waitForJobExecutorToProcessAllJobs(7000L, 250L);
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     @Test
@@ -466,24 +462,24 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // start process
         String pid = runtimeService.startProcessInstanceByKey("asyncUserTask").getId();
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
         // the listener was not yet invoked:
-        assertNull(runtimeService.getVariable(pid, "listener"));
+        assertThat(runtimeService.getVariable(pid, "listener")).isNull();
         // the task listener was not yet invoked:
-        assertNull(runtimeService.getVariable(pid, "taskListener"));
+        assertThat(runtimeService.getVariable(pid, "taskListener")).isNull();
         // there is no usertask
-        assertNull(taskService.createTaskQuery().singleResult());
+        assertThat(taskService.createTaskQuery().singleResult()).isNull();
 
         waitForJobExecutorToProcessAllJobs(7000L, 250L);
         // the listener was now invoked:
-        assertNotNull(runtimeService.getVariable(pid, "listener"));
+        assertThat(runtimeService.getVariable(pid, "listener")).isNotNull();
         // the task listener was now invoked:
-        assertNotNull(runtimeService.getVariable(pid, "taskListener"));
+        assertThat(runtimeService.getVariable(pid, "taskListener")).isNotNull();
 
         // there is a usertask
-        assertNotNull(taskService.createTaskQuery().singleResult());
+        assertThat(taskService.createTaskQuery().singleResult()).isNotNull();
         // and no more job
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
 
         String taskId = taskService.createTaskQuery().singleResult().getId();
         taskService.complete(taskId);
@@ -497,21 +493,21 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncTask");
 
         // now there should be one job in the database:
-        assertEquals(3, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // execute first of 3 parallel multi instance tasks
         managementService.executeJob(managementService.createJobQuery().processInstanceId(processInstance.getId()).list().get(0).getId());
-        assertEquals(2, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
 
         // execute second of 3 parallel multi instance tasks
         managementService.executeJob(managementService.createJobQuery().processInstanceId(processInstance.getId()).list().get(0).getId());
-        assertEquals(1, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
         // execute third of 3 parallel multi instance tasks
         managementService.executeJob(managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         // the job is done
-        assertEquals(0, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivities = historyService.createHistoricActivityInstanceQuery()
@@ -540,10 +536,10 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
                 }
             }
 
-            assertEquals(1, startCount);
-            assertEquals(3, taskCount);
-            assertEquals(2, sequenceFlowCount);
-            assertEquals(1, endCount);
+            assertThat(startCount).isEqualTo(1);
+            assertThat(taskCount).isEqualTo(3);
+            assertThat(sequenceFlowCount).isEqualTo(2);
+            assertThat(endCount).isEqualTo(1);
         }
     }
 
@@ -580,10 +576,10 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
                 }
             }
 
-            assertEquals(1, startCount);
-            assertEquals(3, taskCount);
-            assertEquals(2, sequenceFlowCount);
-            assertEquals(1, endCount);
+            assertThat(startCount).isEqualTo(1);
+            assertThat(taskCount).isEqualTo(3);
+            assertThat(sequenceFlowCount).isEqualTo(2);
+            assertThat(endCount).isEqualTo(1);
         }
     }
 
@@ -594,21 +590,21 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncTask");
 
         // now there should be one job in the database:
-        assertEquals(1, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
         // execute first of 3 sequential multi instance tasks
         managementService.executeJob(managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult().getId());
-        assertEquals(1, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
         // execute second of 3 sequential multi instance tasks
         managementService.executeJob(managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult().getId());
-        assertEquals(1, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
         // execute third of 3 sequential multi instance tasks
         managementService.executeJob(managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         // the job is done
-        assertEquals(0, managementService.createJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivities = historyService.createHistoricActivityInstanceQuery()
@@ -637,10 +633,10 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
                 }
             }
 
-            assertEquals(1, startCount);
-            assertEquals(3, taskCount);
-            assertEquals(2, sequenceFlowCount);
-            assertEquals(1, endCount);
+            assertThat(startCount).isEqualTo(1);
+            assertThat(taskCount).isEqualTo(3);
+            assertThat(sequenceFlowCount).isEqualTo(2);
+            assertThat(endCount).isEqualTo(1);
         }
     }
 
@@ -677,10 +673,10 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
                 }
             }
 
-            assertEquals(1, startCount);
-            assertEquals(3, taskCount);
-            assertEquals(2, sequenceFlowCount);
-            assertEquals(1, endCount);
+            assertThat(startCount).isEqualTo(1);
+            assertThat(taskCount).isEqualTo(3);
+            assertThat(sequenceFlowCount).isEqualTo(2);
+            assertThat(endCount).isEqualTo(1);
         }
     }
 


### PR DESCRIPTION
This is for the `org.flowable.engine.test.bpmn.async` package.  One file had a mix of styles so did the other two in the package too.

I have no idea why the first diff is a diff of the whole file.
