### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -84,8 +85,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 123).singleResult();
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
 
             List<HistoricProcessInstance> instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().list();
             assertThat(instanceList).hasSize(6);
@@ -94,22 +95,24 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             assertThat(instanceList).hasSize(4);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
             assertThat(instanceList.get(0).getProcessDefinitionKey()).isEqualTo(PROCESS_DEFINITION_KEY);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY_2)
                     .singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().finished().singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().listPage(0, 50);
             assertThat(instanceList).hasSize(6);
@@ -150,7 +153,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .list();
             assertThat(instanceList).isEmpty();
             assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLikeIgnoreCase("test", "t3%").includeProcessVariables().count())
-                    .isEqualTo(0);
+                    .isZero();
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().listPage(0, 50);
             assertThat(instanceList).hasSize(6);
@@ -163,9 +166,10 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             assertThat(instanceList).hasSize(1);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
             assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("test", "test").includeProcessVariables().count()).isEqualTo(4);
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY)
@@ -173,18 +177,20 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             assertThat(instanceList).hasSize(2);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY)
                     .listPage(3, 4);
             assertThat(instanceList).hasSize(1);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY)
                     .listPage(4, 2);
@@ -204,8 +210,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 123).deploymentId(deploymentId).singleResult();
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
             assertThat(processInstance.getDeploymentId()).isEqualTo(deploymentId);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
@@ -216,8 +222,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 123).processDefinitionName(PROCESS_DEFINITION_NAME_2).singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
             assertThat(processInstance.getProcessDefinitionName()).isEqualTo(PROCESS_DEFINITION_NAME_2);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
@@ -228,8 +234,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 123).processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("test", "test").processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).singleResult();
@@ -275,8 +281,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .variableValueEquals("anothertest", 123)
                     .processDefinitionId("undefined").endOr().singleResult();
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or()
@@ -289,8 +295,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .endOr()
                     .singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or()
@@ -312,31 +318,33 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .singleResult();
             assertThat(processInstance).isNotNull();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("casetest")).isEqualTo("MyTest");
+            assertThat(variableMap)
+                    .containsExactly(entry("casetest", "MyTest"));
 
             List<HistoricProcessInstance> instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or()
                     .processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionId("undefined").endOr().list();
             assertThat(instanceList).hasSize(4);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY_2)
                     .processDefinitionId("undefined").endOr()
                     .singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().finished().processDefinitionId("undefined")
                     .endOr().singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
 
             instanceList = historyService.createHistoricProcessInstanceQuery().or().variableValueEquals("test", "test").processDefinitionId("undefined").endOr()
                     .includeProcessVariables().listPage(0, 50);
@@ -347,9 +355,10 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             assertThat(instanceList).hasSize(1);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY)
                     .processDefinitionId("undefined").endOr()
@@ -357,9 +366,10 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             assertThat(instanceList).hasSize(2);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY)
                     .processDefinitionId("undefined").endOr()
@@ -367,9 +377,10 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             assertThat(instanceList).hasSize(1);
             processInstance = instanceList.get(0);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("test")).isEqualTo("test");
-            assertThat(variableMap.get("test2")).isEqualTo("test2");
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("test", "test"),
+                            entry("test2", "test2"));
 
             instanceList = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().processDefinitionKey(PROCESS_DEFINITION_KEY)
                     .processDefinitionId("undefined").endOr()
@@ -418,8 +429,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
 
             HistoricProcessInstance processInstance = query1.singleResult();
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
 
             HistoricProcessInstanceQuery query2 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or();
@@ -446,8 +457,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
                     .processDefinitionId("undefined")
                     .endOr();
             variableMap = query3.singleResult().getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
         }
     }
 
@@ -461,8 +472,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             assertThat(historicprocessInstanceQuery.list()).hasSize(6);
             assertThat(historicprocessInstanceQuery.count()).isEqualTo(6);
             Map<String, Object> variableMap = historicprocessInstanceQuery.list().get(4).getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
             for (HistoricProcessInstance processInstance : historicprocessInstanceQuery.list()) {
                 assertThat(processInstance.getDeploymentId()).isEqualTo(deploymentId);
             }
