### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -13,6 +13,7 @@
 
 package org.flowable.engine.test.bpmn.deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.InputStream;
@@ -50,28 +51,28 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentId);
 
         // verify bpmn file name
-        assertEquals(1, deploymentResources.size());
+        assertThat(deploymentResources).hasSize(1);
         String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml";
-        assertEquals(bpmnResourceName, deploymentResources.get(0));
+        assertThat(deploymentResources.get(0)).isEqualTo(bpmnResourceName);
 
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertEquals(bpmnResourceName, processDefinition.getResourceName());
-        assertNull(processDefinition.getDiagramResourceName());
-        assertFalse(processDefinition.hasStartFormKey());
+        assertThat(processDefinition.getResourceName()).isEqualTo(bpmnResourceName);
+        assertThat(processDefinition.getDiagramResourceName()).isNull();
+        assertThat(processDefinition.hasStartFormKey()).isFalse();
 
         ProcessDefinition readOnlyProcessDefinition = ((RepositoryServiceImpl) repositoryService).getDeployedProcessDefinition(processDefinition.getId());
-        assertNull(readOnlyProcessDefinition.getDiagramResourceName());
+        assertThat(readOnlyProcessDefinition.getDiagramResourceName()).isNull();
 
         // verify content
         InputStream deploymentInputStream = repositoryService.getResourceAsStream(deploymentId, bpmnResourceName);
         String contentFromDeployment = readInputStreamToString(deploymentInputStream);
-        assertTrue(contentFromDeployment.length() > 0);
-        assertTrue(contentFromDeployment.contains("process id=\"emptyProcess\""));
+        assertThat(contentFromDeployment.length()).isGreaterThan(0);
+        assertThat(contentFromDeployment.contains("process id=\"emptyProcess\"")).isTrue();
 
         InputStream fileInputStream = ReflectUtil.getResourceAsStream(
                 "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml");
         String contentFromFile = readInputStreamToString(fileInputStream);
