### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/BpmnEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/BpmnEventRegistryConsumerTest.java
@@ -187,7 +187,7 @@ public class BpmnEventRegistryConsumerTest extends FlowableEventRegistryBpmnTest
         assertThat(eventSubscription).isNotNull();
         assertThat(eventSubscription.getEventType()).isEqualTo("myEvent");
 
-        assertThat(runtimeService.createProcessInstanceQuery().list()).hasSize(0);
+        assertThat(runtimeService.createProcessInstanceQuery().list()).isEmpty();
 
         for (int i = 1; i <= 5; i++) {
             inboundEventChannelAdapter.triggerTestEvent();
@@ -208,10 +208,10 @@ public class BpmnEventRegistryConsumerTest extends FlowableEventRegistryBpmnTest
         assertThat(eventSubscription).isNotNull();
         assertThat(eventSubscription.getEventType()).isEqualTo("myEvent");
 
-        assertThat(runtimeService.createProcessInstanceQuery().list()).hasSize(0);
+        assertThat(runtimeService.createProcessInstanceQuery().list()).isEmpty();
         
         inboundEventChannelAdapter.triggerTestEvent("anotherCustomer");
-        assertThat(runtimeService.createProcessInstanceQuery().list()).hasSize(0);
+        assertThat(runtimeService.createProcessInstanceQuery().list()).isEmpty();
 
         for (int i = 1; i <= 5; i++) {
             inboundEventChannelAdapter.triggerTestEvent("testCustomer");
@@ -232,7 +232,7 @@ public class BpmnEventRegistryConsumerTest extends FlowableEventRegistryBpmnTest
         assertThat(eventSubscription).isNotNull();
         assertThat(eventSubscription.getEventType()).isEqualTo("myEvent");
 
-        assertThat(runtimeService.createProcessInstanceQuery().list()).hasSize(0);
+        assertThat(runtimeService.createProcessInstanceQuery().list()).isEmpty();
         
         inboundEventChannelAdapter.triggerTestEvent("payloadStartCustomer");
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().processDefinitionKey("process").singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventPayloadTypesConversionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventPayloadTypesConversionTest.java
@@ -190,7 +190,7 @@ public class EventPayloadTypesConversionTest extends FlowableEventRegistryBpmnTe
 
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
 
@@ -220,7 +220,7 @@ public class EventPayloadTypesConversionTest extends FlowableEventRegistryBpmnTe
 
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
 
@@ -253,7 +253,7 @@ public class EventPayloadTypesConversionTest extends FlowableEventRegistryBpmnTe
 
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
-        assertThat(outboundXmlEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundXmlEventChannelAdapter.receivedEvents).isEmpty();
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         assertThat(outboundXmlEventChannelAdapter.receivedEvents).hasSize(1);
 
@@ -273,7 +273,7 @@ public class EventPayloadTypesConversionTest extends FlowableEventRegistryBpmnTe
 
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
-        assertThat(outboundXmlEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundXmlEventChannelAdapter.receivedEvents).isEmpty();
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         assertThat(outboundXmlEventChannelAdapter.receivedEvents).hasSize(1);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryDataChangeDetectorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryDataChangeDetectorTest.java
@@ -81,18 +81,18 @@ public class EventRegistryDataChangeDetectorTest extends PluggableFlowableTestCa
         EventRepositoryService otherEventRepositoryService = getOtherProcessEngineEventRegistryRepositoryService();
         EventDeploymentManager otherEventDeploymentManager = getOtherProcessEngineEventRegistryDeploymentManager();
         
-        assertThat(eventRepositoryService.createChannelDefinitionQuery().list()).hasSize(0);
-        assertThat(eventDeploymentManager.getChannelDefinitionCache().size()).isEqualTo(0);
+        assertThat(eventRepositoryService.createChannelDefinitionQuery().list()).isEmpty();
+        assertThat(eventDeploymentManager.getChannelDefinitionCache().size()).isZero();
         
-        assertThat(otherEventRepositoryService.createChannelDefinitionQuery().list()).hasSize(0);
-        assertThat(otherEventDeploymentManager.getChannelDefinitionCache().size()).isEqualTo(0);
+        assertThat(otherEventRepositoryService.createChannelDefinitionQuery().list()).isEmpty();
+        assertThat(otherEventDeploymentManager.getChannelDefinitionCache().size()).isZero();
 
         // Set the time for both engines to the same start time
         Date startTime = new Date();
         processEngineConfiguration.getClock().setCurrentTime(startTime);
         otherProcessEngine.getProcessEngineConfiguration().getClock().setCurrentTime(startTime);
 
-        assertThat(eventRegistryEngine.getEventRepositoryService().createEventDefinitionQuery().count()).isEqualTo(0);
+        assertThat(eventRegistryEngine.getEventRepositoryService().createEventDefinitionQuery().count()).isZero();
 
         // Deploy a channel definition on engine1
         EventDeployment engine1Deployment = eventRegistryEngine.getEventRepositoryService().createDeployment().addClasspathResource("org/flowable/engine/test/eventregistry/simpleChannel.channel").deploy();
@@ -103,7 +103,7 @@ public class EventRegistryDataChangeDetectorTest extends PluggableFlowableTestCa
         assertThat(eventDeploymentManager.getChannelDefinitionCache().size()).isEqualTo(1);
         
         assertThat(otherEventRepositoryService.createChannelDefinitionQuery().list()).hasSize(1);
-        assertThat(otherEventDeploymentManager.getChannelDefinitionCache().size()).isEqualTo(0);
+        assertThat(otherEventDeploymentManager.getChannelDefinitionCache().size()).isZero();
 
         // Manually trigger the detect changes logic on engine2
         getOtherProcessEngineEventRegistryManagementService().executeEventRegistryChangeDetection();
@@ -161,7 +161,7 @@ public class EventRegistryDataChangeDetectorTest extends PluggableFlowableTestCa
         eventRegistryEngine.getEventRepositoryService().deleteDeployment(engine2Deployment.getId());
 
         assertThat(eventRepositoryService.createChannelDefinitionQuery().list()).isEmpty(); // removed on engine1
-        assertThat(eventDeploymentManager.getChannelDefinitionCache().size()).isEqualTo(0);
+        assertThat(eventDeploymentManager.getChannelDefinitionCache().size()).isZero();
 
         assertThat(otherEventRepositoryService.createChannelDefinitionQuery().list()).isEmpty(); // but not yet on engine2, timer job needs to pass first
         assertThat(otherEventDeploymentManager.getChannelDefinitionCache().size()).isEqualTo(1);
@@ -170,10 +170,10 @@ public class EventRegistryDataChangeDetectorTest extends PluggableFlowableTestCa
         getOtherProcessEngineEventRegistryManagementService().executeEventRegistryChangeDetection();
 
         assertThat(eventRepositoryService.createChannelDefinitionQuery().list()).isEmpty();
-        assertThat(eventDeploymentManager.getChannelDefinitionCache().size()).isEqualTo(0);
+        assertThat(eventDeploymentManager.getChannelDefinitionCache().size()).isZero();
 
         assertThat(otherEventRepositoryService.createChannelDefinitionQuery().list()).isEmpty();
-        assertThat(otherEventDeploymentManager.getChannelDefinitionCache().size()).isEqualTo(0);
+        assertThat(otherEventDeploymentManager.getChannelDefinitionCache().size()).isZero();
     }
 
     protected EventRegistry getEventRegistry() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryEventSubprocessTest.java
@@ -97,46 +97,46 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("customerIdVar", "kermit");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process", variableMap);
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
         
         inboundEventChannelAdapter.triggerTestEvent("notexisting");
         
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         inboundEventChannelAdapter.triggerTestEvent("kermit");
         
-        assertEquals(6, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(6);
 
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         inboundEventChannelAdapter.triggerTestEvent("kermit");
-        assertEquals(9, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(9);
 
-        assertEquals(3, taskService.createTaskQuery().count());
-        assertEquals(1, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
+        assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(createEventSubscriptionQuery().count()).isZero();
 
         // we still have 7 executions:
-        assertEquals(7, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(7);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
-        assertEquals(4, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -230,23 +230,23 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("customerIdVar", "gonzo");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process", variableMap);
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         inboundEventChannelAdapter.triggerTestEvent("notexisting");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
         
         inboundEventChannelAdapter.triggerTestEvent("gonzo");
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(0, createEventSubscriptionQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(createEventSubscriptionQuery().count()).isZero();
 
         // now let's complete the task in the event subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/MultiTenantBpmnEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/MultiTenantBpmnEventRegistryConsumerTest.java
@@ -230,7 +230,7 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         deployProcessModel("startProcessInstanceTenantA.bpmn20.xml", TENANT_A);
         deployProcessModel("startProcessInstanceTenantB.bpmn20.xml", TENANT_B);
 
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         assertThat(runtimeService.createEventSubscriptionQuery().tenantId(TENANT_A).list())
             .extracting(EventSubscription::getEventType, EventSubscription::getTenantId)
@@ -244,12 +244,12 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         for (int i = 0; i < 5; i++) {
             ((TestInboundChannelAdapter) tenantAChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("customerA");
             assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(i + 1);
-            assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isZero();
         }
 
         ((TestInboundChannelAdapter) tenantBChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("customerA");
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(5L);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(1L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(5);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(1);
 
         waitForJobExecutorOnCondition(10000L, 100L, () -> taskService.createTaskQuery().count() == 6);
         assertThat(taskService.createTaskQuery().orderByTaskName().asc().list())
@@ -263,19 +263,18 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         deployProcessModel("startProcessInstanceSameKeyTenantB.bpmn20.xml", TENANT_B);
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_A);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isZero();
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_B);
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_B);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(2L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(2);
 
         waitForJobExecutorOnCondition(10000L, 100L, () -> taskService.createTaskQuery().count() == 3);
         assertThat(taskService.createTaskQuery().orderByTaskName().asc().list())
             .extracting(Task::getName)
             .containsExactly("task tenant A", "task tenant B", "task tenant B");
-
     }
 
     @Test
@@ -284,13 +283,13 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         deployProcessModel("startUniqueProcessInstanceSameKeyTenantB.bpmn20.xml", TENANT_B);
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_A);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isZero();
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_B);
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_B);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(1L); // unique instance for same correlation
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(1); // unique instance for same correlation
 
         waitForJobExecutorOnCondition(10000L, 100L, () -> taskService.createTaskQuery().count() == 2);
         assertThat(taskService.createTaskQuery().orderByTaskName().asc().list())
@@ -306,19 +305,19 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         String tenantId = runtimeService.createEventSubscriptionQuery().singleResult().getTenantId();
         assertThat(tenantId).isNullOrEmpty();
 
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(0L);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isZero();
 
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_A);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isZero();
 
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).singleResult();
         assertThat(processInstance.getTenantId()).isEqualTo(TENANT_A);
 
         for (int i = 0; i < 4; i++) {
             ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerB", TENANT_B);
-            assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_A).count()).isEqualTo(1);
             assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TENANT_B).count()).isEqualTo(i + 1);
         }
     }
