### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.common.engine.impl.interceptor.CommandExecutor;
@@ -57,28 +60,23 @@ public class JobExecutorCmdExceptionTest extends PluggableFlowableTestCase {
         });
 
         Job job = managementService.createJobQuery().singleResult();
-        assertEquals(3, job.getRetries());
+        assertThat(job.getRetries()).isEqualTo(3);
 
-        try {
-            managementService.executeJob(job.getId());
-            fail("exception expected");
-        } catch (Exception e) {
-            // exception expected;
-        }
+        String jobId = job.getId();
+        assertThatThrownBy(() -> managementService.executeJob(jobId))
+                .isInstanceOf(Exception.class);
 
         job = managementService.createTimerJobQuery().singleResult();
-        assertEquals(2, job.getRetries());
+        assertThat(job.getRetries()).isEqualTo(2);
 
-        try {
-            managementService.moveTimerToExecutableJob(job.getId());
-            managementService.executeJob(job.getId());
-            fail("exception expected");
-        } catch (Exception e) {
-            // exception expected;
-        }
+        assertThatThrownBy(() -> {
+            managementService.moveTimerToExecutableJob(jobId);
+            managementService.executeJob(jobId);
+        })
+                .isInstanceOf(Exception.class);
 
         job = managementService.createTimerJobQuery().singleResult();
-        assertEquals(1, job.getRetries());
+        assertThat(job.getRetries()).isEqualTo(1);
 
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
@@ -99,39 +97,31 @@ public class JobExecutorCmdExceptionTest extends PluggableFlowableTestCase {
         });
 
         Job job = managementService.createJobQuery().singleResult();
-        assertEquals(3, job.getRetries());
-
-        try {
-            managementService.executeJob(job.getId());
-            fail("exception expected");
-        } catch (Exception e) {
-            // exception expected;
-        }
+        assertThat(job.getRetries()).isEqualTo(3);
+        String jobId = job.getId();
+        assertThatThrownBy(() -> managementService.executeJob(jobId))
+                .isInstanceOf(Exception.class);
 
         job = managementService.createTimerJobQuery().singleResult();
-        assertEquals(2, job.getRetries());
+        assertThat(job.getRetries()).isEqualTo(2);
 
-        try {
-            managementService.moveTimerToExecutableJob(job.getId());
-            managementService.executeJob(job.getId());
-            fail("exception expected");
-        } catch (Exception e) {
-            // exception expected;
-        }
+        assertThatThrownBy(() -> {
+            managementService.moveTimerToExecutableJob(jobId);
+            managementService.executeJob(jobId);
+        })
+                .isInstanceOf(Exception.class);
 
         job = managementService.createTimerJobQuery().singleResult();
-        assertEquals(1, job.getRetries());
+        assertThat(job.getRetries()).isEqualTo(1);
 
-        try {
-            managementService.moveTimerToExecutableJob(job.getId());
-            managementService.executeJob(job.getId());
-            fail("exception expected");
-        } catch (Exception e) {
-            // exception expected;
-        }
+        assertThatThrownBy(() -> {
+            managementService.moveTimerToExecutableJob(jobId);
+            managementService.executeJob(jobId);
+        })
+                .isInstanceOf(Exception.class);
 
         job = managementService.createDeadLetterJobQuery().singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
 
         managementService.deleteDeadLetterJob(job.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorCmdHappyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorCmdHappyTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 
 import org.flowable.common.engine.impl.interceptor.Command;
@@ -47,15 +49,15 @@ public class JobExecutorCmdHappyTest extends JobExecutorTestCase {
         });
 
         Job job = managementService.createJobQuery().singleResult();
-        assertNotNull(job);
-        assertEquals(jobId, job.getId());
+        assertThat(job).isNotNull();
+        assertThat(job.getId()).isEqualTo(jobId);
 
-        assertEquals(0, tweetHandler.getMessages().size());
+        assertThat(tweetHandler.getMessages()).isEmpty();
 
         managementService.executeJob(job.getId());
 
-        assertEquals("i'm coding a test", tweetHandler.getMessages().get(0));
-        assertEquals(1, tweetHandler.getMessages().size());
+        assertThat(tweetHandler.getMessages())
+                .containsExactly("i'm coding a test");
     }
 
     static final long SOME_TIME = 928374923546L;
@@ -80,23 +82,23 @@ public class JobExecutorCmdHappyTest extends JobExecutorTestCase {
         });
 
         AcquiredTimerJobEntities acquiredJobs = commandExecutor.execute(new AcquireTimerJobsCmd(asyncExecutor));
