### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/EndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/EndEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.end;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.api.FlowableOptimisticLockingException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -31,7 +33,7 @@ public class EndEventTest extends PluggableFlowableTestCase {
     public void testConcurrentEndOfSameProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskWithDelay");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // We will now start two threads that both complete the task.
         // In the process, the task is followed by a delay of three seconds
@@ -41,8 +43,8 @@ public class EndEventTest extends PluggableFlowableTestCase {
         TaskCompleter taskCompleter1 = new TaskCompleter(task.getId());
         TaskCompleter taskCompleter2 = new TaskCompleter(task.getId());
 
-        assertFalse(taskCompleter1.isSucceeded());
-        assertFalse(taskCompleter2.isSucceeded());
+        assertThat(taskCompleter1.isSucceeded()).isFalse();
+        assertThat(taskCompleter2.isSucceeded()).isFalse();
 
         taskCompleter1.start();
         taskCompleter2.start();
@@ -57,7 +59,7 @@ public class EndEventTest extends PluggableFlowableTestCase {
             successCount++;
         }
 
-        assertEquals("(Only) one thread should have been able to successfully end the process", 1, successCount);
+        assertThat(successCount).as("(Only) one thread should have been able to successfully end the process").isEqualTo(1);
         assertProcessEnded(processInstance.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.engine.test.bpmn.event.end;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,6 +41,7 @@ import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,7 +87,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
-        assertEquals(3, executionEntities);
+        assertThat(executionEntities).isEqualTo(3);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
         taskService.complete(task.getId());
@@ -112,8 +112,8 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         assertProcessEnded(pi.getId());
         
-        assertEquals(1, TerminateExecutionListener.startCalled);
-        assertEquals(1, TerminateExecutionListener.endCalled);
+        assertThat(TerminateExecutionListener.startCalled).isEqualTo(1);
+        assertThat(TerminateExecutionListener.endCalled).isEqualTo(1);
     }
 
     @Test
@@ -141,7 +141,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // should terminate the process and
         long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
-        assertEquals(4, executionEntities);
+        assertThat(executionEntities).isEqualTo(4);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
         taskService.complete(task.getId());
@@ -166,7 +166,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         assertProcessEnded(pi.getId());
@@ -206,7 +206,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
         taskService.complete(task.getId());
@@ -229,7 +229,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId())
                 .taskDefinitionKey("preTerminateEnd").singleResult();
@@ -254,7 +254,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample-terminateAfterExclusiveGateway");
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertNotNull(subProcessInstance);
+        assertThat(subProcessInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
         Map<String, Object> variables = new HashMap<>();
@@ -292,11 +292,11 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Completing the task once should only destroy ONE multi instance
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("task").list();
-        assertEquals(5, tasks.size());
+        assertThat(tasks).hasSize(5);
 
         for (int i = 0; i < 5; i++) {
             taskService.complete(tasks.get(i).getId());
-            assertTrue(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count() > 0);
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count()).isGreaterThan(0);
         }
 
         // Other task will now finish the process instance
@@ -305,7 +305,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         variables.put("input", 1);
         taskService.complete(task.getId(), variables);
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count()).isZero();
         assertHistoricProcessInstanceDetails(pi);
     }
     
@@ -337,7 +337,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateParallel");
         
         HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().processInstanceId(pi.getId()).taskDefinitionKey("task").singleResult();
-        assertNull(historicTask);
+        assertThat(historicTask).isNull();
     }
 
     @Test
@@ -347,7 +347,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // should terminate the subprocess and continue the parent
         long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
