### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -78,14 +78,10 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
     @Test
     public void testDoubleBoundaryMessageEventSameMessageId() {
-        // deployment fails when two boundary message events have the same
-        // messageId
-        try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml").deploy();
-            fail("Deployment should fail because Flowable cannot handle two boundary message events with same messageId.");
-        } catch (Exception e) {
-            assertThat(repositoryService.createDeploymentQuery().count()).isZero();
-        }
+        // deployment fails when two boundary message events have the same messageId
+        assertThatThrownBy(() -> repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml").deploy())
+                .as("Deployment should fail because Flowable cannot handle two boundary message events with same messageId.")
+                .isInstanceOf(Exception.class);
     }
 
     @Test
@@ -105,7 +101,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         assertThat(execution2).isNotNull();
 
-        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
+        assertThat(execution1.getId()).isNotEqualTo(execution2.getId());
 
         // /////////////////////////////////////////////////////////////////////////////////
         // 1. first message received cancels the task and the execution and both subscriptions
@@ -156,7 +152,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         // both executions are not the same
-        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
+        assertThat(execution1.getId()).isNotEqualTo(execution2.getId());
 
         // /////////////////////////////////////////////////////////////////////////////////
         // 1. first message received cancels all tasks and the executions and
@@ -190,7 +186,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         // executions are not the same
-        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
+        assertThat(execution1.getId()).isNotEqualTo(execution2.getId());
 
         List<org.flowable.task.api.Task> userTasks = taskService.createTaskQuery().list();
         assertThat(userTasks).isNotNull();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.bpmn.event.message;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -38,40 +39,40 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testSingleBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(3, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(3);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // 1. case: message received cancels the task
 
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 2nd. case: complete the user task cancels the message subscription
 
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
     }
 
@@ -83,7 +84,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
             repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml").deploy();
             fail("Deployment should fail because Flowable cannot handle two boundary message events with same messageId.");
         } catch (Exception e) {
-            assertEquals(0, repositoryService.createDeploymentQuery().count());
+            assertThat(repositoryService.createDeploymentQuery().count()).isZero();
         }
     }
 
@@ -92,19 +93,19 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testDoubleBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(4, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(4);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         // the executions for both messageEventSubscriptionNames are not the same
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertNotNull(execution1);
+        assertThat(execution1).isNotNull();
 
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertNotNull(execution2);
+        assertThat(execution2).isNotNull();
 
-        assertFalse(execution1.getId().equals(execution2.getId()));
+        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
 
         // /////////////////////////////////////////////////////////////////////////////////
         // 1. first message received cancels the task and the execution and both subscriptions
@@ -115,10 +116,10 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThatThrownBy(() -> runtimeService.messageEventReceived("messageName_2", execution2Id));
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage_1", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_1");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // ///////////////////////////////////////////////////////////////////
         // 2. complete the user task cancels the message subscriptions
@@ -126,19 +127,19 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertNull(execution1);
+        assertThat(execution1).isNull();
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertNull(execution2);
+        assertThat(execution2).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -148,14 +149,14 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // assume we have 9 executions one process instance
         // one execution for scope created for boundary message event
         // five execution because we have loop cardinality 5