-        assertEquals(0, acquiredJobs.size());
+        assertThat(acquiredJobs.size()).isZero();
 
         processEngineConfiguration.getClock().setCurrentTime(new Date(SOME_TIME + (20 * SECOND)));
 
         acquiredJobs = commandExecutor.execute(new AcquireTimerJobsCmd(asyncExecutor));
-        assertEquals(1, acquiredJobs.size());
+        assertThat(acquiredJobs.size()).isEqualTo(1);
 
         TimerJobEntity job = acquiredJobs.getJobs().iterator().next();
 
-        assertEquals(jobId, job.getId());
+        assertThat(job.getId()).isEqualTo(jobId);
 
-        assertEquals(0, tweetHandler.getMessages().size());
+        assertThat(tweetHandler.getMessages()).isEmpty();
 
         Job executableJob = managementService.moveTimerToExecutableJob(jobId);
         commandExecutor.execute(new ExecuteAsyncJobCmd(executableJob.getId()));
 
-        assertEquals("i'm coding a test", tweetHandler.getMessages().get(0));
-        assertEquals(1, tweetHandler.getMessages().size());
+        assertThat(tweetHandler.getMessages().get(0)).isEqualTo("i'm coding a test");
+        assertThat(tweetHandler.getMessages()).hasSize(1);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorExceptionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorExceptionsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 import java.util.concurrent.Callable;
 
@@ -20,7 +22,6 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.TimerJobQuery;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,7 +33,7 @@ public class JobExecutorExceptionsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml" })
     public void testQueryByExceptionWithRealJobExecutor() {
         TimerJobQuery query = managementService.createTimerJobQuery().withException();
-        Assert.assertEquals(0, query.count());
+        assertThat(query.count()).isEqualTo(0);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exceptionInJobExecution");
 
@@ -49,7 +50,7 @@ public class JobExecutorExceptionsTest extends PluggableFlowableTestCase {
         });
 
         query = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).withException();