@@ -475,8 +486,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionName(PROCESS_DEFINITION_NAME_2).endOr().singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
             assertThat(processInstance.getProcessDefinitionName()).isEqualTo(PROCESS_DEFINITION_NAME_2);
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
@@ -487,8 +498,8 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).endOr().singleResult();
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap).hasSize(1);
-            assertThat(variableMap.get("anothertest")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsExactly(entry("anothertest", 123));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionCategory("invalid").endOr().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryAndWithExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryAndWithExceptionTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.history.HistoricProcessInstanceQuery;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -58,11 +59,12 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
 
             HistoricProcessInstanceQuery queryNoException = historyService.createHistoricProcessInstanceQuery();
             assertThat(queryNoException.count()).isEqualTo(1);
-            assertThat(queryNoException.list()).hasSize(1);
-            assertThat(queryNoException.list().get(0).getId()).isEqualTo(processNoException.getId());
+            assertThat(queryNoException.list())
+                    .extracting(HistoricProcessInstance::getId)
+                    .containsExactly(processNoException.getId());
 
             HistoricProcessInstanceQuery queryWithException = historyService.createHistoricProcessInstanceQuery();
-            assertThat(queryWithException.withJobException().count()).isEqualTo(0);
+            assertThat(queryWithException.withJobException().count()).isZero();
             assertThat(queryWithException.withJobException().list()).isEmpty();
 
             ProcessInstance processWithException1 = startProcessInstanceWithFailingJob(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1);
@@ -72,8 +74,9 @@ public class HistoricProcessInstanceQueryAndWithExceptionTest extends PluggableF
 
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             assertThat(queryWithException.withJobException().count()).isEqualTo(1);
-            assertThat(queryWithException.withJobException().list()).hasSize(1);
-            assertThat(queryWithException.withJobException().list().get(0).getId()).isEqualTo(processWithException1.getId());
+            assertThat(queryNoException.withJobException().list())
+                    .extracting(HistoricProcessInstance::getId)
+                    .containsExactly(processWithException1.getId());
 
             ProcessInstance processWithException2 = startProcessInstanceWithFailingJob(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_2);
             TimerJobQuery jobQuery2 = managementService.createTimerJobQuery().processInstanceId(processWithException2.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -22,6 +23,7 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.flowable.task.api.history.HistoricTaskInstance;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -38,9 +40,9 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricProcessInstance> processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).list();
-            assertThat(processes).hasSize(1);
-            assertThat(processes.get(0).getName()).isNull();
-            assertThat(processes.get(0).getDescription()).isNull();
+            assertThat(processes)
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getDescription)
+                    .containsExactly(tuple(null, null));
 
             ObjectNode infoNode = dynamicBpmnService.changeLocalizationName("en-GB", "historicProcessLocalization", "Historic Process Name 'en-GB'");
             dynamicBpmnService.changeLocalizationDescription("en-GB", "historicProcessLocalization", "Historic Process Description 'en-GB'", infoNode);
@@ -51,32 +53,33 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
             dynamicBpmnService.saveProcessDefinitionInfo(processInstance.getProcessDefinitionId(), infoNode);
 
             processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).list();
-            assertThat(processes).hasSize(1);
-            assertThat(processes.get(0).getName()).isNull();
-            assertThat(processes.get(0).getDescription()).isNull();
+            assertThat(processes)
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getDescription)
+                    .containsExactly(tuple(null, null));
 
             processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en-GB").list();
-            assertThat(processes).hasSize(1);
-            assertThat(processes.get(0).getName()).isEqualTo("Historic Process Name 'en-GB'");
-            assertThat(processes.get(0).getDescription()).isEqualTo("Historic Process Description 'en-GB'");
+            assertThat(processes)
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getDescription)
+                    .containsExactly(tuple("Historic Process Name 'en-GB'", "Historic Process Description 'en-GB'"));
 
             processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).listPage(0, 10);
-            assertThat(processes).hasSize(1);
-            assertThat(processes.get(0).getName()).isNull();
-            assertThat(processes.get(0).getDescription()).isNull();
+            assertThat(processes)
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getDescription)
+                    .containsExactly(tuple(null, null));
 
             processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en-GB").listPage(0, 10);
-            assertThat(processes).hasSize(1);
-            assertThat(processes.get(0).getName()).isEqualTo("Historic Process Name 'en-GB'");
-            assertThat(processes.get(0).getDescription()).isEqualTo("Historic Process Description 'en-GB'");
+            assertThat(processes)
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getDescription)
+                    .containsExactly(tuple("Historic Process Name 'en-GB'", "Historic Process Description 'en-GB'"));
 
             HistoricProcessInstance process = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
             assertThat(process.getName()).isNull();
             assertThat(process.getDescription()).isNull();
 
             process = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en-GB").singleResult();
-            assertThat(process.getName()).isEqualTo("Historic Process Name 'en-GB'");
-            assertThat(process.getDescription()).isEqualTo("Historic Process Description 'en-GB'");
+            assertThat(processes)
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getDescription)
+                    .containsExactly(tuple("Historic Process Name 'en-GB'", "Historic Process Description 'en-GB'"));
 
             process = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).locale("en").singleResult();
             assertThat(process.getName()).isEqualTo("Historic Process Name 'en'");
@@ -134,18 +137,18 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
 
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().involvedUser("kermit", "specialLink").count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().involvedUser("kermit", "specialLink").singleResult().getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedUser("kermit", "specialLink").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedUser("kermit", "specialLink").singleResult().getId()).isEqualTo(processInstance.getId());
 
-            assertEquals(0, historyService.createHistoricProcessInstanceQuery().involvedUser("kermit", "undefined").count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedUser("kermit", "undefined").count()).isZero();
 
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "specialLink").processDefinitionKey("undefined").endOr().count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "specialLink").processDefinitionKey("undefined").endOr().singleResult().getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "specialLink").processDefinitionKey("undefined").endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "specialLink").processDefinitionKey("undefined").endOr().singleResult().getId()).isEqualTo(processInstance.getId());
 
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "specialLink").processDefinitionKey("subProcessQueryTest").endOr().count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "specialLink").processDefinitionKey("subProcessQueryTest").endOr().singleResult().getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "specialLink").processDefinitionKey("subProcessQueryTest").endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "specialLink").processDefinitionKey("subProcessQueryTest").endOr().singleResult().getId()).isEqualTo(processInstance.getId());
 
-            assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "undefined").processDefinitionKey("undefined").endOr().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit", "undefined").processDefinitionKey("undefined").endOr().count()).isZero();
         }
     }
     