-        assertTrue(executionEntities > 0);
+        assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
@@ -373,14 +373,14 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(pi.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(pi.getId()).count()).isEqualTo(3);
 
         // Set clock time to '1 hour and 5 seconds' ahead to fire timer
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         // timer has fired
-        assertEquals(0L, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
 
         assertProcessEnded(pi.getId());
 
@@ -392,20 +392,20 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(pi.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(pi.getId()).count()).isEqualTo(3);
 
         // a job for boundary event timer should exist
-        assertEquals(1L, managementService.createTimerJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1L);
 
         // Complete sub process task that leads to a terminate end event
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTermInnerTask").singleResult();
         taskService.complete(task.getId());
 
         // 'preEndInnerTask' task in subprocess should have been terminated, only outerTask should exist
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(pi.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(pi.getId()).count()).isEqualTo(1);
 
         // job for boundary event timer should have been removed
-        assertEquals(0L, managementService.createTimerJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
 
         // complete outerTask
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("outerTask").singleResult();
@@ -422,7 +422,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
-        assertEquals(3, taskService.createTaskQuery().processInstanceId(pi.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(pi.getId()).count()).isEqualTo(3);
 
         // Complete sub process task that leads to a terminate end event
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTermInnerTask").singleResult();
@@ -438,7 +438,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         long executionEntities = runtimeService.createExecutionQuery().count();
-        assertTrue(executionEntities > 0);
+        assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
@@ -461,7 +461,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskName("User Task").singleResult();
         taskService.complete(task.getId());
@@ -476,16 +476,16 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-        assertEquals(4, tasks.size()); // 3 user tasks in MI +1 (preNormalEnd) = 4 (2 were killed because it went directly to the terminate end event)
+        assertThat(tasks).hasSize(4); // 3 user tasks in MI +1 (preNormalEnd) = 4 (2 were killed because it went directly to the terminate end event)
 
         long executionEntitiesCount = runtimeService.createExecutionQuery().count();
-        assertEquals(9, executionEntitiesCount);
+        assertThat(executionEntitiesCount).isEqualTo(9);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
 
         executionEntitiesCount = runtimeService.createExecutionQuery().count();
-        assertEquals(8, executionEntitiesCount);
+        assertThat(executionEntitiesCount).isEqualTo(8);
 
         tasks = taskService.createTaskQuery().list();
         for (org.flowable.task.api.Task t : tasks) {
@@ -505,7 +505,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).taskName("User Task").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId());
@@ -530,14 +530,14 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateInCallActivityConcurrentCallActivity() throws Exception {
         // GIVEN - process instance starts and creates 2 subProcessInstances (with 2 user tasks - preTerminate and my task)
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventInCallActivityConcurrentCallActivity");
-        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).list().size(), is(2));
+        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).list()).hasSize(2);
 
         // WHEN - complete -> terminate end event
         org.flowable.task.api.Task preTerminate = taskService.createTaskQuery().taskName("preTerminate").singleResult();
         taskService.complete(preTerminate.getId());
 
         // THEN - super process is not finished together
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count()).isEqualTo(1);
     }
 
     @Test
@@ -546,7 +546,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         long executionEntities = runtimeService.createExecutionQuery().count();
-        assertTrue(executionEntities > 0);
+        assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
@@ -563,10 +563,10 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         long remainingExecutions = runtimeService.createExecutionQuery().count();
-        assertTrue(remainingExecutions > 0);
+        assertThat(remainingExecutions).isGreaterThan(0);
 
         // three finished
-        assertEquals(3, serviceTaskInvokedCount2);
+        assertThat(serviceTaskInvokedCount2).isEqualTo(3);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
@@ -594,7 +594,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // should terminate the called process and continue the parent
         long executionEntities = runtimeService.createExecutionQuery().count();
-        assertTrue(executionEntities > 0);
+        assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
@@ -613,7 +613,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // should terminate the called process and continue the parent
         long executionEntities = runtimeService.createExecutionQuery().count();
-        assertTrue(executionEntities > 0);
+        assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
@@ -642,7 +642,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // should terminate the called process and continue the parent
         long executionEntities = runtimeService.createExecutionQuery().count();
-        assertTrue(executionEntities > 0);
+        assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
@@ -657,10 +657,10 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMiCallActivity");
 
         List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().taskName("A").list();
