### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -73,7 +73,6 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
-
     }
 
     @Test
@@ -382,7 +381,6 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         taskService.complete(userTask.getId());
 
         // and we are done
-
     }
 
     @Test
@@ -442,7 +440,6 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubProcess");
         taskService.complete(userTask.getId());
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
-
     }
 
     @Test
@@ -487,7 +484,6 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         taskService.complete(userTask.getId());
 
         // and we are done
-
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -13,6 +13,7 @@
 
 package org.flowable.engine.test.bpmn.event.message;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
@@ -38,53 +39,50 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testSingleBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(3, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(3);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // 1. case: message received cancels the task
 
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 2nd. case: complete the user task cancels the message subscription
 
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
     }
 
     @Test
     public void testDoubleBoundaryMessageEventSameMessageId() {
-        // deployment fails when two boundary message events have the same
-        // messageId
-        try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml").deploy();
-            fail("Deployment should fail because Flowable cannot handle two boundary message events with same messageId.");
-        } catch (Exception e) {
-            assertEquals(0, repositoryService.createDeploymentQuery().count());
-        }
+        // deployment fails when two boundary message events have the same messageId
+        assertThatThrownBy(() -> repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml").deploy())
+                .as("Deployment should fail because Flowable cannot handle two boundary message events with same messageId.")
+                .isInstanceOf(Exception.class);
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
@@ -92,19 +90,19 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testDoubleBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(4, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(4);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         // the executions for both messageEventSubscriptionNames are not the same
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertNotNull(execution1);
+        assertThat(execution1).isNotNull();
 
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertNotNull(execution2);
+        assertThat(execution2).isNotNull();
 
-        assertFalse(execution1.getId().equals(execution2.getId()));
+        assertThat(execution1.getId()).isNotEqualTo(execution2.getId());
 
         // /////////////////////////////////////////////////////////////////////////////////
         // 1. first message received cancels the task and the execution and both subscriptions
@@ -115,10 +113,10 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThatThrownBy(() -> runtimeService.messageEventReceived("messageName_2", execution2Id));
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage_1", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_1");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // ///////////////////////////////////////////////////////////////////
         // 2. complete the user task cancels the message subscriptions
@@ -126,19 +124,19 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertNull(execution1);
+        assertThat(execution1).isNull();
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertNull(execution2);
+        assertThat(execution2).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -148,14 +146,14 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // assume we have 9 executions one process instance
         // one execution for scope created for boundary message event
         // five execution because we have loop cardinality 5
-        assertEquals(9, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(9);
 
-        assertEquals(5, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         // both executions are not the same
-        assertFalse(execution1.getId().equals(execution2.getId()));
+        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
 
         // /////////////////////////////////////////////////////////////////////////////////
         // 1. first message received cancels all tasks and the executions and
@@ -167,11 +165,11 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThatThrownBy(() -> runtimeService.messageEventReceived("messageName_2", execution2Id));
 
         // only process instance and running execution left
-        assertEquals(2, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(2);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage_1", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_1");
         taskService.complete(userTask.getId());
         assertProcessEnded(processInstance.getId());
 
@@ -182,18 +180,18 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // assume we have 7 executions one process instance
         // one execution for scope created for boundary message event
         // five execution because we have loop cardinality 5
-        assertEquals(9, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(9);
 
-        assertEquals(5, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         // executions are not the same
-        assertFalse(execution1.getId().equals(execution2.getId()));
+        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
 
         List<org.flowable.task.api.Task> userTasks = taskService.createTaskQuery().list();
-        assertNotNull(userTasks);
-        assertEquals(5, userTasks.size());
+        assertThat(userTasks).isNotNull();
+        assertThat(userTasks).hasSize(5);
 
         // as long as tasks exists, the message subscriptions exist
         for (int i = 0; i < userTasks.size() - 1; i++) {
@@ -201,26 +199,26 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
 
             execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-            assertNotNull(execution1);
+            assertThat(execution1).isNotNull();
             execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-            assertNotNull(execution2);
+            assertThat(execution2).isNotNull();
         }
 
         // only one task left
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         // after last task is completed, no message subscriptions left
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertNull(execution1);
+        assertThat(execution1).isNull();
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertNull(execution2);
+        assertThat(execution2).isNull();
 
         // complete last task to end process
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -234,13 +232,13 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(4, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(4);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // /////////////////////////////////////////////////
         // 1. case: message received cancels the task
@@ -248,10 +246,10 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // /////////////////////////////////////////////////
         // 2nd. case: complete the user task cancels the message subscription
@@ -259,17 +257,17 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -282,18 +280,18 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(5, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(5);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution1);
+        assertThat(execution1).isNotNull();
 
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNotNull(execution2);
+        assertThat(execution2).isNotNull();
 
-        assertNotSame(execution1.getId(), execution2.getId());
+        assertThat(execution2.getId()).isNotSameAs(execution1.getId());
 
         // ///////////////////////////////////////////////////////////
         // first case: we complete the inner usertask.
@@ -301,27 +299,27 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         taskService.complete(userTask.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
 
         // the inner subscription is cancelled
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // the outer subscription still exists
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
 
         // now the outer event subscription is cancelled as well
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterSubprocess", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubprocess");
 
         // now complete the outer usertask
         taskService.complete(userTask.getId());
@@ -335,27 +333,27 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
 
         // the inner subscription is removes
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // the outer subscription still exists
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
 
         // now the outer event subscription is cancelled as well
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterSubprocess", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubprocess");
 
         // now complete the outer usertask
         taskService.complete(userTask.getId());
@@ -369,16 +367,16 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName2", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterOuterMessageBoundary", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterOuterMessageBoundary");
 
         // the inner subscription is removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // the outer subscription is removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
@@ -392,58 +390,58 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testBoundaryMessageEventOnSubprocess() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(5, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(5);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         // 1. case: message one received cancels the task
 
         Execution executionMessageOne = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_one").singleResult();
-        assertNotNull(executionMessageOne);
+        assertThat(executionMessageOne).isNotNull();
 
         runtimeService.messageEventReceived("messageName_one", executionMessageOne.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage_one", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_one");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 2nd. case: message two received cancels the task
 
         runtimeService.startProcessInstanceByKey("process");
 
         Execution executionMessageTwo = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_two").singleResult();
-        assertNotNull(executionMessageTwo);
+        assertThat(executionMessageTwo).isNotNull();
 
         runtimeService.messageEventReceived("messageName_two", executionMessageTwo.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage_two", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_two");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 3rd. case: complete the user task cancels the message subscription
 
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         executionMessageOne = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_one").singleResult();
-        assertNull(executionMessageOne);
+        assertThat(executionMessageOne).isNull();
 
         executionMessageTwo = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_two").singleResult();
-        assertNull(executionMessageTwo);
+        assertThat(executionMessageTwo).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterSubProcess", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubProcess");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
     }
 
@@ -457,22 +455,22 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(18, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(18);
 
         // 5 user tasks
         List<org.flowable.task.api.Task> userTasks = taskService.createTaskQuery().list();
-        assertNotNull(userTasks);
-        assertEquals(5, userTasks.size());
+        assertThat(userTasks).isNotNull();
+        assertThat(userTasks).hasSize(5);
 
         // there are 5 event subscriptions to the event on the inner user task
         List<Execution> executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").list();
-        assertNotNull(executions);
-        assertEquals(5, executions.size());
+        assertThat(executions).isNotNull();
+        assertThat(executions).hasSize(5);
 
         // there is a single event subscription for the event on the subprocess
         executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").list();
-        assertNotNull(executions);
-        assertEquals(1, executions.size());
+        assertThat(executions).isNotNull();
+        assertThat(executions).hasSize(1);
 
         // if we complete the outer message event, all inner executions are
         // removed
@@ -480,11 +478,11 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName2", outerScopeExecution.getId());
 
         executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").list();
-        assertEquals(0, executions.size());
+        assertThat(executions).isEmpty();
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterOuterMessageBoundary", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterOuterMessageBoundary");
 
         taskService.complete(userTask.getId());
 
@@ -502,21 +500,21 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(3, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // ///////////////////////////////////
         // Verify the first task
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("task", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("task");
 
         // ///////////////////////////////////
         // Advance the clock to trigger the timer.
         final TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(userTask.getProcessInstanceId());
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         // After setting the clock to time '1 hour and 5 seconds', the timer should fire.
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
@@ -528,53 +526,53 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         });
         
         // It is a repeating job, so it will come back.
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1L);
 
         // ///////////////////////////////////
         // Verify and complete the first task
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         // ///////////////////////////////////
         // Complete the after timer task
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskTimer").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         // Timer job of boundary event of task should be deleted and timer job
         // of task timer boundary event should be created.
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1L);
 
         // ///////////////////////////////////
         // Verify that the message exists
         userTask = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // ///////////////////////////////////
         // Send the message and verify that we went back to the right spot.
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("task", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("task");
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // ///////////////////////////////////
         // Complete the first task (again).
         taskService.complete(userTask.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // ///////////////////////////////////
         // Verify timer firing.
@@ -590,7 +588,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         });
 
         // It is a repeating job, so it will come back.
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1L);
 
         // After setting the clock to time '3 hours and 5 seconds', the timer should fire again.
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((3 * 60 * 60 * 1000) + 5000)));
@@ -601,12 +599,12 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
             }
         });
         // It is a repeating job, so it will come back.
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1L);
 
         // ///////////////////////////////////
         // Complete the after timer tasks
         final List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("taskAfterTaskTimer").list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
