### PR TITLE
Fix Start of the SharedExecutorServiceAsyncExecutor

### DIFF
--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/multitenant/SharedExecutorServiceAsyncExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/multitenant/SharedExecutorServiceAsyncExecutor.java
@@ -117,6 +117,15 @@ public class SharedExecutorServiceAsyncExecutor extends DefaultAsyncJobExecutor 
 
     @Override
     public void start() {
+    	if (isActive) {
+            return;
+        }
+
+        isActive = true;
+        
+        initializeJobEntityManager();
+        initAsyncJobExecutionThreadPool();
+
         for (String tenantId : timerJobAcquisitionRunnables.keySet()) {
             startTimerJobAcquisitionForTenant(tenantId);
             startAsyncJobAcquisitionForTenant(tenantId);

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/multitenant/SharedExecutorServiceAsyncExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/multitenant/SharedExecutorServiceAsyncExecutor.java
@@ -117,7 +117,7 @@ public class SharedExecutorServiceAsyncExecutor extends DefaultAsyncJobExecutor 
 
     @Override
     public void start() {
-    	if (isActive) {
+        if (isActive) {
             return;
         }
 


### PR DESCRIPTION
In this Pull Request, the following logic has been added to the start of the `SharedExecutorServiceAsyncExecutor`:
- Set the `isActive` property to `true`
- Initialize the `JobEntityManager`
- Initialize the async job execution thread pool

As a result, the [issue](https://forum.flowable.org/t/problems-starting-shared-async-executor/6057) has been fixed that asynchronous jobs were not processed even though the executor had been started.

#### Check List:
* Unit tests: No
* Documentation:  NA