-        assertEquals(contentFromFile, contentFromDeployment);
+        assertThat(contentFromDeployment).isEqualTo(contentFromFile);
     }
 
     private String readInputStreamToString(InputStream inputStream) {
@@ -81,63 +82,55 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
 
     @Test
     public void testViolateBPMNIdMaximumLength() {
-        try {
-            repositoryService.createDeployment()
-                    .addClasspathResource("org/flowable/engine/test/bpmn/deployment/definitionWithLongTargetNamespace.bpmn20.xml")
-                    .deploy();
-            fail();
-        } catch (FlowableException e) {
-            assertTextPresent(Problems.BPMN_MODEL_TARGET_NAMESPACE_TOO_LONG, e.getMessage());
-        }
+        assertThatThrownBy(() ->
+                repositoryService.createDeployment()
+                        .addClasspathResource("org/flowable/engine/test/bpmn/deployment/definitionWithLongTargetNamespace.bpmn20.xml")
+                        .deploy())
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessageContaining(Problems.BPMN_MODEL_TARGET_NAMESPACE_TOO_LONG);
 
         // Verify that nothing is deployed
-        assertEquals(0, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
     public void testViolateProcessDefinitionIdMaximumLength() {
-        try {
-            repositoryService.createDeployment()
-                    .addClasspathResource("org/flowable/engine/test/bpmn/deployment/processWithLongId.bpmn20.xml")
-                    .deploy();
-            fail();
-        } catch (FlowableException e) {
-            assertTextPresent(Problems.PROCESS_DEFINITION_ID_TOO_LONG, e.getMessage());
-        }
+        assertThatThrownBy(() ->
+                repositoryService.createDeployment()
+                        .addClasspathResource("org/flowable/engine/test/bpmn/deployment/processWithLongId.bpmn20.xml")
+                        .deploy())
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessageContaining(Problems.PROCESS_DEFINITION_ID_TOO_LONG);
 
         // Verify that nothing is deployed
-        assertEquals(0, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
     public void testViolateProcessDefinitionNameAndDescriptionMaximumLength() {
-        try {
-            repositoryService.createDeployment()
-                    .addClasspathResource("org/flowable/engine/test/bpmn/deployment/processWithLongNameAndDescription.bpmn20.xml")
-                    .deploy();
-            fail();
-        } catch (FlowableException e) {
-            assertTextPresent(Problems.PROCESS_DEFINITION_NAME_TOO_LONG, e.getMessage());
-            assertTextPresent(Problems.PROCESS_DEFINITION_DOCUMENTATION_TOO_LONG, e.getMessage());
-        }
+        assertThatThrownBy(() ->
+                repositoryService.createDeployment()
+                        .addClasspathResource("org/flowable/engine/test/bpmn/deployment/processWithLongNameAndDescription.bpmn20.xml")
+                        .deploy())
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessageContaining(Problems.PROCESS_DEFINITION_NAME_TOO_LONG)
+                .hasMessageContaining(Problems.PROCESS_DEFINITION_DOCUMENTATION_TOO_LONG);
 
         // Verify that nothing is deployed
-        assertEquals(0, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
     public void testViolateDefinitionTargetNamespaceMaximumLength() {
-        try {
-            repositoryService.createDeployment()
-                    .addClasspathResource("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.definitionWithLongTargetNamespace.bpmn20.xml")
-                    .deploy();
-            fail();
-        } catch (FlowableException e) {
-            assertTextPresent(Problems.BPMN_MODEL_TARGET_NAMESPACE_TOO_LONG, e.getMessage());
-        }
+        assertThatThrownBy(() ->
+                repositoryService.createDeployment()
+                        .addClasspathResource("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.definitionWithLongTargetNamespace.bpmn20.xml")
+                        .deploy())
+                .isExactlyInstanceOf(FlowableException.class)
+                .hasMessageContaining(Problems.BPMN_MODEL_TARGET_NAMESPACE_TOO_LONG);
 
         // Verify that nothing is deployed
-        assertEquals(0, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
@@ -149,12 +142,12 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentId);
 
         // verify bpmn file name
-        assertEquals(1, deploymentResources.size());
-        assertEquals(bpmnResourceName, deploymentResources.get(0));
+        assertThat(deploymentResources)
+                .containsExactly(bpmnResourceName);
 
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").deploy();
         List<org.flowable.engine.repository.Deployment> deploymentList = repositoryService.createDeploymentQuery().list();
-        assertEquals(1, deploymentList.size());
+        assertThat(deploymentList).hasSize(1);
 
         repositoryService.deleteDeployment(deploymentId);
     }
@@ -168,16 +161,16 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").deploy();
 
         List<org.flowable.engine.repository.Deployment> deploymentList = repositoryService.createDeploymentQuery().orderByDeploymentTime().desc().list();
-        assertEquals(2, deploymentList.size());
+        assertThat(deploymentList).hasSize(2);
         List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentList.get(0).getId());
 
         // verify bpmn file name
-        assertEquals(1, deploymentResources.size());
-        assertEquals(bpmnResourceName, deploymentResources.get(0));
+        assertThat(deploymentResources)
+                .containsExactly(bpmnResourceName);
 
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").deploy();
         deploymentList = repositoryService.createDeploymentQuery().list();
-        assertEquals(2, deploymentList.size());
+        assertThat(deploymentList).hasSize(2);
 
         for (org.flowable.engine.repository.Deployment deployment : deploymentList) {
             repositoryService.deleteDeployment(deployment.getId());
@@ -190,7 +183,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         String bpmnResourceName2 = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService2.bpmn20.xml";
         assertThatThrownBy(() -> repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).addClasspathResource(bpmnResourceName2).name("duplicateAtTheSameTime").deploy());
         // Verify that nothing is deployed
-        assertEquals(0, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
@@ -202,13 +195,13 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentId);
 
         // verify bpmn file name
-        assertEquals(1, deploymentResources.size());
-        assertEquals(bpmnResourceName, deploymentResources.get(0));
+        assertThat(deploymentResources)
+                .containsExactly(bpmnResourceName);
 
         bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.bpmn20.xml";
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").deploy();
         List<org.flowable.engine.repository.Deployment> deploymentList = repositoryService.createDeploymentQuery().list();
-        assertEquals(2, deploymentList.size());
+        assertThat(deploymentList).hasSize(2);
 
         for (org.flowable.engine.repository.Deployment deployment : deploymentList) {
             repositoryService.deleteDeployment(deployment.getId());
@@ -222,14 +215,14 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentId);
 
         // verify bpmn file name
-        assertEquals(1, deploymentResources.size());
         String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testStartFormKey.bpmn20.xml";
-        assertEquals(bpmnResourceName, deploymentResources.get(0));
+        assertThat(deploymentResources)
+                .containsExactly(bpmnResourceName);
 
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertEquals(bpmnResourceName, processDefinition.getResourceName());
-        assertNull(processDefinition.getDiagramResourceName());
-        assertTrue(processDefinition.hasStartFormKey());
+        assertThat(processDefinition.getResourceName()).isEqualTo(bpmnResourceName);
+        assertThat(processDefinition.getDiagramResourceName()).isNull();
+        assertThat(processDefinition.hasStartFormKey()).isTrue();
     }
 
     @Test
@@ -250,14 +243,14 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
                 }
             });
 
-            assertNotNull(processDefinition);
+            assertThat(processDefinition).isNotNull();
             BpmnModel processModel = repositoryService.getBpmnModel(processDefinition.getId());
-            assertEquals(14, processModel.getMainProcess().getFlowElements().size());
-            assertEquals(7, processModel.getMainProcess().findFlowElementsOfType(SequenceFlow.class).size());
+            assertThat(processModel.getMainProcess().getFlowElements()).hasSize(14);
+            assertThat(processModel.getMainProcess().findFlowElementsOfType(SequenceFlow.class)).hasSize(7);
 
             // Check that no diagram has been created
             List<String> resourceNames = repositoryService.getDeploymentResourceNames(processDefinition.getDeploymentId());
-            assertEquals(1, resourceNames.size());
+            assertThat(resourceNames).hasSize(1);
 
             repositoryService.deleteDeployment(repositoryService.createDeploymentQuery().singleResult().getId(), true);
         } finally {
@@ -271,19 +264,20 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
     public void testProcessDiagramResource(@DeploymentId String deploymentIdFromDeploymentAnnotation) {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
 
-        assertEquals("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.bpmn20.xml", processDefinition.getResourceName());
+        assertThat(processDefinition.getResourceName()).isEqualTo("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.bpmn20.xml");
         BpmnModel processModel = repositoryService.getBpmnModel(processDefinition.getId());
         List<StartEvent> startEvents = processModel.getMainProcess().findFlowElementsOfType(StartEvent.class);
-        assertEquals(1, startEvents.size());
-        assertEquals("someFormKey", startEvents.get(0).getFormKey());
+        assertThat(startEvents)
+                .extracting(StartEvent::getFormKey)
+                .containsExactly("someFormKey");
 
         String diagramResourceName = processDefinition.getDiagramResourceName();
-        assertEquals("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.jpg", diagramResourceName);
+        assertThat(diagramResourceName).isEqualTo("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.jpg");
 
         InputStream diagramStream = repositoryService.getResourceAsStream(deploymentIdFromDeploymentAnnotation,
                 "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.jpg");
         byte[] diagramBytes = IoUtil.readInputStream(diagramStream, "diagram stream");
-        assertEquals(33343, diagramBytes.length);
+        assertThat(diagramBytes.length).isEqualTo(33343);
     }
 
     @Test
@@ -296,9 +290,9 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         ProcessDefinition processB = repositoryService.createProcessDefinitionQuery().processDefinitionKey("b").singleResult();
         ProcessDefinition processC = repositoryService.createProcessDefinitionQuery().processDefinitionKey("c").singleResult();
 
-        assertEquals("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.a.jpg", processA.getDiagramResourceName());
-        assertEquals("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.b.jpg", processB.getDiagramResourceName());
-        assertEquals("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.c.jpg", processC.getDiagramResourceName());
+        assertThat(processA.getDiagramResourceName()).isEqualTo("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.a.jpg");
+        assertThat(processB.getDiagramResourceName()).isEqualTo("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.b.jpg");
+        assertThat(processC.getDiagramResourceName()).isEqualTo("org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testMultipleDiagramResourcesProvided.c.jpg");
     }
 
     @Test
@@ -306,7 +300,7 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
     public void testProcessDefinitionDescription() {
         String id = repositoryService.createProcessDefinitionQuery().singleResult().getId();
         ProcessDefinition processDefinition = ((RepositoryServiceImpl) repositoryService).getDeployedProcessDefinition(id);
-        assertEquals("This is really good process documentation!", processDefinition.getDescription());
+        assertThat(processDefinition.getDescription()).isEqualTo("This is really good process documentation!");
     }
 
     @Test
@@ -318,14 +312,13 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentId);
 
         // verify bpmn file name