@@ -618,16 +616,16 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // ///////////////////////////////////
         // Complete the third task
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTaskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTaskAfterTask");
         taskService.complete(userTask.getId());
 
         // ///////////////////////////////////
         // We should be done at this point
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -13,7 +13,6 @@
 
 package org.flowable.engine.test.bpmn.event.message;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
@@ -39,49 +38,53 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testSingleBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(3);
+        assertEquals(3, runtimeService.createExecutionQuery().count());
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNotNull();
+        assertNotNull(execution);
 
         // 1. case: message received cancels the task
 
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
+        assertNotNull(userTask);
+        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
 
         // 2nd. case: complete the user task cancels the message subscription
 
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
         taskService.complete(userTask.getId());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
+        assertNotNull(userTask);
+        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+
     }
 
     @Test
     public void testDoubleBoundaryMessageEventSameMessageId() {
-        // deployment fails when two boundary message events have the same messageId
-        assertThatThrownBy(() -> repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml").deploy())
-                .as("Deployment should fail because Flowable cannot handle two boundary message events with same messageId.")
-                .isInstanceOf(Exception.class);
-        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
+        // deployment fails when two boundary message events have the same
+        // messageId
+        try {
+            repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml").deploy();
+            fail("Deployment should fail because Flowable cannot handle two boundary message events with same messageId.");
+        } catch (Exception e) {
+            assertEquals(0, repositoryService.createDeploymentQuery().count());
+        }
     }
 
     @Test
@@ -89,19 +92,19 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testDoubleBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(4);
+        assertEquals(4, runtimeService.createExecutionQuery().count());
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
 
         // the executions for both messageEventSubscriptionNames are not the same
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertThat(execution1).isNotNull();
+        assertNotNull(execution1);
 
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertThat(execution2).isNotNull();
+        assertNotNull(execution2);
 
-        assertThat(execution1.getId()).isNotEqualTo(execution2.getId());
+        assertFalse(execution1.getId().equals(execution2.getId()));
 
         // /////////////////////////////////////////////////////////////////////////////////
         // 1. first message received cancels the task and the execution and both subscriptions
@@ -112,10 +115,10 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThatThrownBy(() -> runtimeService.messageEventReceived("messageName_2", execution2Id));
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_1");
+        assertNotNull(userTask);
+        assertEquals("taskAfterMessage_1", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
 
         // ///////////////////////////////////////////////////////////////////
         // 2. complete the user task cancels the message subscriptions
@@ -123,19 +126,19 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
         taskService.complete(userTask.getId());
 
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertThat(execution1).isNull();
+        assertNull(execution1);
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertThat(execution2).isNull();
+        assertNull(execution2);
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
+        assertNotNull(userTask);
+        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
     @Test
@@ -145,14 +148,14 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // assume we have 9 executions one process instance
         // one execution for scope created for boundary message event
         // five execution because we have loop cardinality 5
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(9);
+        assertEquals(9, runtimeService.createExecutionQuery().count());
 
-        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
+        assertEquals(5, taskService.createTaskQuery().count());
 
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         // both executions are not the same
-        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
+        assertFalse(execution1.getId().equals(execution2.getId()));
 
         // /////////////////////////////////////////////////////////////////////////////////
         // 1. first message received cancels all tasks and the executions and
@@ -164,11 +167,11 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThatThrownBy(() -> runtimeService.messageEventReceived("messageName_2", execution2Id));
 
         // only process instance and running execution left
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(2);
+        assertEquals(2, runtimeService.createExecutionQuery().count());
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_1");
+        assertNotNull(userTask);
+        assertEquals("taskAfterMessage_1", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
         assertProcessEnded(processInstance.getId());
 
@@ -179,18 +182,18 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // assume we have 7 executions one process instance
         // one execution for scope created for boundary message event
         // five execution because we have loop cardinality 5
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(9);
+        assertEquals(9, runtimeService.createExecutionQuery().count());
 
-        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
+        assertEquals(5, taskService.createTaskQuery().count());
 
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         // executions are not the same
-        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
+        assertFalse(execution1.getId().equals(execution2.getId()));
 
         List<org.flowable.task.api.Task> userTasks = taskService.createTaskQuery().list();
-        assertThat(userTasks).isNotNull();
-        assertThat(userTasks).hasSize(5);
+        assertNotNull(userTasks);
+        assertEquals(5, userTasks.size());
 
         // as long as tasks exists, the message subscriptions exist
         for (int i = 0; i < userTasks.size() - 1; i++) {
@@ -198,26 +201,26 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
 
             execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-            assertThat(execution1).isNotNull();
+            assertNotNull(execution1);
             execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-            assertThat(execution2).isNotNull();
+            assertNotNull(execution2);
         }
 
         // only one task left
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
         taskService.complete(userTask.getId());
 
         // after last task is completed, no message subscriptions left
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertThat(execution1).isNull();
+        assertNull(execution1);
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertThat(execution2).isNull();
+        assertNull(execution2);
 
         // complete last task to end process
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
+        assertNotNull(userTask);
+        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -231,13 +234,13 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(4);
+        assertEquals(4, runtimeService.createExecutionQuery().count());
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNotNull();
+        assertNotNull(execution);
 
         // /////////////////////////////////////////////////
         // 1. case: message received cancels the task
@@ -245,10 +248,10 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
+        assertNotNull(userTask);
+        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
 
         // /////////////////////////////////////////////////
         // 2nd. case: complete the user task cancels the message subscription
@@ -256,17 +259,17 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
         taskService.complete(userTask.getId());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
+        assertNotNull(userTask);
+        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
     }
 
     @Test
@@ -279,18 +282,18 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(5);
+        assertEquals(5, runtimeService.createExecutionQuery().count());
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
 
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution1).isNotNull();
+        assertNotNull(execution1);
 
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertThat(execution2).isNotNull();
+        assertNotNull(execution2);
 
-        assertThat(execution2.getId()).isNotSameAs(execution1.getId());
+        assertNotSame(execution1.getId(), execution2.getId());
 
         // ///////////////////////////////////////////////////////////
         // first case: we complete the inner usertask.
@@ -298,27 +301,27 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         taskService.complete(userTask.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
+        assertNotNull(userTask);
+        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
 
         // the inner subscription is cancelled
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         // the outer subscription still exists
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertThat(execution).isNotNull();
+        assertNotNull(execution);
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
 
         // now the outer event subscription is cancelled as well
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubprocess");
+        assertNotNull(userTask);
+        assertEquals("taskAfterSubprocess", userTask.getTaskDefinitionKey());
 
         // now complete the outer usertask
         taskService.complete(userTask.getId());
@@ -332,27 +335,27 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
+        assertNotNull(userTask);
+        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
 
         // the inner subscription is removes
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         // the outer subscription still exists
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertThat(execution).isNotNull();
+        assertNotNull(execution);
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
 
         // now the outer event subscription is cancelled as well
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubprocess");
+        assertNotNull(userTask);
+        assertEquals("taskAfterSubprocess", userTask.getTaskDefinitionKey());
 
         // now complete the outer usertask
         taskService.complete(userTask.getId());
@@ -366,21 +369,22 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName2", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterOuterMessageBoundary");
+        assertNotNull(userTask);
+        assertEquals("taskAfterOuterMessageBoundary", userTask.getTaskDefinitionKey());
 
         // the inner subscription is removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         // the outer subscription is removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
 
         // and we are done
+
     }
 
     @Test