-        Assert.assertEquals(1, query.count());
+        assertThat(query.count()).isEqualTo(1);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorExceptionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorExceptionsTest.java
@@ -33,7 +33,7 @@ public class JobExecutorExceptionsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml" })
     public void testQueryByExceptionWithRealJobExecutor() {
         TimerJobQuery query = managementService.createTimerJobQuery().withException();
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exceptionInJobExecution");
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorFailRetryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorFailRetryTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,7 @@ public class JobExecutorFailRetryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("failedJobRetry");
 
         waitForJobExecutorToProcessAllJobs(1000, 200);
-        assertEquals(1, RetryFailingDelegate.times.size()); // check number of calls of delegate
+        assertThat(RetryFailingDelegate.times).hasSize(1); // check number of calls of delegate
 
         // process throws exception two times, with 6 seconds in between
         RetryFailingDelegate.shallThrow = true; // throw exception in Service delegate
@@ -40,8 +42,8 @@ public class JobExecutorFailRetryTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("failedJobRetry");
 
         executeJobExecutorForTime(14000, 500);
-        assertEquals(2, RetryFailingDelegate.times.size()); // check number of calls of delegate
+        assertThat(RetryFailingDelegate.times).hasSize(2); // check number of calls of delegate
         long timeDiff = RetryFailingDelegate.times.get(1) - RetryFailingDelegate.times.get(0);
-        assertTrue(timeDiff > 6000 && timeDiff < 12000); // check time difference between calls. Just roughly
+        assertThat(timeDiff > 6000 && timeDiff < 12000).isTrue(); // check time difference between calls. Just roughly
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobExecutorTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -69,6 +71,6 @@ public class JobExecutorTest extends JobExecutorTestCase {
         expectedMessages.add("timer-one");
         expectedMessages.add("timer-two");
 
-        assertEquals(new TreeSet<>(expectedMessages), new TreeSet<>(messages));
+        assertThat(new TreeSet<>(messages)).isEqualTo(new TreeSet<>(expectedMessages));
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobProcessorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/JobProcessorTest.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.JobInfo;
@@ -19,8 +23,6 @@ import org.flowable.job.service.JobProcessor;
 import org.flowable.job.service.JobProcessorContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Tests the functionality of the {@link JobProcessor} and the persistence of the {@link JobInfo#getCustomValues()} field.
@@ -99,13 +101,13 @@ public class JobProcessorTest extends ResourceFlowableTestCase {
             if (jobProcessorContext.isInPhase(JobProcessorContext.Phase.BEFORE_EXECUTE)) {
                 // check the random custom value as the before execute phase is executed in the async thread
                 String customValues = jobProcessorContext.getJobEntity().getCustomValues();
-                assertEquals("The custom values must be equal", randomCustomValues, customValues);
+                assertThat(customValues).as("The custom values must be equal").isEqualTo(randomCustomValues);
             }
         }
     }
 
     private static void assertCheckSum(int expectedCheckSum) {
-        assertEquals("The checksum must be equal", expectedCheckSum, CHECK_SUM.get());
+        assertThat(CHECK_SUM.get()).as("The checksum must be equal").isEqualTo(expectedCheckSum);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/ResetExpiredJobsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/ResetExpiredJobsTest.java
@@ -118,7 +118,6 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("myProcess");
         Job job = managementService.createJobQuery().singleResult();
-        assertThat(job).isNotNull();
         assertThat(job).isInstanceOf(JobEntity.class);
         
         JobEntity jobEntity = (JobEntity) job;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/ResetExpiredJobsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/ResetExpiredJobsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -55,13 +57,13 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
 
         // Starting process instance will make one job ready
         runtimeService.startProcessInstanceByKey("myProcess");
-        assertEquals(1, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(1);
 
         // Running the 'reset expired' logic should have no effect now
         JobServiceConfiguration jobServiceConfiguration = (JobServiceConfiguration) processEngineConfiguration.getServiceConfigurations().get(EngineConfigurationConstants.KEY_JOB_SERVICE_CONFIG);
         int expiredJobsPagesSize = processEngineConfiguration.getAsyncExecutorResetExpiredJobsPageSize();
         List<? extends JobInfoEntity> expiredJobs = managementService.executeCommand(new FindExpiredJobsCmd(expiredJobsPagesSize, jobServiceConfiguration.getJobEntityManager()));
-        assertEquals(0, expiredJobs.size());
+        assertThat(expiredJobs).isEmpty();
         assertJobDetails(false);
 
         // Run the acquire logic. This should lock the job
@@ -70,7 +72,7 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
 
         // Running the 'reset expired' logic should have no effect, the lock time is not yet passed
         expiredJobs = managementService.executeCommand(new FindExpiredJobsCmd(expiredJobsPagesSize, jobServiceConfiguration.getJobEntityManager()));
-        assertEquals(0, expiredJobs.size());
+        assertThat(expiredJobs).isEmpty();
         assertJobDetails(true);
 
         // Move clock to past the lock time
@@ -79,7 +81,7 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
 
         // Running the reset logic should now reset the lock
         expiredJobs = managementService.executeCommand(new FindExpiredJobsCmd(expiredJobsPagesSize,  jobServiceConfiguration.getJobEntityManager()));
-        assertTrue(expiredJobs.size() > 0);
+        assertThat(expiredJobs).hasSizeGreaterThan(0);
 
         List<String> jobIds = new ArrayList<>();
         for (JobInfoEntity jobEntity : expiredJobs) {
@@ -96,15 +98,15 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
         // Start two new process instances, those jobs should not be locked
         runtimeService.startProcessInstanceByKey("myProcess");
         runtimeService.startProcessInstanceByKey("myProcess");
-        assertEquals(3, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(3);
         assertJobDetails(true);
 
         List<Job> unlockedJobs = managementService.createJobQuery().unlocked().list();
-        assertEquals(2, unlockedJobs.size());
+        assertThat(unlockedJobs).hasSize(2);
         for (Job job : unlockedJobs) {
             JobEntity jobEntity = (JobEntity) job;
-            assertNull(jobEntity.getLockOwner());
-            assertNull(jobEntity.getLockExpirationTime());
+            assertThat(jobEntity.getLockOwner()).isNull();
+            assertThat(jobEntity.getLockExpirationTime()).isNull();
         }
     }
     
@@ -116,24 +118,26 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
 
         runtimeService.startProcessInstanceByKey("myProcess");
         Job job = managementService.createJobQuery().singleResult();
-        assertNotNull(job);
-        assertTrue(job instanceof JobEntity);
+        assertThat(job).isNotNull();
+        assertThat(job).isInstanceOf(JobEntity.class);
         
         JobEntity jobEntity = (JobEntity) job;
-        assertNull(jobEntity.getLockOwner());
-        assertNull(jobEntity.getLockExpirationTime());
+        assertThat(jobEntity.getLockOwner()).isNull();
+        assertThat(jobEntity.getLockExpirationTime()).isNull();
         
         int expiredJobsPagesSize = processEngineConfiguration.getAsyncExecutorResetExpiredJobsPageSize();
         JobServiceConfiguration jobServiceConfiguration = (JobServiceConfiguration) processEngineConfiguration.getServiceConfigurations().get(EngineConfigurationConstants.KEY_JOB_SERVICE_CONFIG);
         List<? extends JobInfoEntity> expiredJobs = managementService.executeCommand(new FindExpiredJobsCmd(expiredJobsPagesSize, jobServiceConfiguration.getJobEntityManager()));
-        assertEquals(0, expiredJobs.size());
+        assertThat(expiredJobs).isEmpty();
         
         // Move time to timeout + 1 second. This should trigger the max timeout and the job should be reset (unacquired: reinserted as a new job)
         processEngineConfiguration.getClock().setCurrentTime(new Date(startOfTestTime.getTime() + (processEngineConfiguration.getAsyncExecutorResetExpiredJobsMaxTimeout() + 1000)));
       
         expiredJobs = managementService.executeCommand(new FindExpiredJobsCmd(expiredJobsPagesSize, jobServiceConfiguration.getJobEntityManager()));
-        assertEquals(1, expiredJobs.size());
-        assertEquals(job.getId(), expiredJobs.get(0).getId());
+        assertThat(expiredJobs)
+                .extracting(JobInfoEntity::getId)
+                .containsExactly(job.getId());
+
         assertJobDetails(false);
 
         List<String> jobIds = new ArrayList<>();
@@ -141,10 +145,10 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
             jobIds.add(j.getId());
         }
         managementService.executeCommand(new ResetExpiredJobsCmd(jobIds, jobServiceConfiguration.getJobEntityManager()));
-        assertEquals(0, managementService.executeCommand(new FindExpiredJobsCmd(expiredJobsPagesSize, jobServiceConfiguration.getJobEntityManager())).size());
+        assertThat(managementService.executeCommand(new FindExpiredJobsCmd(expiredJobsPagesSize, jobServiceConfiguration.getJobEntityManager()))).isEmpty();
         
-        assertNull(managementService.createJobQuery().jobId(job.getId()).singleResult());
-        assertNotNull(managementService.createJobQuery().singleResult());
+        assertThat(managementService.createJobQuery().jobId(job.getId()).singleResult()).isNull();
+        assertThat(managementService.createJobQuery().singleResult()).isNotNull();
     }
 
     @Test
@@ -170,7 +174,7 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
                 }
             });
         }