@@ -331,21 +330,32 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         runtimeService.createProcessInstanceBuilder().processDefinitionKey("process").fallbackToDefaultTenant().overrideProcessDefinitionTenantId(TENANT_B).start();
 
         // Event subscription should be for specific tenants
-        assertThat(runtimeService.createEventSubscriptionQuery().list()).extracting(EventSubscription::getTenantId).containsOnly(TENANT_A, TENANT_B);
+        assertThat(runtimeService.createEventSubscriptionQuery().list())
+                .extracting(EventSubscription::getTenantId)
+                .containsOnly(TENANT_A, TENANT_B);
 
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("no_correlation", TENANT_A);
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("no_correlation", TENANT_B);
-        assertThat(runtimeService.createEventSubscriptionQuery().list()).extracting(EventSubscription::getTenantId).containsOnly(TENANT_A, TENANT_B);
-        assertThat(taskService.createTaskQuery().list()).extracting(Task::getName).containsOnly("Task with boundary event", "Task with boundary event");
+        assertThat(runtimeService.createEventSubscriptionQuery().list())
+                .extracting(EventSubscription::getTenantId)
+                .containsOnly(TENANT_A, TENANT_B);
+        assertThat(taskService.createTaskQuery().list())
+                .extracting(Task::getName)
+                .containsOnly("Task with boundary event", "Task with boundary event");
 
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("abc", TENANT_A); // abc = correlation
-        assertThat(runtimeService.createEventSubscriptionQuery().list()).extracting(EventSubscription::getTenantId).containsOnly(TENANT_B);
-        assertThat(taskService.createTaskQuery().list()).extracting(Task::getName).containsOnly("Task with boundary event", "Task tenantA");
+        assertThat(runtimeService.createEventSubscriptionQuery().list())
+                .extracting(EventSubscription::getTenantId)
+                .containsOnly(TENANT_B);
+        assertThat(taskService.createTaskQuery().list())
+                .extracting(Task::getName)
+                .containsOnly("Task with boundary event", "Task tenantA");
 
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("abc", TENANT_B);
         assertThat(runtimeService.createEventSubscriptionQuery().list()).isEmpty();
