### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.java
@@ -53,9 +53,9 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
         String procId = runtimeService.startProcessInstanceByKey("CatchErrorInEmbeddedSubProcess").getId();
 
         // The process will throw an error event, which is caught and escalated by a User org.flowable.task.service.Task
-        assertEquals(1, taskService.createTaskQuery().taskDefinitionKey("taskAfterErrorCatch2").count());
+        assertThat(taskService.createTaskQuery().taskDefinitionKey("taskAfterErrorCatch2").count()).isEqualTo(1);
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalated Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
         taskService.complete(task.getId());
@@ -96,8 +96,8 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
     public void testMultipleCatchErrorInTopLevelProcess() {
         String procId = runtimeService.startProcessInstanceByKey("MultipleCatchErrorInTopLevelProcess").getId();
         Task task = taskService.createTaskQuery().processInstanceId(procId).singleResult();
-        assertNotNull(task);
-        assertEquals("taskAfterErrorCatch2", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterErrorCatch2");
     }
     
     @Test
@@ -105,8 +105,8 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
     public void testMultipleCatchErrorInTopLevelProcessFirst() {
         String procId = runtimeService.startProcessInstanceByKey("MultipleCatchErrorInTopLevelProcess").getId();
         Task task = taskService.createTaskQuery().processInstanceId(procId).singleResult();
-        assertNotNull(task);
-        assertEquals("taskAfterErrorCatch", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterErrorCatch");
     }
 
     @Test
@@ -133,7 +133,7 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
         variableMap.put(STANDALONE_SUBPROCESS_FLAG_VARIABLE_NAME, true);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROCESS_KEY_UNDER_TEST, variableMap);
         
-        assertNotNull(processInstance.getId());
+        assertThat(processInstance.getId()).isNotNull();
     }
 
     @Test
@@ -234,9 +234,9 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
     private void assertThatErrorHasBeenCaught(String procId) {
         // The process will throw an error event,
         // which is caught and escalated by a User org.flowable.task.service.Task
-        assertEquals("No tasks found in task list.", 1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).as("No tasks found in task list.").isEqualTo(1);
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalated Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the org.flowable.task.service.Task will end the process instance
         taskService.complete(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ErrorPropagationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ErrorPropagationTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.engine.test.bpmn.event.error;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
@@ -39,10 +38,10 @@ public class ErrorPropagationTest {
                     "org/flowable/engine/test/bpmn/event/error/throwError.bpmn" })
     public void test() {
         ProcessInstance processInstance = flowableRule.getRuntimeService().startProcessInstanceByKey("catchError4");
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         final org.flowable.task.api.Task task = flowableRule.getTaskService().createTaskQuery().singleResult();
 
-        assertEquals("MyErrorTaskNested", task.getName());
+        assertThat(task.getName()).isEqualTo("MyErrorTaskNested");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/mapError/BoundaryErrorMapTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.bpmn.event.error.mapError;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,7 +37,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -45,7 +48,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -56,7 +59,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -68,7 +71,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("nestedExceptionClass", IllegalArgumentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     // exception does not match the single mapping
@@ -79,14 +82,12 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
 
         Map<String, Object> vars = new HashMap<>();
         vars.put("exceptionClass", IllegalStateException.class.getName());
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
 
-        try {
-            runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-            fail("exception expected, as there is no matching exception map");
-        } catch (Exception e) {
-            assertFalse(FlagDelegate.isVisited());
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars))
+                .as("exception expected, as there is no matching exception map")
+                .isInstanceOf(Exception.class);
+        assertThat(FlagDelegate.isVisited()).isFalse();
     }
 
     @Test
@@ -96,14 +97,12 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
 
         Map<String, Object> vars = new HashMap<>();
         vars.put("exceptionClass", IllegalArgumentException.class.getName());
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
 
-        try {
-            runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-            fail("exception expected, as there is no matching exception map");
-        } catch (Exception e) {
-            assertFalse(FlagDelegate.isVisited());
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars))
+                .as("exception expected, as there is no matching exception map")
+                .isInstanceOf(Exception.class);
+        assertThat(FlagDelegate.isVisited()).isFalse();
     }
 
     @Test
@@ -113,14 +112,12 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
 
         Map<String, Object> vars = new HashMap<>();
         vars.put("exceptionClass", IllegalArgumentException.class.getName());
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
 
-        try {
-            runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-            fail("exception expected, as there is no matching exception map");
-        } catch (Exception e) {
-            assertFalse(FlagDelegate.isVisited());
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars))
+                .as("exception expected, as there is no matching exception map")
+                .isInstanceOf(Exception.class);
+        assertThat(FlagDelegate.isVisited()).isFalse();
     }
 
     @Test
@@ -131,14 +128,12 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         Map<String, Object> vars = new HashMap<>();
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
         vars.put("nestedExceptionClass", IllegalStateException.class.getName());
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
 
-        try {
-            runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-            fail("exception expected, as there is no matching exception map");
-        } catch (Exception e) {
-            assertFalse(FlagDelegate.isVisited());
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars))
+                .as("exception expected, as there is no matching exception map")
+                .isInstanceOf(Exception.class);
+        assertThat(FlagDelegate.isVisited()).isFalse();
     }
 
     // exception matches by inheritance
@@ -150,14 +145,12 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         Map<String, Object> vars = new HashMap<>();
         vars.put("exceptionClass", BoundaryEventChildException.class.getName());
         vars.put("nestedExceptionClass", IllegalStateException.class.getName());
-        assertEquals(0, ServiceTaskTestMock.CALL_COUNT.get());
+        assertThat(ServiceTaskTestMock.CALL_COUNT.get()).isZero();
 
-        try {
-            runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-            fail("exception expected, as there is no matching exception map");
-        } catch (Exception e) {
-            assertFalse(FlagDelegate.isVisited());
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars))
+                .as("exception expected, as there is no matching exception map")
+                .isInstanceOf(Exception.class);
+        assertThat(FlagDelegate.isVisited()).isFalse();
     }
 
     // exception matches by inheritance
@@ -169,7 +162,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         FlagDelegate.reset();
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     // exception matches by inheritance
@@ -182,7 +175,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         FlagDelegate.reset();
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     // check the default map
@@ -194,7 +187,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         FlagDelegate.reset();
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -205,7 +198,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         FlagDelegate.reset();
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -216,7 +209,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         FlagDelegate.reset();
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -227,7 +220,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("processWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -238,7 +231,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("subprocssWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -251,7 +244,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("callProcssWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -264,7 +257,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("callProcssWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
     @Test
@@ -277,7 +270,7 @@ public class BoundaryErrorMapTest extends PluggableFlowableTestCase {
         vars.put("exceptionClass", BoundaryErrorParentException.class.getName());
 
         runtimeService.startProcessInstanceByKey("callProcssWithSingleExceptionMap", vars);
-        assertTrue(FlagDelegate.isVisited());
+        assertThat(FlagDelegate.isVisited()).isTrue();
     }
 
 }


### PR DESCRIPTION
In the `org.flowable.engine.test.bpmn.event.error` package there were 2 files with mixed assertion styles so they were converted to a single format.  At the same time the remaining 2 files in the package were updated.