-        assertEquals(9, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(9);
 
-        assertEquals(5, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         // both executions are not the same
-        assertFalse(execution1.getId().equals(execution2.getId()));
+        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
 
         // /////////////////////////////////////////////////////////////////////////////////
         // 1. first message received cancels all tasks and the executions and
@@ -167,11 +168,11 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThatThrownBy(() -> runtimeService.messageEventReceived("messageName_2", execution2Id));
 
         // only process instance and running execution left
-        assertEquals(2, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(2);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage_1", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_1");
         taskService.complete(userTask.getId());
         assertProcessEnded(processInstance.getId());
 
@@ -182,18 +183,18 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // assume we have 7 executions one process instance
         // one execution for scope created for boundary message event
         // five execution because we have loop cardinality 5
-        assertEquals(9, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(9);
 
-        assertEquals(5, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
         // executions are not the same
-        assertFalse(execution1.getId().equals(execution2.getId()));
+        assertThat(execution1.getId().equals(execution2.getId())).isFalse();
 
         List<org.flowable.task.api.Task> userTasks = taskService.createTaskQuery().list();
-        assertNotNull(userTasks);
-        assertEquals(5, userTasks.size());
+        assertThat(userTasks).isNotNull();
+        assertThat(userTasks).hasSize(5);
 
         // as long as tasks exists, the message subscriptions exist
         for (int i = 0; i < userTasks.size() - 1; i++) {
@@ -201,26 +202,26 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
 
             execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-            assertNotNull(execution1);
+            assertThat(execution1).isNotNull();
             execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-            assertNotNull(execution2);
+            assertThat(execution2).isNotNull();
         }
 
         // only one task left
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         // after last task is completed, no message subscriptions left
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
-        assertNull(execution1);
+        assertThat(execution1).isNull();
         execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
-        assertNull(execution2);
+        assertThat(execution2).isNull();
 
         // complete last task to end process
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -234,13 +235,13 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(4, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(4);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // /////////////////////////////////////////////////
         // 1. case: message received cancels the task
@@ -248,10 +249,10 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // /////////////////////////////////////////////////
         // 2nd. case: complete the user task cancels the message subscription
@@ -259,17 +260,17 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -282,18 +283,18 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(5, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(5);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         Execution execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution1);
+        assertThat(execution1).isNotNull();
 
         Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNotNull(execution2);
+        assertThat(execution2).isNotNull();
 
-        assertNotSame(execution1.getId(), execution2.getId());
+        assertThat(execution2.getId()).isNotSameAs(execution1.getId());
 
         // ///////////////////////////////////////////////////////////
         // first case: we complete the inner usertask.
@@ -301,27 +302,27 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         taskService.complete(userTask.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
 
         // the inner subscription is cancelled
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // the outer subscription still exists
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
 
         // now the outer event subscription is cancelled as well
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterSubprocess", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubprocess");
 
         // now complete the outer usertask
         taskService.complete(userTask.getId());
@@ -335,27 +336,27 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
 
         // the inner subscription is removes
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // the outer subscription still exists
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
 
         // now the outer event subscription is cancelled as well
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterSubprocess", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubprocess");
 
         // now complete the outer usertask
         taskService.complete(userTask.getId());
@@ -369,16 +370,16 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName2", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterOuterMessageBoundary", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterOuterMessageBoundary");
 
         // the inner subscription is removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // the outer subscription is removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // now complete the second usertask
         taskService.complete(userTask.getId());
@@ -392,58 +393,58 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
     public void testBoundaryMessageEventOnSubprocess() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(5, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(5);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         // 1. case: message one received cancels the task
 
         Execution executionMessageOne = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_one").singleResult();
-        assertNotNull(executionMessageOne);
+        assertThat(executionMessageOne).isNotNull();
 
         runtimeService.messageEventReceived("messageName_one", executionMessageOne.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage_one", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_one");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 2nd. case: message two received cancels the task
 
         runtimeService.startProcessInstanceByKey("process");
 
         Execution executionMessageTwo = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_two").singleResult();
-        assertNotNull(executionMessageTwo);
+        assertThat(executionMessageTwo).isNotNull();
 
         runtimeService.messageEventReceived("messageName_two", executionMessageTwo.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage_two", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_two");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 3rd. case: complete the user task cancels the message subscription
 
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         executionMessageOne = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_one").singleResult();
-        assertNull(executionMessageOne);
+        assertThat(executionMessageOne).isNull();
 
         executionMessageTwo = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_two").singleResult();
-        assertNull(executionMessageTwo);
+        assertThat(executionMessageTwo).isNull();
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterSubProcess", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubProcess");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
     }
 
@@ -457,22 +458,22 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(18, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(18);
 
         // 5 user tasks
         List<org.flowable.task.api.Task> userTasks = taskService.createTaskQuery().list();
-        assertNotNull(userTasks);
-        assertEquals(5, userTasks.size());
+        assertThat(userTasks).isNotNull();
+        assertThat(userTasks).hasSize(5);
 
         // there are 5 event subscriptions to the event on the inner user task
         List<Execution> executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").list();
-        assertNotNull(executions);
-        assertEquals(5, executions.size());
+        assertThat(executions).isNotNull();
+        assertThat(executions).hasSize(5);
 
         // there is a single event subscription for the event on the subprocess
         executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").list();
-        assertNotNull(executions);
-        assertEquals(1, executions.size());
+        assertThat(executions).isNotNull();
+        assertThat(executions).hasSize(1);
 
         // if we complete the outer message event, all inner executions are
         // removed
@@ -480,11 +481,11 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         runtimeService.messageEventReceived("messageName2", outerScopeExecution.getId());
 
         executions = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").list();
-        assertEquals(0, executions.size());
+        assertThat(executions).isEmpty();
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterOuterMessageBoundary", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterOuterMessageBoundary");
 
         taskService.complete(userTask.getId());
 
@@ -502,21 +503,21 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(3, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // ///////////////////////////////////
         // Verify the first task
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("task", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("task");
 
         // ///////////////////////////////////
         // Advance the clock to trigger the timer.
         final TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(userTask.getProcessInstanceId());
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         // After setting the clock to time '1 hour and 5 seconds', the timer should fire.
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
@@ -528,53 +529,53 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         });
         
         // It is a repeating job, so it will come back.
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1L);
 
         // ///////////////////////////////////
         // Verify and complete the first task
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         // ///////////////////////////////////
         // Complete the after timer task
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskTimer").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         // Timer job of boundary event of task should be deleted and timer job
         // of task timer boundary event should be created.
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1L);
 
         // ///////////////////////////////////
         // Verify that the message exists
         userTask = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // ///////////////////////////////////
         // Send the message and verify that we went back to the right spot.
         runtimeService.messageEventReceived("messageName", execution.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("task", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("task");
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         // ///////////////////////////////////
         // Complete the first task (again).
         taskService.complete(userTask.getId());
 
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // ///////////////////////////////////
         // Verify timer firing.
@@ -590,7 +591,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         });
 
         // It is a repeating job, so it will come back.
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1L);
 
         // After setting the clock to time '3 hours and 5 seconds', the timer should fire again.
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((3 * 60 * 60 * 1000) + 5000)));
@@ -601,12 +602,12 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
             }
         });
         // It is a repeating job, so it will come back.
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1L);
 
         // ///////////////////////////////////
         // Complete the after timer tasks
         final List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("taskAfterTaskTimer").list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
