### PR TITLE
Fix test to ignore order of entries.

### DIFF
--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionActiveActivitiesCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ExecutionActiveActivitiesCollectionResourceTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.javacrumbs.jsonunit.core.Option;
+
 /**
  * @author Frederik Heremans
  */
@@ -47,6 +49,7 @@ public class ExecutionActiveActivitiesCollectionResourceTest extends BaseSpringR
         assertThat(responseNode).isNotNull();
         assertThat(responseNode.isArray()).isTrue();
         assertThatJson(responseNode)
+                .when(Option.IGNORING_ARRAY_ORDER)
                 .isEqualTo("["
                         + "'waitState', 'anotherWaitState'"
                         + "]");


### PR DESCRIPTION
This was found in a recent run of a PR with JDK11.