-        assertEquals(5, aTasks.size());
+        assertThat(aTasks).hasSize(5);
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
-        assertEquals(5, bTasks.size());
+        assertThat(bTasks).hasSize(5);
 
         // Completing B should terminate one instance (it goes to a terminate end event)
         int bTasksCompleted = 0;
@@ -670,11 +670,11 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             bTasksCompleted++;
 
             aTasks = taskService.createTaskQuery().taskName("A").list();
-            assertEquals(5 - bTasksCompleted, aTasks.size());
+            assertThat(aTasks).hasSize(5 - bTasksCompleted);
         }
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("After call activity", task.getName());
+        assertThat(task.getName()).isEqualTo("After call activity");
 
         taskService.complete(task.getId());
         
@@ -690,10 +690,10 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testMiCallActivity");
 
         List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().taskName("A").list();
-        assertEquals(1, aTasks.size());
+        assertThat(aTasks).hasSize(1);
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
-        assertEquals(1, bTasks.size());
+        assertThat(bTasks).hasSize(1);
 
         // Completing B should terminate one instance (it goes to a terminate end event)
         for (int i = 0; i < 9; i++) {
@@ -706,15 +706,15 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
             if (i != 8) {
                 aTasks = taskService.createTaskQuery().taskName("A").list();
-                assertEquals("Expected task for i=" + i, 1, aTasks.size());
+                assertThat(aTasks).hasSize(1);
 
                 bTasks = taskService.createTaskQuery().taskName("B").list();
-                assertEquals("Expected task for i=" + i, 1, bTasks.size());
+                assertThat(bTasks).hasSize(1);
             }
         }
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("After call activity", task.getName());
+        assertThat(task.getName()).isEqualTo("After call activity");
 
         taskService.complete(task.getId());
         
@@ -744,7 +744,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // should terminate the called process and continue the parent
         long executionEntities = runtimeService.createExecutionQuery().count();
-        assertTrue(executionEntities > 0);
+        assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
         taskService.complete(task.getId());
@@ -769,34 +769,32 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedSubprocesses");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals("D", tasks.get(2).getName());
-        assertEquals("E", tasks.get(3).getName());
-        assertEquals("F", tasks.get(4).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B", "D", "E", "F");
 
         // Completing E should finish the lower subprocess and make 'H' active
         taskService.complete(tasks.get(3).getId());
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Completing A should make C active
         taskService.complete(tasks.get(0).getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Completing C should make I active
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Completing I and B should make G active
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("G").singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
         taskService.complete(tasks.get(1).getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("G").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
     }
 
     @Test
@@ -834,7 +832,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Should have 7 tasks C active
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").list();
-        assertEquals(7, tasks.size());
+        assertThat(tasks).hasSize(7);
 
         // Completing these should lead to task I being active
         for (org.flowable.task.api.Task task : tasks) {
@@ -842,18 +840,18 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         }
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // Should have 3 instances of E active
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
         // Completing these should make H active
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId());
         }
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
     }
 
     @Test
@@ -866,17 +864,17 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         // Should have 7 tasks C active after each other
         for (int i = 0; i < 7; i++) {
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").singleResult();
-            assertNotNull("Task was null for i = " + i, task);
+            assertThat(task).isNotNull();
             taskService.complete(task.getId());
         }
 
         // I should be active now
-        assertNotNull(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult()).isNotNull();
 
         // Should have 3 instances of E active after each other
         for (int i = 0; i < 3; i++) {
-            assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("D").count());
-            assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("F").count());
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("D").count()).isEqualTo(1);
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("F").count()).isEqualTo(1);
 
             // Completing F should not finish the subprocess
             taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("F").singleResult().getId());
@@ -885,7 +883,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
         }
 
-        assertNotNull(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult()).isNotNull();
     }
 
     @Test