@@ -159,18 +162,18 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
 
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().involvedGroup("sales", "specialLink").count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().involvedGroup("sales", "specialLink").singleResult().getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroup("sales", "specialLink").count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroup("sales", "specialLink").singleResult().getId()).isEqualTo(processInstance.getId());
 
-            assertEquals(0, historyService.createHistoricProcessInstanceQuery().involvedGroup("sales", "undefined").count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroup("sales", "undefined").count()).isZero();
 
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "specialLink").processDefinitionKey("undefined").endOr().count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "specialLink").processDefinitionKey("undefined").endOr().singleResult().getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "specialLink").processDefinitionKey("undefined").endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "specialLink").processDefinitionKey("undefined").endOr().singleResult().getId()).isEqualTo(processInstance.getId());
 
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "specialLink").processDefinitionKey("subProcessQueryTest").endOr().count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "specialLink").processDefinitionKey("subProcessQueryTest").endOr().singleResult().getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "specialLink").processDefinitionKey("subProcessQueryTest").endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "specialLink").processDefinitionKey("subProcessQueryTest").endOr().singleResult().getId()).isEqualTo(processInstance.getId());
 
-            assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "undefined").processDefinitionKey("undefined").endOr().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedGroup("sales", "undefined").processDefinitionKey("undefined").endOr().count()).isZero();
         }
 
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
                 .isEqualTo(2);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).count()).isEqualTo(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).count()).isEqualTo(1);
-        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).count()).isEqualTo(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).list()).hasSize(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).list()).isEmpty();
@@ -75,7 +76,8 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
                     .variableValueEquals("test", 123).processDefinitionVersion(1).singleResult();
             assertThat(processInstance.getProcessDefinitionVersion().intValue()).isEqualTo(1);
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap.get("test")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(entry("test", 123));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", 456).processDefinitionVersion(1).singleResult();
@@ -85,7 +87,8 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
                     .variableValueEquals("anothertest", 456).processDefinitionVersion(2).singleResult();
             assertThat(processInstance.getProcessDefinitionVersion().intValue()).isEqualTo(2);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap.get("anothertest")).isEqualTo(456);
+            assertThat(variableMap)
+                    .containsOnly(entry("anothertest", 456));
         }
     }
 
@@ -95,8 +98,8 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
                 .isEqualTo(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count())
                 .isEqualTo(1);
-        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count()).isEqualTo(0);
-        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count()).isZero();
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list())
                 .hasSize(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list())
@@ -112,7 +115,7 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
         assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count())
                 .isEqualTo(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().count())
-                .isEqualTo(0);
+                .isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().list())
                 .hasSize(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().list())
@@ -126,13 +129,15 @@ public class HistoricProcessInstanceQueryVersionTest extends PluggableFlowableTe
                     .or().variableValueEquals("test", "invalid").processDefinitionVersion(1).endOr().singleResult();
             assertThat(processInstance.getProcessDefinitionVersion().intValue()).isEqualTo(1);
             Map<String, Object> variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap.get("test")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(entry("test", 123));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .or().variableValueEquals("anothertest", "invalid").processDefinitionVersion(2).endOr().singleResult();
             assertThat(processInstance.getProcessDefinitionVersion().intValue()).isEqualTo(2);
             variableMap = processInstance.getProcessVariables();
-            assertThat(variableMap.get("anothertest")).isEqualTo(456);
+            assertThat(variableMap)
+                    .containsOnly(entry("anothertest", 456));
 
             processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
                     .variableValueEquals("anothertest", "invalid").processDefinitionVersion(3).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -75,12 +76,12 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricTaskInstance task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("gonzo").singleResult();
             Map<String, Object> variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
             assertThat(task.getProcessVariables()).isEmpty();
-            assertThat(variableMap.get("testVar")).isNotNull();
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isNotNull();
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
 
             List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().list();
             assertThat(tasks).hasSize(3);
@@ -116,10 +117,12 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").singleResult();
-            assertThat(task.getProcessVariables()).hasSize(2);
             assertThat(task.getTaskLocalVariables()).isEmpty();
-            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+            assertThat(task.getProcessVariables())
+                    .containsOnly(
+                            entry("processVar", true),
+                            entry("anotherProcessVar", 123)
+                    );
 
             task = historyService.createHistoricTaskInstanceQuery().taskVariableValueLike("testVar", "someVaria%").singleResult();
             assertThat(task).isNotNull();
@@ -135,8 +138,8 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             tasks = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskInvolvedUser("kermit").orderByTaskCreateTime().asc()
                     .list();
             assertThat(tasks).hasSize(3);
-            assertThat(tasks.get(0).getTaskLocalVariables()).hasSize(1);
-            assertThat(tasks.get(0).getTaskLocalVariables().get("test")).isEqualTo("test");
+            assertThat(tasks.get(0).getTaskLocalVariables())
+                    .containsOnly(entry("test", "test"));
             assertThat(tasks.get(0).getProcessVariables()).isEmpty();
 
             tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskInvolvedUser("kermit").orderByTaskCreateTime().asc().list();
@@ -147,22 +150,26 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().taskAssignee("kermit")
                     .taskVariableValueEquals("localVar", "test").singleResult();
             assertThat(task.getProcessVariables()).isEmpty();
-            assertThat(task.getTaskLocalVariables()).hasSize(1);
-            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
+            assertThat(task.getTaskLocalVariables())
+                    .containsOnly(entry("localVar", "test"));
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").taskVariableValueEquals("localVar", "test")
                     .singleResult();
