### PR TITLE
Fix v5 compat issues when setting business key on process instance

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceBusinessKeyCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceBusinessKeyCmd.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.impl.cmd;
 
+import static org.flowable.engine.impl.util.CommandContextUtil.getProcessEngineConfiguration;
+
 import java.io.Serializable;
 
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
@@ -54,6 +56,12 @@ public class SetProcessInstanceBusinessKeyCmd implements Command<Void>, Serializ
         ExecutionEntityManager executionManager = CommandContextUtil.getExecutionEntityManager(commandContext);
         ExecutionEntity processInstance = executionManager.findById(processInstanceId);
         if (processInstance == null) {
+            if (getProcessEngineConfiguration(commandContext).isFlowable5CompatibilityEnabled()) {
+                getProcessEngineConfiguration(commandContext).getFlowable5CompatibilityHandler().updateBusinessKey(processInstanceId,
+                        businessKey);
+                return null;
+            }
+            
             throw new FlowableObjectNotFoundException("No process instance found for id = '" + processInstanceId + "'.", ProcessInstance.class);
         } else if (!processInstance.isProcessInstanceType()) {
             throw new FlowableIllegalArgumentException("A process instance id is required, but the provided id " + "'" + processInstanceId + "' " + "points to a child execution of process instance " + "'"

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceBusinessKeyCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceBusinessKeyCmd.java
@@ -13,7 +13,6 @@
 
 package org.flowable.engine.impl.cmd;
 
-import static org.flowable.engine.impl.util.CommandContextUtil.getProcessEngineConfiguration;
 
 import java.io.Serializable;
 
@@ -56,8 +55,8 @@ public class SetProcessInstanceBusinessKeyCmd implements Command<Void>, Serializ
         ExecutionEntityManager executionManager = CommandContextUtil.getExecutionEntityManager(commandContext);
         ExecutionEntity processInstance = executionManager.findById(processInstanceId);
         if (processInstance == null) {
-            if (getProcessEngineConfiguration(commandContext).isFlowable5CompatibilityEnabled()) {
-                getProcessEngineConfiguration(commandContext).getFlowable5CompatibilityHandler().updateBusinessKey(processInstanceId,
+            if (CommandContextUtil.getProcessEngineConfiguration(commandContext).isFlowable5CompatibilityEnabled()) {
+                CommandContextUtil.getProcessEngineConfiguration(commandContext).getFlowable5CompatibilityHandler().updateBusinessKey(processInstanceId,
                         businessKey);
                 return null;
             }


### PR DESCRIPTION
The command for setting the business key on a process instance did not properly handle the case of a process instance started via the v5 compatibility layer. The existing code tried to lookup the process instance in the v6 cache. If this did not succeed, it did not fallback to v5, but exitedthrew with an exception instead. This fix provides an additional fallback to the v5 by dispatching the business key update down to the v5 compatibility layer.

#### Check List:
* Unit tests: NO
* Documentation: NA