@@ -946,13 +944,13 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Completing 'before A' of one instance
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("task_subprocess_1").singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
         taskService.complete(tasks.get(5).getId());
 
         // Multi instance call activity is sequential, so expecting 5 more times the same task
         for (int i = 0; i < 6; i++) {
             task = taskService.createTaskQuery().taskName("subprocess1_task").singleResult();
-            assertNotNull("Task is null for index " + i, task);
+            assertThat(task).isNotNull();
             taskService.complete(task.getId());
         }
 
@@ -989,7 +987,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
                 Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
         taskService.complete(tasks.get(5).getId());
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("subprocess1_task").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
@@ -999,7 +997,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     private List<org.flowable.task.api.Task> assertTaskNames(ProcessInstance processInstance, List<String> taskNames) {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
         for (int i = 0; i < taskNames.size(); i++) {
-            assertEquals("Task name at index " + i + " does not match", taskNames.get(i), tasks.get(i).getName());
+            assertThat(tasks.get(i).getName()).as("Task name at index " + i + " does not match").isEqualTo(taskNames.get(i));
         }
         return tasks;
     }
@@ -1013,16 +1011,16 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         Map<String, List<ExtensionElement>> extensionElements = bpmnModel.getProcesses().get(0)
                 .findFlowElementsOfType(EndEvent.class).get(0).getExtensionElements();
-        assertThat(extensionElements.size(), is(1));
+        assertThat(extensionElements).hasSize(1);
         List<ExtensionElement> strangeProperties = extensionElements.get("strangeProperty");
-        assertThat(strangeProperties.size(), is(1));
+        assertThat(strangeProperties).hasSize(1);
         ExtensionElement strangeProperty = strangeProperties.get(0);
-        assertThat(strangeProperty.getNamespace(), is("http://activiti.org/bpmn"));
-        assertThat(strangeProperty.getElementText(), is("value"));
-        assertThat(strangeProperty.getAttributes().size(), is(1));
+        assertThat(strangeProperty.getNamespace()).isEqualTo("http://activiti.org/bpmn");
+        assertThat(strangeProperty.getElementText()).isEqualTo("value");
+        assertThat(strangeProperty.getAttributes()).hasSize(1);
         ExtensionAttribute id = strangeProperty.getAttributes().get("id").get(0);
-        assertThat(id.getName(), is("id"));
-        assertThat(id.getValue(), is("strangeId"));
+        assertThat(id.getName()).isEqualTo("id");
+        assertThat(id.getValue()).isEqualTo("strangeId");
 
         repositoryService.deleteDeployment(deployment.getId());
     }
@@ -1036,7 +1034,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         variableMap.put("has_bad_pixel_pattern", true);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("skybox_image_pull_request", variableMap);
         String processInstanceId = processInstance.getId();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         while (processInstance != null) {
             List<Execution> executionList = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
             String activityId = "";
@@ -1069,9 +1067,9 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
                     .processInstanceId(processInstanceId).singleResult();
 
-            assertNotNull(historicProcessInstance.getEndTime());
-            assertNotNull(historicProcessInstance.getDurationInMillis());
-            assertNotNull(historicProcessInstance.getEndActivityId());
+            assertThat(historicProcessInstance.getEndTime()).isNotNull();
+            assertThat(historicProcessInstance.getDurationInMillis()).isNotNull();
+            assertThat(historicProcessInstance.getEndActivityId()).isNotNull();
         }
     }
 
@@ -1080,9 +1078,9 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
                     .processInstanceId(processInstance.getId()).singleResult();
             if (expectedDeleteReason == null) {
-                assertNull(historicProcessInstance.getDeleteReason());
+                assertThat(historicProcessInstance.getDeleteReason()).isNull();
             } else {
-                assertTrue(historicProcessInstance.getDeleteReason().startsWith(expectedDeleteReason));
+                assertThat(historicProcessInstance.getDeleteReason().startsWith(expectedDeleteReason)).isTrue();
             }
         }
     }
