### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.java
@@ -13,6 +13,9 @@
 
 package org.flowable.engine.test.bpmn.gateway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Date;
 
 import org.flowable.engine.history.DeleteReason;
@@ -38,19 +41,19 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi1 = runtimeService.startProcessInstanceByKey("catchSignal");
 
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         runtimeService.startProcessInstanceByKey("throwSignal");
 
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(0, managementService.createJobQuery().count());
-        assertEquals(0, managementService.createTimerJobQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(managementService.createJobQuery().count()).isZero();
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("afterSignal").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
@@ -64,23 +67,23 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("catchSignal");
 
-        assertEquals(1, createEventSubscriptionQuery().count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         processEngineConfiguration.getClock().setCurrentTime(new Date(processEngineConfiguration.getClock().getCurrentTime().getTime() + 10000));
 
         // wait for timer to fire
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000, 100);
 
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(0, managementService.createJobQuery().count());
-        assertEquals(0, managementService.createTimerJobQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(managementService.createJobQuery().count()).isZero();
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("afterTimer").singleResult();
 
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         taskService.complete(task.getId());
         
@@ -95,31 +98,31 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("catchSignal");
 
-        assertEquals(2, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
         EventSubscriptionQueryImpl messageEventSubscriptionQuery = createEventSubscriptionQuery().eventType("message");
-        assertEquals(1, messageEventSubscriptionQuery.count());
-        assertEquals(1, createEventSubscriptionQuery().eventType("signal").count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(messageEventSubscriptionQuery.count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().eventType("signal").count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("newInvoice").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         execution = runtimeService.createExecutionQuery().signalEventSubscriptionName("alert").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         processEngineConfiguration.getClock().setCurrentTime(new Date(processEngineConfiguration.getClock().getCurrentTime().getTime() + 10000));
 
         EventSubscription messageEventSubscription = messageEventSubscriptionQuery.singleResult();
         runtimeService.messageEventReceived(messageEventSubscription.getEventName(), messageEventSubscription.getExecutionId());
 
-        assertEquals(0, createEventSubscriptionQuery().count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-        assertEquals(0, managementService.createTimerJobQuery().count());
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
+        assertThat(managementService.createJobQuery().count()).isZero();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("afterMessage").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
@@ -130,16 +133,9 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
     @Test
     public void testConnectedToActivity() {
-
-        try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.testConnectedToActivity.bpmn20.xml").deploy();
-            fail("exception expected");
-        } catch (Exception e) {
-            if (!e.getMessage().contains("Event based gateway can only be connected to elements of type intermediateCatchEvent")) {
-                fail("different exception expected");
-            }
-        }
-
+        assertThatThrownBy(() -> repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.testConnectedToActivity.bpmn20.xml").deploy())
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("Event based gateway can only be connected to elements of type intermediateCatchEvent");
     }
 
     @Test
@@ -150,15 +146,15 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
         // Trying to fire the signal should fail, job not yet created
         runtimeService.signalEventReceived("alert");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
 
         managementService.executeJob(job.getId());
         runtimeService.signalEventReceived("alert");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("afterSignal", task.getName());
+        assertThat(task.getName()).isEqualTo("afterSignal");
     }
 
     private EventSubscriptionQueryImpl createEventSubscriptionQuery() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayDefaultFlowTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayDefaultFlowTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.gateway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,8 +46,8 @@ public class InclusiveGatewayDefaultFlowTest extends PluggableFlowableTestCase {
     public void testDefaultFlowOnly() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("usertask1").singleResult();
-        assertNotNull(execution);
-        assertEquals("usertask1", execution.getActivityId());
+        assertThat(execution).isNotNull();
+        assertThat(execution.getActivityId()).isEqualTo("usertask1");
     }
 
     @Test
@@ -55,7 +57,7 @@ public class InclusiveGatewayDefaultFlowTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, variables);
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("usertask2").singleResult();
-        assertNotNull(execution);
-        assertEquals("usertask2", execution.getActivityId());
+        assertThat(execution).isNotNull();
+        assertThat(execution.getActivityId()).isEqualTo("usertask2");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.bpmn.gateway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,31 +63,33 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testDivergingInclusiveGateway() {
-        for (int i = 1; i <= 3; i++) {
-            ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", CollectionUtil.singletonMap("input", i));
-            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-            List<String> expectedNames = new ArrayList<>();
-            if (i == 1) {
-                expectedNames.add(TASK1_NAME);
-            }
-            if (i <= 2) {
-                expectedNames.add(TASK2_NAME);
-            }
-            expectedNames.add(TASK3_NAME);
-            assertEquals(4 - i, tasks.size());
-            for (org.flowable.task.api.Task task : tasks) {
-                expectedNames.remove(task.getName());
-            }
-            assertEquals(0, expectedNames.size());
-            runtimeService.deleteProcessInstance(pi.getId(), "testing deletion");
-        }
+        ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", CollectionUtil.singletonMap("input", 1));
+        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder(TASK1_NAME, TASK2_NAME, TASK3_NAME);
+        runtimeService.deleteProcessInstance(pi.getId(), "testing deletion");
+
+        pi = runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", CollectionUtil.singletonMap("input", 2));
+        tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder(TASK2_NAME, TASK3_NAME);
+        runtimeService.deleteProcessInstance(pi.getId(), "testing deletion");
+
+        pi = runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", CollectionUtil.singletonMap("input", 3));
+        tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder(TASK3_NAME);
+        runtimeService.deleteProcessInstance(pi.getId(), "testing deletion");
     }
 
     @Test
     @Deployment
     public void testMergingInclusiveGateway() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveGwMerging", CollectionUtil.singletonMap("input", 2));
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         runtimeService.deleteProcessInstance(pi.getId(), "testing deletion");
     }
@@ -92,14 +97,14 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testPartialMergingInclusiveGateway() {
-        ProcessInstance pi = runtimeService.startProcessInstanceByKey("partialInclusiveGwMerging", CollectionUtil.singletonMap("input", 2));
+        ProcessInstance pi = runtimeService.startProcessInstanceByKey("partialInclusiveGwMerging", CollectionUtil.singletonMap("input", 3));
         org.flowable.task.api.Task partialTask = taskService.createTaskQuery().singleResult();
-        assertEquals("partialTask", partialTask.getTaskDefinitionKey());
+        assertThat(partialTask.getTaskDefinitionKey()).isEqualTo("partialTask");
 
         taskService.complete(partialTask.getId());
 
         org.flowable.task.api.Task fullTask = taskService.createTaskQuery().singleResult();
-        assertEquals("theTask", fullTask.getTaskDefinitionKey());
+        assertThat(fullTask.getTaskDefinitionKey()).isEqualTo("theTask");
 
         runtimeService.deleteProcessInstance(pi.getId(), "testing deletion");
     }
@@ -107,12 +112,8 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testNoSequenceFlowSelected() {
-        try {
-            runtimeService.startProcessInstanceByKey("inclusiveGwNoSeqFlowSelected", CollectionUtil.singletonMap("input", 4));
-            fail();
-        } catch (FlowableException e) {
-            // Exception expected
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("inclusiveGwNoSeqFlowSelected", CollectionUtil.singletonMap("input", 4)))
+                .isInstanceOf(FlowableException.class);
     }
 
     /**
@@ -124,11 +125,11 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parentActivationOnNonJoiningEnd");
 
         List<Execution> executionsBefore = runtimeService.createExecutionQuery().list();
-        assertEquals(3, executionsBefore.size());
+        assertThat(executionsBefore).hasSize(3);
 
         // start first round of tasks
         List<org.flowable.task.api.Task> firstTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, firstTasks.size());
+        assertThat(firstTasks).hasSize(2);
 
         for (org.flowable.task.api.Task t : firstTasks) {
             taskService.complete(t.getId());
@@ -136,14 +137,14 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         // start second round of tasks
         List<org.flowable.task.api.Task> secondTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, secondTasks.size());
+        assertThat(secondTasks).hasSize(2);
 
         // complete one task
         org.flowable.task.api.Task task = secondTasks.get(0);
         taskService.complete(task.getId());
 
         List<Execution> executionsAfter = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executionsAfter.size());
+        assertThat(executionsAfter).hasSize(2);
 
         Execution execution = null;
         for (Execution e : executionsAfter) {
@@ -154,14 +155,14 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         // and should have one active activity
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(execution.getId());
-        assertEquals(1, activeActivityIds.size());
+        assertThat(activeActivityIds).hasSize(1);
 
         // Completing last task should finish the process instance
 
         org.flowable.task.api.Task lastTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(lastTask.getId());
 
-        assertEquals(0l, runtimeService.createProcessInstanceQuery().active().count());
+        assertThat(runtimeService.createProcessInstanceQuery().active().count()).isZero();
     }
 
     /**
@@ -171,8 +172,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     @Deployment
     public void testWhitespaceInExpression() {
         // Starting a process instance will lead to an exception if whitespace
-        // are
-        // incorrectly handled
+        // are incorrectly handled
         runtimeService.startProcessInstanceByKey("inclusiveWhiteSpaceInExpression", CollectionUtil.singletonMap("input", 1));
     }
 
@@ -181,12 +181,9 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     public void testUnknownVariableInExpression() {
         // Instead of 'input' we're starting a process instance with the name
         // 'iinput' (ie. a typo)
-        try {
-            runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", CollectionUtil.singletonMap("iinput", 1));
-            fail();
-        } catch (FlowableException e) {
-            assertTextPresent("Unknown property used in expression", e.getMessage());
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", CollectionUtil.singletonMap("iinput", 1)))
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("Unknown property used in expression");
     }
 
     @Test
@@ -194,14 +191,9 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     public void testDecideBasedOnBeanProperty() {
         runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanProperty", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(150)));
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
-        Map<String, String> expectedNames = new HashMap<>();
-        expectedNames.put(BEAN_TASK2_NAME, BEAN_TASK2_NAME);
-        expectedNames.put(BEAN_TASK3_NAME, BEAN_TASK3_NAME);
-        for (org.flowable.task.api.Task task : tasks) {
-            expectedNames.remove(task.getName());
-        }
-        assertEquals(0, expectedNames.size());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder(BEAN_TASK2_NAME, BEAN_TASK3_NAME);
     }
 
     @Test
@@ -212,47 +204,32 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         orders.add(new InclusiveGatewayTestOrder(300));
         orders.add(new InclusiveGatewayTestOrder(175));
 
-        try {
-            runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnListOrArrayOfBeans", CollectionUtil.singletonMap("orders", orders));
-            fail();
-        } catch (FlowableException e) {
-            // expect an exception to be thrown here as there is
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnListOrArrayOfBeans", CollectionUtil.singletonMap("orders", orders)))
+                .isInstanceOf(FlowableException.class);
 
         orders.set(1, new InclusiveGatewayTestOrder(175));
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnListOrArrayOfBeans", CollectionUtil.singletonMap("orders", orders));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals(BEAN_TASK3_NAME, task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo(BEAN_TASK3_NAME);
 
         orders.set(1, new InclusiveGatewayTestOrder(125));
         pi = runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnListOrArrayOfBeans", CollectionUtil.singletonMap("orders", orders));
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertNotNull(tasks);
-        assertEquals(2, tasks.size());
-        List<String> expectedNames = new ArrayList<>();
-        expectedNames.add(BEAN_TASK2_NAME);
-        expectedNames.add(BEAN_TASK3_NAME);
-        for (org.flowable.task.api.Task t : tasks) {
-            expectedNames.remove(t.getName());
-        }
-        assertEquals(0, expectedNames.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder(BEAN_TASK2_NAME, BEAN_TASK3_NAME);
 
         // Arrays are usable in exactly the same way
         InclusiveGatewayTestOrder[] orderArray = orders.toArray(new InclusiveGatewayTestOrder[orders.size()]);
         orderArray[1].setPrice(10);
         pi = runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnListOrArrayOfBeans", CollectionUtil.singletonMap("orders", orderArray));
         tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertNotNull(tasks);
-        assertEquals(3, tasks.size());
-        expectedNames.clear();
-        expectedNames.add(BEAN_TASK1_NAME);
-        expectedNames.add(BEAN_TASK2_NAME);
-        expectedNames.add(BEAN_TASK3_NAME);
-        for (org.flowable.task.api.Task t : tasks) {
-            expectedNames.remove(t.getName());
-        }
-        assertEquals(0, expectedNames.size());
+        assertThat(tasks).isNotNull();
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder(BEAN_TASK1_NAME, BEAN_TASK2_NAME, BEAN_TASK3_NAME);
     }
 
     @Test
@@ -260,38 +237,25 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     public void testDecideBasedOnBeanMethod() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(200)));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals(BEAN_TASK3_NAME, task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo(BEAN_TASK3_NAME);
 
         pi = runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(125)));
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertEquals(2, tasks.size());
-        List<String> expectedNames = new ArrayList<>();
-        expectedNames.add(BEAN_TASK2_NAME);
-        expectedNames.add(BEAN_TASK3_NAME);
-        for (org.flowable.task.api.Task t : tasks) {
-            expectedNames.remove(t.getName());
-        }
-        assertEquals(0, expectedNames.size());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder(BEAN_TASK2_NAME, BEAN_TASK3_NAME);
 
-        try {
-            runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(300)));
-            fail();
-        } catch (FlowableException e) {
-            // Should get an exception indicating that no path could be taken
-        }
-
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(300))))
+                .isInstanceOf(FlowableException.class);
     }
 
     @Test
     @Deployment
     public void testInvalidMethodExpression() {
-        try {
-            runtimeService.startProcessInstanceByKey("inclusiveInvalidMethodExpression", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(50)));
-            fail();
-        } catch (FlowableException e) {
-            assertTextPresent("Unknown method used in expression", e.getMessage());
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("inclusiveInvalidMethodExpression", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(50))))
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("Unknown method used in expression");
     }
 
     @Test
@@ -300,25 +264,21 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         // Input == 1 -> default is not selected, other 2 tasks are selected
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveGwDefaultSequenceFlow", CollectionUtil.singletonMap("input", 1));
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertEquals(2, tasks.size());
-        Map<String, String> expectedNames = new HashMap<>();
-        expectedNames.put("Input is one", "Input is one");
-        expectedNames.put("Input is three or one", "Input is three or one");
-        for (org.flowable.task.api.Task t : tasks) {
-            expectedNames.remove(t.getName());
-        }
-        assertEquals(0, expectedNames.size());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder("Input is one", "Input is three or one");
+
         runtimeService.deleteProcessInstance(pi.getId(), null);
 
         // Input == 3 -> default is not selected, "one or three" is selected
         pi = runtimeService.startProcessInstanceByKey("inclusiveGwDefaultSequenceFlow", CollectionUtil.singletonMap("input", 3));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertEquals("Input is three or one", task.getName());
+        assertThat(task.getName()).isEqualTo("Input is three or one");
 
         // Default input
         pi = runtimeService.startProcessInstanceByKey("inclusiveGwDefaultSequenceFlow", CollectionUtil.singletonMap("input", 5));
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertEquals("Default input", task.getName());
+        assertThat(task.getName()).isEqualTo("Default input");
     }
 
     @Test
@@ -326,19 +286,14 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     public void testNoIdOnSequenceFlow() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveNoIdOnSequenceFlow", CollectionUtil.singletonMap("input", 3));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertEquals("Input is more than one", task.getName());
+        assertThat(task.getName()).isEqualTo("Input is more than one");
 
         // Both should be enabled on 1
         pi = runtimeService.startProcessInstanceByKey("inclusiveNoIdOnSequenceFlow", CollectionUtil.singletonMap("input", 1));
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertEquals(2, tasks.size());
-        Map<String, String> expectedNames = new HashMap<>();
-        expectedNames.put("Input is one", "Input is one");
-        expectedNames.put("Input is more than one", "Input is more than one");
-        for (org.flowable.task.api.Task t : tasks) {
-            expectedNames.remove(t.getName());
-        }
-        assertEquals(0, expectedNames.size());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder("Input is one", "Input is more than one");
     }
 
     /**
@@ -352,13 +307,15 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveTestLoop", CollectionUtil.singletonMap("counter", 1));
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("task C", task.getName());
+        assertThat(task.getName()).isEqualTo("task C");
 
         taskService.complete(task.getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isZero();
         
-        assertEquals("Found executions: " + runtimeService.createExecutionQuery().list(), 0, runtimeService.createExecutionQuery().count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().count())
+                .as("Found executions: " + runtimeService.createExecutionQuery().list())
+                .isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count()).isZero();
     }
 
     @Test
@@ -369,52 +326,49 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         variableMap.put("a", 1);
         variableMap.put("b", 1);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("InclusiveGateway", variableMap);
-        assertNotNull(processInstance.getId());
+        assertThat(processInstance.getId()).isNotNull();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         taskService.complete(tasks.get(0).getId());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         taskService.complete(tasks.get(1).getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskAssignee("c").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         variableMap = new HashMap<>();
         variableMap.put("a", 1);
         variableMap.put("b", 2);
         processInstance = runtimeService.startProcessInstanceByKey("InclusiveGateway", variableMap);
-        assertNotNull(processInstance.getId());
+        assertThat(processInstance.getId()).isNotNull();
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, taskService.createTaskQuery().count());
-
-        task = tasks.get(0);
-        assertEquals("a", task.getAssignee());
-        taskService.complete(task.getId());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(tasks)
+                .extracting(Task::getAssignee)
+                .containsExactly("a");
+        taskService.complete(tasks.get(0).getId());
 
         task = taskService.createTaskQuery().taskAssignee("c").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
-        variableMap = new HashMap<>();
-        variableMap.put("a", 2);
-        variableMap.put("b", 2);
-        try {
-            runtimeService.startProcessInstanceByKey("InclusiveGateway", variableMap);
-            fail();
-        } catch (FlowableException e) {
-            assertTrue(e.getMessage().contains("No outgoing sequence flow"));
-        }
+        Map<String, Object> newVariableMap = new HashMap<>();
+        newVariableMap.put("a", 2);
+        newVariableMap.put("b", 2);
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("InclusiveGateway", newVariableMap))
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("No outgoing sequence flow");
     }
 
     @Test
@@ -422,8 +376,8 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     public void testJoinAfterParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("InclusiveGateway");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals("Task1", task.getName());
+        assertThat(task).isNotNull();
+        assertThat(task.getName()).isEqualTo("Task1");
 
         taskService.complete(task.getId());
 
@@ -432,7 +386,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
                 .activityId("receiveTask1")
                 .singleResult();
 
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         runtimeService.trigger(execution.getId());
 
         execution = runtimeService.createExecutionQuery()
@@ -440,7 +394,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
                 .activityId("receiveTask1")
                 .singleResult();
 
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
     }
 
     @Test
@@ -449,37 +403,37 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     public void testJoinAfterCall() {
         // Test case to test act-1026
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("InclusiveGatewayAfterCall");
-        assertNotNull(processInstance.getId());
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(processInstance.getId()).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
 
         // now complete task A and check number of remaining tasks.
         // inclusive gateway should wait for the "Task B" and "Task C"
         org.flowable.task.api.Task taskA = taskService.createTaskQuery().taskName("Task A").singleResult();
-        assertNotNull(taskA);
+        assertThat(taskA).isNotNull();
         taskService.complete(taskA.getId());
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // now complete task B and check number of remaining tasks
         // inclusive gateway should wait for "Task C"
         org.flowable.task.api.Task taskB = taskService.createTaskQuery().taskName("Task B").singleResult();
-        assertNotNull(taskB);
+        assertThat(taskB).isNotNull();
         taskService.complete(taskB.getId());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // now complete task C. Gateway activates and "Task C" remains
         org.flowable.task.api.Task taskC = taskService.createTaskQuery().taskName("Task C").singleResult();
-        assertNotNull(taskC);
+        assertThat(taskC).isNotNull();
         taskService.complete(taskC.getId());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // check that remaining task is in fact task D
         org.flowable.task.api.Task taskD = taskService.createTaskQuery().taskName("Task D").singleResult();
-        assertNotNull(taskD);
-        assertEquals("Task D", taskD.getName());
+        assertThat(taskD).isNotNull();
+        assertThat(taskD.getName()).isEqualTo("Task D");
         taskService.complete(taskD.getId());
 
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
     }
 
     @Test
@@ -487,7 +441,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
     public void testAsyncBehavior() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async");
         waitForJobExecutorToProcessAllJobs(10000L, 250);
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -497,24 +451,24 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         varMap.put("input", 1);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwDirectSequenceFlow", varMap);
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
-        assertEquals("theTask1", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask1");
         taskService.complete(task.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         varMap = new HashMap<>();
         varMap.put("input", 3);
         processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwDirectSequenceFlow", varMap);
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         varMap = new HashMap<>();
         varMap.put("input", 0);
         processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwDirectSequenceFlow", varMap);
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
 
     @Test
@@ -525,26 +479,26 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         varMap.put("input", 10);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwSkipExpression", varMap);
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
-        assertEquals("theTask1", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask1");
         taskService.complete(task.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         varMap = new HashMap<>();
         varMap.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", true);
         varMap.put("input", 30);
         processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwSkipExpression", varMap);
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         varMap = new HashMap<>();
         varMap.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", true);
         varMap.put("input", 3);
         processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwSkipExpression", varMap);
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
     
     @Test
@@ -557,14 +511,14 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         varMap.put("input", 10);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwSkipExpression", varMap);
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals("theTask1", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask1");
 
         varMap = new HashMap<>();
         varMap.put("input", 30);
         processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwSkipExpression", varMap);
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         dynamicBpmnService.removeEnableSkipExpression(infoNode);
         dynamicBpmnService.saveProcessDefinitionInfo(processDefinition.getId(), infoNode);
@@ -572,8 +526,8 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         varMap.put("input", 10);
         processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwSkipExpression", varMap);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertEquals("theTask2", task.getTaskDefinitionKey());
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask2");
         
         dynamicBpmnService.enableSkipExpression(infoNode);
         dynamicBpmnService.changeSkipExpression("flow2", "${input < 30}", infoNode);
@@ -588,7 +542,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
                 fail("expected theTask2 and theTask3 only");
             }
         }
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
     }
 
     @Test
@@ -599,26 +553,26 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("testMultipleProcessInstancesMergedBug");
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance1.getId()).taskName("A").singleResult().getId());
         org.flowable.task.api.Task taskCInPi1 = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
-        assertNotNull(taskCInPi1);
+        assertThat(taskCInPi1).isNotNull();
 
         // Start second process instance, continue A. Process instance should be in B
         ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("testMultipleProcessInstancesMergedBug", CollectionUtil.singletonMap("var", "goToB"));
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance2.getId()).taskName("A").singleResult().getId());
         org.flowable.task.api.Task taskBInPi2 = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
-        assertNotNull(taskBInPi2);
+        assertThat(taskBInPi2).isNotNull();
 
         // Verify there is an inactive execution in the inclusive gateway before the task complete of process instance 1
         // (cannot combine activityId and inactive together, hence the workaround)
-        assertEquals(2, getInactiveExecutionsInActivityId("inclusiveGw").size());
+        assertThat(getInactiveExecutionsInActivityId("inclusiveGw")).hasSize(2);
 
         // Completing C of PI 1 should not trigger C
         taskService.complete(taskCInPi1.getId());
 
         // Verify structure after complete.
         // Before bugfix: in BOTH process instances the inactive execution was removed (result was 0)
-        assertEquals(1, getInactiveExecutionsInActivityId("inclusiveGw").size());
+        assertThat(getInactiveExecutionsInActivityId("inclusiveGw")).hasSize(1);
 
-        assertEquals(1L, taskService.createTaskQuery().taskName("After Merge").count());
+        assertThat(taskService.createTaskQuery().taskName("After Merge").count()).isEqualTo(1);
 
         // Finish both processes
 
@@ -629,7 +583,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
             }
             tasks = taskService.createTaskQuery().list();
         }
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
     }
 
@@ -655,7 +609,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
                 .processDefinitionId(instance.getProcessDefinitionId())
                 .list();
 
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         String executionId = processEngine.getManagementService().executeCommand(new Command<String>() {
             @Override
@@ -666,12 +620,11 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
                 List<EventSubscription> subs = CommandContextUtil
                         .getEventSubscriptionService()
                         .findEventSubscriptionsByQueryCriteria(q);
+                assertThat(subs)
+                        .extracting(EventSubscription::getEventName)
+                        .containsExactly("test");
 
-                assertEquals(1, subs.size());
-                EventSubscription sub = subs.get(0);
-                assertEquals("test", sub.getEventName());
-
-                return sub.getExecutionId();
+                return subs.get(0).getExecutionId();
             }
         });
 
@@ -681,8 +634,8 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
                 .processDefinitionId(instance.getProcessDefinitionId())
                 .list();
 
-        //since it is non interupting, we now expect 3 tasks to be present
-        assertEquals(3, tasks.size());
+        //since it is non interrupting, we now expect 3 tasks to be present
+        assertThat(tasks).hasSize(3);
 
     }
 
@@ -708,86 +661,86 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         List<Execution> childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //1x MultiInstance root, 3x parallel MultiInstance and 9x UserTasks executions (3 task executions per parallel multiInstance subProcess)
-        assertEquals(13, childExecutions.size());
+        assertThat(childExecutions).hasSize(13);
         Map<String, List<Execution>> classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         //9x UserTasks
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(3, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(3, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(3, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(3);
 
         //Finish a couple of tasks
         taskService.complete(classifiedTasks.get("taskInclusive2").get(0).getId());
         taskService.complete(classifiedTasks.get("taskInclusive3").get(1).getId());
 
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(13, childExecutions.size());
+        assertThat(childExecutions).hasSize(13);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive3").size());
-        assertNotNull(classifiedExecutions.get("inclusiveJoin"));
-        assertEquals(2, classifiedExecutions.get("inclusiveJoin").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(2);
+        assertThat(classifiedExecutions.get("inclusiveJoin")).isNotNull();
+        assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
 
         //7x pending User Tasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(3, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(2, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(2, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(2);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(2);
 
         //Finish the rest of the tasks
         classifiedTasks.values().stream().flatMap(List::stream).forEach(this::completeTask);
 
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(7, childExecutions.size());
+        assertThat(childExecutions).hasSize(7);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("postForkTask"));
-        assertEquals(3, classifiedExecutions.get("postForkTask").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("postForkTask")).isNotNull();
+        assertThat(classifiedExecutions.get("postForkTask")).hasSize(3);
 
         //3x pending User Tasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
-        tasks.forEach(task-> assertEquals("postForkTask", task.getTaskDefinitionKey()));
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(task-> assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the remaining tasks in the SubProcess
         tasks.forEach(this::completeTask);
 
         //MultiInstance subProcess ended, only the last task of the process remains
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, childExecutions.size());
+        assertThat(childExecutions).hasSize(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Finish the process
         taskService.complete(task.getId());
         
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -797,51 +750,51 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         List<Execution> childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //1x MultiInstance root, 1x Sequential MultiInstance and 3x UserTasks executions
-        assertEquals(5, childExecutions.size());
+        assertThat(childExecutions).hasSize(5);
         Map<String, List<Execution>> classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(2, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(1);
 
         //3x UserTasks
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(1, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(1, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(1, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(1);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(1);
 
         //Finish one of the activities
         taskService.complete(classifiedTasks.get("taskInclusive3").get(0).getId());
 
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(5, childExecutions.size());
+        assertThat(childExecutions).hasSize(5);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(2, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive2").size());
-        assertNull(classifiedExecutions.get("taskInclusive3"));
-        assertNotNull(classifiedExecutions.get("inclusiveJoin"));
-        assertEquals(1, classifiedExecutions.get("inclusiveJoin").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNull();
+        assertThat(classifiedExecutions.get("inclusiveJoin")).isNotNull();
+        assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(1);
 
         //2x pending User Tasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(2, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertFalse(classifiedTasks.containsKey("taskInclusive3"));
+        assertThat(classifiedTasks).hasSize(2);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks).doesNotContainKeys("taskInclusive3");
 
         //Finish the rest of the tasks
         Stream.concat(classifiedTasks.get("taskInclusive1").stream(), classifiedTasks.get("taskInclusive2").stream())
@@ -849,69 +802,69 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         //1x MultiInstance root, 1x Sequential MultiInstance, 1x User Task after the gateway join
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(3, childExecutions.size());
+        assertThat(childExecutions).hasSize(3);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(2, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("postForkTask"));
-        assertEquals(1, classifiedExecutions.get("postForkTask").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
+        assertThat(classifiedExecutions.get("postForkTask")).isNotNull();
+        assertThat(classifiedExecutions.get("postForkTask")).hasSize(1);
 
         //Last task of this multiInstance subProcess instance
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("postForkTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask");
         taskService.complete(task.getId());
 
         //The next sequence should start
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //1x MultiInstance root, 1x Sequential MultiInstance and 3x UserTasks executions
-        assertEquals(5, childExecutions.size());
+        assertThat(childExecutions).hasSize(5);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(2, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(1, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(1, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(1, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(1);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(1);
 
         //Finish the inclusive gateway tasks
         tasks.forEach(this::completeTask);
 
         //last task of the sequence
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("postForkTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask");
         taskService.complete(task.getId());
 
         //Last Sequence
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(5, childExecutions.size());
+        assertThat(childExecutions).hasSize(5);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         tasks.forEach(this::completeTask);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("postForkTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask");
         taskService.complete(task.getId());
 
         //last task of the process, after the multiInstance subProcess
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, childExecutions.size());
+        assertThat(childExecutions).hasSize(1);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Finish the process
         taskService.complete(task.getId());
         
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
 
@@ -922,29 +875,29 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         List<Execution> childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //1x MultiInstance root, 3x parallel MultiInstance, 3x NestedSubProcess and 9x UserTasks executions
-        assertEquals(16, childExecutions.size());
+        assertThat(childExecutions).hasSize(16);
         Map<String, List<Execution>> classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("nestedSubProcess"));
-        assertEquals(3, classifiedExecutions.get("nestedSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("nestedSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("nestedSubProcess")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         //9x UserTasks
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(3, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(3, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(3, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(3);
 
         //Finish a couple of Tasks
         taskService.complete(classifiedTasks.get("taskInclusive1").get(1).getId());
@@ -952,31 +905,31 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //1x MultiInstance root, 3x parallel MultiInstance, 3x NestedSubProcess and 7x UserTasks executions, 2x Gw Join executions
-        assertEquals(16, childExecutions.size());
+        assertThat(childExecutions).hasSize(16);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("nestedSubProcess"));
-        assertEquals(3, classifiedExecutions.get("nestedSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive3").size());
-        assertNotNull(classifiedExecutions.get("inclusiveJoin"));
-        assertEquals(2, classifiedExecutions.get("inclusiveJoin").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("nestedSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("nestedSubProcess")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(2);
+        assertThat(classifiedExecutions.get("inclusiveJoin")).isNotNull();
+        assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
 
         //7x UserTasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(2, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(3, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(2, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(2);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(2);
 
         //Finish one "multiInstance subProcess"
         Stream<Execution> tempStream = Stream.concat(classifiedExecutions.get("taskInclusive1").stream(), classifiedExecutions.get("taskInclusive2").stream());
@@ -998,56 +951,56 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //1x MultiInstance root, 3x parallel MultiInstance, 3x NestedSubProcess, 4x UserTasks executions, 2x Gw Join executions, 1 postFork task Execution
-        assertEquals(14, childExecutions.size());
+        assertThat(childExecutions).hasSize(14);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("nestedSubProcess"));
-        assertEquals(3, classifiedExecutions.get("nestedSubProcess").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive3").size());
-        assertNotNull(classifiedExecutions.get("inclusiveJoin"));
-        assertEquals(2, classifiedExecutions.get("inclusiveJoin").size());
-        assertNotNull(classifiedExecutions.get("postForkTask"));
-        assertEquals(1, classifiedExecutions.get("postForkTask").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("nestedSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("nestedSubProcess")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(1);
+        assertThat(classifiedExecutions.get("inclusiveJoin")).isNotNull();
+        assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
+        assertThat(classifiedExecutions.get("postForkTask")).isNotNull();
+        assertThat(classifiedExecutions.get("postForkTask")).hasSize(1);
 
         //5x UserTasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(4, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(1, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(2, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(1, classifiedTasks.get("taskInclusive3").size());
-        assertTrue(classifiedTasks.containsKey("postForkTask"));
-        assertEquals(1, classifiedTasks.get("postForkTask").size());
+        assertThat(classifiedTasks).hasSize(4);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(2);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(1);
+        assertThat(classifiedTasks).containsKey("postForkTask");
+        assertThat(classifiedTasks.get("postForkTask")).hasSize(1);
 
         //Finish all gateWayTasks
         tasks.stream().filter(t-> !t.getTaskDefinitionKey().equals("postForkTask")).forEach(this::completeTask);
 
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //1x MultiInstance root, 3x parallel MultiInstance, 3x NestedSubProcess, 4x postFork task Execution
-        assertEquals(10, childExecutions.size());
+        assertThat(childExecutions).hasSize(10);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("nestedSubProcess"));
-        assertEquals(3, classifiedExecutions.get("nestedSubProcess").size());
-        assertNotNull(classifiedExecutions.get("postForkTask"));
-        assertEquals(3, classifiedExecutions.get("postForkTask").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("nestedSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("nestedSubProcess")).hasSize(3);
+        assertThat(classifiedExecutions.get("postForkTask")).isNotNull();
+        assertThat(classifiedExecutions.get("postForkTask")).hasSize(3);
 
         //3x UserTasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(1, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("postForkTask"));
-        assertEquals(3, classifiedTasks.get("postForkTask").size());
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks).containsKey("postForkTask");
+        assertThat(classifiedTasks.get("postForkTask")).hasSize(3);
 
         //Finish the nested subprocess tasks
         tasks.forEach(this::completeTask);
@@ -1055,16 +1008,18 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //MultiInstance subProcesses finish as the nested subProcesses end
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         //1x User task execution
-        assertEquals(1, childExecutions.size());
-        assertEquals("lastTask", childExecutions.get(0).getActivityId());
+        assertThat(childExecutions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("lastTask");
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
-        assertEquals("lastTask", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("lastTask");
 
         //Finish the process
         tasks.forEach(this::completeTask);
         
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -1075,39 +1030,39 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         //1x Process Root, 3x Call activity roots
         List<Execution> processExecutionRoots = runtimeService.createExecutionQuery().onlyProcessInstanceExecutions().list();
-        assertEquals(4, processExecutionRoots.size());
+        assertThat(processExecutionRoots).hasSize(4);
         Map<String, List<Execution>> classifiedRoots = processExecutionRoots.stream()
             .collect(Collectors.toMap(e -> e.getSuperExecutionId() != null ? "callActivity" : null, Collections::singletonList, AbstractFlowableTestCase::mergeLists));
-        assertEquals(1, classifiedRoots.get(null).size());
-        assertEquals(3, classifiedRoots.get("callActivity").size());
+        assertThat(classifiedRoots.get(null)).hasSize(1);
+        assertThat(classifiedRoots.get("callActivity")).hasSize(3);
 
         //1x MultiInstance root, 3x parallel MultiInstance, 3x CalledActivitySubProcesses and 9x UserTasks executions
         List<Execution> childExecutions = processExecutionRoots.stream()
             .flatMap(rootProcess -> runtimeService.createExecutionQuery().processInstanceId(rootProcess.getId()).onlyChildExecutions().list().stream())
             .collect(Collectors.toList());
-        assertEquals(16, childExecutions.size());
+        assertThat(childExecutions).hasSize(16);
         Map<String, List<Execution>> classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("callActivity"));
-        assertEquals(3, classifiedExecutions.get("callActivity").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("callActivity")).isNotNull();
+        assertThat(classifiedExecutions.get("callActivity")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         //9x UserTasks
         List<Task> tasks = taskService.createTaskQuery().list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(3, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(3, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(3, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(3);
 
         //Finish a couple of Tasks
         taskService.complete(classifiedTasks.get("taskInclusive1").get(1).getId());
@@ -1119,29 +1074,29 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
             .flatMap(rootProcess -> runtimeService.createExecutionQuery().processInstanceId(rootProcess.getId()).onlyChildExecutions().list().stream())
             .collect(Collectors.toList());
         //1x MultiInstance root, 3x parallel MultiInstance, 3x CalledActivitySubProcesses and 7x UserTasks executions
-        assertEquals(14, childExecutions.size());
+        assertThat(childExecutions).hasSize(14);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(4, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("callActivity"));
-        assertEquals(3, classifiedExecutions.get("callActivity").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(3, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
+        assertThat(classifiedExecutions.get("callActivity")).isNotNull();
+        assertThat(classifiedExecutions.get("callActivity")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(2);
 
         //7x UserTasks
         tasks = taskService.createTaskQuery().list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(2, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(3, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(2, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(2);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(2);
 
         //Finish one "multiInstance subProcess"
         Stream<Execution> tempStream = Stream.concat(classifiedExecutions.get("taskInclusive1").stream(), classifiedExecutions.get("taskInclusive2").stream());
@@ -1164,29 +1119,29 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
             .flatMap(rootProcess -> runtimeService.createExecutionQuery().processInstanceId(rootProcess.getId()).onlyChildExecutions().list().stream())
             .collect(Collectors.toList());
         //1x MultiInstance root, 2x parallel MultiInstance, 2x CalledActivitySubProcesses and 4x UserTasks executions
-        assertEquals(9, childExecutions.size());
+        assertThat(childExecutions).hasSize(9);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertNotNull(classifiedExecutions.get("multiInstanceSubProcess"));
-        assertEquals(3, classifiedExecutions.get("multiInstanceSubProcess").size());
-        assertNotNull(classifiedExecutions.get("callActivity"));
-        assertEquals(2, classifiedExecutions.get("callActivity").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive1"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive1").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive2"));
-        assertEquals(2, classifiedExecutions.get("taskInclusive2").size());
-        assertNotNull(classifiedExecutions.get("taskInclusive3"));
-        assertEquals(1, classifiedExecutions.get("taskInclusive3").size());
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(3);
+        assertThat(classifiedExecutions.get("callActivity")).isNotNull();
+        assertThat(classifiedExecutions.get("callActivity")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(2);
+        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
+        assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(1);
 
         //4x UserTasks
         tasks = taskService.createTaskQuery().list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertEquals(3, classifiedTasks.size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive1"));
-        assertEquals(1, classifiedTasks.get("taskInclusive1").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive2"));
-        assertEquals(2, classifiedTasks.get("taskInclusive2").size());
-        assertTrue(classifiedTasks.containsKey("taskInclusive3"));
-        assertEquals(1, classifiedTasks.get("taskInclusive3").size());
+        assertThat(classifiedTasks).hasSize(3);
+        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
+        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks.get("taskInclusive2")).hasSize(2);
+        assertThat(classifiedTasks).containsKey("taskInclusive3");
+        assertThat(classifiedTasks.get("taskInclusive3")).hasSize(1);
 
         //Finish pending tasks
         tasks.stream().forEach(this::completeTask);
@@ -1194,16 +1149,17 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //Called process should have ended, only the initial root process should remain
         //1x Process Root, 3x Call activity roots
         processExecutionRoots = runtimeService.createExecutionQuery().onlyProcessInstanceExecutions().list();
-        assertEquals(1, processExecutionRoots.size());
-        assertNull(processExecutionRoots.get(0).getSuperExecutionId());
+        assertThat(processExecutionRoots).hasSize(1);
+        assertThat(processExecutionRoots.get(0).getSuperExecutionId()).isNull();
 
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
-        assertEquals(1, childExecutions.size());
-        assertEquals("lastTask", childExecutions.get(0).getActivityId());
+        assertThat(childExecutions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("lastTask");
 
         //1x UserTasks
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("lastTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Finish the process
         taskService.complete(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -663,24 +663,20 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 3x parallel MultiInstance and 9x UserTasks executions (3 task executions per parallel multiInstance subProcess)
         assertThat(childExecutions).hasSize(13);
         Map<String, List<Execution>> classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         //9x UserTasks
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(3);
 
         //Finish a couple of tasks
@@ -690,26 +686,21 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(childExecutions).hasSize(13);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3", "inclusiveJoin");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(2);
-        assertThat(classifiedExecutions.get("inclusiveJoin")).isNotNull();
         assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
 
         //7x pending User Tasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(2);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(2);
 
         //Finish the rest of the tasks
@@ -718,15 +709,15 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(childExecutions).hasSize(7);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "postForkTask");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("postForkTask")).isNotNull();
         assertThat(classifiedExecutions.get("postForkTask")).hasSize(3);
 
         //3x pending User Tasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(task-> assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask"));
+        tasks.forEach(task -> assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the remaining tasks in the SubProcess
         tasks.forEach(this::completeTask);
@@ -739,7 +730,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         //Finish the process
         taskService.complete(task.getId());
-        
+
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
@@ -752,24 +743,20 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 1x Sequential MultiInstance and 3x UserTasks executions
         assertThat(childExecutions).hasSize(5);
         Map<String, List<Execution>> classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(1);
 
         //3x UserTasks
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(1);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(1);
 
         //Finish one of the activities
@@ -778,35 +765,32 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(childExecutions).hasSize(5);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "taskInclusive1", "taskInclusive2", "inclusiveJoin");
+        assertThat(classifiedExecutions).doesNotContainKey("taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNull();
-        assertThat(classifiedExecutions.get("inclusiveJoin")).isNotNull();
         assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(1);
 
         //2x pending User Tasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(2);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2");
         assertThat(classifiedTasks).doesNotContainKeys("taskInclusive3");
 
         //Finish the rest of the tasks
         Stream.concat(classifiedTasks.get("taskInclusive1").stream(), classifiedTasks.get("taskInclusive2").stream())
-            .forEach(this::completeTask);
+                .forEach(this::completeTask);
 
         //1x MultiInstance root, 1x Sequential MultiInstance, 1x User Task after the gateway join
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(childExecutions).hasSize(3);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "postForkTask");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
-        assertThat(classifiedExecutions.get("postForkTask")).isNotNull();
         assertThat(classifiedExecutions.get("postForkTask")).hasSize(1);
 
         //Last task of this multiInstance subProcess instance
@@ -819,22 +803,18 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 1x Sequential MultiInstance and 3x UserTasks executions
         assertThat(childExecutions).hasSize(5);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(1);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(1);
 
         //Finish the inclusive gateway tasks
@@ -863,7 +843,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         //Finish the process
         taskService.complete(task.getId());
-        
+
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
@@ -877,26 +857,21 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 3x parallel MultiInstance, 3x NestedSubProcess and 9x UserTasks executions
         assertThat(childExecutions).hasSize(16);
         Map<String, List<Execution>> classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "nestedSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("nestedSubProcess")).isNotNull();
         assertThat(classifiedExecutions.get("nestedSubProcess")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         //9x UserTasks
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(3);
 
         //Finish a couple of Tasks
@@ -907,28 +882,22 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 3x parallel MultiInstance, 3x NestedSubProcess and 7x UserTasks executions, 2x Gw Join executions
         assertThat(childExecutions).hasSize(16);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "nestedSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3", "inclusiveJoin");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("nestedSubProcess")).isNotNull();
         assertThat(classifiedExecutions.get("nestedSubProcess")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(2);
-        assertThat(classifiedExecutions.get("inclusiveJoin")).isNotNull();
         assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
 
         //7x UserTasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(2);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(2);
 
         //Finish one "multiInstance subProcess"
@@ -953,32 +922,24 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 3x parallel MultiInstance, 3x NestedSubProcess, 4x UserTasks executions, 2x Gw Join executions, 1 postFork task Execution
         assertThat(childExecutions).hasSize(14);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "nestedSubProcess", "taskInclusive1", "taskInclusive2", "taskInclusive3", "inclusiveJoin", "postForkTask");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("nestedSubProcess")).isNotNull();
         assertThat(classifiedExecutions.get("nestedSubProcess")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(1);
-        assertThat(classifiedExecutions.get("inclusiveJoin")).isNotNull();
         assertThat(classifiedExecutions.get("inclusiveJoin")).hasSize(2);
-        assertThat(classifiedExecutions.get("postForkTask")).isNotNull();
         assertThat(classifiedExecutions.get("postForkTask")).hasSize(1);
 
         //5x UserTasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(4);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3", "postForkTask");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(2);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(1);
-        assertThat(classifiedTasks).containsKey("postForkTask");
         assertThat(classifiedTasks.get("postForkTask")).hasSize(1);
 
         //Finish all gateWayTasks
@@ -988,18 +949,17 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 3x parallel MultiInstance, 3x NestedSubProcess, 4x postFork task Execution
         assertThat(childExecutions).hasSize(10);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "nestedSubProcess", "postForkTask");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("nestedSubProcess")).isNotNull();
         assertThat(classifiedExecutions.get("nestedSubProcess")).hasSize(3);
-        assertThat(classifiedExecutions.get("postForkTask")).isNotNull();
         assertThat(classifiedExecutions.get("postForkTask")).hasSize(3);
 
         //3x UserTasks
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(1);
-        assertThat(classifiedTasks).containsKey("postForkTask");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("postForkTask");
         assertThat(classifiedTasks.get("postForkTask")).hasSize(3);
 
         //Finish the nested subprocess tasks
@@ -1042,26 +1002,21 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
             .collect(Collectors.toList());
         assertThat(childExecutions).hasSize(16);
         Map<String, List<Execution>> classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "callActivity", "taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("callActivity")).isNotNull();
         assertThat(classifiedExecutions.get("callActivity")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(3);
 
         //9x UserTasks
         List<Task> tasks = taskService.createTaskQuery().list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(3);
 
         //Finish a couple of Tasks
@@ -1076,26 +1031,21 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 3x parallel MultiInstance, 3x CalledActivitySubProcesses and 7x UserTasks executions
         assertThat(childExecutions).hasSize(14);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "callActivity", "taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(4);
-        assertThat(classifiedExecutions.get("callActivity")).isNotNull();
         assertThat(classifiedExecutions.get("callActivity")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(2);
 
         //7x UserTasks
         tasks = taskService.createTaskQuery().list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(2);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(2);
 
         //Finish one "multiInstance subProcess"
@@ -1121,26 +1071,21 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //1x MultiInstance root, 2x parallel MultiInstance, 2x CalledActivitySubProcesses and 4x UserTasks executions
         assertThat(childExecutions).hasSize(9);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
-        assertThat(classifiedExecutions.get("multiInstanceSubProcess")).isNotNull();
+        assertThat(classifiedExecutions)
+                .containsKeys("multiInstanceSubProcess", "callActivity", "taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(3);
-        assertThat(classifiedExecutions.get("callActivity")).isNotNull();
         assertThat(classifiedExecutions.get("callActivity")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive1")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedExecutions.get("taskInclusive2")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(2);
-        assertThat(classifiedExecutions.get("taskInclusive3")).isNotNull();
         assertThat(classifiedExecutions.get("taskInclusive3")).hasSize(1);
 
         //4x UserTasks
         tasks = taskService.createTaskQuery().list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKey("taskInclusive1");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
-        assertThat(classifiedTasks).containsKey("taskInclusive2");
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(2);
-        assertThat(classifiedTasks).containsKey("taskInclusive3");
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(1);
 
         //Finish pending tasks

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ParallelGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ParallelGatewayTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.gateway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.common.engine.impl.history.HistoryLevel;
@@ -29,7 +31,6 @@ import org.flowable.eventsubscription.api.EventSubscription;
 import org.flowable.eventsubscription.service.impl.EventSubscriptionQueryImpl;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -45,35 +46,35 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
     @Deployment
     public void testSplitMergeNoWaitstates() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("forkJoinNoWaitStates");
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
 
     @Test
     @Deployment
     public void testUnstructuredConcurrencyTwoForks() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("unstructuredConcurrencyTwoForks");
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
 
     @Test
     @Deployment
     public void testUnstructuredConcurrencyTwoJoins() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("unstructuredConcurrencyTwoJoins");
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
 
     @Test
     @Deployment
     public void testForkFollowedByOnlyEndEvents() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("forkFollowedByEndEvents");
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
 
     @Test
     @Deployment
     public void testNestedForksFollowedByEndEvents() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nestedForksFollowedByEndEvents");
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
 
     // ACT-482
@@ -85,36 +86,39 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
         // After process starts, only task 0 should be active
         TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
         List<org.flowable.task.api.Task> tasks = query.list();
-        assertEquals(1, tasks.size());
-        assertEquals("Task 0", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task 0");
 
         // Completing task 0 will create org.flowable.task.service.Task A and B
         taskService.complete(tasks.get(0).getId());
         tasks = query.list();
-        assertEquals(2, tasks.size());
-        assertEquals("Task A", tasks.get(0).getName());
-        assertEquals("Task B", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A", "Task B");
 
         // Completing task A should not trigger any new tasks
         taskService.complete(tasks.get(0).getId());
         tasks = query.list();
-        assertEquals(1, tasks.size());
-        assertEquals("Task B", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task B");
 
         // Completing task B creates tasks B1 and B2
         taskService.complete(tasks.get(0).getId());
         tasks = query.list();
-        assertEquals(2, tasks.size());
-        assertEquals("Task B1", tasks.get(0).getName());
-        assertEquals("Task B2", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task B1", "Task B2");
 
         // Completing B1 and B2 will activate both joins, and process reaches
         // task C
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
         tasks = query.list();
-        assertEquals(1, tasks.size());
-        assertEquals("Task C", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task C");
     }
 
     /**
@@ -129,21 +133,22 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
         // from the sub process
         TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
         List<org.flowable.task.api.Task> tasks = query.list();
-        assertEquals(2, tasks.size());
-        assertEquals("Another task", tasks.get(0).getName());
-        assertEquals("Some Task", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Another task", "Some Task");
 
         // we complete the task from the parent process, the root execution is
         // recycled, the task in the sub process is still there
         taskService.complete(tasks.get(1).getId());
         tasks = query.list();
-        assertEquals(1, tasks.size());
-        assertEquals("Another task", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Another task");
 
         // we end the task in the sub process and the sub process instance end
         // is propagated to the parent process
         taskService.complete(tasks.get(0).getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isZero();
 
         // There is a QA config without history, so we cannot work with this:
         // assertEquals(1,
@@ -160,7 +165,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
             for (HistoricActivityInstance h : history) {
                 assertActivityInstancesAreSame(h, runtimeService.createActivityInstanceQuery().activityInstanceId(h.getId()).singleResult());
                 if (h.getActivityId().equals("parallelgateway2")) {
-                    assertNotNull(h.getEndTime());
+                    assertThat(h.getEndTime()).isNotNull();
                 }
             }
         }
@@ -171,13 +176,13 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
     public void testAsyncBehavior() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async");
         waitForJobExecutorToProcessAllJobs(20000L, 250L);
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     /*
      * @Test
      * @Deployment public void testAsyncBehavior() { for (int i = 0; i < 100; i++) { ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("async"); } assertEquals(200,
-     * managementService.createJobQuery().count()); waitForJobExecutorToProcessAllJobs(120000, 5000); assertEquals(0, managementService.createJobQuery().count()); assertEquals(0,
+     * managementService.createJobQuery().count()); waitForJobExecutorToProcessAllJobs(120000, 5000); assertThat(managementService.createJobQuery().count()).isZero(); assertEquals(0,
      * runtimeService.createProcessInstanceQuery().count()); }
      */
 
@@ -188,12 +193,12 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
         
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().list();
-            assertEquals(41, historicActivityInstances.size());
+            assertThat(historicActivityInstances).hasSize(41);
             for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
-                Assert.assertNotNull(historicActivityInstance.getStartTime());
-                Assert.assertNotNull(historicActivityInstance.getEndTime());
+                assertThat(historicActivityInstance.getStartTime()).isNotNull();
+                assertThat(historicActivityInstance.getEndTime()).isNotNull();
                 if (historicActivityInstance.getActivityId().startsWith("flow")) {
-                    assertEquals(historicActivityInstance.getStartTime(), historicActivityInstance.getEndTime());
+                    assertThat(historicActivityInstance.getEndTime()).isEqualTo(historicActivityInstance.getStartTime());
                 }
             }
         }
@@ -215,7 +220,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 .processInstanceId(processInstance.getProcessInstanceId())
                 .list();
 
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         processEngine.getManagementService().executeCommand(new Command<String>() {
             @Override
@@ -226,12 +231,11 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 List<EventSubscription> subs = CommandContextUtil
                         .getEventSubscriptionService()
                         .findEventSubscriptionsByQueryCriteria(q);
+                assertThat(subs)
+                        .extracting(EventSubscription::getEventName)
+                        .containsExactly("testmessage");
 
-                assertEquals(1, subs.size());
-                EventSubscription sub = subs.get(0);
-                assertEquals("testmessage", sub.getEventName());
-
-                return sub.getExecutionId();
+                return subs.get(0).getExecutionId();
             }
         });
         taskService.complete(tasks.get(0).getId());
@@ -240,12 +244,12 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 .processInstanceId(processInstance.getProcessInstanceId())
                 .taskName("task 2")
                 .list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         taskService.complete(tasks.get(0).getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getProcessInstanceId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         processEngine.getManagementService().executeCommand(new Command<String>() {
             @Override
@@ -256,12 +260,11 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 List<EventSubscription> subs = CommandContextUtil
                         .getEventSubscriptionService()
                         .findEventSubscriptionsByQueryCriteria(q);
+                assertThat(subs)
+                        .extracting(EventSubscription::getEventName)
+                        .containsExactly("testmessage");
 
-                assertEquals(1, subs.size());
-                EventSubscription sub = subs.get(0);
-                assertEquals("testmessage", sub.getEventName());
-
-                return sub.getExecutionId();
+                return subs.get(0).getExecutionId();
             }
         });
 


### PR DESCRIPTION
There was one file in the `org.flowable.engine.test.bpmn.gateway` package that had mixed assertion types.  Fixed that file and then did the other 4 files in the same package.