-        assertThat(taskService.createTaskQuery().list()).extracting(Task::getName).containsOnly("Task tenantA", "Task tenantB");
-
+        assertThat(taskService.createTaskQuery().list())
+                .extracting(Task::getName)
+                .containsOnly("Task tenantA", "Task tenantB");
     }
 
     @Test
@@ -359,17 +369,17 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
 
         // Triggering through the tenant A channel should only correlate
         ((TestInboundChannelAdapter) tenantAChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("ABC");
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1L);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(0L);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isZero();
 
         runtimeService.createProcessInstanceBuilder().processDefinitionKey("process").tenantId(TENANT_A).start();
         ((TestInboundChannelAdapter) tenantAChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("Doesn't correlate");
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1L);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(0L);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isZero();
 
         ((TestInboundChannelAdapter) tenantBChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("ABC");
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1L);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(1L);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(1);
     }
 
     @Test
@@ -383,21 +393,21 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
 
         // Triggering through the tenant A channel should only correlate
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("ABC", TENANT_A);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1L);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(0L);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isZero();
 
         runtimeService.createProcessInstanceBuilder().processDefinitionKey("process").tenantId(TENANT_A).start();
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("Doesn't correlate", TENANT_A);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1L);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(0L);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isZero();
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("ABC", TENANT_A);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(2L);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(0L);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isZero();
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("ABC", TENANT_B);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(2L);
-        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(1L);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant A").count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().taskName("Task from tenant B").count()).isEqualTo(1);
     }
 
     private static class TestInboundChannelAdapter implements InboundEventChannelAdapter {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendEventTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendEventTaskTest.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.engine.test.eventregistry;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -117,7 +118,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
     public void testSendEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
         
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -125,19 +126,21 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         taskService.complete(task.getId());
         
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(AsyncSendEventJobHandler.TYPE, job.getJobHandlerType());
-        assertEquals("sendEventTask", job.getElementId());
-        
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(job).isNotNull();
+        assertThat(job.getJobHandlerType()).isEqualTo(AsyncSendEventJobHandler.TYPE);
+        assertThat(job.getElementId()).isEqualTo("sendEventTask");
+
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         
         assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
 
         JsonNode jsonNode = processEngineConfiguration.getObjectMapper().readTree(outboundEventChannelAdapter.receivedEvents.get(0));
-        assertThat(jsonNode).hasSize(1);
-        assertThat(jsonNode.get("eventProperty").asText()).isEqualTo("test");
+        assertThatJson(jsonNode)
+                .isEqualTo("{"
+                        + "   eventProperty: 'test'"
+                        + " }");
     }
     
     @Test