@@ -1093,13 +1091,13 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             for (String taskName : taskNames) {
                 List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery()
                         .processInstanceId(processInstance.getId()).taskName(taskName).list();
-                assertTrue(historicTaskInstances.size() > 0);
+                assertThat(historicTaskInstances).hasSizeGreaterThan(0);
                 for (HistoricTaskInstance historicTaskInstance : historicTaskInstances) {
-                    assertNotNull(historicTaskInstance.getEndTime());
+                    assertThat(historicTaskInstance.getEndTime()).isNotNull();
                     if (expectedDeleteReason == null) {
-                        assertNull(historicTaskInstance.getDeleteReason());
+                        assertThat(historicTaskInstance.getDeleteReason()).isNull();
                     } else {
-                        assertTrue(historicTaskInstance.getDeleteReason().startsWith(expectedDeleteReason));
+                        assertThat(historicTaskInstance.getDeleteReason()).startsWith(expectedDeleteReason);
                     }
                 }
             }
@@ -1112,13 +1110,13 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             for (String activityId : activityIds) {
                 List<HistoricActivityInstance> historicActiviyInstances = historyService.createHistoricActivityInstanceQuery()
                         .activityId(activityId).processInstanceId(processInstance.getId()).list();
-                assertTrue(historicActiviyInstances.size() > 0);
+                assertThat(historicActiviyInstances).hasSizeGreaterThan(0);
                 for (HistoricActivityInstance historicActiviyInstance : historicActiviyInstances) {
-                    assertNotNull(historicActiviyInstance.getEndTime());
+                    assertThat(historicActiviyInstance.getEndTime()).isNotNull();
                     if (expectedDeleteReason == null) {
-                        assertNull(historicActiviyInstance.getDeleteReason());
+                        assertThat(historicActiviyInstance.getDeleteReason()).isNull();
                     } else {
-                        assertTrue(historicActiviyInstance.getDeleteReason().startsWith(expectedDeleteReason));
+                        assertThat(historicActiviyInstance.getDeleteReason()).startsWith(expectedDeleteReason);
                     }
                 }
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -1080,7 +1080,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             if (expectedDeleteReason == null) {
                 assertThat(historicProcessInstance.getDeleteReason()).isNull();
             } else {
-                assertThat(historicProcessInstance.getDeleteReason().startsWith(expectedDeleteReason)).isTrue();
+                assertThat(historicProcessInstance.getDeleteReason()).startsWith(expectedDeleteReason);
             }
         }
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.end;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.common.engine.impl.util.CollectionUtil;
@@ -19,6 +21,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,7 +38,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         taskService.complete(aTask.getId());
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(8, bTasks.size());
+        assertThat(bTasks).hasSize(8);
 
         // Complete 2 tasks by going to task C. The 3th tasks goes to the MI terminate end and shuts down the MI.
         for (int i = 0; i < 2; i++) {
@@ -44,15 +47,15 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         }
 
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
-        assertEquals(6, bTasks.size());
+        assertThat(bTasks).hasSize(6);
 
         taskService.complete(bTasks.get(0).getId(), CollectionUtil.singletonMap("myVar", "toEnd"));
 
         org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("AfterMi", afterMiTask.getName());
+        assertThat(afterMiTask.getName()).isEqualTo("AfterMi");
         taskService.complete(afterMiTask.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -64,22 +67,22 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         taskService.complete(aTask.getId());
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, bTasks.size());
+        assertThat(bTasks).hasSize(1);
         taskService.complete(bTasks.get(0).getId(), CollectionUtil.singletonMap("myVar", "toC"));
 
         List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
-        assertEquals(1, cTasks.size());
+        assertThat(cTasks).hasSize(1);
         taskService.complete(cTasks.get(0).getId());
 
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
-        assertEquals(1, bTasks.size());
+        assertThat(bTasks).hasSize(1);
         taskService.complete(bTasks.get(0).getId(), CollectionUtil.singletonMap("myVar", "toEnd"));
 
         org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("AfterMi", afterMiTask.getName());