-        assertEquals(1, deploymentResources.size());
-        assertEquals(bpmnResourceName, deploymentResources.get(0));
+        assertThat(deploymentResources)
+                .containsExactly(bpmnResourceName);
 
         repositoryService.createDeployment().enableDuplicateFiltering().addClasspathResource(bpmnResourceName).name("twice").tenantId("Tenant_B").deploy();
         List<org.flowable.engine.repository.Deployment> deploymentList = repositoryService.createDeploymentQuery().list();
-        // Now, we should have two deployment for same process file, one for
-        // each tenant
-        assertEquals(2, deploymentList.size());
+        // Now, we should have two deployment for same process file, one for each tenant
+        assertThat(deploymentList).hasSize(2);
 
         for (org.flowable.engine.repository.Deployment deployment : deploymentList) {
             repositoryService.deleteDeployment(deployment.getId());
@@ -335,18 +328,14 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
     @Test
     public void testV5Deployment() {
         String bpmnResourceName = "org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml";
-        try {
-            repositoryService.createDeployment()
-                    .addClasspathResource(bpmnResourceName)
-                    .deploymentProperty(DeploymentProperties.DEPLOY_AS_FLOWABLE5_PROCESS_DEFINITION, Boolean.TRUE)
-                    .name("v5")
-                    .deploy();
-
-            fail("Expected deployment exception because v5 compatibility handler is not enabled");
-
-        } catch (FlowableException e) {
-            // expected
-        }
+        assertThatThrownBy(() ->
+                repositoryService.createDeployment()
+                        .addClasspathResource(bpmnResourceName)
+                        .deploymentProperty(DeploymentProperties.DEPLOY_AS_FLOWABLE5_PROCESS_DEFINITION, Boolean.TRUE)
+                        .name("v5")
+                        .deploy())
+                .isExactlyInstanceOf(FlowableException.class)
+                .as("Expected deployment exception because v5 compatibility handler is not enabled");
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/MessageEventsAndNewVersionDeploymentsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/MessageEventsAndNewVersionDeploymentsTest.java
@@ -13,6 +13,7 @@
 
 package org.flowable.engine.test.bpmn.deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
@@ -50,19 +51,19 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
     public void testMessageBoundaryEvent() {
         String deploymentId1 = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKey("messageTest");
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
 
         String deploymentId2 = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKey("messageTest");
-        assertEquals(2, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).hasSize(2);
 
         assertReceiveMessage("myMessage", 2);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         for (org.flowable.task.api.Task task : tasks) {
-            assertEquals("Task after message", task.getName());
+            assertThat(task.getName()).isEqualTo("Task after message");
         }
 
         cleanup(deploymentId1, deploymentId2);
@@ -75,19 +76,19 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
     public void testBoundaryEventSubscriptionDeletedOnDeploymentDelete() {
         String deploymentId = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKey("messageTest");
-        assertEquals("My Task", taskService.createTaskQuery().singleResult().getName());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");
 
         String deploymentId2 = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKey("messageTest");
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(2, getAllEventSubscriptions().size());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(getAllEventSubscriptions()).hasSize(2);
 
         repositoryService.deleteDeployment(deploymentId, true);
-        assertEquals("My Task", taskService.createTaskQuery().singleResult().getName());
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");
+        assertThat(getAllEventSubscriptions()).hasSize(1);
 
         repositoryService.deleteDeployment(deploymentId2, true);
-        assertEquals(0, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).isEmpty();
     }
 
     /**
@@ -97,21 +98,21 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
     public void testBoundaryEventSubscriptionsDeletedOnProcessInstanceDelete() {
         String deploymentId1 = deployBoundaryMessageTestProcess();
         runtimeService.startProcessInstanceByKey("messageTest");
-        assertEquals("My Task", taskService.createTaskQuery().singleResult().getName());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");
 
         String deploymentId2 = deployBoundaryMessageTestProcess();
         ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("messageTest");
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(2, getAllEventSubscriptions().size());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(getAllEventSubscriptions()).hasSize(2);
 
         // Deleting PI of second deployment
         runtimeService.deleteProcessInstance(processInstance2.getId(), "testing");
-        assertEquals("My Task", taskService.createTaskQuery().singleResult().getName());
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");
+        assertThat(getAllEventSubscriptions()).hasSize(1);
 
         runtimeService.messageEventReceived("myMessage", getExecutionIdsForMessageEventSubscription("myMessage").get(0));
-        assertEquals(0, getAllEventSubscriptions().size());
-        assertEquals("Task after message", taskService.createTaskQuery().singleResult().getName());
+        assertThat(getAllEventSubscriptions()).isEmpty();
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("Task after message");
 
         cleanup(deploymentId1, deploymentId2);
     }
@@ -123,17 +124,17 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
     @Test
     public void testStartMessageEvent() {
         String deploymentId1 = deployStartMessageTestProcess();
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
         assertEventSubscriptionsCount(1);
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         String deploymentId2 = deployStartMessageTestProcess();
         assertEventSubscriptionsCount(1);
 
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
         assertEventSubscriptionsCount(1);
 
         cleanup(deploymentId1, deploymentId2);
@@ -146,7 +147,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
 
         String deploymentId1 = deployStartMessageTestProcess();
         List<EventSubscription> eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(1, eventSubscriptions.size());
+        assertThat(eventSubscriptions).hasSize(1);
 
         String deploymentId2 = deployStartMessageTestProcess();
         eventSubscriptions = getAllEventSubscriptions();
@@ -154,22 +155,23 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
 
         repositoryService.deleteDeployment(deploymentId2, true);
         eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(1, eventSubscriptions.size());
+        assertThat(eventSubscriptions).hasSize(1);
 
         cleanup(deploymentId1);
-        assertEquals(0, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).isEmpty();
 
         // Deploy two versions of process definition, delete the first
         deploymentId1 = deployStartMessageTestProcess();
         deploymentId2 = deployStartMessageTestProcess();
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
         repositoryService.deleteDeployment(deploymentId1, true);
         eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(1, eventSubscriptions.size());
-        assertEquals(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId2).singleResult().getId(), eventSubscriptions.get(0).getProcessDefinitionId());
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getProcessDefinitionId)
+                .containsExactly(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId2).singleResult().getId());
 
         cleanup(deploymentId2);
-        assertEquals(0, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).isEmpty();
     }
 
     /**
@@ -178,29 +180,30 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
     @Test
     public void testDeployIntermediateVersionWithoutMessageStartEvent() {
         String deploymentId1 = deployStartMessageTestProcess();
-        assertEquals(1, getAllEventSubscriptions().size());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         assertEventSubscriptionsCount(1);
 
         String deploymentId2 = deployProcessWithoutEvents();
-        assertEquals(0, getAllEventSubscriptions().size());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(getAllEventSubscriptions()).isEmpty();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         assertEventSubscriptionsCount(0);
 
         String deploymentId3 = deployStartMessageTestProcess();
-        assertEquals(1, getAllEventSubscriptions().size());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
         assertEventSubscriptionsCount(1);
 
         List<EventSubscription> eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId3).singleResult().getId(),
-                eventSubscriptions.get(0).getProcessDefinitionId());
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getProcessDefinitionId)
+                .containsExactly(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId3).singleResult().getId());
 
         cleanup(deploymentId1, deploymentId2, deploymentId3);
     }
@@ -264,7 +267,7 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         String deploymentId2 = deployProcessWithoutEvents();
         assertEventSubscriptionsCount(0);
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
         repositoryService.deleteDeployment(deploymentId2, true);
         assertEventSubscriptionsCount(1); // the first is now the one with the signal
         runtimeService.startProcessInstanceByMessage("myStartMessage");
@@ -280,16 +283,16 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         String deploymentId3 = deployStartMessageTestProcess();
         String deploymentId4 = deployProcessWithoutEvents();
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         repositoryService.deleteDeployment(deploymentId2, true);
         repositoryService.deleteDeployment(deploymentId3, true);
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         repositoryService.deleteDeployment(deploymentId1, true);
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
         cleanup(deploymentId4);
     }
 
@@ -300,16 +303,16 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         String deploymentId3 = deployStartMessageTestProcess();
         String deploymentId4 = deployProcessWithoutEvents();
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         repositoryService.deleteDeployment(deploymentId2, true);
         repositoryService.deleteDeployment(deploymentId3, true);
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         repositoryService.deleteDeployment(deploymentId4, true);
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         cleanup(deploymentId1);
     }
 
@@ -324,39 +327,39 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
 
         String deploymentId1 = deployProcessWithBothStartAndBoundaryMessage();
         assertEventSubscriptionsCount(1);
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         runtimeService.startProcessInstanceByMessage("myStartMessage");
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(3, getAllEventSubscriptions().size()); // 1 for the start, 2 for the boundary
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
+        assertThat(getAllEventSubscriptions()).hasSize(3); // 1 for the start, 2 for the boundary
 
         // Deploy version with only a boundary signal
         String deploymentId2 = deployBoundaryMessageTestProcess();
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
         assertEventSubscriptionsCount(2); // 2 boundary events remain
 
         // Deploy version with signal start
         String deploymentId3 = deployStartMessageTestProcess();
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(3, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(3);
         assertEventSubscriptionsCount(3);
 
         // Delete last version again, making the one with the boundary the latest
         repositoryService.deleteDeployment(deploymentId3, true);
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myStartMessage"));
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count()); // -1, cause process instance of deploymentId3 is gone too
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2); // -1, cause process instance of deploymentId3 is gone too
         assertEventSubscriptionsCount(2); // The 2 boundary remains
 
         // Test the boundary signal
         assertReceiveMessage("myBoundaryMessage", 2);
-        assertEquals(2, taskService.createTaskQuery().taskName("Task after boundary message").list().size());
+        assertThat(taskService.createTaskQuery().taskName("Task after boundary message").list()).hasSize(2);
 
         // Delete second version
         repositoryService.deleteDeployment(deploymentId2, true);
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(3, runtimeService.createProcessInstanceQuery().count()); // -1, cause process instance of deploymentId3 is gone too
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(3); // -1, cause process instance of deploymentId3 is gone too
         assertEventSubscriptionsCount(2); // 2 boundaries
 
         cleanup(deploymentId1);
@@ -368,9 +371,9 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         // Deploy process with both boundary and start event
 
         String deploymentId1 = deployProcessWithBothStartAndBoundarySameMessage();
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
         assertEventSubscriptionsCount(1);
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         for (int i = 0; i < 9; i++) {
             // Every iteration will signal the boundary event of the previous iteration!
@@ -378,14 +381,14 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
         }
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(9, historyService.createHistoricProcessInstanceQuery().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(9);
         }
-        assertEquals(10, getAllEventSubscriptions().size()); // 1 for the start, 9 for boundary
+        assertThat(getAllEventSubscriptions()).hasSize(10); // 1 for the start, 9 for boundary
 
         // Deploy version with only a start signal. The boundary events should still react though!
         String deploymentId2 = deployStartMessageTestProcess();
         runtimeService.startProcessInstanceByMessage("myStartMessage");
-        assertEquals(10, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(10);
         assertEventSubscriptionsCount(10); // Remains 10: 1 one was removed, but one added for the new message
 
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByMessage("myMessage"));
@@ -452,8 +455,8 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
                 .list();
 
         for (EventSubscription entity : eventSubscriptionEntities) {
-            assertEquals("message", entity.getEventType());
-            assertNotNull(entity.getProcessDefinitionId());
+            assertThat(entity.getEventType()).isEqualTo("message");
+            assertThat(entity.getProcessDefinitionId()).isNotNull();
         }
 
         return eventSubscriptionEntities;
@@ -461,14 +464,14 @@ public class MessageEventsAndNewVersionDeploymentsTest extends PluggableFlowable
 
     private void assertReceiveMessage(String messageName, int executionIdsCount) {
         List<String> executionIds = getExecutionIdsForMessageEventSubscription(messageName);
-        assertEquals(executionIdsCount, executionIds.size());
+        assertThat(executionIds).hasSize(executionIdsCount);
         for (String executionId : executionIds) {
             runtimeService.messageEventReceived(messageName, executionId);
         }
     }
 
-    private void assertEventSubscriptionsCount(long count) {
-        assertEquals(count, getAllEventSubscriptions().size());
+    private void assertEventSubscriptionsCount(int count) {
+        assertThat(getAllEventSubscriptions()).hasSize(count);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
@@ -81,22 +81,22 @@ public class ParsedDeploymentTest extends PluggableFlowableTestCase {
 
         List<ProcessDefinitionEntity> processDefinitions = parsedDeployment.getAllProcessDefinitions();
 
-        assertThat(parsedDeployment.getDeployment()).isSameAs(entity);
+        assertThat(parsedDeployment.getDeployment()).isEqualTo(entity);
         assertThat(processDefinitions).hasSize(4);
 
         ProcessDefinitionEntity id1 = getProcessDefinitionEntityFromList(processDefinitions, ID1_ID);
         ProcessDefinitionEntity id2 = getProcessDefinitionEntityFromList(processDefinitions, ID2_ID);
         assertThat(parsedDeployment.getBpmnParseForProcessDefinition(id1))
-                .isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id2));
-        assertThat(parsedDeployment.getBpmnModelForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel());
-        assertThat(parsedDeployment.getProcessModelForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey()));
+                .isEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id2));
+        assertThat(parsedDeployment.getBpmnModelForProcessDefinition(id1)).isEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel());
+        assertThat(parsedDeployment.getProcessModelForProcessDefinition(id1)).isEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey()));
         assertThat(parsedDeployment.getResourceForProcessDefinition(id1).getName()).isEqualTo(IDR_XML_NAME);
         assertThat(parsedDeployment.getResourceForProcessDefinition(id2).getName()).isEqualTo(IDR_XML_NAME);
 
         ProcessDefinitionEntity en1 = getProcessDefinitionEntityFromList(processDefinitions, EN1_ID);
         ProcessDefinitionEntity en2 = getProcessDefinitionEntityFromList(processDefinitions, EN2_ID);
         assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1))
-                .isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(en2));
+                .isEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(en2));
         assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1)).isNotEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id2));
         assertThat(parsedDeployment.getResourceForProcessDefinition(en1).getName()).isEqualTo(EN_XML_NAME);
         assertThat(parsedDeployment.getResourceForProcessDefinition(en2).getName()).isEqualTo(EN_XML_NAME);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
@@ -13,10 +13,7 @@
 
 package org.flowable.engine.test.bpmn.deployment;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
@@ -84,25 +81,25 @@ public class ParsedDeploymentTest extends PluggableFlowableTestCase {
 
         List<ProcessDefinitionEntity> processDefinitions = parsedDeployment.getAllProcessDefinitions();
 
-        assertThat(parsedDeployment.getDeployment(), sameInstance(entity));
-        assertThat(processDefinitions.size(), equalTo(4));
+        assertThat(parsedDeployment.getDeployment()).isSameAs(entity);
+        assertThat(processDefinitions).hasSize(4);
 
         ProcessDefinitionEntity id1 = getProcessDefinitionEntityFromList(processDefinitions, ID1_ID);
         ProcessDefinitionEntity id2 = getProcessDefinitionEntityFromList(processDefinitions, ID2_ID);
-        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(id1),
-                sameInstance(parsedDeployment.getBpmnParseForProcessDefinition(id2)));
-        assertThat(parsedDeployment.getBpmnModelForProcessDefinition(id1), sameInstance(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel()));
-        assertThat(parsedDeployment.getProcessModelForProcessDefinition(id1), sameInstance(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey())));
-        assertThat(parsedDeployment.getResourceForProcessDefinition(id1).getName(), equalTo(IDR_XML_NAME));
-        assertThat(parsedDeployment.getResourceForProcessDefinition(id2).getName(), equalTo(IDR_XML_NAME));
+        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(id1))
+                .isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id2));
+        assertThat(parsedDeployment.getBpmnModelForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel());
+        assertThat(parsedDeployment.getProcessModelForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey()));
+        assertThat(parsedDeployment.getResourceForProcessDefinition(id1).getName()).isEqualTo(IDR_XML_NAME);
+        assertThat(parsedDeployment.getResourceForProcessDefinition(id2).getName()).isEqualTo(IDR_XML_NAME);
 
         ProcessDefinitionEntity en1 = getProcessDefinitionEntityFromList(processDefinitions, EN1_ID);
         ProcessDefinitionEntity en2 = getProcessDefinitionEntityFromList(processDefinitions, EN2_ID);
-        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1),
-                sameInstance(parsedDeployment.getBpmnParseForProcessDefinition(en2)));
-        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1), not(equalTo(parsedDeployment.getBpmnParseForProcessDefinition(id2))));
-        assertThat(parsedDeployment.getResourceForProcessDefinition(en1).getName(), equalTo(EN_XML_NAME));
-        assertThat(parsedDeployment.getResourceForProcessDefinition(en2).getName(), equalTo(EN_XML_NAME));
+        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1))
+                .isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(en2));
+        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1)).isNotEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id2));
+        assertThat(parsedDeployment.getResourceForProcessDefinition(en1).getName()).isEqualTo(EN_XML_NAME);
+        assertThat(parsedDeployment.getResourceForProcessDefinition(en2).getName()).isEqualTo(EN_XML_NAME);
     }
 
     private ProcessDefinitionEntity getProcessDefinitionEntityFromList(List<ProcessDefinitionEntity> list, String idString) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
@@ -81,22 +81,21 @@ public class ParsedDeploymentTest extends PluggableFlowableTestCase {
 
         List<ProcessDefinitionEntity> processDefinitions = parsedDeployment.getAllProcessDefinitions();
 
-        assertThat(parsedDeployment.getDeployment()).isEqualTo(entity);
+        assertThat(parsedDeployment.getDeployment()).isSameAs(entity);
         assertThat(processDefinitions).hasSize(4);
 
         ProcessDefinitionEntity id1 = getProcessDefinitionEntityFromList(processDefinitions, ID1_ID);
         ProcessDefinitionEntity id2 = getProcessDefinitionEntityFromList(processDefinitions, ID2_ID);
-        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(id1))
-                .isEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id2));
-        assertThat(parsedDeployment.getBpmnModelForProcessDefinition(id1)).isEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel());
-        assertThat(parsedDeployment.getProcessModelForProcessDefinition(id1)).isEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey()));
+        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id2));
+        assertThat(parsedDeployment.getBpmnModelForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel());
+        assertThat(parsedDeployment.getProcessModelForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey()));
         assertThat(parsedDeployment.getResourceForProcessDefinition(id1).getName()).isEqualTo(IDR_XML_NAME);
         assertThat(parsedDeployment.getResourceForProcessDefinition(id2).getName()).isEqualTo(IDR_XML_NAME);
 
         ProcessDefinitionEntity en1 = getProcessDefinitionEntityFromList(processDefinitions, EN1_ID);
         ProcessDefinitionEntity en2 = getProcessDefinitionEntityFromList(processDefinitions, EN2_ID);
         assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1))
-                .isEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(en2));
+                .isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(en2));
         assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1)).isNotEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id2));
         assertThat(parsedDeployment.getResourceForProcessDefinition(en1).getName()).isEqualTo(EN_XML_NAME);
         assertThat(parsedDeployment.getResourceForProcessDefinition(en2).getName()).isEqualTo(EN_XML_NAME);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/SignalEventsAndNewVersionDeploymentsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/SignalEventsAndNewVersionDeploymentsTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.common.engine.impl.history.HistoryLevel;
@@ -53,16 +55,16 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         String deploymentId = deployBoundarySignalTestProcess();
 
         runtimeService.startProcessInstanceByKey("signalTest");
-        assertEquals(2, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).hasSize(2);
 
         runtimeService.signalEventReceived("mySignal");
-        assertEquals(0, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).isEmpty();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         for (org.flowable.task.api.Task task : tasks) {
-            assertEquals("Task after signal", task.getName());
+            assertThat(task.getName()).isEqualTo("Task after signal");
         }
 
         cleanup(deploymentId);
@@ -75,19 +77,19 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
     public void testBoundaryEventSubscriptionDeletedOnDeploymentDelete() {
         String deploymentId = deployBoundarySignalTestProcess();
         runtimeService.startProcessInstanceByKey("signalTest");
-        assertEquals("My Task", taskService.createTaskQuery().singleResult().getName());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");
 
         String deploymentId2 = deployBoundarySignalTestProcess();
         runtimeService.startProcessInstanceByKey("signalTest");
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(2, getAllEventSubscriptions().size());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(getAllEventSubscriptions()).hasSize(2);
 
         repositoryService.deleteDeployment(deploymentId, true);
-        assertEquals("My Task", taskService.createTaskQuery().singleResult().getName());
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");
+        assertThat(getAllEventSubscriptions()).hasSize(1);
 
         repositoryService.deleteDeployment(deploymentId2, true);
-        assertEquals(0, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).isEmpty();
     }
 
     /**
@@ -97,21 +99,21 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
     public void testBoundaryEventSubscrptionsDeletedOnProcessInstanceDelete() {
         String deploymentId1 = deployBoundarySignalTestProcess();
         runtimeService.startProcessInstanceByKey("signalTest");
-        assertEquals("My Task", taskService.createTaskQuery().singleResult().getName());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");
 
         String deploymentId2 = deployBoundarySignalTestProcess();
         ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("signalTest");
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(2, getAllEventSubscriptions().size());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(getAllEventSubscriptions()).hasSize(2);
 
         // Deleting PI of second deployment
         runtimeService.deleteProcessInstance(processInstance2.getId(), "testing");
-        assertEquals("My Task", taskService.createTaskQuery().singleResult().getName());
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");
+        assertThat(getAllEventSubscriptions()).hasSize(1);
 
         runtimeService.signalEventReceived("mySignal");
-        assertEquals(0, getAllEventSubscriptions().size());
-        assertEquals("Task after signal", taskService.createTaskQuery().singleResult().getName());
+        assertThat(getAllEventSubscriptions()).isEmpty();
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("Task after signal");
 
         cleanup(deploymentId1, deploymentId2);
     }
@@ -123,14 +125,14 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
     @Test
     public void testStartSignalEvent() {
         String deploymentId1 = deployStartSignalTestProcess();
-        assertEquals(1, getAllEventSubscriptions().size());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         String deploymentId2 = deployStartSignalTestProcess();
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
+        assertThat(getAllEventSubscriptions()).hasSize(1);
 
         cleanup(deploymentId1, deploymentId2);
     }
@@ -142,30 +144,31 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
 
         String deploymentId1 = deployStartSignalTestProcess();
         List<EventSubscription> eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(1, eventSubscriptions.size());
+        assertThat(eventSubscriptions).hasSize(1);
 
         String deploymentId2 = deployStartSignalTestProcess();
         eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(1, eventSubscriptions.size());
+        assertThat(eventSubscriptions).hasSize(1);
 
         repositoryService.deleteDeployment(deploymentId2, true);
         eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(1, eventSubscriptions.size());
+        assertThat(eventSubscriptions).hasSize(1);
 
         cleanup(deploymentId1);
-        assertEquals(0, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).isEmpty();
 
         // Deploy two versions of process definition, delete the first
         deploymentId1 = deployStartSignalTestProcess();
         deploymentId2 = deployStartSignalTestProcess();
-        assertEquals(1, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
         repositoryService.deleteDeployment(deploymentId1, true);
         eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(1, eventSubscriptions.size());
-        assertEquals(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId2).singleResult().getId(), eventSubscriptions.get(0).getProcessDefinitionId());
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getProcessDefinitionId)
+                .containsExactly(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId2).singleResult().getId());
 
         cleanup(deploymentId2);
-        assertEquals(0, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).isEmpty();
     }
 
     /**
@@ -174,29 +177,30 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
     @Test
     public void testDeployIntermediateVersionWithoutSignalStartEvent() {
         String deploymentId1 = deployStartSignalTestProcess();
-        assertEquals(1, getAllEventSubscriptions().size());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         assertEventSubscriptionsCount(1);
 
         String deploymentId2 = deployProcessWithoutEvents();
-        assertEquals(0, getAllEventSubscriptions().size());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(getAllEventSubscriptions()).isEmpty();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         assertEventSubscriptionsCount(0);
 
         String deploymentId3 = deployStartSignalTestProcess();
-        assertEquals(1, getAllEventSubscriptions().size());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(getAllEventSubscriptions()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
         assertEventSubscriptionsCount(1);
 
         List<EventSubscription> eventSubscriptions = getAllEventSubscriptions();
-        assertEquals(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId3).singleResult().getId(),
-                eventSubscriptions.get(0).getProcessDefinitionId());
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getProcessDefinitionId)
+                .containsExactly(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId3).singleResult().getId());
 
         cleanup(deploymentId1, deploymentId2, deploymentId3);
     }
@@ -260,7 +264,7 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         String deploymentId2 = deployProcessWithoutEvents();
         assertEventSubscriptionsCount(0);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
         repositoryService.deleteDeployment(deploymentId2, true);
         assertEventSubscriptionsCount(1); // the first is now the one with the signal
         runtimeService.signalEventReceived("myStartSignal");
@@ -276,16 +280,16 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         String deploymentId3 = deployStartSignalTestProcess();
         String deploymentId4 = deployProcessWithoutEvents();
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         repositoryService.deleteDeployment(deploymentId2, true);
         repositoryService.deleteDeployment(deploymentId3, true);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         repositoryService.deleteDeployment(deploymentId1, true);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
         cleanup(deploymentId4);
     }
 
@@ -296,16 +300,16 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
         String deploymentId3 = deployStartSignalTestProcess();
         String deploymentId4 = deployProcessWithoutEvents();
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         repositoryService.deleteDeployment(deploymentId2, true);
         repositoryService.deleteDeployment(deploymentId3, true);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         repositoryService.deleteDeployment(deploymentId4, true);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
         cleanup(deploymentId1);
     }
 
@@ -320,39 +324,39 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
 
         String deploymentId1 = deployProcessWithBothStartAndBoundarySignal();
         assertEventSubscriptionsCount(1);
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         runtimeService.signalEventReceived("myStartSignal");
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(3, getAllEventSubscriptions().size()); // 1 for the start, 2 for the boundary
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
+        assertThat(getAllEventSubscriptions()).hasSize(3); // 1 for the start, 2 for the boundary
 
         // Deploy version with only a boundary signal
         String deploymentId2 = deployBoundarySignalTestProcess();
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
         assertEventSubscriptionsCount(2);
 
         // Deploy version with signal start
         String deploymentId3 = deployStartSignalTestProcess();
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(3, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(3);
         assertEventSubscriptionsCount(3);
 
         // Delete last version again, making the one with the boundary the latest
         repositoryService.deleteDeployment(deploymentId3, true);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count()); // -1, cause process instance of deploymentId3 is gone too
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2); // -1, cause process instance of deploymentId3 is gone too
         assertEventSubscriptionsCount(2);
 
         // Test the boundary signal
         runtimeService.signalEventReceived("myBoundarySignal");
-        assertEquals(2, taskService.createTaskQuery().taskName("Task after boundary signal").list().size());
+        assertThat(taskService.createTaskQuery().taskName("Task after boundary signal").list()).hasSize(2);
 
         // Delete second version
         repositoryService.deleteDeployment(deploymentId2, true);
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(3, runtimeService.createProcessInstanceQuery().count()); // -1, cause process instance of deploymentId3 is gone too
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(3); // -1, cause process instance of deploymentId3 is gone too
         assertEventSubscriptionsCount(2);
 
         cleanup(deploymentId1);
@@ -365,25 +369,25 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
 
         String deploymentId1 = deployProcessWithBothStartAndBoundarySignalSameSignal();
         assertEventSubscriptionsCount(1);
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         for (int i = 0; i < 9; i++) {
             // Every iteration will signal the boundary event of the previous iteration!
             runtimeService.signalEventReceived("mySignal");
-            assertEquals(2, getAllEventSubscriptions().size());
+            assertThat(getAllEventSubscriptions()).hasSize(2);
         }
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(9, historyService.createHistoricProcessInstanceQuery().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(9);
         }
-        assertEquals(2, getAllEventSubscriptions().size());
+        assertThat(getAllEventSubscriptions()).hasSize(2);
 
         runtimeService.signalEventReceived("myStartSignal");
 
         // Deploy version with only a start signal. The boundary events should still react though!
         String deploymentId2 = deployStartSignalTestProcess();
         runtimeService.signalEventReceived("myStartSignal");
-        assertEquals(2, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(2);
         assertEventSubscriptionsCount(2);
 
         cleanup(deploymentId1, deploymentId2);
@@ -433,14 +437,14 @@ public class SignalEventsAndNewVersionDeploymentsTest extends PluggableFlowableT
                 .list();
 
         for (EventSubscription eventSubscriptionEntity : eventSubscriptions) {
-            assertEquals("signal", eventSubscriptionEntity.getEventType());
-            assertNotNull(eventSubscriptionEntity.getProcessDefinitionId());
+            assertThat(eventSubscriptionEntity.getEventType()).isEqualTo("signal");
+            assertThat(eventSubscriptionEntity.getProcessDefinitionId()).isNotNull();
         }
         return eventSubscriptions;
     }
 
-    private void assertEventSubscriptionsCount(long count) {
-        assertEquals(count, getAllEventSubscriptions().size());
+    private void assertEventSubscriptionsCount(int count) {
+        assertThat(getAllEventSubscriptions()).hasSize(count);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/TimerEventsAndNewVersionDeploymentsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/TimerEventsAndNewVersionDeploymentsTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.job.api.Job;
 import org.junit.jupiter.api.Test;
@@ -57,7 +59,7 @@ public class TimerEventsAndNewVersionDeploymentsTest extends PluggableFlowableTe
         repositoryService.deleteDeployment(deploymentId4, true);
         assertTimerJobs(1);
         Job job = managementService.createTimerJobQuery().singleResult();
-        assertEquals(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId3).singleResult().getId(), job.getProcessDefinitionId());
+        assertThat(job.getProcessDefinitionId()).isEqualTo(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId3).singleResult().getId());
 
         cleanup(deploymentId1, deploymentId2, deploymentId3);
     }
@@ -78,7 +80,7 @@ public class TimerEventsAndNewVersionDeploymentsTest extends PluggableFlowableTe
         repositoryService.deleteDeployment(deploymentId4, true);
         assertTimerJobs(1);
         Job job = managementService.createTimerJobQuery().singleResult();
-        assertEquals(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId1).singleResult().getId(), job.getProcessDefinitionId());
+        assertThat(job.getProcessDefinitionId()).isEqualTo(repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId1).singleResult().getId());
 
         cleanup(deploymentId1);
     }
@@ -105,7 +107,7 @@ public class TimerEventsAndNewVersionDeploymentsTest extends PluggableFlowableTe
     }
 
     private void assertTimerJobs(long count) {
-        assertEquals(count, managementService.createTimerJobQuery().timers().count());
+        assertThat(managementService.createTimerJobQuery().timers().count()).isEqualTo(count);
     }
 
     private void cleanup(String... deploymentIds) {


### PR DESCRIPTION
This is for the `org.flowable.engine.test.bpmn.deployment` package.  Some files had a mix of styles so I converted the whole package of 6 files.