@@ -145,7 +148,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
     public void testSendEventSynchronously() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -158,8 +161,10 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
 
         JsonNode jsonNode = processEngineConfiguration.getObjectMapper().readTree(outboundEventChannelAdapter.receivedEvents.get(0));
-        assertThat(jsonNode).hasSize(1);
-        assertThat(jsonNode.get("eventProperty").asText()).isEqualTo("test");
+        assertThatJson(jsonNode)
+                .isEqualTo("{"
+                        + "   eventProperty: 'test'"
+                        + " }");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -175,7 +180,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
                         .variable("accountNumber", 123)
                         .start();
         
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -183,20 +188,22 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         taskService.complete(task.getId());
         
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(AsyncSendEventJobHandler.TYPE, job.getJobHandlerType());
-        assertEquals("sendEventTask", job.getElementId());
+        assertThat(job).isNotNull();
+        assertThat(job.getJobHandlerType()).isEqualTo(AsyncSendEventJobHandler.TYPE);
+        assertThat(job.getElementId()).isEqualTo("sendEventTask");
         
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         
         assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
 
         JsonNode jsonNode = processEngineConfiguration.getObjectMapper().readTree(outboundEventChannelAdapter.receivedEvents.get(0));
-        assertThat(jsonNode).hasSize(2);
-        assertThat(jsonNode.get("nameProperty").asText()).isEqualTo("someName");
-        assertThat(jsonNode.get("numberProperty").asText()).isEqualTo("123");
+        assertThatJson(jsonNode)
+                .isEqualTo("{"
+                        + "   nameProperty: 'someName',"
+                        + "   numberProperty: 123"
+                        + " }");
     }
     
     @Test