+        assertThat(afterMiTask.getName()).isEqualTo("AfterMi");
         taskService.complete(afterMiTask.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -91,26 +94,26 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         taskService.complete(aTask.getId());
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(5, bTasks.size());
+        assertThat(bTasks).hasSize(5);
 
         // Complete one b task to get one C and D
         taskService.complete(bTasks.get(0).getId());
 
         // C and D should now be active
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(6, tasks.size());
+        assertThat(tasks).hasSize(6);
         // 0-3 are B tasks
-        assertEquals("C", tasks.get(4).getName());
-        assertEquals("D", tasks.get(5).getName());
+        assertThat(tasks.get(4).getName()).isEqualTo("C");
+        assertThat(tasks.get(5).getName()).isEqualTo("D");
 
         // Completing C should terminate the multi instance
         taskService.complete(tasks.get(4).getId());
 
         org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("AfterMi", afterMiTask.getName());
+        assertThat(afterMiTask.getName()).isEqualTo("AfterMi");
         taskService.complete(afterMiTask.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -122,25 +125,25 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         taskService.complete(aTask.getId());
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, bTasks.size());
+        assertThat(bTasks).hasSize(1);
 
         // Complete one b task to get one C and D
         taskService.complete(bTasks.get(0).getId());
 
         // C and D should now be active
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("C", tasks.get(0).getName());
-        assertEquals("D", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("C", "D");
 
         // Completing C should terminate the multi instance
         taskService.complete(tasks.get(0).getId());
 
         org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("AfterMi", afterMiTask.getName());
+        assertThat(afterMiTask.getName()).isEqualTo("AfterMi");
         taskService.complete(afterMiTask.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -152,12 +155,12 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMiCallActivity");
 
         org.flowable.task.api.Task taskA = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("A", taskA.getName());
+        assertThat(taskA.getName()).isEqualTo("A");
         taskService.complete(taskA.getId());
 
         // After completing A, four B's should be active (due to the call activity)
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
-        assertEquals(4, bTasks.size());
+        assertThat(bTasks).hasSize(4);
 
         // Completing 3 B tasks, giving 3 C's and D's
         for (int i = 0; i < 3; i++) {
@@ -165,17 +168,17 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         }
 
         List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
-        assertEquals(3, cTasks.size());
+        assertThat(cTasks).hasSize(3);
         List<org.flowable.task.api.Task> dTasks = taskService.createTaskQuery().taskName("D").list();
-        assertEquals(3, dTasks.size());
+        assertThat(dTasks).hasSize(3);
 
         // Completing one of the C tasks should terminate the whole multi instance
         taskService.complete(cTasks.get(0).getId());
 
         List<org.flowable.task.api.Task> afterMiTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, afterMiTasks.size());
-        assertEquals("AfterMi", afterMiTasks.get(0).getName());
-        assertEquals("Parallel task", afterMiTasks.get(1).getName());
+        assertThat(afterMiTasks)
+                .extracting(Task::getName)
+                .containsExactly("AfterMi", "Parallel task");
     }
 
     @Test
@@ -187,25 +190,25 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMiCallActivity");
 
         org.flowable.task.api.Task taskA = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("A", taskA.getName());
+        assertThat(taskA.getName()).isEqualTo("A");
         taskService.complete(taskA.getId());
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
-        assertEquals(1, bTasks.size());
+        assertThat(bTasks).hasSize(1);
         taskService.complete(bTasks.get(0).getId());
 
         List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
-        assertEquals(1, cTasks.size());
+        assertThat(cTasks).hasSize(1);
         List<org.flowable.task.api.Task> dTasks = taskService.createTaskQuery().taskName("D").list();
-        assertEquals(1, dTasks.size());
+        assertThat(dTasks).hasSize(1);
 
         // Completing one of the C tasks should terminate the whole multi instance
         taskService.complete(cTasks.get(0).getId());
 
         List<org.flowable.task.api.Task> afterMiTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, afterMiTasks.size());
-        assertEquals("AfterMi", afterMiTasks.get(0).getName());
-        assertEquals("Parallel task", afterMiTasks.get(1).getName());
+        assertThat(afterMiTasks)
+                .extracting(Task::getName)
+                .containsExactly("AfterMi", "Parallel task");
     }
 
     @Test