@@ -618,16 +619,16 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // ///////////////////////////////////
         // Complete the third task
         userTask = taskService.createTaskQuery().singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTaskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTaskAfterTask");
         taskService.complete(userTask.getId());
 
         // ///////////////////////////////////
         // We should be done at this point
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
@@ -56,30 +56,30 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // the process instance must have a message event subscription:
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("newMessage").singleResult();
-        assertNotNull(execution);
-        assertEquals(expectedNumberOfEventSubscriptions, createEventSubscriptionQuery().count());
-        assertEquals(numberOfExecutions, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(execution).isNotNull();
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(expectedNumberOfEventSubscriptions);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(numberOfExecutions);
 
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("task", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
         taskService.complete(task.getId());
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertProcessEnded(processInstance.getId());
 
         // now we start a new instance but this time we trigger the event subprocess:
         processInstance = runtimeService.startProcessInstanceByKey("process");
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("newMessage").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         runtimeService.messageEventReceived("newMessage", execution.getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("eventSubProcessTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("eventSubProcessTask");
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -94,16 +94,16 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
                 .messageEventSubscriptionName("newMessage")
                 .singleResult();
 
-        assertNotNull(execution);
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(execution).isNotNull();
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("task", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
         taskService.complete(task.getId());
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         // now we start a new instance but this time we trigger the event subprocess:
         processInstance = runtimeService.startProcessInstanceByKey("process");
@@ -114,21 +114,21 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("newMessage", execution.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // now let's first complete the task in the main flow:
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         // we still have 3 executions:
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // now let's complete the task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         // #################### again, the other way around:
 
@@ -140,28 +140,28 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("newMessage", execution.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // we still have 3 executions:
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testNonInterruptingMultipleInstances() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -169,45 +169,45 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
                 .singleResult();
 
         runtimeService.messageEventReceived("newMessage", execution.getId());
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         runtimeService.messageEventReceived("newMessage", execution.getId());
-        assertEquals(7, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(7);
 
-        assertEquals(3, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
 
         // we still have 6 executions:
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testNonInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -215,45 +215,45 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
                 .singleResult();
 
         runtimeService.messageEventReceived("eventMessage", execution.getId());
-        assertEquals(6, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(6);
 
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         runtimeService.messageEventReceived("eventMessage", execution.getId());
-        assertEquals(9, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(9);
 
-        assertEquals(3, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
 
         // we still have 7 executions:
-        assertEquals(7, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(7);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
-        assertEquals(4, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -261,40 +261,40 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
                 .singleResult();
 
         runtimeService.messageEventReceived("eventMessage", execution.getId());
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isZero();
 
         // now let's complete the task in the event subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment
     public void testStartingAdditionalTasks() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
                 .messageEventSubscriptionName("Start another task")
                 .singleResult();
         
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -303,7 +303,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("Start another sub task", execution.getId());
         
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -312,64 +312,64 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         
         runtimeService.messageEventReceived("Start another task", execution.getId());
         
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksNoNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
                 .messageEventSubscriptionName("Start another task")
                 .singleResult();
         
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
@@ -377,15 +377,15 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
     public void testStartingAdditionalTasksWithNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
         
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -394,20 +394,20 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("Start another sub task", execution.getId());
         
-        assertEquals(2, createEventSubscriptionQuery().count());
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -416,8 +416,8 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         
         runtimeService.messageEventReceived("Start another task", execution.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -426,49 +426,49 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         
         runtimeService.messageEventReceived("Start another task", execution.getId());
         
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
         
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("additionalTask").list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         
         taskService.complete(tasks.get(0).getId());
         
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment
     public void testStartingAdditionalTasksInterrupting() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
                 .messageEventSubscriptionName("Start another task")
                 .singleResult();
         
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -477,41 +477,41 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("Start another sub task", execution.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.testStartingAdditionalTasksInterrupting.bpmn20.xml")
     public void testStartingAdditionalTasksInterruptingWithMainEventSubProcessInterrupt() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
                 .messageEventSubscriptionName("Start another task")
                 .singleResult();
         
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -520,7 +520,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         runtimeService.messageEventReceived("Start another sub task", execution.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -529,13 +529,13 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         
         runtimeService.messageEventReceived("Start another task", execution.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -25,6 +25,8 @@ import org.flowable.eventsubscription.api.EventSubscription;
 import org.flowable.eventsubscription.service.impl.EventSubscriptionQueryImpl;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
 /**
  * @author Tijs Rademakers
  */
@@ -36,27 +38,27 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("process");
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
-        assertNotNull(activeActivityIds);
-        assertEquals(1, activeActivityIds.size());
-        assertTrue(activeActivityIds.contains("messageCatch"));
+        assertThat(activeActivityIds).isNotNull();
+        assertThat(activeActivityIds)
+                .containsExactly("messageCatch");
 
         String messageName = "newInvoiceMessage";
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).singleResult();
 
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().executionId(execution.getId()).singleResult();
-        assertNotNull(eventSubscription);
-        assertEquals(messageName, eventSubscription.getEventName());
+        assertThat(eventSubscription).isNotNull();
+        assertThat(eventSubscription.getEventName()).isEqualTo(messageName);
 
         eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(execution.getProcessInstanceId()).singleResult();
-        assertNotNull(eventSubscription);
-        assertEquals(messageName, eventSubscription.getEventName());
+        assertThat(eventSubscription).isNotNull();
+        assertThat(eventSubscription.getEventName()).isEqualTo(messageName);
 
         runtimeService.messageEventReceived(messageName, execution.getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
     }
@@ -69,18 +71,18 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("process", variableMap);
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
-        assertNotNull(activeActivityIds);
-        assertEquals(1, activeActivityIds.size());
-        assertTrue(activeActivityIds.contains("messageCatch"));
+        assertThat(activeActivityIds).isNotNull();
+        assertThat(activeActivityIds)
+                .containsExactly("messageCatch");
 
         String messageName = "testMessage";
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         runtimeService.messageEventReceived(messageName, execution.getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
     }
 
@@ -91,26 +93,25 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("process");
 
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(pi.getId());
-        assertNotNull(activeActivityIds);
-        assertEquals(2, activeActivityIds.size());
-        assertTrue(activeActivityIds.contains("messageCatch1"));
-        assertTrue(activeActivityIds.contains("messageCatch2"));
+        assertThat(activeActivityIds).isNotNull();
+        assertThat(activeActivityIds)
+                .containsOnly("messageCatch1", "messageCatch2");
 
         String messageName = "newInvoiceMessage";
         List<Execution> executions = runtimeService.createExecutionQuery().messageEventSubscriptionName(messageName).list();
 
-        assertNotNull(executions);
-        assertEquals(2, executions.size());
+        assertThat(executions).isNotNull();
+        assertThat(executions).hasSize(2);
 
         runtimeService.messageEventReceived(messageName, executions.get(0).getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         runtimeService.messageEventReceived(messageName, executions.get(1).getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
     }
@@ -120,20 +121,20 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
     public void testAsyncTriggeredMessageEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
 
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).messageEventSubscriptionName("newMessage").singleResult();
-        assertNotNull(execution);
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(2, runtimeService.createExecutionQuery().count());
+        assertThat(execution).isNotNull();
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(2);
 
         runtimeService.messageEventReceivedAsync("newMessage", execution.getId());
 
-        assertEquals(1, managementService.createJobQuery().messages().count());
+        assertThat(managementService.createJobQuery().messages().count()).isEqualTo(1);
 
         waitForJobExecutorToProcessAllJobs(8000L, 200L);
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     private EventSubscriptionQueryImpl createEventSubscriptionQuery() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
@@ -18,6 +18,8 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.test.Deployment;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
 /**
  * 
  * @author Tijs Rademakers
@@ -29,76 +31,76 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableFlowableTe
     public void testSingleNonInterruptingBoundaryMessageEvent() {
         runtimeService.startProcessInstanceByKey("process");
 
-        assertEquals(3, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(3);
 
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // 1. case: message received before completing the task
 
         runtimeService.messageEventReceived("messageName", execution.getId());
         // event subscription not removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessage").singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
         taskService.complete(userTask.getId());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         // send a message a second time
         runtimeService.messageEventReceived("messageName", execution.getId());
         // event subscription not removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessage").singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterMessage", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
         taskService.complete(userTask.getId());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         // now complete the user task with the message boundary event
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         taskService.complete(userTask.getId());
 
         // event subscription removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterTask").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
 
         taskService.complete(userTask.getId());
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 2nd. case: complete the user task cancels the message subscription
 
         runtimeService.startProcessInstanceByKey("process");
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        assertNotNull(userTask);
+        assertThat(userTask).isNotNull();
         taskService.complete(userTask.getId());
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
-        assertNull(execution);
+        assertThat(execution).isNull();
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterTask").singleResult();
-        assertNotNull(userTask);
-        assertEquals("taskAfterTask", userTask.getTaskDefinitionKey());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
         taskService.complete(userTask.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
 }


### PR DESCRIPTION
In the `org.flowable.engine.test.bpmn.event.message` package there were 2 files with mixed assertion styles so they were converted to a single format. At the same time the 3 other files in the package were updated.