-        assertEquals(nrOfJobsToCreate, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(nrOfJobsToCreate);
 
         // Running the reset expired runnable should trigger them all
         ResetExpiredJobsRunnable resetExpiredJobsRunnable = new ResetExpiredJobsRunnable("test-reset-expired",
@@ -180,8 +184,8 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
         List<Job> jobs = managementService.createJobQuery().list();
         for (Job job : jobs) {
             JobEntityImpl jobEntity = (JobEntityImpl) job;
-            assertNull(jobEntity.getLockOwner());
-            assertNull(jobEntity.getLockExpirationTime());
+            assertThat(jobEntity.getLockOwner()).isNull();
+            assertThat(jobEntity.getLockExpirationTime()).isNull();
 
             managementService.deleteJob(job.getId());
         }
@@ -195,15 +199,15 @@ public class ResetExpiredJobsTest extends PluggableFlowableTestCase {
         }
 
         Job job = jobQuery.singleResult();
-        assertTrue(job instanceof JobEntity);
+        assertThat(job).isInstanceOf(JobEntity.class);
         JobEntity jobEntity = (JobEntity) job;
 
         if (locked) {
-            assertNotNull(jobEntity.getLockOwner());
-            assertNotNull(jobEntity.getLockExpirationTime());
+            assertThat(jobEntity.getLockOwner()).isNotNull();
+            assertThat(jobEntity.getLockExpirationTime()).isNotNull();
         } else {
-            assertNull(jobEntity.getLockOwner());
-            assertNull(jobEntity.getLockExpirationTime());
+            assertThat(jobEntity.getLockOwner()).isNull();
+            assertThat(jobEntity.getLockExpirationTime()).isNull();
         }
     }
 


### PR DESCRIPTION
In the `org.flowable.engine.test.jobexecutor` package this PR updates the remaining files that were not using `assertj`.