@@ -215,9 +218,9 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
                 "terminateNestedMiEmbeddedSubprocess", CollectionUtil.singletonMap("var", "notEnd"));
 
         List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("A").list();
-        assertEquals(12, aTasks.size());
+        assertThat(aTasks).hasSize(12);
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
-        assertEquals(72, bTasks.size());
+        assertThat(bTasks).hasSize(72);
 
         // Completing a few B's will create a subprocess with some C's
         int nrOfBTasksCompleted = 3;
@@ -226,21 +229,21 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         }
 
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
-        assertEquals(72 - nrOfBTasksCompleted, bTasks.size());
+        assertThat(bTasks).hasSize(72 - nrOfBTasksCompleted);
 
         // Firing the timer --> inner MI gets destroyed
         List<Job> timers = managementService.createTimerJobQuery().list();
-        assertEquals(nrOfBTasksCompleted, timers.size());
+        assertThat(timers).hasSize(nrOfBTasksCompleted);
         managementService.moveTimerToExecutableJob(timers.get(0).getId());
         managementService.executeJob(timers.get(0).getId());
 
         // We only completed 3 B's. 3 other ones should be destroyed too (as one inner multi instance are 6 instances of B)
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
-        assertEquals(66, bTasks.size());
+        assertThat(bTasks).hasSize(66);
 
         // One of the inner multi instances should have been killed
         List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery().taskName("AfterInnerMi").list();
-        assertEquals(1, afterInnerMiTasks.size());
+        assertThat(afterInnerMiTasks).hasSize(1);
 
         for (org.flowable.task.api.Task aTask : aTasks) {
             taskService.complete(aTask.getId());
@@ -253,7 +256,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
             nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         }
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -263,9 +266,9 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
                 "terminateNestedMiEmbeddedSubprocess", CollectionUtil.singletonMap("var", "toEnd"));
 
         List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("A").list();
-        assertEquals(12, aTasks.size());
+        assertThat(aTasks).hasSize(12);
         List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("AfterInnerMi").list();
-        assertEquals(12, afterInnerMiTasks.size());
+        assertThat(afterInnerMiTasks).hasSize(12);
 
     }
 
@@ -276,26 +279,26 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
                 "terminateNestedMiEmbeddedSubprocess", CollectionUtil.singletonMap("var", "notEnd"));
 
         List<org.flowable.task.api.Task> aTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("A").list();
-        assertEquals(1, aTasks.size());
+        assertThat(aTasks).hasSize(1);
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
-        assertEquals(1, bTasks.size());
+        assertThat(bTasks).hasSize(1);
 
         taskService.complete(bTasks.get(0).getId());
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
-        assertEquals(0, bTasks.size());
+        assertThat(bTasks).isEmpty();
 
         // Firing the timer --> inner MI gets destroyed
         List<Job> timers = managementService.createTimerJobQuery().list();
-        assertEquals(1, timers.size());
+        assertThat(timers).hasSize(1);
         managementService.moveTimerToExecutableJob(timers.get(0).getId());
         managementService.executeJob(timers.get(0).getId());
 
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
-        assertEquals(0, bTasks.size());
+        assertThat(bTasks).isEmpty();
 
         // One of the inner multi instances should have been killed
         List<org.flowable.task.api.Task> afterInnerMiTasks = taskService.createTaskQuery().taskName("AfterInnerMi").list();
-        assertEquals(1, afterInnerMiTasks.size());
+        assertThat(afterInnerMiTasks).hasSize(1);
 
         for (org.flowable.task.api.Task aTask : aTasks) {
             taskService.complete(aTask.getId());
@@ -308,7 +311,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
             nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         }
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
 }


### PR DESCRIPTION
There was one file in `org.flowable.engine.test.bpmn.event.end` that had a mixture of assertion types so it was updated along with 2 other test files in the same directory.

FWIW, my list of files with a mix of assertion types if down to single digits.