@@ -388,58 +392,59 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testBoundaryMessageEventOnSubprocess() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(5);
+        assertEquals(5, runtimeService.createExecutionQuery().count());
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
 
         // 1. case: message one received cancels the task
 
         Execution executionMessageOne = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_one").singleResult();
-        assertThat(executionMessageOne).isNotNull();
+        assertNotNull(executionMessageOne);
 
         runtimeService.messageEventReceived("messageName_one", executionMessageOne.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_one");
+        assertNotNull(userTask);
+        assertEquals("taskAfterMessage_one", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
 
         // 2nd. case: message two received cancels the task
 
         runtimeService.startProcessInstanceByKey("process");
 
         Execution executionMessageTwo = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_two").singleResult();
-        assertThat(executionMessageTwo).isNotNull();
+        assertNotNull(executionMessageTwo);
 
         runtimeService.messageEventReceived("messageName_two", executionMessageTwo.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_two");
+        assertNotNull(userTask);
+        assertEquals("taskAfterMessage_two", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
 
         // 3rd. case: complete the user task cancels the message subscription
 
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
         taskService.complete(userTask.getId());
 
         executionMessageOne = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_one").singleResult();
-        assertThat(executionMessageOne).isNull();
+        assertNull(executionMessageOne);
 
         executionMessageTwo = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_two").singleResult();
-        assertThat(executionMessageTwo).isNull();
+        assertNull(executionMessageTwo);
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubProcess");
+        assertNotNull(userTask);
+        assertEquals("taskAfterSubProcess", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+
     }
 
     @Test
@@ -452,22 +457,22 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(18);
+        assertEquals(18, runtimeService.createExecutionQuery().count());
 
         // 5 user tasks
         List<org.flowable.task.api.Task> userTasks = taskService.createTaskQuery().list();
-        assertThat(userTasks).isNotNull();
-        assertThat(userTasks).hasSize(5);
+        assertNotNull(userTasks);
+        assertEquals(5, userTasks.size());
 
         // there are 5 event subscriptions to the event on the inner user task
         List<Execution> executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").list();
-        assertThat(executions).isNotNull();
-        assertThat(executions).hasSize(5);
+        assertNotNull(executions);
+        assertEquals(5, executions.size());
 
         // there is a single event subscription for the event on the subprocess
         executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").list();
-        assertThat(executions).isNotNull();
-        assertThat(executions).hasSize(1);
+        assertNotNull(executions);
+        assertEquals(1, executions.size());
 
         // if we complete the outer message event, all inner executions are
         // removed
@@ -475,15 +480,16 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName2", outerScopeExecution.getId());
 
         executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").list();
-        assertThat(executions).isEmpty();
+        assertEquals(0, executions.size());
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterOuterMessageBoundary");
+        assertNotNull(userTask);
+        assertEquals("taskAfterOuterMessageBoundary", userTask.getTaskDefinitionKey());
 
         taskService.complete(userTask.getId());
 
         // and we are done
+
     }
 
     @Test
@@ -496,21 +502,21 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(3);
+        assertEquals(3, runtimeService.createExecutionQuery().count());
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         // ///////////////////////////////////
         // Verify the first task
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("task");
+        assertNotNull(userTask);
+        assertEquals("task", userTask.getTaskDefinitionKey());
 
         // ///////////////////////////////////
         // Advance the clock to trigger the timer.
         final TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(userTask.getProcessInstanceId());
-        assertThat(jobQuery.count()).isEqualTo(1);
+        assertEquals(1, jobQuery.count());
 
         // After setting the clock to time '1 hour and 5 seconds', the timer should fire.
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
@@ -522,53 +528,53 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         });
         
         // It is a repeating job, so it will come back.
-        assertThat(jobQuery.count()).isEqualTo(1L);
+        assertEquals(1L, jobQuery.count());
 
         // ///////////////////////////////////
         // Verify and complete the first task
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
         taskService.complete(userTask.getId());
 
         // ///////////////////////////////////
         // Complete the after timer task
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskTimer").singleResult();
-        assertThat(userTask).isNotNull();
+        assertNotNull(userTask);
         taskService.complete(userTask.getId());
 
         // Timer job of boundary event of task should be deleted and timer job
         // of task timer boundary event should be created.
-        assertThat(jobQuery.count()).isEqualTo(1L);
+        assertEquals(1L, jobQuery.count());
 
         // ///////////////////////////////////
         // Verify that the message exists
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
+        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNotNull();
+        assertNotNull(execution);
 
         // ///////////////////////////////////
         // Send the message and verify that we went back to the right spot.
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("task");
+        assertNotNull(userTask);
+        assertEquals("task", userTask.getTaskDefinitionKey());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
 
         // ///////////////////////////////////
         // Complete the first task (again).
         taskService.complete(userTask.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
+        assertNotNull(userTask);
+        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNotNull();
+        assertNotNull(execution);
 
         // ///////////////////////////////////
         // Verify timer firing.
@@ -584,7 +590,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         });
 
         // It is a repeating job, so it will come back.
