### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -25,6 +27,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
+import org.flowable.task.api.Task;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.Test;
@@ -47,17 +50,16 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("repeatWithDuration");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-
-        org.flowable.task.api.Task task = tasks.get(0);
-        assertEquals("Task A", task.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A");
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(task.getId());
+        taskService.complete(tasks.get(0).getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // R/<duration> is persisted with start date in ISO 8601 Zulu time.
         String repeatStr = ((TimerJobEntity) jobs.get(0)).getRepeat();
@@ -66,16 +68,16 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
 
         // Validate that repeat string is in ISO8601 Zulu time.
         DateTime startDateTime = ISODateTimeFormat.dateTime().parseDateTime(startDateStr);
-        assertEquals(startDateTime, new DateTime(baseTime));
+        assertThat(new DateTime(baseTime)).isEqualTo(startDateTime);
 
         // boundary events
         Job executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
 
         managementService.executeJob(executableJob.getId());
 
-        assertEquals(0, managementService.createJobQuery().list().size());
+        assertThat(managementService.createJobQuery().list()).isEmpty();
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         nextTimeCal.add(Calendar.SECOND, 15);
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
@@ -83,9 +85,9 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
         executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(executableJob.getId());
 
-        assertEquals(0, managementService.createJobQuery().list().size());
+        assertThat(managementService.createJobQuery().list()).isEmpty();
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         nextTimeCal.add(Calendar.SECOND, 15);
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
@@ -94,41 +96,41 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
         managementService.executeJob(executableJob.getId());
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         tasks = taskService.createTaskQuery().list();
-        task = tasks.get(0);
-        assertEquals("Task B", task.getName());
-        assertEquals(1, tasks.size());
-        taskService.complete(task.getId());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task B");
+        taskService.complete(tasks.get(0).getId());
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance historicInstance = historyService.createHistoricProcessInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .singleResult();
-            assertNotNull(historicInstance.getEndTime());
+            assertThat(historicInstance.getEndTime()).isNotNull();
         }
 
         // now all the process instances should be completed
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // no jobs
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         // no tasks
         tasks = taskService.createTaskQuery().list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEndTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -23,6 +25,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.flowable.task.api.Task;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -56,25 +59,24 @@ public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCa
         runtimeService.setVariable(processInstance.getId(), "EndDateForBoundary", dateStr);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-
-        org.flowable.task.api.Task task = tasks.get(0);
-        assertEquals("Task A", task.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A");
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(task.getId());
+        taskService.complete(tasks.get(0).getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // boundary events
         Job executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(executableJob.getId());
 
-        assertEquals(0, managementService.createJobQuery().list().size());
+        assertThat(managementService.createJobQuery().list()).isEmpty();
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         nextTimeCal.add(Calendar.MINUTE, 15); // after 15 minutes
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
@@ -82,9 +84,9 @@ public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCa
         executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(executableJob.getId());
 
-        assertEquals(0, managementService.createJobQuery().list().size());
+        assertThat(managementService.createJobQuery().list()).isEmpty();
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         nextTimeCal.add(Calendar.MINUTE, 5); // after another 5 minutes (20 minutes and 1 second from the baseTime) the BoundaryEndTime is reached
         nextTimeCal.add(Calendar.SECOND, 1);
@@ -94,42 +96,42 @@ public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCa
         managementService.executeJob(executableJob.getId());
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         tasks = taskService.createTaskQuery().list();
-        task = tasks.get(0);
-        assertEquals("Task B", task.getName());
-        assertEquals(1, tasks.size());
-        taskService.complete(task.getId());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task B");
+        taskService.complete(tasks.get(0).getId());
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance historicInstance = historyService.createHistoricProcessInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .singleResult();
-            assertNotNull(historicInstance.getEndTime());
+            assertThat(historicInstance.getEndTime()).isNotNull();
         }
 
         // now all the process instances should be completed
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // no jobs
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         // no tasks
         tasks = taskService.createTaskQuery().list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -3,7 +3,7 @@
  * You may obtain a copy of the License at
  * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,9 @@
  */
 
 package org.flowable.engine.test.bpmn.event.timer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.Collections;
 import java.util.Date;
@@ -24,6 +27,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.junit.jupiter.api.Test;
 
@@ -41,55 +45,57 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         // After process start, there should be 3 timers created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("nonInterruptingTimersOnUserTask");
         org.flowable.task.api.Task task1 = taskService.createTaskQuery().singleResult();
-        assertEquals("First Task", task1.getName());
+        assertThat(task1.getName()).isEqualTo("First Task");
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(2, jobs.size());
+        assertThat(jobs).hasSize(2);
 
         // After setting the clock to time '1 hour and 5 seconds', the first timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         Job job = managementService.createTimerJobQuery().executable().singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         // we still have one timer more to fire
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         // and we are still in the first state, but in the second state as well!
-        assertEquals(2L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         List<org.flowable.task.api.Task> taskList = taskService.createTaskQuery().orderByTaskName().desc().list();
-        assertEquals("First Task", taskList.get(0).getName());
-        assertEquals("Escalation Task 1", taskList.get(1).getName());
+        assertThat(taskList)
+                .extracting(Task::getName)
+                .containsExactly("First Task", "Escalation Task 1");
 
         // complete the task and end the forked execution
         taskService.complete(taskList.get(1).getId());
 
         // but we still have the original executions
-        assertEquals(1L, taskService.createTaskQuery().count());
-        assertEquals("First Task", taskService.createTaskQuery().singleResult().getName());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("First Task");
 
         // After setting the clock to time '2 hour and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((2 * 60 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
 
         // no more timers to fire
-        assertEquals(0L, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         // and we are still in the first state, but in the next escalation state as well
-        assertEquals(2L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         taskList = taskService.createTaskQuery().orderByTaskName().desc().list();
-        assertEquals("First Task", taskList.get(0).getName());
-        assertEquals("Escalation Task 2", taskList.get(1).getName());
+        assertThat(taskList)
+                .extracting(Task::getName)
+                .containsExactly("First Task", "Escalation Task 2");
 
         // This time we end the main task
         taskService.complete(taskList.get(0).getId());
 
         // but we still have the escalation task
-        assertEquals(1L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         org.flowable.task.api.Task escalationTask = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalation Task 2", escalationTask.getName());
+        assertThat(escalationTask.getName()).isEqualTo("Escalation Task 2");
 
         taskService.complete(escalationTask.getId());
 
@@ -106,29 +112,29 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         // After process start, there should be 3 timers created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("testJoin");
         org.flowable.task.api.Task task1 = taskService.createTaskQuery().singleResult();
-        assertEquals("Main Task", task1.getName());
+        assertThat(task1.getName()).isEqualTo("Main Task");
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // After setting the clock to time '1 hour and 5 seconds', the first timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         // timer has fired
-        assertEquals(0L, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         // we now have both tasks
-        assertEquals(2L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // end the first
         taskService.complete(task1.getId());
 
         // we now have one task left
-        assertEquals(1L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         org.flowable.task.api.Task task2 = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalation Task", task2.getName());
+        assertThat(task2.getName()).isEqualTo("Escalation Task");
 
         // complete the task, the parallel gateway should fire
         taskService.complete(task2.getId());
@@ -141,17 +147,17 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     @Deployment
     public void testTimerOnConcurrentTasks() {
         String procId = runtimeService.startProcessInstanceByKey("nonInterruptingOnConcurrentTasks").getId();
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
 
         // Complete task that was reached by non interrupting timer
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
         taskService.complete(task.getId());
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // Complete other tasks
         for (org.flowable.task.api.Task t : taskService.createTaskQuery().list()) {
@@ -165,19 +171,19 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.testTimerOnConcurrentTasks.bpmn20.xml" })
     public void testTimerOnConcurrentTasks2() {
         String procId = runtimeService.startProcessInstanceByKey("nonInterruptingOnConcurrentTasks").getId();
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
 
         // Complete 2 tasks that will trigger the join
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("firstTask").singleResult();
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().taskDefinitionKey("secondTask").singleResult();
         taskService.complete(task.getId());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // Finally, complete the task that was created due to the timer
         task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
@@ -192,29 +198,27 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         String processInstanceId = runtimeService.startProcessInstanceByKey("nonInterruptingCycle").getId();
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstanceId).list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // boundary events
         waitForJobExecutorToProcessAllJobs(2000, 100);
 
         // a new job must be prepared because there are indefinite number of repeats 1 hour interval");
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstanceId).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstanceId).count()).isEqualTo(1);
 
         moveByMinutes(60);
         waitForJobExecutorToProcessAllJobs(2000, 100);
 
         // a new job must be prepared because there are indefinite number of repeats 1 hour interval");
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstanceId).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstanceId).count()).isEqualTo(1);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         moveByMinutes(60);
-        try {
-            waitForJobExecutorToProcessAllJobs(2000, 100);
-        } catch (Exception ex) {
-            fail("No more jobs since the user completed the task");
-        }
+        assertThatCode(() -> { waitForJobExecutorToProcessAllJobs(2000, 100); })
+                .as("No more jobs since the user completed the task")
+                .doesNotThrowAnyException();
     }
 
     /*
@@ -227,7 +231,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         TaskQuery tq = taskService.createTaskQuery().taskAssignee("kermit");
 
-        assertEquals(1, tq.count());
+        assertThat(tq.count()).isEqualTo(1);
 
         // Simulate timer
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -236,7 +240,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         tq = taskService.createTaskQuery().taskAssignee("kermit");
 
-        assertEquals(2, tq.count());
+        assertThat(tq.count()).isEqualTo(2);
 
         List<org.flowable.task.api.Task> tasks = tq.list();
 
@@ -261,25 +265,24 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // The Execution Query should work normally and find executions in state "task"
         List<Execution> executions = runtimeService.createExecutionQuery().activityId("task").list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(executions.get(0).getId());
-        assertEquals(2, activeActivityIds.size());
         Collections.sort(activeActivityIds);
-        assertEquals("task", activeActivityIds.get(0));
-        assertEquals("timer", activeActivityIds.get(1));
+        assertThat(activeActivityIds)
+                .containsExactly("task", "timer");
 
         runtimeService.trigger(executions.get(0).getId());
 
-        // // After setting the clock to time '1 hour and 5 seconds', the second
+        // After setting the clock to time '1 hour and 5 seconds', the second
         // timer should fire
         // processEngineConfiguration.getClock().setCurrentTime(new
         // Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         // waitForJobExecutorToProcessAllJobs(7000L, 25L);
-        // assertEquals(0L, jobQuery.count());
+        // assertThat(jobQuery.count())..isZero();
 
         // which means the process has ended
         assertProcessEnded(pi.getId());
@@ -289,12 +292,12 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     @Deployment
     public void testTimerOnConcurrentSubprocess() {
         String procId = runtimeService.startProcessInstanceByKey("testTimerOnConcurrentSubprocess").getId();
-        assertEquals(4, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(4);
 
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
-        assertEquals(5, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         // Complete 4 tasks that will trigger the join
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("sub1task1").singleResult();
@@ -305,7 +308,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().taskDefinitionKey("sub2task2").singleResult();
         taskService.complete(task.getId());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // Finally, complete the task that was created due to the timer
         task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
@@ -318,12 +321,12 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.testTimerOnConcurrentSubprocess.bpmn20.xml")
     public void testTimerOnConcurrentSubprocess2() {
         String procId = runtimeService.startProcessInstanceByKey("testTimerOnConcurrentSubprocess").getId();
-        assertEquals(4, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(4);
 
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
-        assertEquals(5, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("sub1task1").singleResult();
         taskService.complete(task.getId());
@@ -338,7 +341,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().taskDefinitionKey("sub2task2").singleResult();
         taskService.complete(task.getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isZero();
 
         assertProcessEnded(procId);
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
@@ -75,7 +75,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         jobQuery = managementService.createTimerJobQuery();
-        assertThat(jobQuery.count()).isEqualTo(0);
+        assertThat(jobQuery.count()).isZero();
     }
 
     @Test
@@ -95,7 +95,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().setCurrentTime(Date.from(yesterday.plus(200, ChronoUnit.SECONDS)));
 
         waitForJobExecutorToProcessAllJobs(10000L, 25L);
-        assertThat(jobQuery.count()).isEqualTo(0);
+        assertThat(jobQuery.count()).isZero();
 
         assertProcessEnded(pi.getId());
         processEngineConfiguration.getClock().reset();
@@ -115,7 +115,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
 
         processEngineConfiguration.getClock().setCurrentTime(Date.from(yesterday.plus(200, ChronoUnit.SECONDS)));
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000L, 100L);
-        assertThat(jobQuery.count()).isEqualTo(0);
+        assertThat(jobQuery.count()).isZero();
 
         assertProcessEnded(pi.getId());
         processEngineConfiguration.getClock().reset();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Instant;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -37,12 +39,12 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
     @Deployment
     public void testExpressionStartTimerEvent() throws Exception {
         TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         jobQuery = managementService.createTimerJobQuery();
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
     }
 
     @Test
@@ -55,7 +57,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         Calendar nowCal = processEngineConfiguration.getClock().getCurrentCalendar();
         nowCal.add(Calendar.MINUTE, 3);
@@ -63,7 +65,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         
         try {
             waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000L, 25L);
-            assertEquals(0L, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
             assertProcessEnded(pi.getId());
         } finally {
@@ -78,7 +80,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         Calendar nowCal = processEngineConfiguration.getClock().getCurrentCalendar();
         nowCal.add(Calendar.MINUTE, 3);
@@ -86,7 +88,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         
         try {
             waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000L, 25L);
-            assertEquals(0L, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
             assertProcessEnded(pi.getId());
             

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Calendar;
@@ -27,6 +29,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 
 public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
@@ -41,17 +44,17 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         // After process start, there should be timer created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample");
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
         
         Job job = managementService.createTimerJobQuery().elementId("timer").singleResult();
-        assertEquals("timer", job.getElementId());
-        assertEquals("Timer catch", job.getElementName());
+        assertThat(job.getElementId()).isEqualTo("timer");
+        assertThat(job.getElementName()).isEqualTo("Timer catch");
 
         // After setting the clock to time '50minutes and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
 
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
         assertProcessEnded(pi.getProcessInstanceId());
 
     }
@@ -66,38 +69,38 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("timerEventWithStartAndDuration");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        org.flowable.task.api.Task task = tasks.get(0);
-        assertEquals("Task A", task.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A");
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         Date startDate = new Date();
         runtimeService.setVariable(pi.getId(), "StartDate", startDate);
-        taskService.complete(task.getId());
+        taskService.complete(tasks.get(0).getId());
 
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         processEngineConfiguration.getClock().setCurrentTime(new Date(startDate.getTime() + 7000L));
 
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId()).executable();
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         processEngineConfiguration.getClock().setCurrentTime(new Date(startDate.getTime() + 11000L));
         waitForJobExecutorToProcessAllJobs(15000L, 25L);
 
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        task = tasks.get(0);
-        assertEquals("Task B", task.getName());
-        taskService.complete(task.getId());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task B");
+        taskService.complete(tasks.get(0).getId());
 
         assertProcessEnded(pi.getProcessInstanceId());
 
@@ -122,21 +125,21 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi2 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables2);
         ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables3);
 
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count());
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count());
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi3.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi3.getId()).count()).isEqualTo(1);
 
         // After setting the clock to one second in the future the timers should fire
         List<Job> jobs = managementService.createTimerJobQuery().executable().list();
-        assertEquals(3, jobs.size());
+        assertThat(jobs).hasSize(3);
         for (Job job : jobs) {
             managementService.moveTimerToExecutableJob(job.getId());
             managementService.executeJob(job.getId());
         }
 
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count());
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count());
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(pi3.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count()).isZero();
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count()).isZero();
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi3.getId()).count()).isZero();
 
         assertProcessEnded(pi1.getProcessInstanceId());
         assertProcessEnded(pi2.getProcessInstanceId());
@@ -186,26 +189,26 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("rescheduleTimer", variables);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         long diffInMilliseconds = Math.abs(startTimeInMillis - timerJob.getDuedate().getTime());
-        assertTrue(diffInMilliseconds < 100);
+        assertThat(diffInMilliseconds).isLessThan(100);
 
         // reschedule timer for two hours from now
         calendar = Calendar.getInstance();
         calendar.add(Calendar.HOUR, 2);
         Job rescheduledJob = managementService.rescheduleTimeDateJob(timerJob.getId(), sdf.format(calendar.getTime()));
-        assertNotNull(rescheduledJob);
-        assertNotNull(rescheduledJob.getId());
-        assertNotSame(timerJob.getId(), rescheduledJob.getId());
+        assertThat(rescheduledJob).isNotNull();
+        assertThat(rescheduledJob.getId()).isNotNull();
+        assertThat(rescheduledJob.getId()).isNotSameAs(timerJob.getId());
 
         Job timer = managementService.createTimerJobQuery().singleResult();
-        assertEquals(rescheduledJob.getId(), timer.getId());
+        assertThat(timer.getId()).isEqualTo(rescheduledJob.getId());
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         diffInMilliseconds = Math.abs(startTimeInMillis - timerJob.getDuedate().getTime());
-        assertTrue(diffInMilliseconds > (59 * 60 * 1000));
+        assertThat(diffInMilliseconds).isGreaterThan(59 * 60 * 1000);
 
         // Move clock forward 1 hour from now
         calendar = Calendar.getInstance();
@@ -216,9 +219,9 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         // Confirm timer has not run
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         // Move clock forward 2 hours from now
         calendar = Calendar.getInstance();
@@ -228,9 +231,9 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         // Confirm timer has run
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
     }
 
     @Test
@@ -242,7 +245,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         // After process start, there should be timer created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("parallelIntermediateTimers");
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(2, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(2);
 
         // After setting the clock to time '50minutes and 5 seconds', the bouth timers should fire in parralel
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
@@ -251,10 +254,11 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
                     this.processEngineConfiguration, this.managementService, 20000L, 250L
             );
 
-            assertEquals(0, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             assertProcessEnded(pi.getProcessInstanceId());
-            assertTrue("Timer paths must be executed 2 times (or more, with tx retries) without failure repetition",
-                    IntermediateTimerEventTestCounter.getCount() >= 2);
+            assertThat(IntermediateTimerEventTestCounter.getCount())
+                    .as("Timer paths must be executed 2 times (or more, with tx retries).isTrue() without failure repetition")
+                    .isGreaterThanOrEqualTo(2);
         } finally {
             processEngineConfiguration.getClock().reset();
         }


### PR DESCRIPTION
In the `org.flowable.engine.test.bpmn.event.timer` package there were 4 files with mixed assertion styles so they were converted to a single format. At the same time the remaining files in the package were updated.   This is part 1 of 2.