@@ -204,7 +211,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
     public void testTriggerableSendEvent() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
         
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -217,20 +224,22 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         assertThat(eventSubscription.getProcessInstanceId()).isEqualTo(processInstance.getId());
         
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(AsyncSendEventJobHandler.TYPE, job.getJobHandlerType());
-        assertEquals("sendEventTask", job.getElementId());
+        assertThat(job).isNotNull();
+        assertThat(job.getJobHandlerType()).isEqualTo(AsyncSendEventJobHandler.TYPE);
+        assertThat(job.getElementId()).isEqualTo("sendEventTask");
         
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         
         assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
 
         JsonNode jsonNode = processEngineConfiguration.getObjectMapper().readTree(outboundEventChannelAdapter.receivedEvents.get(0));
-        assertThat(jsonNode).hasSize(1);
-        assertThat(jsonNode.get("eventProperty").asText()).isEqualTo("test");
-        
+        assertThatJson(jsonNode)
+                .isEqualTo("{"
+                        + "   eventProperty: 'test'"
+                        + " }");
+
         ObjectMapper objectMapper = new ObjectMapper();
 
         InboundChannelModel inboundChannel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("test-channel");
@@ -280,7 +289,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
     public void testTriggerableSendEventSynchronously() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
 
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -327,7 +336,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
                 .variable("customerIdVar", "someId")
                 .start();
         
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -340,20 +349,22 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         assertThat(eventSubscription.getProcessInstanceId()).isEqualTo(processInstance.getId());
         
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(AsyncSendEventJobHandler.TYPE, job.getJobHandlerType());
-        assertEquals("sendEventTask", job.getElementId());
+        assertThat(job).isNotNull();
+        assertThat(job.getJobHandlerType()).isEqualTo(AsyncSendEventJobHandler.TYPE);
+        assertThat(job.getElementId()).isEqualTo("sendEventTask");
         
-        assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(0);
+        assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         
         assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
 
         JsonNode jsonNode = processEngineConfiguration.getObjectMapper().readTree(outboundEventChannelAdapter.receivedEvents.get(0));
-        assertThat(jsonNode).hasSize(1);
-        assertThat(jsonNode.get("eventProperty").asText()).isEqualTo("test");
-        
+        assertThatJson(jsonNode)
+                .isEqualTo("{"
+                        + "   eventProperty: 'test'"
+                        + " }");
+
         ObjectMapper objectMapper = new ObjectMapper();
 
         InboundChannelModel inboundChannel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("test-channel");


### PR DESCRIPTION
There were 3 files in the `org.flowable.engine.test.eventregistry` package that had a mixture of assertion styles.  I took the opportunity to update some of the other files in the package at the same time. 
