### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -25,6 +27,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
+import org.flowable.task.api.Task;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.Test;
@@ -47,17 +50,16 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("repeatWithDuration");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-
-        org.flowable.task.api.Task task = tasks.get(0);
-        assertEquals("Task A", task.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A");
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(task.getId());
+        taskService.complete(tasks.get(0).getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // R/<duration> is persisted with start date in ISO 8601 Zulu time.
         String repeatStr = ((TimerJobEntity) jobs.get(0)).getRepeat();
@@ -66,16 +68,16 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
 
         // Validate that repeat string is in ISO8601 Zulu time.
         DateTime startDateTime = ISODateTimeFormat.dateTime().parseDateTime(startDateStr);
-        assertEquals(startDateTime, new DateTime(baseTime));
+        assertThat(new DateTime(baseTime)).isEqualTo(startDateTime);
 
         // boundary events
         Job executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
 
         managementService.executeJob(executableJob.getId());
 
-        assertEquals(0, managementService.createJobQuery().list().size());
+        assertThat(managementService.createJobQuery().list()).isEmpty();
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         nextTimeCal.add(Calendar.SECOND, 15);
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
@@ -83,9 +85,9 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
         executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(executableJob.getId());
 
-        assertEquals(0, managementService.createJobQuery().list().size());
+        assertThat(managementService.createJobQuery().list()).isEmpty();
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         nextTimeCal.add(Calendar.SECOND, 15);
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
@@ -94,41 +96,41 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
         managementService.executeJob(executableJob.getId());
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         tasks = taskService.createTaskQuery().list();
-        task = tasks.get(0);
-        assertEquals("Task B", task.getName());
-        assertEquals(1, tasks.size());
-        taskService.complete(task.getId());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task B");
+        taskService.complete(tasks.get(0).getId());
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance historicInstance = historyService.createHistoricProcessInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .singleResult();
-            assertNotNull(historicInstance.getEndTime());
+            assertThat(historicInstance.getEndTime()).isNotNull();
         }
 
         // now all the process instances should be completed
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // no jobs
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         // no tasks
         tasks = taskService.createTaskQuery().list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEndTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -23,6 +25,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.flowable.task.api.Task;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -56,25 +59,24 @@ public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCa
         runtimeService.setVariable(processInstance.getId(), "EndDateForBoundary", dateStr);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-
-        org.flowable.task.api.Task task = tasks.get(0);
-        assertEquals("Task A", task.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A");
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(task.getId());
+        taskService.complete(tasks.get(0).getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // boundary events
         Job executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(executableJob.getId());
 
-        assertEquals(0, managementService.createJobQuery().list().size());
+        assertThat(managementService.createJobQuery().list()).isEmpty();
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         nextTimeCal.add(Calendar.MINUTE, 15); // after 15 minutes
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());
@@ -82,9 +84,9 @@ public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCa
         executableJob = managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(executableJob.getId());
 
-        assertEquals(0, managementService.createJobQuery().list().size());
+        assertThat(managementService.createJobQuery().list()).isEmpty();
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         nextTimeCal.add(Calendar.MINUTE, 5); // after another 5 minutes (20 minutes and 1 second from the baseTime) the BoundaryEndTime is reached
         nextTimeCal.add(Calendar.SECOND, 1);
@@ -94,42 +96,42 @@ public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCa
         managementService.executeJob(executableJob.getId());
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         tasks = taskService.createTaskQuery().list();
-        task = tasks.get(0);
-        assertEquals("Task B", task.getName());
-        assertEquals(1, tasks.size());
-        taskService.complete(task.getId());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task B");
+        taskService.complete(tasks.get(0).getId());
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance historicInstance = historyService.createHistoricProcessInstanceQuery()
                     .processInstanceId(processInstance.getId())
                     .singleResult();
-            assertNotNull(historicInstance.getEndTime());
+            assertThat(historicInstance.getEndTime()).isNotNull();
         }
 
         // now all the process instances should be completed
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // no jobs
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         // no tasks
         tasks = taskService.createTaskQuery().list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -3,7 +3,7 @@
  * You may obtain a copy of the License at
  * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,9 @@
  */
 
 package org.flowable.engine.test.bpmn.event.timer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.Collections;
 import java.util.Date;
@@ -24,6 +27,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.junit.jupiter.api.Test;
 
@@ -41,55 +45,57 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         // After process start, there should be 3 timers created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("nonInterruptingTimersOnUserTask");
         org.flowable.task.api.Task task1 = taskService.createTaskQuery().singleResult();
-        assertEquals("First Task", task1.getName());
+        assertThat(task1.getName()).isEqualTo("First Task");
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(2, jobs.size());
+        assertThat(jobs).hasSize(2);
 
         // After setting the clock to time '1 hour and 5 seconds', the first timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         Job job = managementService.createTimerJobQuery().executable().singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         // we still have one timer more to fire
-        assertEquals(1L, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         // and we are still in the first state, but in the second state as well!
-        assertEquals(2L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         List<org.flowable.task.api.Task> taskList = taskService.createTaskQuery().orderByTaskName().desc().list();
-        assertEquals("First Task", taskList.get(0).getName());
-        assertEquals("Escalation Task 1", taskList.get(1).getName());
+        assertThat(taskList)
+                .extracting(Task::getName)
+                .containsExactly("First Task", "Escalation Task 1");
 
         // complete the task and end the forked execution
         taskService.complete(taskList.get(1).getId());
 
         // but we still have the original executions
-        assertEquals(1L, taskService.createTaskQuery().count());
-        assertEquals("First Task", taskService.createTaskQuery().singleResult().getName());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("First Task");
 
         // After setting the clock to time '2 hour and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((2 * 60 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
 
         // no more timers to fire
-        assertEquals(0L, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         // and we are still in the first state, but in the next escalation state as well
-        assertEquals(2L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         taskList = taskService.createTaskQuery().orderByTaskName().desc().list();
-        assertEquals("First Task", taskList.get(0).getName());
-        assertEquals("Escalation Task 2", taskList.get(1).getName());
+        assertThat(taskList)
+                .extracting(Task::getName)
+                .containsExactly("First Task", "Escalation Task 2");
 
         // This time we end the main task
         taskService.complete(taskList.get(0).getId());
 
         // but we still have the escalation task
-        assertEquals(1L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         org.flowable.task.api.Task escalationTask = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalation Task 2", escalationTask.getName());
+        assertThat(escalationTask.getName()).isEqualTo("Escalation Task 2");
 
         taskService.complete(escalationTask.getId());
 
@@ -106,29 +112,29 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         // After process start, there should be 3 timers created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("testJoin");
         org.flowable.task.api.Task task1 = taskService.createTaskQuery().singleResult();
-        assertEquals("Main Task", task1.getName());
+        assertThat(task1.getName()).isEqualTo("Main Task");
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // After setting the clock to time '1 hour and 5 seconds', the first timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobs(7000L, 25L);
 
         // timer has fired
-        assertEquals(0L, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         // we now have both tasks
-        assertEquals(2L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // end the first
         taskService.complete(task1.getId());
 
         // we now have one task left
-        assertEquals(1L, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         org.flowable.task.api.Task task2 = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalation Task", task2.getName());
+        assertThat(task2.getName()).isEqualTo("Escalation Task");
 
         // complete the task, the parallel gateway should fire
         taskService.complete(task2.getId());
@@ -141,17 +147,17 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     @Deployment
     public void testTimerOnConcurrentTasks() {
         String procId = runtimeService.startProcessInstanceByKey("nonInterruptingOnConcurrentTasks").getId();
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
 
         // Complete task that was reached by non interrupting timer
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
         taskService.complete(task.getId());
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // Complete other tasks
         for (org.flowable.task.api.Task t : taskService.createTaskQuery().list()) {
@@ -165,19 +171,19 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     @Deployment(resources = { "org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.testTimerOnConcurrentTasks.bpmn20.xml" })
     public void testTimerOnConcurrentTasks2() {
         String procId = runtimeService.startProcessInstanceByKey("nonInterruptingOnConcurrentTasks").getId();
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
 
         // Complete 2 tasks that will trigger the join
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("firstTask").singleResult();
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().taskDefinitionKey("secondTask").singleResult();
         taskService.complete(task.getId());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // Finally, complete the task that was created due to the timer
         task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
@@ -192,29 +198,27 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         String processInstanceId = runtimeService.startProcessInstanceByKey("nonInterruptingCycle").getId();
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstanceId).list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // boundary events
         waitForJobExecutorToProcessAllJobs(2000, 100);
 
         // a new job must be prepared because there are indefinite number of repeats 1 hour interval");
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstanceId).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstanceId).count()).isEqualTo(1);
 
         moveByMinutes(60);
         waitForJobExecutorToProcessAllJobs(2000, 100);
 
         // a new job must be prepared because there are indefinite number of repeats 1 hour interval");
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstanceId).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstanceId).count()).isEqualTo(1);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         moveByMinutes(60);
-        try {
-            waitForJobExecutorToProcessAllJobs(2000, 100);
-        } catch (Exception ex) {
-            fail("No more jobs since the user completed the task");
-        }
+        assertThatCode(() -> { waitForJobExecutorToProcessAllJobs(2000, 100); })
+                .as("No more jobs since the user completed the task")
+                .doesNotThrowAnyException();
     }
 
     /*
@@ -227,7 +231,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         TaskQuery tq = taskService.createTaskQuery().taskAssignee("kermit");
 
-        assertEquals(1, tq.count());
+        assertThat(tq.count()).isEqualTo(1);
 
         // Simulate timer
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -236,7 +240,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         tq = taskService.createTaskQuery().taskAssignee("kermit");
 
-        assertEquals(2, tq.count());
+        assertThat(tq.count()).isEqualTo(2);
 
         List<org.flowable.task.api.Task> tasks = tq.list();
 
@@ -261,25 +265,24 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // The Execution Query should work normally and find executions in state "task"
         List<Execution> executions = runtimeService.createExecutionQuery().activityId("task").list();
-        assertEquals(1, executions.size());
+        assertThat(executions).hasSize(1);
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(executions.get(0).getId());
-        assertEquals(2, activeActivityIds.size());
         Collections.sort(activeActivityIds);
-        assertEquals("task", activeActivityIds.get(0));
-        assertEquals("timer", activeActivityIds.get(1));
+        assertThat(activeActivityIds)
+                .containsExactly("task", "timer");
 
         runtimeService.trigger(executions.get(0).getId());
 
-        // // After setting the clock to time '1 hour and 5 seconds', the second
+        // After setting the clock to time '1 hour and 5 seconds', the second
         // timer should fire
         // processEngineConfiguration.getClock().setCurrentTime(new
         // Date(startTime.getTime() + ((60 * 60 * 1000) + 5000)));
         // waitForJobExecutorToProcessAllJobs(7000L, 25L);
-        // assertEquals(0L, jobQuery.count());
+        // assertThat(jobQuery.count())..isZero();
 
         // which means the process has ended
         assertProcessEnded(pi.getId());
@@ -289,12 +292,12 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     @Deployment
     public void testTimerOnConcurrentSubprocess() {
         String procId = runtimeService.startProcessInstanceByKey("testTimerOnConcurrentSubprocess").getId();
-        assertEquals(4, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(4);
 
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
-        assertEquals(5, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         // Complete 4 tasks that will trigger the join
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("sub1task1").singleResult();
@@ -305,7 +308,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().taskDefinitionKey("sub2task2").singleResult();
         taskService.complete(task.getId());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // Finally, complete the task that was created due to the timer
         task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
@@ -318,12 +321,12 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
     @Deployment(resources = "org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.testTimerOnConcurrentSubprocess.bpmn20.xml")
     public void testTimerOnConcurrentSubprocess2() {
         String procId = runtimeService.startProcessInstanceByKey("testTimerOnConcurrentSubprocess").getId();
-        assertEquals(4, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(4);
 
         Job timer = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(timer.getId());
         managementService.executeJob(timer.getId());
-        assertEquals(5, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("sub1task1").singleResult();
         taskService.complete(task.getId());
@@ -338,7 +341,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().taskDefinitionKey("sub2task2").singleResult();
         taskService.complete(task.getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isZero();
 
         assertProcessEnded(procId);
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/DurationTimeTimerEventTest.java
@@ -75,7 +75,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 200L);
 
         jobQuery = managementService.createTimerJobQuery();
-        assertThat(jobQuery.count()).isEqualTo(0);
+        assertThat(jobQuery.count()).isZero();
     }
 
     @Test
@@ -95,7 +95,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
         processEngineConfiguration.getClock().setCurrentTime(Date.from(yesterday.plus(200, ChronoUnit.SECONDS)));
 
         waitForJobExecutorToProcessAllJobs(10000L, 25L);
-        assertThat(jobQuery.count()).isEqualTo(0);
+        assertThat(jobQuery.count()).isZero();
 
         assertProcessEnded(pi.getId());
         processEngineConfiguration.getClock().reset();
@@ -115,7 +115,7 @@ public class DurationTimeTimerEventTest extends PluggableFlowableTestCase {
 
         processEngineConfiguration.getClock().setCurrentTime(Date.from(yesterday.plus(200, ChronoUnit.SECONDS)));
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000L, 100L);
-        assertThat(jobQuery.count()).isEqualTo(0);
+        assertThat(jobQuery.count()).isZero();
 
         assertProcessEnded(pi.getId());
         processEngineConfiguration.getClock().reset();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/InstantTimeTimerEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Instant;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -37,12 +39,12 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
     @Deployment
     public void testExpressionStartTimerEvent() throws Exception {
         TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         waitForJobExecutorToProcessAllJobs(7000L, 200L);
 
         jobQuery = managementService.createTimerJobQuery();
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
     }
 
     @Test
@@ -55,7 +57,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         Calendar nowCal = processEngineConfiguration.getClock().getCurrentCalendar();
         nowCal.add(Calendar.MINUTE, 3);
@@ -63,7 +65,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         
         try {
             waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000L, 25L);
-            assertEquals(0L, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
             assertProcessEnded(pi.getId());
         } finally {
@@ -78,7 +80,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         Calendar nowCal = processEngineConfiguration.getClock().getCurrentCalendar();
         nowCal.add(Calendar.MINUTE, 3);
@@ -86,7 +88,7 @@ public class InstantTimeTimerEventTest extends ResourceFlowableTestCase {
         
         try {
             waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000L, 25L);
-            assertEquals(0L, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
             assertProcessEnded(pi.getId());
             

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Calendar;
@@ -27,6 +29,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
 import org.flowable.job.api.TimerJobQuery;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 
 public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
@@ -41,17 +44,17 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         // After process start, there should be timer created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample");
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
         
         Job job = managementService.createTimerJobQuery().elementId("timer").singleResult();
-        assertEquals("timer", job.getElementId());
-        assertEquals("Timer catch", job.getElementName());
+        assertThat(job.getElementId()).isEqualTo("timer");
+        assertThat(job.getElementName()).isEqualTo("Timer catch");
 
         // After setting the clock to time '50minutes and 5 seconds', the second timer should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 25L);
 
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
         assertProcessEnded(pi.getProcessInstanceId());
 
     }
@@ -66,38 +69,38 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("timerEventWithStartAndDuration");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        org.flowable.task.api.Task task = tasks.get(0);
-        assertEquals("Task A", task.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task A");
 
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         Date startDate = new Date();
         runtimeService.setVariable(pi.getId(), "StartDate", startDate);
-        taskService.complete(task.getId());
+        taskService.complete(tasks.get(0).getId());
 
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         processEngineConfiguration.getClock().setCurrentTime(new Date(startDate.getTime() + 7000L));
 
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId()).executable();
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         processEngineConfiguration.getClock().setCurrentTime(new Date(startDate.getTime() + 11000L));
         waitForJobExecutorToProcessAllJobs(15000L, 25L);
 
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
-        task = tasks.get(0);
-        assertEquals("Task B", task.getName());
-        taskService.complete(task.getId());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Task B");
+        taskService.complete(tasks.get(0).getId());
 
         assertProcessEnded(pi.getProcessInstanceId());
 
@@ -122,21 +125,21 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi2 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables2);
         ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables3);
 
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count());
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count());
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi3.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi3.getId()).count()).isEqualTo(1);
 
         // After setting the clock to one second in the future the timers should fire
         List<Job> jobs = managementService.createTimerJobQuery().executable().list();
-        assertEquals(3, jobs.size());
+        assertThat(jobs).hasSize(3);
         for (Job job : jobs) {
             managementService.moveTimerToExecutableJob(job.getId());
             managementService.executeJob(job.getId());
         }
 
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count());
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count());
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(pi3.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count()).isZero();
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi2.getId()).count()).isZero();
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi3.getId()).count()).isZero();
 
         assertProcessEnded(pi1.getProcessInstanceId());
         assertProcessEnded(pi2.getProcessInstanceId());
@@ -186,26 +189,26 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("rescheduleTimer", variables);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
         long diffInMilliseconds = Math.abs(startTimeInMillis - timerJob.getDuedate().getTime());
-        assertTrue(diffInMilliseconds < 100);
+        assertThat(diffInMilliseconds).isLessThan(100);
 
         // reschedule timer for two hours from now
         calendar = Calendar.getInstance();
         calendar.add(Calendar.HOUR, 2);
         Job rescheduledJob = managementService.rescheduleTimeDateJob(timerJob.getId(), sdf.format(calendar.getTime()));
-        assertNotNull(rescheduledJob);
-        assertNotNull(rescheduledJob.getId());
-        assertNotSame(timerJob.getId(), rescheduledJob.getId());
+        assertThat(rescheduledJob).isNotNull();
+        assertThat(rescheduledJob.getId()).isNotNull();
+        assertThat(rescheduledJob.getId()).isNotSameAs(timerJob.getId());
 
         Job timer = managementService.createTimerJobQuery().singleResult();
-        assertEquals(rescheduledJob.getId(), timer.getId());
+        assertThat(timer.getId()).isEqualTo(rescheduledJob.getId());
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         diffInMilliseconds = Math.abs(startTimeInMillis - timerJob.getDuedate().getTime());
-        assertTrue(diffInMilliseconds > (59 * 60 * 1000));
+        assertThat(diffInMilliseconds).isGreaterThan(59 * 60 * 1000);
 
         // Move clock forward 1 hour from now
         calendar = Calendar.getInstance();
@@ -216,9 +219,9 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         // Confirm timer has not run
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(timerJob);
+        assertThat(timerJob).isNotNull();
 
         // Move clock forward 2 hours from now
         calendar = Calendar.getInstance();
@@ -228,9 +231,9 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         // Confirm timer has run
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(timerJob);
+        assertThat(timerJob).isNull();
     }
 
     @Test
@@ -242,7 +245,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         // After process start, there should be timer created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("parallelIntermediateTimers");
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(2, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(2);
 
         // After setting the clock to time '50minutes and 5 seconds', the bouth timers should fire in parralel
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
@@ -251,10 +254,11 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
                     this.processEngineConfiguration, this.managementService, 20000L, 250L
             );
 
-            assertEquals(0, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             assertProcessEnded(pi.getProcessInstanceId());
-            assertTrue("Timer paths must be executed 2 times (or more, with tx retries) without failure repetition",
-                    IntermediateTimerEventTestCounter.getCount() >= 2);
+            assertThat(IntermediateTimerEventTestCounter.getCount())
+                    .as("Timer paths must be executed 2 times (or more, with tx retries).isTrue() without failure repetition")
+                    .isGreaterThanOrEqualTo(2);
         } finally {
             processEngineConfiguration.getClock().reset();
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.java
@@ -31,6 +31,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.api.event.TestFlowableEntityEventListener;
 import org.flowable.job.api.Job;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -72,13 +73,13 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
 
         // deploy the process
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.testCycleDateStartTimerEvent.bpmn20.xml").deploy();
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1);
 
         // AFTER DEPLOYMENT
         // when the process is deployed there will be created a timerStartEvent
         // job which will wait to be executed.
         List<Job> jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // dueDate should be after 24 hours from the process deployment
         Instant dueDateInstant = instant.plus(1, ChronoUnit.DAYS);
@@ -88,11 +89,11 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
 
         // No process instances
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // No tasks
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
 
         // ADVANCE THE CLOCK
         // advance the clock to 11 dec -> the system will execute the pending
@@ -101,19 +102,19 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(5000L, 200);
 
         // there must be a pending job because the endDate is not reached yet");
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         // After the first startEvent Execution should be one process instance started
         processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(1, processInstances.size());
+        assertThat(processInstances).hasSize(1);
 
         // one task to be executed (the userTask "Task A")
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         // one new job will be created (and the old one will be deleted after execution)
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         // 12th December 2025
         dueDateInstant = instant.plus(2, ChronoUnit.DAYS);
@@ -127,20 +128,20 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
         // After the second startEvent Execution should have 2 process instances started
         // (since the first one was not completed)
         processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).hasSize(2);
 
         // Because the endDate 12.dec.2025 is reached
         // the current job will be deleted after execution and a new one will
         // not be created.
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         // 2 tasks to be executed (the userTask "Task A")
         // one task for each process instance
         tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         // count "timer fired" events
         int timerFiredCount = 0;
@@ -166,34 +167,34 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
                 eventDeletedCount++;
             }
         }
-        assertEquals(2, timerFiredCount); // 2 timers fired
-        assertEquals(4, eventCreatedCount); // 4 jobs created, each timer creates one timer and one executable job
-        assertEquals(4, eventDeletedCount); // 4 jobs deleted, each timer results in deleting one timer and one executable job
+        assertThat(timerFiredCount).isEqualTo(2); // 2 timers fired
+        assertThat(eventCreatedCount).isEqualTo(4); // 4 jobs created, each timer creates one timer and one executable job
+        assertThat(eventDeletedCount).isEqualTo(4); // 4 jobs deleted, each timer results in deleting one timer and one executable job
 
         // for each processInstance
         // let's complete the userTasks where the process is hanging in order to
         // complete the processes.
         for (ProcessInstance processInstance : processInstances) {
             tasks = taskService.createTaskQuery().processInstanceId(processInstance.getProcessInstanceId()).list();
-            org.flowable.task.api.Task task = tasks.get(0);
-            assertEquals("Task A", task.getName());
-            assertEquals(1, tasks.size());
-            taskService.complete(task.getId());
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("Task A");
+            taskService.complete(tasks.get(0).getId());
         }
 
         // now All the process instances should be completed
         processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // no jobs
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
         jobs = managementService.createJobQuery().list();
-        assertEquals(0, jobs.size());
+        assertThat(jobs).isEmpty();
 
         // no tasks
         tasks = taskService.createTaskQuery().list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
 
         listener.clearEventsReceived();
         processEngineConfiguration.setClock(previousClock);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayInputStream;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -50,16 +52,16 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         try {
             // After process start, there should be timer created
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             Date startTime = Date.from(Instant.now().plus(2, ChronoUnit.HOURS));
             processEngineConfiguration.getClock().setCurrentTime(startTime);
             waitForJobExecutorToProcessAllJobs(5000L, 200L);
     
             List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
-            assertEquals(1, pi.size());
+            assertThat(pi).hasSize(1);
     
-            assertEquals(0, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
         } finally {
             processEngineConfiguration.resetClock();
@@ -72,17 +74,17 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         try {
             // After process start, there should be timer created
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
-            assertEquals("myCategory", jobQuery.singleResult().getCategory());
+            assertThat(jobQuery.count()).isEqualTo(1);
+            assertThat(jobQuery.singleResult().getCategory()).isEqualTo("myCategory");
     
             Date startTime = Date.from(Instant.now().plus(2, ChronoUnit.HOURS));
             processEngineConfiguration.getClock().setCurrentTime(startTime);
             waitForJobExecutorToProcessAllJobs(5000L, 200L);
     
             List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
-            assertEquals(1, pi.size());
+            assertThat(pi).hasSize(1);
     
-            assertEquals(0, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
         } finally {
             processEngineConfiguration.resetClock();
@@ -97,23 +99,23 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
             
             // After process start, there should be timer created
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
-            assertEquals("myCategory", jobQuery.singleResult().getCategory());
+            assertThat(jobQuery.count()).isEqualTo(1);
+            assertThat(jobQuery.singleResult().getCategory()).isEqualTo("myCategory");
     
             Date startTime = Date.from(Instant.now().plus(2, ChronoUnit.HOURS));
             processEngineConfiguration.getClock().setCurrentTime(startTime);
             
-            assertEquals(0, getTimerJobsCount());
+            assertThat(getTimerJobsCount()).isZero();
             
             processEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory("myCategory");
             
-            assertEquals(1, getTimerJobsCount());
+            assertThat(getTimerJobsCount()).isEqualTo(1);
             
             waitForJobExecutorToProcessAllJobs(5000L, 200L);
     
-            assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").count());
+            assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").count()).isEqualTo(1);
             
-            assertEquals(0, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
         } finally {
             processEngineConfiguration.resetClock();
@@ -127,15 +129,15 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         try {
             // After process start, there should be timer created
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             processEngineConfiguration.getClock().setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:12:30"));
             waitForJobExecutorToProcessAllJobs(7000L, 200L);
     
             List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
-            assertEquals(1, pi.size());
+            assertThat(pi).hasSize(1);
     
-            assertEquals(0, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
         } finally {
             processEngineConfiguration.resetClock();
@@ -151,7 +153,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
     
             // After process start, there should be timer created
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             final ProcessInstanceQuery piq = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample");
     
@@ -163,7 +165,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 }
             });
     
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             moveByMinutes(6);
             waitForJobExecutorOnCondition(4000, 500, new Callable<Boolean>() {
@@ -173,7 +175,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 }
             });
     
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
             // have to manually delete pending timer
             cleanDB();
             
@@ -191,8 +193,8 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
     
             // After process start, there should be timer created
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
-            assertEquals("myCategory", jobQuery.singleResult().getCategory());
+            assertThat(jobQuery.count()).isEqualTo(1);
+            assertThat(jobQuery.singleResult().getCategory()).isEqualTo("myCategory");
     
             final ProcessInstanceQuery piq = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample");
     
@@ -204,8 +206,8 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 }
             });
     
-            assertEquals(1, jobQuery.count());
-            assertEquals("myCategory", jobQuery.singleResult().getCategory());
+            assertThat(jobQuery.count()).isEqualTo(1);
+            assertThat(jobQuery.singleResult().getCategory()).isEqualTo("myCategory");
     
             moveByMinutes(6);
             waitForJobExecutorOnCondition(4000, 500, new Callable<Boolean>() {
@@ -215,8 +217,8 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 }
             });
     
-            assertEquals(1, jobQuery.count());
-            assertEquals("myCategory", jobQuery.singleResult().getCategory());
+            assertThat(jobQuery.count()).isEqualTo(1);
+            assertThat(jobQuery.singleResult().getCategory()).isEqualTo("myCategory");
             
             // have to manually delete pending timer
             cleanDB();
@@ -239,19 +241,19 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
     
             // After process start, there should be timer created
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             moveByMinutes(6);
             String jobId = managementService.createTimerJobQuery().executable().singleResult().getId();
             managementService.moveTimerToExecutableJob(jobId);
             managementService.executeJob(jobId);
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             moveByMinutes(6);
             jobId = managementService.createTimerJobQuery().executable().singleResult().getId();
             managementService.moveTimerToExecutableJob(jobId);
             managementService.executeJob(jobId);
-            assertEquals(0, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
         } finally {
             processEngineConfiguration.resetClock();
@@ -264,15 +266,15 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         try {
             // ACT-1415: fixed start-date is an expression
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             processEngineConfiguration.getClock().setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:12:30"));
             waitForJobExecutorToProcessAllJobs(7000L, 200L);
     
             List<ProcessInstance> pi = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample").list();
-            assertEquals(1, pi.size());
+            assertThat(pi).hasSize(1);
     
-            assertEquals(0, jobQuery.count());
+            assertThat(jobQuery.count()).isZero();
             
         } finally {
             processEngineConfiguration.resetClock();
@@ -288,13 +290,13 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
     
             // After process start, there should be timer created
             TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             // we deploy new process version, with some small change
             String process = new String(IoUtil.readInputStream(getClass().getResourceAsStream("StartTimerEventTest.testVersionUpgradeShouldCancelJobs.bpmn20.xml"), "")).replaceAll("beforeChange", "changed");
             String id = repositoryService.createDeployment().addInputStream("StartTimerEventTest.testVersionUpgradeShouldCancelJobs.bpmn20.xml", new ByteArrayInputStream(process.getBytes())).deploy().getId();
     
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             moveByMinutes(5);
             waitForJobExecutorOnCondition(10000, 500, new Callable<Boolean>() {
@@ -318,7 +320,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                     }
                 }
             });
-            assertEquals(1, jobQuery.count());
+            assertThat(jobQuery.count()).isEqualTo(1);
     
             cleanDB();
             repositoryService.deleteDeployment(id, true);
@@ -337,7 +339,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
 
         // After process start, there should be timer created
         TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         // Reset deployment cache
         processEngineConfiguration.getProcessDefinitionCache().clear();
@@ -347,7 +349,7 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("startTimer");
 
         // No new jobs should have been created
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
     }
 
     // Test for ACT-1533
@@ -360,20 +362,20 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
 
         // After process start, there should be timer created
         TimerJobQuery jobQuery = managementService.createTimerJobQuery();
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         // we deploy new process version, with some small change
         String processChanged = processXml.replaceAll("beforeChange", "changed");
         String secondDeploymentId = repositoryService.createDeployment().addInputStream("StartTimerEventTest.testVersionUpgradeShouldCancelJobs.bpmn20.xml",
                 new ByteArrayInputStream(processChanged.getBytes())).deploy().getId();
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         // Remove the first deployment
         repositoryService.deleteDeployment(firstDeploymentId, true);
 
         // The removal of an old version should not affect timer deletion
         // ACT-1533: this was a bug, and the timer was deleted!
-        assertEquals(1, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(1);
 
         // Cleanup
         cleanDB();
@@ -389,9 +391,9 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                     .addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testOldJobsDeletedOnRedeploy.bpmn20.xml")
                     .deploy();
 
-            assertEquals(i + 1, repositoryService.createDeploymentQuery().count());
-            assertEquals(i + 1, repositoryService.createProcessDefinitionQuery().count());
-            assertEquals(1, managementService.createTimerJobQuery().count());
+            assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(i + 1);
+            assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(i + 1);
+            assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         }
 
@@ -400,8 +402,8 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
             repositoryService.deleteDeployment(processDefinition.getDeploymentId(), true);
         }
 
-        assertEquals(0, managementService.createTimerJobQuery().count());
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
+        assertThat(managementService.createJobQuery().count()).isZero();
 
     }
 
@@ -418,61 +420,61 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 .addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testTimersRecreatedOnDeploymentDelete_v1.bpmn20.xml")
                 .deploy().getId();
 
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         // Deploy v2: no timer -> previous should be deleted
         String deployment2 = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testTimersRecreatedOnDeploymentDelete_v2.bpmn20.xml")
                 .deploy().getId();
 
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(2, repositoryService.createProcessDefinitionQuery().count());
-        assertEquals(0, managementService.createTimerJobQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(2);
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
 
         // Deploy v3: no timer
         String deployment3 = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testTimersRecreatedOnDeploymentDelete_v3.bpmn20.xml")
                 .deploy().getId();
 
-        assertEquals(3, repositoryService.createDeploymentQuery().count());
-        assertEquals(3, repositoryService.createProcessDefinitionQuery().count());
-        assertEquals(0, managementService.createTimerJobQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(3);
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(3);
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
 
         // Deploy v4: no timer
         String deployment4 = repositoryService.createDeployment()
                 .addClasspathResource("org/flowable/engine/test/bpmn/event/timer/StartTimerEventTest.testTimersRecreatedOnDeploymentDelete_v4.bpmn20.xml")
                 .deploy().getId();
 
-        assertEquals(4, repositoryService.createDeploymentQuery().count());
-        assertEquals(4, repositoryService.createProcessDefinitionQuery().count());
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(4);
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(4);
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         // Delete v4 -> V3 active. No timer active anymore (v3 doesn't have a timer)
         repositoryService.deleteDeployment(deployment4, true);
-        assertEquals(3, repositoryService.createDeploymentQuery().count());
-        assertEquals(3, repositoryService.createProcessDefinitionQuery().count());
-        assertEquals(0, managementService.createTimerJobQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(3);
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(3);
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
 
         // Delete v2 --> V3 still active, nothing changed there
         repositoryService.deleteDeployment(deployment2, true);
-        assertEquals(2, repositoryService.createDeploymentQuery().count());
-        assertEquals(2, repositoryService.createProcessDefinitionQuery().count());
-        assertEquals(0, managementService.createTimerJobQuery().count()); // v3 is still active
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(2);
+        assertThat(managementService.createTimerJobQuery().count()).isZero(); // v3 is still active
 
         // Delete v3 -> fallback to v1
         repositoryService.deleteDeployment(deployment3, true);
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         // Cleanup
         for (ProcessDefinition processDefinition : repositoryService.createProcessDefinitionQuery().processDefinitionKey("timer").orderByProcessDefinitionVersion().desc().list()) {
             repositoryService.deleteDeployment(processDefinition.getDeploymentId(), true);
         }
 
-        assertEquals(0, managementService.createTimerJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
 
     }
 
@@ -495,9 +497,9 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 .tenantId(testTenant)
                 .deploy().getId();
 
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count());
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count());
-        assertEquals(1, managementService.createTimerJobQuery().jobTenantId(testTenant).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count()).isEqualTo(1);
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().jobTenantId(testTenant).count()).isEqualTo(1);
 
         // Deploy v2: no timer -> previous should be deleted
         String deployment2 = repositoryService.createDeployment()
@@ -505,9 +507,9 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 .tenantId(testTenant)
                 .deploy().getId();
 
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count());
-        assertEquals(2, repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count());
-        assertEquals(0, managementService.createTimerJobQuery().jobTenantId(testTenant).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count()).isEqualTo(2);
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count()).isEqualTo(2);
+        assertThat(managementService.createTimerJobQuery().jobTenantId(testTenant).count()).isZero();
 
         // Deploy v3: no timer
         String deployment3 = repositoryService.createDeployment()
@@ -515,9 +517,9 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 .tenantId(testTenant)
                 .deploy().getId();
 
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count());
-        assertEquals(3, repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count());
-        assertEquals(0, managementService.createTimerJobQuery().jobTenantId(testTenant).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count()).isEqualTo(3);
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count()).isEqualTo(3);
+        assertThat(managementService.createTimerJobQuery().jobTenantId(testTenant).count()).isZero();
 
         // Deploy v4: no timer
         String deployment4 = repositoryService.createDeployment()
@@ -525,34 +527,34 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                 .tenantId(testTenant)
                 .deploy().getId();
 
-        assertEquals(4, repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count());
-        assertEquals(4, repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count());
-        assertEquals(1, managementService.createTimerJobQuery().jobTenantId(testTenant).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count()).isEqualTo(4);
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count()).isEqualTo(4);
+        assertThat(managementService.createTimerJobQuery().jobTenantId(testTenant).count()).isEqualTo(1);
 
         // Delete v4 -> V3 active. No timer active anymore (v3 doesn't have a timer)
         repositoryService.deleteDeployment(deployment4, true);
-        assertEquals(3, repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count());
-        assertEquals(3, repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count());
-        assertEquals(0, managementService.createTimerJobQuery().jobTenantId(testTenant).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count()).isEqualTo(3);
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count()).isEqualTo(3);
+        assertThat(managementService.createTimerJobQuery().jobTenantId(testTenant).count()).isZero();
 
         // Delete v2 --> V3 still active, nothing changed there
         repositoryService.deleteDeployment(deployment2, true);
-        assertEquals(2, repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count());
-        assertEquals(2, repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count());
-        assertEquals(0, managementService.createTimerJobQuery().jobTenantId(testTenant).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count()).isEqualTo(2);
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count()).isEqualTo(2);
+        assertThat(managementService.createTimerJobQuery().jobTenantId(testTenant).count()).isZero();
 
         // Delete v3 -> fallback to v1
         repositoryService.deleteDeployment(deployment3, true);
-        assertEquals(1, repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count());
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count());
-        assertEquals(1, managementService.createTimerJobQuery().jobTenantId(testTenant).count());
+        assertThat(repositoryService.createDeploymentQuery().deploymentTenantId(testTenant).count()).isEqualTo(1);
+        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(testTenant).count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().jobTenantId(testTenant).count()).isEqualTo(1);
 
         // Cleanup
         for (ProcessDefinition processDefinition : repositoryService.createProcessDefinitionQuery().processDefinitionKey("timer").orderByProcessDefinitionVersion().desc().list()) {
             repositoryService.deleteDeployment(processDefinition.getDeploymentId(), true);
         }
 
-        assertEquals(0, managementService.createTimerJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
 
     }
 
@@ -569,8 +571,8 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
                     .deploy().getId();
     
             // After deployment, should have 4 jobs for the 4 timer events
-            assertEquals(4, managementService.createTimerJobQuery().count());
-            assertEquals(0, managementService.createTimerJobQuery().executable().count());
+            assertThat(managementService.createTimerJobQuery().count()).isEqualTo(4);
+            assertThat(managementService.createTimerJobQuery().executable().count()).isZero();
     
             // Path A : triggered at start + 10 seconds (18:50:11) (R2)
             // Path B: triggered at start + 5 seconds (18:50:06) (R3)
@@ -581,12 +583,12 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
             Date newDate = new Date(startTime.getTime() + (7 * 1000));
             processEngineConfiguration.getClock().setCurrentTime(newDate);
             List<Job> executableTimers = managementService.createTimerJobQuery().executable().list();
-            assertEquals(1, executableTimers.size());
+            assertThat(executableTimers).hasSize(1);
     
             executeJobs(executableTimers);
             validateTaskCounts(0, 1, 0, 0);
-            assertEquals(4, managementService.createTimerJobQuery().count());
-            assertEquals(0, managementService.createTimerJobQuery().executable().count());
+            assertThat(managementService.createTimerJobQuery().count()).isEqualTo(4);
+            assertThat(managementService.createTimerJobQuery().executable().count()).isZero();
     
             // New situation:
             // Path A : triggered at start + 10 seconds (18:50:11) (R2)
@@ -599,11 +601,11 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getClock().setCurrentTime(newDate);
     
             executableTimers = managementService.createTimerJobQuery().executable().list();
-            assertEquals(2, executableTimers.size());
+            assertThat(executableTimers).hasSize(2);
             executeJobs(executableTimers);
             validateTaskCounts(1, 2, 0, 0);
-            assertEquals(4, managementService.createTimerJobQuery().count());
-            assertEquals(0, managementService.createTimerJobQuery().executable().count());
+            assertThat(managementService.createTimerJobQuery().count()).isEqualTo(4);
+            assertThat(managementService.createTimerJobQuery().executable().count()).isZero();
     
             // New situation:
             // Path A : triggered at start + 2*10 seconds (18:50:21) (R1 - was R2) [CHANGED]
@@ -616,11 +618,11 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getClock().setCurrentTime(newDate);
     
             executableTimers = managementService.createTimerJobQuery().executable().list();
-            assertEquals(2, executableTimers.size());
+            assertThat(executableTimers).hasSize(2);
             executeJobs(executableTimers);
             validateTaskCounts(1, 3, 1, 0);
-            assertEquals(2, managementService.createTimerJobQuery().count());
-            assertEquals(0, managementService.createTimerJobQuery().executable().count());
+            assertThat(managementService.createTimerJobQuery().count()).isEqualTo(2);
+            assertThat(managementService.createTimerJobQuery().executable().count()).isZero();
     
             // New situation:
             // Path A : triggered at start + 2*10 seconds (18:50:21) (R1 - was R2) [CHANGED]
@@ -633,11 +635,11 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getClock().setCurrentTime(newDate);
     
             executableTimers = managementService.createTimerJobQuery().executable().list();
-            assertEquals(2, executableTimers.size());
+            assertThat(executableTimers).hasSize(2);
             executeJobs(executableTimers);
             validateTaskCounts(2, 3, 1, 1);
-            assertEquals(1, managementService.createTimerJobQuery().count());
-            assertEquals(0, managementService.createTimerJobQuery().executable().count());
+            assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
+            assertThat(managementService.createTimerJobQuery().executable().count()).isZero();
     
             // New situation:
             // Path A : all repeats used up
@@ -654,10 +656,10 @@ public class StartTimerEventTest extends PluggableFlowableTestCase {
     }
 
     protected void validateTaskCounts(long taskACount, long taskBCount, long taskCCount, long taskDCount) {
-        assertEquals("task A counts are incorrect", taskACount, taskService.createTaskQuery().taskName("Task A").count());
-        assertEquals("task B counts are incorrect", taskBCount, taskService.createTaskQuery().taskName("Task B").count());
-        assertEquals("task C counts are incorrect", taskCCount, taskService.createTaskQuery().taskName("Task C").count());
-        assertEquals("task D counts are incorrect", taskDCount, taskService.createTaskQuery().taskName("Task D").count());
+        assertThat(taskService.createTaskQuery().taskName("Task A").count()).as("task A counts are incorrect").isEqualTo(taskACount);
+        assertThat(taskService.createTaskQuery().taskName("Task B").count()).as("task B counts are incorrect").isEqualTo(taskBCount);
+        assertThat(taskService.createTaskQuery().taskName("Task C").count()).as("task C counts are incorrect").isEqualTo(taskCCount);
+        assertThat(taskService.createTaskQuery().taskName("Task D").count()).as("task D counts are incorrect").isEqualTo(taskDCount);
     }
 
     protected void executeJobs(List<Job> jobs) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimeExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimeExpressionTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -38,10 +40,10 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
 
         // After process start, there should be timer created
         ProcessInstance pi1 = runtimeService.startProcessInstanceByKey("intermediateTimerEventExample", variables1);
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(pi1.getId()).count()).isEqualTo(1);
 
         List<Job> jobs = managementService.createTimerJobQuery().executable().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
         return jobs.get(0).getDuedate();
     }
 
@@ -51,7 +53,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         Date dt = new Date();
 
         Date dueDate = testExpression(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(dt));
-        assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(dt), new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(dueDate));
+        assertThat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(dueDate)).isEqualTo(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(dt));
     }
 
     @Test
@@ -60,7 +62,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         Date dt = new Date();
 
         Date dueDate = testExpression(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(dt));
-        assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(dt), new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(dueDate));
+        assertThat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(dueDate)).isEqualTo(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(dt));
     }
 
     @Test
@@ -69,7 +71,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         Date dt = new Date();
 
         Date dueDate = testExpression(new SimpleDateFormat("yyyy-MM-dd'T'HH").format(new Date()));
-        assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH").format(dt), new SimpleDateFormat("yyyy-MM-dd'T'HH").format(dueDate));
+        assertThat(new SimpleDateFormat("yyyy-MM-dd'T'HH").format(dueDate)).isEqualTo(new SimpleDateFormat("yyyy-MM-dd'T'HH").format(dt));
     }
 
     @Test
@@ -78,7 +80,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         Date dt = new Date();
 
         Date dueDate = testExpression(new SimpleDateFormat("yyyy-MM-dd").format(new Date()));
-        assertEquals(new SimpleDateFormat("yyyy-MM-dd").format(dt), new SimpleDateFormat("yyyy-MM-dd").format(dueDate));
+        assertThat(new SimpleDateFormat("yyyy-MM-dd").format(dueDate)).isEqualTo(new SimpleDateFormat("yyyy-MM-dd").format(dt));
     }
 
     @Test
@@ -87,7 +89,7 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         Date dt = new Date();
 
         Date dueDate = testExpression(new SimpleDateFormat("yyyy-MM").format(new Date()));
-        assertEquals(new SimpleDateFormat("yyyy-MM").format(dt), new SimpleDateFormat("yyyy-MM").format(dueDate));
+        assertThat(new SimpleDateFormat("yyyy-MM").format(dueDate)).isEqualTo(new SimpleDateFormat("yyyy-MM").format(dt));
     }
 
     @Test
@@ -96,6 +98,6 @@ public class TimeExpressionTest extends PluggableFlowableTestCase {
         Date dt = new Date();
 
         Date dueDate = testExpression(new SimpleDateFormat("yyyy").format(new Date()));
-        assertEquals(new SimpleDateFormat("yyyy").format(dt), new SimpleDateFormat("yyyy").format(dueDate));
+        assertThat(new SimpleDateFormat("yyyy").format(dueDate)).isEqualTo(new SimpleDateFormat("yyyy").format(dt));
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerCustomCalendarTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerCustomCalendarTest.java
@@ -13,9 +13,8 @@
 
 package org.flowable.engine.test.bpmn.event.timer;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Date;
 import java.util.List;
@@ -42,23 +41,27 @@ public class TimerCustomCalendarTest extends ResourceFlowableTestCase {
     @Deployment
     public void testCycleTimer() {
         List<Job> jobs = this.managementService.createTimerJobQuery().list();
-
-        assertThat("One job is scheduled", jobs.size(), is(1));
-        assertThat("Job must be scheduled by custom business calendar to Date(1000)", jobs.get(0).getDuedate(), is(new Date(1000)));
-
-        managementService.moveTimerToExecutableJob(jobs.get(0).getId());
-        managementService.executeJob(jobs.get(0).getId());
-
-        jobs = this.managementService.createTimerJobQuery().list();
-
-        assertThat("One job is scheduled (repetition is 2x)", jobs.size(), is(1));
-        assertThat("Job must be scheduled by custom business calendar to Date(1000)", jobs.get(0).getDuedate(), is(new Date(1000)));
+        assertThat(jobs)
+                .extracting(Job::getDuedate)
+                .as("One job is scheduled; Job must be scheduled by custom business calendar to Date(1000)")
+                .containsExactly(new Date(1000));
 
         managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(jobs.get(0).getId());
 
         jobs = this.managementService.createTimerJobQuery().list();
-        assertThat("There must be no job.", jobs.isEmpty());
+        assertThat(jobs)
+                .extracting(Job::getDuedate)
+                .as("One job is scheduled (repetition is 2x); Job must be scheduled by custom business calendar to Date(1000)")
+                .containsExactly(new Date(1000));
+
+        managementService.moveTimerToExecutableJob(jobs.get(0).getId());
+        managementService.executeJob(jobs.get(0).getId());
+
+        jobs = this.managementService.createTimerJobQuery().list();
+        assertThat(jobs)
+                .as("There must be no job.")
+                .isEmpty();
     }
 
     @Test
@@ -67,9 +70,10 @@ public class TimerCustomCalendarTest extends ResourceFlowableTestCase {
         ProcessInstance processInstance = this.runtimeService.startProcessInstanceByKey("testCustomDurationCalendar");
 
         List<Job> jobs = this.managementService.createTimerJobQuery().list();
-
-        assertThat("One job is scheduled", jobs.size(), is(1));
-        assertThat("Job must be scheduled by custom business calendar to Date(1000)", jobs.get(0).getDuedate(), is(new Date(1000)));
+        assertThat(jobs)
+                .extracting(Job::getDuedate)
+                .as("One job is scheduled; Job must be scheduled by custom business calendar to Date(1000)")
+                .containsExactly(new Date(1000));
 
         managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(jobs.get(0).getId());
@@ -82,12 +86,10 @@ public class TimerCustomCalendarTest extends ResourceFlowableTestCase {
     @Test
     @Deployment
     public void testInvalidDurationTimerCalendar() {
-        try {
-            this.runtimeService.startProcessInstanceByKey("testCustomDurationCalendar");
-            fail("Activiti exception expected - calendar not found");
-        } catch (FlowableException e) {
-            assertThat(e.getMessage(), containsString("INVALID does not exist"));
-        }
+        assertThatThrownBy(() -> this.runtimeService.startProcessInstanceByKey("testCustomDurationCalendar"))
+                .as("Exception expected - calendar not found")
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("INVALID does not exist");
     }
 
     @Test
@@ -96,8 +98,10 @@ public class TimerCustomCalendarTest extends ResourceFlowableTestCase {
         this.runtimeService.startProcessInstanceByKey("testBoundaryTimer");
 
         List<Job> jobs = this.managementService.createTimerJobQuery().list();
-        assertThat("One job is scheduled", jobs.size(), is(1));
-        assertThat("Job must be scheduled by custom business calendar to Date(1000)", jobs.get(0).getDuedate(), is(new Date(1000)));
+        assertThat(jobs)
+                .extracting(Job::getDuedate)
+                .as("One job is scheduled; Job must be scheduled by custom business calendar to Date(1000)")
+                .containsExactly(new Date(1000));
 
         managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(jobs.get(0).getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.java
@@ -42,30 +42,30 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // the process instance must have a timer job:
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
 
         // if we trigger the usertask, the process terminates and the timer job is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("task", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
         taskService.complete(task.getId());
 
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertProcessEnded(processInstance.getId());
 
         // now we start a new instance but this time we trigger the timer job:
         processInstance = runtimeService.startProcessInstanceByKey("process");
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         job = managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("eventSubProcessTask", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("eventSubProcessTask");
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -76,155 +76,155 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // the process instance must have a timer job:
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(job).isNotNull();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("task", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
         taskService.complete(task.getId());
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         // now we start a new instance but this time we trigger the event subprocess:
         processInstance = runtimeService.startProcessInstanceByKey("process");
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         job = managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // now let's first complete the task in the main flow:
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         // we still have 3 executions:
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // now let's complete the task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         // #################### again, the other way around:
 
         processInstance = runtimeService.startProcessInstanceByKey("process");
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         job = managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         // we still have 3 executions:
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testNonInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(job).isNotNull();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         job = managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
-        assertEquals(6, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(6);
 
-        assertEquals(2, taskService.createTaskQuery().count());
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         job = managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
-        assertEquals(9, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(9);
 
-        assertEquals(3, taskService.createTaskQuery().count());
-        assertEquals(1, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         // we still have 7 executions:
-        assertEquals(7, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(7);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
-        assertEquals(4, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment
     public void testInterruptingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(job).isNotNull();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         job = managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
-        assertEquals(5, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
-        assertEquals(1, taskService.createTaskQuery().count());
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         // now let's complete the task in the event subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment
     public void testStartingAdditionalTasks() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         String firstTimerJobId = job.getId();
 
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, jobs.size());
+        assertThat(jobs).hasSize(2);
         
         String secondTimerJobId = null;
         for (Job timerJob : jobs) {
@@ -236,67 +236,67 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         job = managementService.moveTimerToExecutableJob(secondTimerJobId);
         managementService.executeJob(job.getId());
         
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         job = managementService.moveTimerToExecutableJob(firstTimerJobId);
         managementService.executeJob(job.getId());
         
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.testStartingAdditionalTasks.bpmn20.xml")
     public void testStartingAdditionalTasksNoNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
 
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, jobs.size());
+        assertThat(jobs).hasSize(2);
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
         jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(1, jobs.size());
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(jobs).hasSize(1);
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
@@ -304,18 +304,18 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
     public void testStartingAdditionalTasksWithNestedEventSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         String firstTimerJobId = job.getId();
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, jobs.size());
+        assertThat(jobs).hasSize(2);
         
         String secondTimerJobId = null;
         for (Job timerJob : jobs) {
@@ -327,57 +327,57 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         job = managementService.moveTimerToExecutableJob(secondTimerJobId);
         managementService.executeJob(job.getId());
         
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
         taskService.complete(task.getId());
         
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(job).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(job).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         job = managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
         
-        assertEquals(2, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(0, managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment
     public void testStartingAdditionalTasksInterrupting() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         String firstTimerJobId = job.getId();
 
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, jobs.size());
+        assertThat(jobs).hasSize(2);
 
         String secondTimerJobId = null;
         for (Job timerJob : jobs) {
@@ -389,38 +389,38 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         job = managementService.moveTimerToExecutableJob(secondTimerJobId);
         managementService.executeJob(job.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
         taskService.complete(task.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
     
     @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.testStartingAdditionalTasksInterrupting.bpmn20.xml")
     public void testStartingAdditionalTasksInterruptingWithMainEventSubProcessInterrupt() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startingAdditionalTasks");
-        assertEquals(3, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         String firstTimerJobId = job.getId();
 
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
         taskService.complete(task.getId());
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, jobs.size());
+        assertThat(jobs).hasSize(2);
 
         String secondTimerJobId = null;
         for (Job timerJob : jobs) {
@@ -432,18 +432,18 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         job = managementService.moveTimerToExecutableJob(secondTimerJobId);
         managementService.executeJob(job.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         job = managementService.moveTimerToExecutableJob(firstTimerJobId);
         managementService.executeJob(job.getId());
         
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
         taskService.complete(task.getId());
 
         // done!
-        assertEquals(0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
     @Test


### PR DESCRIPTION
In the `org.flowable.engine.test.bpmn.event.timer` package there were 4 files with mixed assertion styles so they were converted to a single format. At the same time the remaining files in the package were updated.