-            assertThat(task.getProcessVariables()).hasSize(2);
             assertThat(task.getTaskLocalVariables()).isEmpty();
-            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+            assertThat(task.getProcessVariables())
+                    .containsOnly(
+                            entry("processVar", true),
+                            entry("anotherProcessVar", 123)
+                    );
 
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().includeProcessVariables().taskAssignee("kermit").singleResult();
-            assertThat(task.getProcessVariables()).hasSize(2);
-            assertThat(task.getTaskLocalVariables()).hasSize(1);
-            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
-            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+            assertThat(task.getTaskLocalVariables())
+                    .containsOnly(entry("localVar", "test"));
+            assertThat(task.getProcessVariables())
+                    .containsOnly(
+                            entry("processVar", true),
+                            entry("anotherProcessVar", 123)
+                    );
 
             task = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").singleResult();
             taskService.complete(task.getId());
@@ -171,22 +178,22 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
 
             task = (HistoricTaskInstance) historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().finished().singleResult();
             variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
             assertThat(task.getProcessVariables()).isEmpty();
-            assertThat(variableMap.get("testVar")).isNotNull();
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isNotNull();
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
 
-            assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
             assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
                     .isEqualTo(taskId);
             assertThat(historyService.createHistoricTaskInstanceQuery().taskInvolvedGroups(Collections.singleton("testGroup")).singleResult().getId())
                     .isEqualTo(taskId);
-            assertThat(historyService.createHistoricTaskInstanceQuery().
-                    or().taskInvolvedGroups(Collections.singleton("testGroup")).taskInvolvedUser("kermit").endOr().count()).isEqualTo(3);
-            assertThat(historyService.createHistoricTaskInstanceQuery().
-                    or().taskInvolvedGroups(Collections.singleton("testGroup")).processInstanceId("undefined").endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery()
+                    .or().taskInvolvedGroups(Collections.singleton("testGroup")).taskInvolvedUser("kermit").endOr().count()).isEqualTo(3);
+            assertThat(historyService.createHistoricTaskInstanceQuery()
+                    .or().taskInvolvedGroups(Collections.singleton("testGroup")).processInstanceId("undefined").endOr().count()).isEqualTo(1);
         }
     }
 
@@ -202,12 +209,12 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .singleResult();
 
             Map<String, Object> variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
             assertThat(task.getProcessVariables()).isEmpty();
-            assertThat(variableMap.get("testVar")).isNotNull();
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isNotNull();
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
 
             List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().list();
             assertThat(tasks).hasSize(3);
@@ -254,15 +261,17 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().or().taskAssignee("kermit")
                     .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
             assertThat(task.getProcessVariables()).isEmpty();
-            assertThat(task.getTaskLocalVariables()).hasSize(1);
-            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
+            assertThat(task.getTaskLocalVariables())
+                    .containsOnly(entry("localVar", "test"));
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().taskAssignee("kermit")
                     .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
-            assertThat(task.getProcessVariables()).hasSize(2);
             assertThat(task.getTaskLocalVariables()).isEmpty();
-            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+            assertThat(task.getProcessVariables())
+                    .containsOnly(
+                            entry("processVar", true),
+                            entry("anotherProcessVar", 123)
+                    );
 
             task = historyService.createHistoricTaskInstanceQuery()
                     .includeTaskLocalVariables()
@@ -271,10 +280,12 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .taskVariableValueLike("testVar", "someVar%")
                     .endOr()
                     .singleResult();
-            assertThat(task.getTaskLocalVariables()).hasSize(2);
             assertThat(task.getProcessVariables()).isEmpty();
-            assertThat(task.getTaskLocalVariables().get("testVar")).isEqualTo("someVariable");
-            assertThat(task.getTaskLocalVariables().get("testVar2")).isEqualTo(123);
+            assertThat(task.getTaskLocalVariables())
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
 
             task = historyService.createHistoricTaskInstanceQuery()
                     .includeTaskLocalVariables()
@@ -283,10 +294,12 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .taskVariableValueLikeIgnoreCase("testVar", "somevar%")
                     .endOr()
                     .singleResult();
-            assertThat(task.getTaskLocalVariables()).hasSize(2);
             assertThat(task.getProcessVariables()).isEmpty();
-            assertThat(task.getTaskLocalVariables().get("testVar")).isEqualTo("someVariable");
-            assertThat(task.getTaskLocalVariables().get("testVar2")).isEqualTo(123);
+            assertThat(task.getTaskLocalVariables())
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
 
             task = historyService.createHistoricTaskInstanceQuery()
                     .includeTaskLocalVariables()
@@ -304,9 +317,9 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
                     .endOr()
                     .orderByTaskCreateTime().asc().list();
             assertThat(tasks).hasSize(3);
-            assertThat(tasks.get(0).getTaskLocalVariables()).hasSize(1);
-            assertThat(tasks.get(0).getTaskLocalVariables().get("test")).isEqualTo("test");
             assertThat(tasks.get(0).getProcessVariables()).isEmpty();
+            assertThat(tasks.get(0).getTaskLocalVariables())
+                    .containsOnly(entry("test", "test"));
 
             tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables()
                     .or()
@@ -324,23 +337,29 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             assertThat(task.getProcessVariables()).isEmpty();
             assertThat(task.getTaskLocalVariables()).hasSize(1);
             assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
