### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/BoundaryConditionalEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/BoundaryConditionalEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.conditional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -35,22 +37,22 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
 
         // After process start, usertask in subprocess should exist
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         
         runtimeService.trigger(execution.getId());
         
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         
         runtimeService.setVariable(processInstance.getId(), "myVar", "test");
         
         runtimeService.trigger(execution.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfterConditionalCatch", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterConditionalCatch");
         
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -64,10 +66,10 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
 
         // After process start, usertask in subprocess should exist
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         
         taskService.complete(task.getId());
         
@@ -82,33 +84,33 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
 
         // After process start, usertask in subprocess should exist
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         
         runtimeService.trigger(execution.getId());
         
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         
         runtimeService.setVariable(processInstance.getId(), "myVar", "test");
         
         runtimeService.trigger(execution.getId());
 
-        assertEquals(2, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
         
         runtimeService.trigger(execution.getId());
         
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
         
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskAfterConditionalCatch").list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
         
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         taskService.complete(task.getId());
         
         assertProcessEnded(processInstance.getId());
@@ -122,10 +124,10 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
 
         // After process start, usertask in subprocess should exist
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         
         taskService.complete(task.getId());
         
@@ -140,35 +142,35 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
 
         // After process start, usertask in subprocess should exist
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         
         runtimeService.trigger(execution.getId());
         
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
 
-        assertEquals(2, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
         
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
         
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
         
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test2"));
         
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
         
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskAfterConditionalCatch").list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
         
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
         taskService.complete(task.getId());
         
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/ConditionalEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/ConditionalEventSubprocessTest.java
@@ -38,122 +38,122 @@ public class ConditionalEventSubprocessTest extends PluggableFlowableTestCase {
     @Deployment
     public void testNonInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(2, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
 
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
-        assertEquals(8, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(8);
 
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test2"));
-        assertEquals(8, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(8);
 
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         // we still have 7 executions:
-        assertEquals(7, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(7);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
-        assertEquals(4, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(2, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
 
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
-        assertEquals(4, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // now let's complete the task in the event subprocess
         Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment
     public void testNonInterruptingNestedSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
-        assertEquals(6, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(6);
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
-        assertEquals(9, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(9);
 
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test2"));
-        assertEquals(9, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(9);
 
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         // now let's first complete the task in the main flow:
         Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         // we still have 8 executions:
-        assertEquals(8, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(8);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment
     public void testInterruptingNestedSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // now let's complete the task in the event subprocess
         Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/ConditionalIntermediateCatchEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/ConditionalIntermediateCatchEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.conditional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -34,23 +36,23 @@ public class ConditionalIntermediateCatchEventTest extends PluggableFlowableTest
 
         // After process start, usertask in subprocess should exist
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBeforeConditionalCatch", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBeforeConditionalCatch");
         
         taskService.complete(task.getId());
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         
         runtimeService.trigger(execution.getId());
         
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
         
         runtimeService.setVariable(processInstance.getId(), "myVar", "test");
         
         runtimeService.trigger(execution.getId());
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfterConditionalCatch", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterConditionalCatch");
         
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
@@ -64,21 +66,21 @@ public class ConditionalIntermediateCatchEventTest extends PluggableFlowableTest
 
         // After process start, usertask in subprocess should exist
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskBeforeConditionalCatch", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBeforeConditionalCatch");
         
         taskService.complete(task.getId());
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         
         runtimeService.evaluateConditionalEvents(processInstance.getId());
         
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
         
         runtimeService.evaluateConditionalEvents(processInstance.getId(), Collections.singletonMap("myVar", "test"));
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("taskAfterConditionalCatch", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterConditionalCatch");
         
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());


### PR DESCRIPTION
In the `org.flowable.engine.test.bpmn.event.conditional` package there was 1 file with mixed assertion styles so it was converted to a single format.  At the same time the remaining 2 files in the package were updated.