-        assertThat(jobQuery.count()).isEqualTo(1L);
+        assertEquals(1L, jobQuery.count());
 
         // After setting the clock to time '3 hours and 5 seconds', the timer should fire again.
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((3 * 60 * 60 * 1000) + 5000)));
@@ -595,12 +601,12 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
             }
         });
         // It is a repeating job, so it will come back.
-        assertThat(jobQuery.count()).isEqualTo(1L);
+        assertEquals(1L, jobQuery.count());
 
         // ///////////////////////////////////
         // Complete the after timer tasks
         final List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("taskAfterTaskTimer").list();
-        assertThat(tasks).hasSize(2);
+        assertEquals(2, tasks.size());
 
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
@@ -612,16 +618,16 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // ///////////////////////////////////
         // Complete the third task
         userTask = taskService.createTaskQuery().singleResult();
-        assertThat(userTask).isNotNull();
-        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTaskAfterTask");
+        assertNotNull(userTask);
+        assertEquals("taskAfterTaskAfterTask", userTask.getTaskDefinitionKey());
         taskService.complete(userTask.getId());
 
         // ///////////////////////////////////
         // We should be done at this point
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertThat(execution).isNull();
+        assertNull(execution);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
@@ -56,30 +56,30 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // the process instance must have a message event subscription:
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("newMessage").singleResult();
-        assertNotNull(execution);
-        assertEquals(expectedNumberOfEventSubscriptions, createEventSubscriptionQuery().count());
-        assertEquals(numberOfExecutions, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(execution).isNotNull();
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(expectedNumberOfEventSubscriptions);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(numberOfExecutions);
 
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("task", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
         taskService.complete(task.getId());
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertProcessEnded(processInstance.getId());
 
         // now we start a new instance but this time we trigger the event subprocess:
         processInstance = runtimeService.startProcessInstanceByKey("process");
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("newMessage").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         runtimeService.messageEventReceived("newMessage", execution.getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("eventSubProcessTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("eventSubProcessTask");
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -94,16 +94,16 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
                 .messageEventSubscriptionName("newMessage")
                 .singleResult();
 
-        assertNotNull(execution);
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(execution).isNotNull();
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("task", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
         taskService.complete(task.getId());
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         // now we start a new instance but this time we trigger the event subprocess:
         processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -114,21 +114,21 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("newMessage", execution.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // now let's first complete the task in the main flow:
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         // we still have 3 executions:
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // now let's complete the task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         // #################### again, the other way around:
 
@@ -140,28 +140,28 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("newMessage", execution.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // we still have 3 executions:
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testNonInterruptingMultipleInstances() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -169,45 +169,45 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
                 .singleResult();
 
         runtimeService.messageEventReceived("newMessage", execution.getId());
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         runtimeService.messageEventReceived("newMessage", execution.getId());
-        assertEquals(7, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(7);
 
-        assertEquals(3, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
 
         // we still have 6 executions:
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testNonInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -215,45 +215,45 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
                 .singleResult();
 
         runtimeService.messageEventReceived("eventMessage", execution.getId());
-        assertEquals(6, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(6);
 
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         runtimeService.messageEventReceived("eventMessage", execution.getId());
-        assertEquals(9, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(9);
 
-        assertEquals(3, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
 
         // we still have 7 executions:
-        assertEquals(7, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(7);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
-        assertEquals(4, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -261,40 +261,40 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
                 .singleResult();
 
         runtimeService.messageEventReceived("eventMessage", execution.getId());
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isZero();
 
         // now let's complete the task in the event subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment
     public void testStartingAdditionalTasks() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
                 .messageEventSubscriptionName("Start another task")
                 .singleResult();
         
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -303,7 +303,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("Start another sub task", execution.getId());
         
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -312,64 +312,64 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         
         runtimeService.messageEventReceived("Start another task", execution.getId());
         
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksNoNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
                 .messageEventSubscriptionName("Start another task")
                 .singleResult();
         
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
@@ -377,15 +377,15 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
     public void testStartingAdditionalTasksWithNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
         
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -394,20 +394,20 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("Start another sub task", execution.getId());
         
-        assertEquals(2, createEventSubscriptionQuery().count());
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -416,8 +416,8 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         
         runtimeService.messageEventReceived("Start another task", execution.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -426,49 +426,49 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         
         runtimeService.messageEventReceived("Start another task", execution.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
         
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("additionalTask").list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         
         taskService.complete(tasks.get(0).getId());
         
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment
     public void testStartingAdditionalTasksInterrupting() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
                 .messageEventSubscriptionName("Start another task")
                 .singleResult();
         
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -477,41 +477,41 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("Start another sub task", execution.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.testStartingAdditionalTasksInterrupting.bpmn20.xml")
     public void testStartingAdditionalTasksInterruptingWithMainEventSubProcessInterrupt() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
                 .messageEventSubscriptionName("Start another task")
                 .singleResult();
         
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -520,7 +520,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("Start another sub task", execution.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -529,13 +529,13 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         
         runtimeService.messageEventReceived("Start another task", execution.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageExpressionTest.java
@@ -50,13 +50,17 @@ public class MessageExpressionTest extends PluggableFlowableTestCase {
             CollectionUtil.singletonMap("boundaryMessage", "actualBoundaryMessage"));
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertThat(tasks).extracting(Task::getName).containsExactly("T1");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("T1");
 
         runtimeService.messageEventReceived(
             "actualBoundaryMessage",
             runtimeService.createEventSubscriptionQuery().eventName("actualBoundaryMessage").singleResult().getExecutionId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertThat(tasks).extracting(Task::getName).containsExactly("T2");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("T2");
     }
 
     @Test
@@ -74,13 +78,16 @@ public class MessageExpressionTest extends PluggableFlowableTestCase {
         assertThat(executionId).isNotNull();
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertThat(tasks).extracting(Task::getName).containsExactly("User task");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("User task");
 
         runtimeService.messageEventReceived("actualMessageValue", executionId);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertThat(tasks).extracting(Task::getName).containsExactly("T1");
-
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("T1");
     }
 
     protected void assertMesageEventSubscriptions(String ... names) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.event.message;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,27 +38,27 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("process");
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
-        assertNotNull(activeActivityIds);
-        assertEquals(1, activeActivityIds.size());
-        assertTrue(activeActivityIds.contains("messageCatch"));
+        assertThat(activeActivityIds).isNotNull();
+        assertThat(activeActivityIds)
+                .containsOnly("messageCatch");
 
         String messageName = "newInvoiceMessage";
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).singleResult();
 
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().executionId(execution.getId()).singleResult();
-        assertNotNull(eventSubscription);
-        assertEquals(messageName, eventSubscription.getEventName());
+        assertThat(eventSubscription).isNotNull();
+        assertThat(eventSubscription.getEventName()).isEqualTo(messageName);
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(execution.getProcessInstanceId()).singleResult();
-        assertNotNull(eventSubscription);
-        assertEquals(messageName, eventSubscription.getEventName());
+        assertThat(eventSubscription).isNotNull();
+        assertThat(eventSubscription.getEventName()).isEqualTo(messageName);
 
         runtimeService.messageEventReceived(messageName, execution.getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
     }
@@ -69,18 +71,18 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("process", variableMap);
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
-        assertNotNull(activeActivityIds);
-        assertEquals(1, activeActivityIds.size());
-        assertTrue(activeActivityIds.contains("messageCatch"));
+        assertThat(activeActivityIds).isNotNull();
+        assertThat(activeActivityIds)
+                .containsOnly("messageCatch");
 
         String messageName = "testMessage";
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         runtimeService.messageEventReceived(messageName, execution.getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
     }
 
@@ -91,26 +93,25 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("process");
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
-        assertNotNull(activeActivityIds);
-        assertEquals(2, activeActivityIds.size());
-        assertTrue(activeActivityIds.contains("messageCatch1"));
-        assertTrue(activeActivityIds.contains("messageCatch2"));
+        assertThat(activeActivityIds).isNotNull();
+        assertThat(activeActivityIds)
+                .containsOnly("messageCatch1", "messageCatch2");
 
         String messageName = "newInvoiceMessage";
         List<Execution> executions = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).list();
 
-        assertNotNull(executions);
-        assertEquals(2, executions.size());
+        assertThat(executions).isNotNull();
+        assertThat(executions).hasSize(2);
 
         runtimeService.messageEventReceived(messageName, executions.get(0).getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         runtimeService.messageEventReceived(messageName, executions.get(1).getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
     }
@@ -120,20 +121,20 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
     public void testAsyncTriggeredMessageEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
 
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).messageEventSubscriptionName("newMessage").singleResult();
-        assertNotNull(execution);
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(2, runtimeService.createExecutionQuery().count());
+        assertThat(execution).isNotNull();
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(2);
 
         runtimeService.messageEventReceivedAsync("newMessage", execution.getId());
 
-        assertEquals(1, managementService.createJobQuery().messages().count());
+        assertThat(managementService.createJobQuery().messages().count()).isEqualTo(1);
 
         waitForJobExecutorToProcessAllJobs(8000L, 200L);
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     private EventSubscriptionQueryImpl createEventSubscriptionQuery() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -39,8 +39,8 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
         assertThat(activeActivityIds).isNotNull();
-        assertThat(activeActivityIds)
-                .containsOnly("messageCatch");
+        assertThat(activeActivityIds).hasSize(1);
+        assertThat(activeActivityIds.contains("messageCatch")).isTrue();
 
         String messageName = "newInvoiceMessage";
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).singleResult();
@@ -72,8 +72,8 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
         assertThat(activeActivityIds).isNotNull();
-        assertThat(activeActivityIds)
-                .containsOnly("messageCatch");
+        assertThat(activeActivityIds).hasSize(1);
+        assertThat(activeActivityIds.contains("messageCatch")).isTrue();
 
         String messageName = "testMessage";
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).singleResult();
@@ -94,8 +94,9 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
         assertThat(activeActivityIds).isNotNull();
-        assertThat(activeActivityIds)
-                .containsOnly("messageCatch1", "messageCatch2");
+        assertThat(activeActivityIds).hasSize(2);
+        assertThat(activeActivityIds.contains("messageCatch1")).isTrue();
+        assertThat(activeActivityIds.contains("messageCatch2")).isTrue();
 
         String messageName = "newInvoiceMessage";
         List<Execution> executions = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).list();
@@ -132,9 +133,9 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         assertThat(managementService.createJobQuery().messages().count()).isEqualTo(1);
 
         waitForJobExecutorToProcessAllJobs(8000L, 200L);
-        assertThat(createEventSubscriptionQuery().count()).isZero();
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
-        assertThat(managementService.createJobQuery().count()).isZero();
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(managementService.createJobQuery().count()).isEqualTo(0);
     }
 
     private EventSubscriptionQueryImpl createEventSubscriptionQuery() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.event.message;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.test.Deployment;
@@ -29,76 +31,76 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableFlowableTe
     public void testSingleNonInterruptingBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(3, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(3);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // 1. case: message received before completing the task
 
         runtimeService.messageEventReceived("messageName", execution.getId());
         // event subscription not removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessage").singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
         taskService.complete(userTask.getId());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         // send a message a second time
         runtimeService.messageEventReceived("messageName", execution.getId());
         // event subscription not removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessage").singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
         taskService.complete(userTask.getId());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         // now complete the user task with the message boundary event
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         taskService.complete(userTask.getId());
 
         // event subscription removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterTask").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         taskService.complete(userTask.getId());
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 2nd. case: complete the user task cancels the message subscription
 
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterTask").singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.java
@@ -13,6 +13,9 @@
 
 package org.flowable.engine.test.bpmn.event.message;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Calendar;
 import java.util.List;
 
@@ -37,7 +40,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().list();
 
-        assertEquals(1, eventSubscriptions.size());
+        assertThat(eventSubscriptions).hasSize(1);
 
         repositoryService.deleteDeployment(deploymentId);
     }
@@ -46,26 +49,19 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
     public void testSameMessageNameFails() {
         String deploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.testSingleMessageStartEvent.bpmn20.xml")
                 .deploy().getId();
-        try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/otherProcessWithNewInvoiceMessage.bpmn20.xml").deploy();
-            fail("exception expected");
-        } catch (FlowableException e) {
-            assertTrue(e.getMessage().contains("there already is a message event subscription for the message with name"));
-        }
+        assertThatThrownBy(() -> repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/otherProcessWithNewInvoiceMessage.bpmn20.xml").deploy())
+                .hasMessageContaining("there already is a message event subscription for the message with name")
+                .isExactlyInstanceOf(FlowableException.class);
 
         // clean db:
         repositoryService.deleteDeployment(deploymentId);
-
     }
 
     @Test
     public void testSameMessageNameInSameProcessFails() {
-        try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/testSameMessageNameInSameProcessFails.bpmn20.xml").deploy();
-            fail("exception expected: Cannot have more than one message event subscription with name 'newInvoiceMessage' for scope");
-        } catch (FlowableException e) {
-            e.printStackTrace();
-        }
+        assertThatThrownBy(() -> repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/testSameMessageNameInSameProcessFails.bpmn20.xml").deploy())
+                .as("exception expected: Cannot have more than one message event subscription with name 'newInvoiceMessage' for scope")
+                .isExactlyInstanceOf(FlowableException.class);
     }
 
     @Test
@@ -76,8 +72,8 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().list();
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
 
-        assertEquals(1, eventSubscriptions.size());
-        assertEquals(1, processDefinitions.size());
+        assertThat(eventSubscriptions).hasSize(1);
+        assertThat(processDefinitions).hasSize(1);
 
         String newDeploymentId = repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.testSingleMessageStartEvent.bpmn20.xml")
                 .deploy().getId();
@@ -85,20 +81,20 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         List<EventSubscription> newEventSubscriptions = runtimeService.createEventSubscriptionQuery().list();
         List<ProcessDefinition> newProcessDefinitions = repositoryService.createProcessDefinitionQuery().list();
 
-        assertEquals(1, newEventSubscriptions.size());
-        assertEquals(2, newProcessDefinitions.size());
+        assertThat(newEventSubscriptions).hasSize(1);
+        assertThat(newProcessDefinitions).hasSize(2);
         for (ProcessDefinition processDefinition : newProcessDefinitions) {
             if (processDefinition.getVersion() == 1) {
                 for (EventSubscription subscription : newEventSubscriptions) {
-                    assertFalse(subscription.getConfiguration().equals(processDefinition.getId()));
+                    assertThat(subscription.getConfiguration()).isNotEqualTo(processDefinition.getId());
                 }
             } else {
                 for (EventSubscription subscription : newEventSubscriptions) {
-                    assertEquals(subscription.getConfiguration(), processDefinition.getId());
+                    assertThat(processDefinition.getId()).isEqualTo(subscription.getConfiguration());
                 }
             }
         }
-        assertFalse(eventSubscriptions.equals(newEventSubscriptions));
+        assertThat(eventSubscriptions).isNotEqualTo(newEventSubscriptions);
 
         repositoryService.deleteDeployment(deploymentId);
         repositoryService.deleteDeployment(newDeploymentId);
@@ -112,10 +108,10 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByMessage("newInvoiceMessage");
 
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
 
@@ -125,10 +121,10 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
         processInstance = runtimeService.startProcessInstanceByKey("singleMessageStartEvent");
 
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
 
@@ -140,10 +136,10 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         
         processInstance = runtimeService.startProcessInstanceByMessage("newInvoiceMessage");
 
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
 
@@ -154,17 +150,19 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
     @Deployment
     public void testBusinessKeySet() {
         ProcessInstance pi1 = runtimeService.startProcessInstanceByKey("start-by-message-1", "business-key-123");
-        assertEquals("business-key-123", runtimeService.createProcessInstanceQuery()
+        assertThat(runtimeService.createProcessInstanceQuery()
                 .processInstanceId(pi1.getProcessInstanceId())
                 .singleResult()
-                .getBusinessKey());
+                .getBusinessKey())
+                .isEqualTo("business-key-123");
 
         ProcessInstance pi2 = runtimeService.startProcessInstanceByMessage("start-by-message", "business-key-456");
         // This step fails as the businessKey is null
-        assertEquals("business-key-456", runtimeService.createProcessInstanceQuery()
+        assertThat(runtimeService.createProcessInstanceQuery()
                 .processInstanceId(pi2.getProcessInstanceId())
                 .singleResult()
-                .getBusinessKey());
+                .getBusinessKey())
+                .isEqualTo("business-key-456");
     }
 
     @Test
@@ -175,10 +173,10 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testProcess");
 
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("taskAfterNoneStart").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
 
@@ -188,10 +186,10 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
         processInstance = runtimeService.startProcessInstanceByMessage("newInvoiceMessage");
 
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         task = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessageStart").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
 
@@ -207,10 +205,10 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByMessage("newInvoiceMessage");
 
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessageStart").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
 
@@ -220,10 +218,10 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
 
         processInstance = runtimeService.startProcessInstanceByMessage("newInvoiceMessage2");
 
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         task = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessageStart2").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
 
@@ -232,9 +230,9 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         // starting the process using startProcessInstanceByKey is possible, the
         // first message start event will be the default:
         processInstance = runtimeService.startProcessInstanceByKey("testProcess");
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
         task = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessageStart").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -269,8 +267,8 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
     }
 
     protected void assertEventSubscriptionQuery(EventSubscriptionQuery query, int count) {
-        assertEquals(count, query.count());
-        assertEquals(count, query.list().size());
+        assertThat(query.count()).isEqualTo(count);
+        assertThat(query.list()).hasSize(count);
     }
 
 }


### PR DESCRIPTION
In the `org.flowable.engine.test.bpmn.event.message` package there were 2 files with mixed assertion styles so they were converted to a single format.  At the same time the remaining 4 files in the package were updated.