+            assertThat(task.getTaskLocalVariables())
+                    .containsOnly(entry("localVar", "test"));
 
             task = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().taskAssignee("kermit").or()
                     .taskVariableValueEquals("localVar", "test")
                     .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
-            assertThat(task.getProcessVariables()).hasSize(2);
             assertThat(task.getTaskLocalVariables()).isEmpty();
-            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+            assertThat(task.getProcessVariables())
+                    .containsOnly(
+                            entry("processVar", true),
+                            entry("anotherProcessVar", 123)
+                    );
 
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().includeProcessVariables().or().taskAssignee("kermit")
                     .taskVariableValueEquals("localVar", "nonExisting")
                     .endOr().singleResult();
-            assertThat(task.getProcessVariables()).hasSize(2);
-            assertThat(task.getTaskLocalVariables()).hasSize(1);
-            assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
-            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+            assertThat(task.getTaskLocalVariables())
+                    .containsOnly(entry("localVar", "test"));
+            assertThat(task.getProcessVariables())
+                    .containsOnly(
+                            entry("processVar", true),
+                            entry("anotherProcessVar", 123)
+                    );
 
             task = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").singleResult();
             taskService.complete(task.getId());
@@ -350,12 +369,12 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             task = historyService.createHistoricTaskInstanceQuery().includeTaskLocalVariables().or().finished()
                     .taskVariableValueEquals("localVar", "nonExisting").endOr().singleResult();
             variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
             assertThat(task.getProcessVariables()).isEmpty();
-            assertThat(variableMap.get("testVar")).isNotNull();
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isNotNull();
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
         }
     }
 
@@ -387,9 +406,11 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             }
             query1 = query1.endOr();
             HistoricTaskInstance task = query1.singleResult();
-            assertThat(task.getProcessVariables()).hasSize(2);
-            assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-            assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+            assertThat(task.getProcessVariables())
+                    .containsOnly(
+                            entry("processVar", true),
+                            entry("anotherProcessVar", 123)
+                    );
         }
     }
 
@@ -427,7 +448,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             taskService.complete(task.getId());
 
-            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
             tasks = historyService.createHistoricTaskInstanceQuery().taskCandidateUser("kermit").list();
             assertThat(tasks).hasSize(3);
@@ -543,27 +564,33 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             assertThat(tasks).hasSize(1);
             HistoricTaskInstance task = tasks.get(0);
             Map<String, Object> variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
 
             tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc()
                     .listPage(1, 2);
             assertThat(tasks).hasSize(2);
             task = tasks.get(1);
             variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
 
             tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc()
                     .listPage(2, 4);
             assertThat(tasks).hasSize(1);
             task = tasks.get(0);
             variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
 
             tasks = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().includeTaskLocalVariables().orderByTaskPriority().asc()
                     .listPage(4, 2);
@@ -580,9 +607,11 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             assertThat(tasks).hasSize(1);
             HistoricTaskInstance task = tasks.get(0);
             Map<String, Object> variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
             assertThat(task.getIdentityLinks()).hasSize(1);
             IdentityLinkInfo identityLink = task.getIdentityLinks().get(0);
             assertThat(identityLink.getProcessInstanceId()).isNull();
@@ -596,9 +625,11 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             assertThat(tasks).hasSize(2);
             task = tasks.get(1);
             variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
             assertThat(task.getIdentityLinks()).hasSize(1);
             identityLink = task.getIdentityLinks().get(0);
             assertThat(identityLink.getProcessInstanceId()).isNull();
@@ -612,9 +643,11 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             assertThat(tasks).hasSize(1);
             task = tasks.get(0);
             variableMap = task.getTaskLocalVariables();
-            assertThat(variableMap).hasSize(2);
-            assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-            assertThat(variableMap.get("testVar2")).isEqualTo(123);
+            assertThat(variableMap)
+                    .containsOnly(
+                            entry("testVar", "someVariable"),
+                            entry("testVar2", 123)
+                    );
             assertThat(task.getIdentityLinks()).hasSize(1);
             identityLink = task.getIdentityLinks().get(0);
             assertThat(identityLink.getProcessInstanceId()).isNull();
@@ -725,7 +758,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
 
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count()).isEqualTo(0);
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).withoutTaskDueDate().count()).isZero();
 
             task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -743,22 +776,19 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     @Test
     public void testQueryWithIncludeTaskVariableAndTaskCategory() {
         List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").list();
-        for (HistoricTaskInstance task : tasks) {
-            assertThat(task.getCategory()).isNotNull();
-            assertThat(task.getCategory()).isEqualTo("testCategory");
-        }
+        assertThat(tasks)
+                .extracting(HistoricTaskInstance::getCategory)
+                .containsOnly("testCategory");
 
         tasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").includeTaskLocalVariables().list();
-        for (HistoricTaskInstance task : tasks) {
-            assertThat(task.getCategory()).isNotNull();
-            assertThat(task.getCategory()).isEqualTo("testCategory");
-        }
+        assertThat(tasks)
+                .extracting(HistoricTaskInstance::getCategory)
+                .containsOnly("testCategory");
 
         tasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("gonzo").includeProcessVariables().list();
-        for (HistoricTaskInstance task : tasks) {
-            assertThat(task.getCategory()).isNotNull();
-            assertThat(task.getCategory()).isEqualTo("testCategory");
-        }
+        assertThat(tasks)
+                .extracting(HistoricTaskInstance::getCategory)
+                .containsOnly("testCategory");
     }
 
     /**

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -43,7 +44,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
-        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         // Complete the task and check if the size is count 1
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -59,10 +60,10 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
-        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
-        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
-        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
-        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelActivityProcess.bpmn20.xml" })
@@ -94,33 +95,24 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
-        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
         assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
 
-        boolean hasProcessVariable = false;
-        boolean hasTaskVariable = false;
         List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-        for (HistoricVariableInstance historicVariableInstance : variables) {
-            if ("var1".equals(historicVariableInstance.getVariableName())) {
-                hasProcessVariable = true;
-                assertThat(historicVariableInstance.getValue()).isEqualTo("test");
-                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
-                assertThat(historicVariableInstance.getTaskId()).isNull();
+        assertThat(variables)
+                .extracting(
+                        HistoricVariableInstance::getVariableName,
+                        HistoricVariableInstance::getValue,
+                        HistoricVariableInstance::getProcessInstanceId,
+                        HistoricVariableInstance::getTaskId)
+                .containsOnly(
+                        tuple("var1", "test", processInstance.getProcessInstanceId(), null),
+                        tuple("localVar1", "test2", processInstance.getProcessInstanceId(), task.getId())
+                );
 
-            } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
-                hasTaskVariable = true;
-                assertThat(historicVariableInstance.getValue()).isEqualTo("test2");
-                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
-                assertThat(historicVariableInstance.getTaskId()).isEqualTo(task.getId());
-            }
-        }
-
-        assertThat(hasProcessVariable).isTrue();
-        assertThat(hasTaskVariable).isTrue();
-
-        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelAuditProcess.bpmn20.xml" })
@@ -165,28 +157,19 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
 
         assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
 
-        boolean hasProcessVariable = false;
-        boolean hasTaskVariable = false;
         List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-        for (HistoricVariableInstance historicVariableInstance : variables) {
-            if ("var1".equals(historicVariableInstance.getVariableName())) {
-                hasProcessVariable = true;
-                assertThat(historicVariableInstance.getValue()).isEqualTo("test");
-                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
-                assertThat(historicVariableInstance.getTaskId()).isNull();
+        assertThat(variables)
+                .extracting(
+                        HistoricVariableInstance::getVariableName,
+                        HistoricVariableInstance::getValue,
+                        HistoricVariableInstance::getProcessInstanceId,
+                        HistoricVariableInstance::getTaskId)
+                .containsOnly(
+                        tuple("var1", "test", processInstance.getProcessInstanceId(), null),
+                        tuple("localVar1", "test2", processInstance.getProcessInstanceId(), task.getId())
+                );
 
-            } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
-                hasTaskVariable = true;
-                assertThat(historicVariableInstance.getValue()).isEqualTo("test2");
-                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
-                assertThat(historicVariableInstance.getTaskId()).isEqualTo(task.getId());
-            }
-        }
-
-        assertThat(hasProcessVariable).isTrue();
-        assertThat(hasTaskVariable).isTrue();
-
-        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Deployment(resources = { "org/flowable/engine/test/api/history/oneTaskHistoryLevelFullProcess.bpmn20.xml" })
@@ -231,26 +214,17 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
 
         assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
 
-        boolean hasProcessVariable = false;
-        boolean hasTaskVariable = false;
         List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-        for (HistoricVariableInstance historicVariableInstance : variables) {
-            if ("var1".equals(historicVariableInstance.getVariableName())) {
-                hasProcessVariable = true;
-                assertThat(historicVariableInstance.getValue()).isEqualTo("test");
-                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
-                assertThat(historicVariableInstance.getTaskId()).isNull();
-
-            } else if ("localVar1".equals(historicVariableInstance.getVariableName())) {
-                hasTaskVariable = true;
-                assertThat(historicVariableInstance.getValue()).isEqualTo("test2");
-                assertThat(historicVariableInstance.getProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
-                assertThat(historicVariableInstance.getTaskId()).isEqualTo(task.getId());
-            }
-        }
-
-        assertThat(hasProcessVariable).isTrue();
-        assertThat(hasTaskVariable).isTrue();
+        assertThat(variables)
+                .extracting(
+                        HistoricVariableInstance::getVariableName,
+                        HistoricVariableInstance::getValue,
+                        HistoricVariableInstance::getProcessInstanceId,
+                        HistoricVariableInstance::getTaskId)
+                .containsOnly(
+                        tuple("var1", "test", processInstance.getProcessInstanceId(), null),
+                        tuple("localVar1", "test2", processInstance.getProcessInstanceId(), task.getId())
+                );
 
         assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceDisableTaskLogTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceDisableTaskLogTest.java
@@ -40,7 +40,7 @@ public class HistoryServiceDisableTaskLogTest extends CustomConfigurationFlowabl
     @AfterEach
     public void deleteTasks() {
         if (task != null) {
-            assertThat(historyService.createHistoricTaskLogEntryQuery().count()).isEqualTo(0l);
+            assertThat(historyService.createHistoricTaskLogEntryQuery().count()).isZero();
             taskService.deleteTask(task.getId(), true);
         }
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -15,6 +15,7 @@ package org.flowable.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -61,7 +62,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQuery() {
         // With a clean ProcessEngine, no instances should be available
-        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
@@ -82,7 +83,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
     public void testHistoricProcessInstanceQueryOrderBy() {
         // With a clean ProcessEngine, no instances should be available
-        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
@@ -262,14 +263,14 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(processInstance.getDeleteReason()).isEqualTo(DeleteReason.PROCESS_INSTANCE_DELETED);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).notDeleted();
-        assertThat(processInstanceQuery.count()).isEqualTo(0);
+        assertThat(processInstanceQuery.count()).isZero();
 
         historyService.deleteHistoricProcessInstance(processInstanceId);
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId);
-        assertThat(processInstanceQuery.count()).isEqualTo(0);
+        assertThat(processInstanceQuery.count()).isZero();
 
         processInstanceId = runtimeService.startProcessInstanceByKey("oneTaskProcess").getId();
         runtimeService.deleteProcessInstance(processInstanceId, "custom message");
@@ -289,7 +290,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(processInstance.getDeleteReason()).isEqualTo("custom message");
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).notDeleted();
-        assertThat(processInstanceQuery.count()).isEqualTo(0);
+        assertThat(processInstanceQuery.count()).isZero();
     }
 
     @Test
@@ -312,7 +313,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(processInstances).hasSize(5);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentId("invalid");
-        assertThat(processInstanceQuery.count()).isEqualTo(0);
+        assertThat(processInstanceQuery.count()).isZero();
     }
 
     @Test
@@ -339,7 +340,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         deploymentIds = new ArrayList<>();
         deploymentIds.add("invalid");
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentIdIn(deploymentIds);
-        assertThat(processInstanceQuery.count()).isEqualTo(0);
+        assertThat(processInstanceQuery.count()).isZero();
     }
 
     @Test
@@ -361,7 +362,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(taskInstances).hasSize(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentId("invalid");
-        assertThat(taskInstanceQuery.count()).isEqualTo(0);
+        assertThat(taskInstanceQuery.count()).isZero();
     }
 
     @Test
@@ -391,7 +392,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         deploymentIds = new ArrayList<>();
         deploymentIds.add("invalid");
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentIdIn(deploymentIds);
-        assertThat(taskInstanceQuery.count()).isEqualTo(0);
+        assertThat(taskInstanceQuery.count()).isZero();
     }
 
     @Test
@@ -413,13 +414,13 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(taskInstances).hasSize(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentId("invalid").endOr();
-        assertThat(taskInstanceQuery.count()).isEqualTo(0);
+        assertThat(taskInstanceQuery.count()).isZero();
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().taskDefinitionKey("theTask").deploymentId("invalid").endOr();
         assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("theTask").or().deploymentId("invalid").endOr();
-        assertThat(taskInstanceQuery.count()).isEqualTo(0);
+        assertThat(taskInstanceQuery.count()).isZero();
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery()
                 .or()
@@ -477,7 +478,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
                 .processDefinitionId("invalid")
                 .endOr()
                 .processInstanceBusinessKey("2");
-        assertThat(taskInstanceQuery.count()).isEqualTo(0);
+        assertThat(taskInstanceQuery.count()).isZero();
     }
 
     @Test
@@ -508,13 +509,13 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         deploymentIds = new ArrayList<>();
         deploymentIds.add("invalid");
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentIdIn(deploymentIds).processDefinitionId("invalid").endOr();
-        assertThat(taskInstanceQuery.count()).isEqualTo(0);
+        assertThat(taskInstanceQuery.count()).isZero();
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().taskDefinitionKey("theTask").deploymentIdIn(deploymentIds).endOr();
         assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("theTask").or().deploymentIdIn(deploymentIds).endOr();
-        assertThat(taskInstanceQuery.count()).isEqualTo(0);
+        assertThat(taskInstanceQuery.count()).isZero();
     }
 
     @Test
@@ -525,9 +526,9 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId())
                 .list();
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).getName()).isEqualTo("my task");
-        assertThat(tasks.get(0).getDescription()).isNull();
+        assertThat(tasks)
+                .extracting(HistoricTaskInstance::getName, HistoricTaskInstance::getDescription)
+                .containsExactly(tuple("my task", null));
 
         ObjectNode infoNode = dynamicBpmnService.changeLocalizationName("en-GB", "theTask", "My localized name");
         dynamicBpmnService.changeLocalizationDescription("en-GB", "theTask", "My localized description", infoNode);
@@ -535,24 +536,24 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).list();
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).getName()).isEqualTo("my task");
-        assertThat(tasks.get(0).getDescription()).isNull();
+        assertThat(tasks)
+                .extracting(HistoricTaskInstance::getName, HistoricTaskInstance::getDescription)
+                .containsExactly(tuple("my task", null));
 
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-GB").list();
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).getName()).isEqualTo("My localized name");
-        assertThat(tasks.get(0).getDescription()).isEqualTo("My localized description");
+        assertThat(tasks)
+                .extracting(HistoricTaskInstance::getName, HistoricTaskInstance::getDescription)
+                .containsExactly(tuple("My localized name", "My localized description"));
 
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).listPage(0, 10);
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).getName()).isEqualTo("my task");
-        assertThat(tasks.get(0).getDescription()).isNull();
+        assertThat(tasks)
+                .extracting(HistoricTaskInstance::getName, HistoricTaskInstance::getDescription)
+                .containsExactly(tuple("my task", null));
 
         tasks = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).locale("en-GB").listPage(0, 10);
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).getName()).isEqualTo("My localized name");
-        assertThat(tasks.get(0).getDescription()).isEqualTo("My localized description");
+        assertThat(tasks)
+                .extracting(HistoricTaskInstance::getName, HistoricTaskInstance::getDescription)
+                .containsExactly(tuple("My localized name", "My localized description"));
 
         HistoricTaskInstance task = historyService.createHistoricTaskInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId())
                 .singleResult();
@@ -646,29 +647,25 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         // Test GREATER_THAN_OR_EQUAL, should return 3 results
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("stringVar", "abcdef").count()).isEqualTo(3);
-        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("stringVar", "z").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThanOrEqual("stringVar", "z").count()).isZero();
 
         // Test LESS_THAN, should return 2 results
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueLessThan("stringVar", "abcdeg").list();
-        assertThat(processInstances).hasSize(2);
-        List<String> expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
-        List<String> ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
-        ids.removeAll(expectedIds);
-        assertThat(ids).isEmpty();
+        assertThat(processInstances)
+                .extracting(HistoricProcessInstance::getId)
+                .containsOnly(processInstance1.getId(), processInstance2.getId());
 
-        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThan("stringVar", "abcdef").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThan("stringVar", "abcdef").count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "z").count()).isEqualTo(3);
 
         // Test LESS_THAN_OR_EQUAL
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "abcdef").list();
-        assertThat(processInstances).hasSize(2);
-        expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
-        ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
-        ids.removeAll(expectedIds);
-        assertThat(ids).isEmpty();
+        assertThat(processInstances)
+                .extracting(HistoricProcessInstance::getId)
+                .containsOnly(processInstance1.getId(), processInstance2.getId());
 
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "z").count()).isEqualTo(3);
-        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "aa").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("stringVar", "aa").count()).isZero();
 
         // Test LIKE
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "azert%").singleResult();
@@ -684,7 +681,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "a%").count()).isEqualTo(3);
-        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "%x%").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLike("stringVar", "%x%").count()).isZero();
 
         // Test value-only matching
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals("azerty").singleResult();
@@ -692,11 +689,9 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueEquals("abcdef").list();
-        assertThat(processInstances).hasSize(2);
-        expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
-        ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
-        ids.removeAll(expectedIds);
-        assertThat(ids).isEmpty();
+        assertThat(processInstances)
+                .extracting(HistoricProcessInstance::getId)
+                .containsOnly(processInstance1.getId(), processInstance2.getId());
 
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals("notmatchinganyvalues").singleResult();
         assertThat(resultInstance).isNull();
@@ -813,7 +808,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(resultInstance).isNotNull();
         assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
-        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("dateVar", nextYear.getTime()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("dateVar", nextYear.getTime()).count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueGreaterThan("dateVar", oneYearAgo.getTime()).count()).isEqualTo(3);
 
         // Test GREATER_THAN_OR_EQUAL
@@ -829,21 +824,18 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         // Test LESS_THAN
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", nextYear.getTime()).list();
-        assertThat(processInstances).hasSize(2);
+        assertThat(processInstances)
+                .extracting(HistoricProcessInstance::getId)
+                .containsOnly(processInstance1.getId(), processInstance2.getId());
 
-        List<String> expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
-        List<String> ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
-        ids.removeAll(expectedIds);
-        assertThat(ids).isEmpty();
-
-        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", date1).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", date1).count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThan("dateVar", twoYearsLater.getTime()).count()).isEqualTo(3);
 
         // Test LESS_THAN_OR_EQUAL
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("dateVar", nextYear.getTime()).list();
         assertThat(processInstances).hasSize(3);
 
-        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("dateVar", oneYearAgo.getTime()).count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueLessThanOrEqual("dateVar", oneYearAgo.getTime()).count()).isZero();
 
         // Test value-only matching
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals(nextYear.getTime()).singleResult();
@@ -851,11 +843,9 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(resultInstance.getId()).isEqualTo(processInstance3.getId());
 
         processInstances = historyService.createHistoricProcessInstanceQuery().variableValueEquals(date1).list();
-        assertThat(processInstances).hasSize(2);
-        expectedIds = Arrays.asList(processInstance1.getId(), processInstance2.getId());
-        ids = new ArrayList<>(Arrays.asList(processInstances.get(0).getId(), processInstances.get(1).getId()));
-        ids.removeAll(expectedIds);
-        assertThat(ids).isEmpty();
+        assertThat(processInstances)
+                .extracting(HistoricProcessInstance::getId)
+                .containsOnly(processInstance1.getId(), processInstance2.getId());
 
         resultInstance = historyService.createHistoricProcessInstanceQuery().variableValueEquals(twoYearsLater.getTime()).singleResult();
         assertThat(resultInstance).isNull();
@@ -925,7 +915,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list()).hasSize(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).count()).isEqualTo(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").list()).isEmpty();
-        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr()
                 .list().get(0).getProcessDefinitionName()).isEqualTo(processDefinitionName);
         assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr()
@@ -946,7 +936,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).list()).hasSize(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).count()).isEqualTo(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").list()).isEmpty();
-        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").count()).isEqualTo(0);
+        assertThat(historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionCategory(processDefinitionCategory).processDefinitionId("invalid")
                 .endOr().list()).hasSize(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().or().processDefinitionCategory(processDefinitionCategory).processDefinitionId("invalid")


### PR DESCRIPTION
Made another pass for the `org.flowable.engine.test.api.history` package after I noticed that one of the files I had done previously was updated to include the older style `assertEquals()` instead of `assertThat`.

