### PR TITLE
Use assertj fluent style in flowable-engine module

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
@@ -430,7 +430,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("User Task1 in Parent");
 
         // validate that the variable was copied back when Call Activity finished
-        assertThat("Mary Smith").isEqualTo(runtimeService.getVariable(processInstance.getId(), "Name"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Mary Smith");
 
         // complete user task so that parent process will terminate normally
         taskService.complete(task.getId());
@@ -693,7 +693,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
 
         // Completing ends the process instance
         jobs.forEach(job -> managementService.executeJob(job.getId()));
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     // Same as testCallActivityAsyncComplete, but now using the real job executor instead of fetching and executing jobs manually
@@ -706,7 +706,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
     public void testCallActivityAsyncCompleteRealExecutor() {
         runtimeService.startProcessInstanceByKey("testAsyncComplete");
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(20000L, 200L);
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
@@ -262,12 +262,12 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         // Check with empty null
         FlowableEngineEventType[] types = FlowableEngineEventType.getTypesFromString(null);
         assertThat(types).isNotNull();
-        assertThat(types.length).isEqualTo(0);
+        assertThat(types.length).isZero();
 
         // Check with empty string
         types = FlowableEngineEventType.getTypesFromString("");
         assertThat(types).isNotNull();
-        assertThat(types.length).isEqualTo(0);
+        assertThat(types.length).isZero();
 
         // Single value
         types = FlowableEngineEventType.getTypesFromString("ENTITY_CREATED");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
@@ -304,7 +304,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfInstances()).isEqualTo(2);
         assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfActiveInstances()).isEqualTo(1);
         assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfCompletedInstances()).isEqualTo(1);
-        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).isSequential()).isEqualTo(false);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).isSequential()).isFalse();
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
@@ -422,9 +422,9 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
 
         assertThat(activityEvent.getActivityId()).isEqualTo("task");
         assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfInstances()).isEqualTo(2);
-        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfActiveInstances()).isEqualTo(0);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfActiveInstances()).isZero();
         assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).getNumberOfCompletedInstances()).isEqualTo(2);
-        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).isSequential()).isEqualTo(false);
+        assertThat(((FlowableMultiInstanceActivityCompletedEvent) activityEvent).isSequential()).isFalse();
 
         activityEvent = (FlowableActivityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(activityEvent.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
@@ -793,8 +793,8 @@ public class HistoryServiceTaskLogTest {
                 hasManagement = true;
             }
 
-            assertThat(hasKermit).isEqualTo(true);
-            assertThat(hasManagement).isEqualTo(true);
+            assertThat(hasKermit).isTrue();
+            assertThat(hasManagement).isTrue();
 
             taskService.complete(tasks.get(0).getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
@@ -104,7 +104,7 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
         assertThat(user.getFirstName()).isEqualTo("John");
         assertThat(user.getLastName()).isEqualTo("Doe");
         assertThat(user.getEmail()).isEqualTo("johndoe@alfresco.com");
-        assertThat(user.getTenantId()).isEqualTo(null);
+        assertThat(user.getTenantId()).isNull();
 
         identityService.deleteUser(user.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeActivityInstanceTest.java
@@ -217,7 +217,7 @@ public class RuntimeActivityInstanceTest extends PluggableFlowableTestCase {
 
         runtimeService.trigger(runtimeService.createExecutionQuery().processInstanceId(pi.getId()).onlyChildExecutions().singleResult().getId());
 
-        assertThat(0L).isEqualTo(runtimeService.createActivityInstanceQuery().processInstanceId(pi.getId()).count());
+        assertThat(runtimeService.createActivityInstanceQuery().processInstanceId(pi.getId()).count()).isZero();
     }
 
     protected void assertThatActivityInstancesAreSame(String userTask) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
@@ -108,7 +108,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("task2");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(1);
@@ -174,7 +174,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskAfter");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -1172,7 +1172,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(4);
 
         Optional<Execution> parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
-        assertThat(parallelJoinExecution.isPresent()).isFalse();
+        assertThat(parallelJoinExecution).isNotPresent();
 
         taskService.complete(tasks.get(0).getId());
 
@@ -1183,7 +1183,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(3);
 
         parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
-        assertThat(parallelJoinExecution.isPresent()).isTrue();
+        assertThat(parallelJoinExecution).isPresent();
         assertThat(((ExecutionEntity) parallelJoinExecution.get()).isActive()).isFalse();
 
         taskService.complete(tasks.get(0).getId());
@@ -1304,7 +1304,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(5);
 
         Optional<Execution> parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
-        assertThat(parallelJoinExecution.isPresent()).isFalse();
+        assertThat(parallelJoinExecution).isNotPresent();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").singleResult();
         taskService.complete(task.getId());
@@ -1322,7 +1322,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(4);
 
         parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
-        assertThat(parallelJoinExecution.isPresent()).isTrue();
+        assertThat(parallelJoinExecution).isPresent();
         assertThat(((ExecutionEntity) parallelJoinExecution.get()).isActive()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").singleResult();
@@ -1442,7 +1442,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(5);
 
         Optional<Execution> inclusiveJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("inclusiveJoin")).findFirst();
-        assertThat(inclusiveJoinExecution.isPresent()).isTrue();
+        assertThat(inclusiveJoinExecution).isPresent();
         assertThat(((ExecutionEntity) inclusiveJoinExecution.get()).isActive()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
@@ -90,7 +90,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -133,7 +133,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("firstTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -171,7 +171,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -206,7 +206,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -262,7 +262,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -312,7 +312,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("secondTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -369,7 +369,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         Job timer = (Job) entityEvent.getEntity();
         assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -429,7 +429,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -462,7 +462,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
         Job timerJob2 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob2).isNotNull();
-        assertThat(!timerJob1.getExecutionId().equals(timerJob2.getExecutionId())).isTrue();
+        assertThat(timerJob1.getExecutionId()).isNotEqualTo(timerJob2.getExecutionId());
 
         // Verify events
         Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
@@ -491,7 +491,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         timer = (Job) entityEvent.getEntity();
         assertThat(getJobActivityId(timer)).isEqualTo("secondTimerEvent");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         Job job = managementService.moveTimerToExecutableJob(timerJob2.getId());
         managementService.executeJob(job.getId());
@@ -545,7 +545,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -600,7 +600,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -660,7 +660,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -715,7 +715,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -778,7 +778,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -841,7 +841,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -905,7 +905,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -976,7 +976,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1042,7 +1042,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1099,7 +1099,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1154,7 +1154,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
         managementService.executeJob(executableJob.getId());
@@ -1211,7 +1211,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask2");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1270,7 +1270,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask2");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1320,7 +1320,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         Job timer = (Job) entityEvent.getEntity();
         assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -1387,7 +1387,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         Job timer = (Job) entityEvent.getEntity();
         assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1448,7 +1448,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         Job timer = (Job) entityEvent.getEntity();
         assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         Job executableTimerJob = managementService.moveTimerToExecutableJob(timerJob.getId());
         managementService.executeJob(executableTimerJob.getId());
@@ -1501,7 +1501,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1569,7 +1569,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1624,7 +1624,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1691,7 +1691,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1745,7 +1745,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1811,7 +1811,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1864,7 +1864,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1932,7 +1932,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -1992,7 +1992,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTaskAfter");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -2047,7 +2047,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTaskAfter");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -2102,7 +2102,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -2164,7 +2164,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subTask");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -2229,7 +2229,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subtask2");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 
@@ -2285,7 +2285,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED);
         assertThat(((FlowableActivityEvent) event).getActivityId()).isEqualTo("subtask2");
 
-        assertThat(!iterator.hasNext()).isTrue();
+        assertThat(iterator.hasNext()).isFalse();
 
         taskService.complete(task.getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
@@ -358,8 +358,8 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
         assertThat(migrationResult.getAllMigrationParts()).hasSize(successInstances.size() + failedInstances.size());
         assertThat(migrationResult.getWaitingMigrationParts()).isEmpty();
-        assertThat(migrationResult.getSuccessfulMigrationParts()).hasSize(successInstances.size());
-        assertThat(migrationResult.getFailedMigrationParts()).hasSize(failedInstances.size());
+        assertThat(migrationResult.getSuccessfulMigrationParts()).hasSameSizeAs(successInstances);
+        assertThat(migrationResult.getFailedMigrationParts()).hasSameSizeAs(failedInstances);
 
         for (ProcessInstanceBatchMigrationPartResult part : migrationResult.getSuccessfulMigrationParts()) {
             assertThat(part.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
@@ -382,11 +382,11 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         assertThat(searchBatches.get(0).getCreateTime()).isNotNull();
 
         assertThat(managementService.createBatchQuery().searchKey(version1ProcessDef.getId()).count()).isEqualTo(1);
-        assertThat(managementService.createBatchQuery().searchKey(version2ProcessDef.getId()).count()).isEqualTo(0);
-        assertThat(managementService.createBatchQuery().searchKey2(version1ProcessDef.getId()).count()).isEqualTo(0);
+        assertThat(managementService.createBatchQuery().searchKey(version2ProcessDef.getId()).count()).isZero();
+        assertThat(managementService.createBatchQuery().searchKey2(version1ProcessDef.getId()).count()).isZero();
         assertThat(managementService.createBatchQuery().searchKey2(version2ProcessDef.getId()).count()).isEqualTo(1);
         assertThat(managementService.createBatchQuery().createTimeLowerThan(new Date()).count()).isEqualTo(1);
-        assertThat(managementService.createBatchQuery().createTimeHigherThan(new Date()).count()).isEqualTo(0);
+        assertThat(managementService.createBatchQuery().createTimeHigherThan(new Date()).count()).isZero();
 
         List<BatchPart> searchBatchParts = managementService.findBatchPartsByBatchId(migrationBatch.getId());
         assertThat(searchBatchParts).hasSize(20);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
@@ -114,7 +114,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .migrateToProcessDefinition(version2ProcessDef.getId())
                 .validateMigration(processInstance.getId());
 
-        assertThat(validationResult.isMigrationValid()).isEqualTo(true);
+        assertThat(validationResult.isMigrationValid()).isTrue();
 
         // Migrate process
         ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
@@ -721,7 +721,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivityInstancesAfter = historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc()
                     .list();
-            assertThat(historicActivityInstancesAfter).hasSize(historicActivityInstancesBefore.size());
+            assertThat(historicActivityInstancesAfter).hasSameSizeAs(historicActivityInstancesBefore);
             assertThat(historicActivityInstancesBefore)
                     .usingElementComparatorIgnoringFields("revision", "processDefinitionId")
                     .containsExactlyInAnyOrderElementsOf(historicActivityInstancesAfter);
@@ -729,7 +729,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTaskInstancesAfter = historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().list();
 
-                assertThat(historicTaskInstancesAfter).hasSize(historicTaskInstancesBefore.size());
+                assertThat(historicTaskInstancesAfter).hasSameSizeAs(historicTaskInstancesBefore);
                 assertThat(historicTaskInstancesBefore)
                         .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "originalPersistentState", "lastUpdateTime")
                         .containsExactlyInAnyOrderElementsOf(historicTaskInstancesAfter);
@@ -819,7 +819,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivityInstancesAfter = historyService.createHistoricActivityInstanceQuery().orderByExecutionId().asc()
                     .list();
-            assertThat(historicActivityInstancesAfter).hasSize(historicActivityInstancesBefore.size());
+            assertThat(historicActivityInstancesAfter).hasSameSizeAs(historicActivityInstancesBefore);
             assertThat(historicActivityInstancesBefore)
                     .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "assignee", "originalPersistentState")
                     .containsExactlyInAnyOrderElementsOf(historicActivityInstancesAfter);
@@ -827,7 +827,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
                 List<HistoricTaskInstance> historicTaskInstancesAfter = historyService.createHistoricTaskInstanceQuery().orderByExecutionId().asc().list();
 
-                assertThat(historicTaskInstancesAfter).hasSize(historicTaskInstancesBefore.size());
+                assertThat(historicTaskInstancesAfter).hasSameSizeAs(historicTaskInstancesBefore);
                 assertThat(historicTaskInstancesBefore)
                         .usingElementComparatorIgnoringFields("revision", "processDefinitionId", "assignee", "originalPersistentState", "lastUpdateTime")
                         .containsExactlyInAnyOrderElementsOf(historicTaskInstancesAfter);
@@ -1174,7 +1174,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         List<Task> tasksAfter = taskService.createTaskQuery().list();
-        assertThat(tasksAfter.size()).isEqualTo(1);
+        assertThat(tasksAfter).hasSize(1);
         Task taskAfter = tasksAfter.get(0);
         assertThat(taskAfter.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
         assertThat(taskAfter.getTaskDefinitionKey()).isEqualTo("userTask1Id");
@@ -1182,7 +1182,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<HistoricTaskInstance> historicTaskInstancesAfter = historyService.createHistoricTaskInstanceQuery().list();
-            assertThat(historicTaskInstancesAfter.size()).isEqualTo(1);
+            assertThat(historicTaskInstancesAfter).hasSize(1);
             HistoricTaskInstance historicTaskAfter = historicTaskInstancesAfter.get(0);
             assertThat(historicTaskAfter.getProcessDefinitionId()).isEqualTo(version2ProcessDef.getId());
             assertThat(historicTaskAfter.getTaskDefinitionKey()).isEqualTo("userTask1Id");
@@ -1533,7 +1533,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .containsExactly(FlowableEngineEventType.TIMER_SCHEDULED);
         Optional<FlowableEvent> timerEvent = changeStateEventListener.getEvents().stream()
                 .filter(event -> event.getType().equals(FlowableEngineEventType.TIMER_SCHEDULED)).findFirst();
-        assertThat(timerEvent.isPresent()).isTrue();
+        assertThat(timerEvent).isPresent();
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) timerEvent.get();
         Job timer = (Job) entityEvent.getEntity();
         assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
@@ -1637,7 +1637,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .containsExactly(FlowableEngineEventType.JOB_CANCELED);
         Optional<FlowableEvent> jobCancelEvent = changeStateEventListener.getEvents().stream()
                 .filter(event -> event.getType().equals(FlowableEngineEventType.JOB_CANCELED)).findFirst();
-        assertThat(jobCancelEvent.isPresent()).isTrue();
+        assertThat(jobCancelEvent).isPresent();
         FlowableEngineEntityEvent entityEvent = (FlowableEngineEntityEvent) jobCancelEvent.get();
         Job timer = (Job) entityEvent.getEntity();
         assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -1567,7 +1567,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
             List<HistoricDetail> resultSet = historyService.createHistoricDetailQuery().processInstanceId(processInstanceId).list();
             for (HistoricDetail currentHistoricDetail : resultSet) {
-                assertThat(currentHistoricDetail instanceof HistoricDetailVariableInstanceUpdateEntity).isTrue();
+                assertThat(currentHistoricDetail).isInstanceOf(HistoricDetailVariableInstanceUpdateEntity.class);
                 HistoricDetailVariableInstanceUpdateEntity historicVariableUpdate = (HistoricDetailVariableInstanceUpdateEntity) currentHistoricDetail;
 
                 if (historicVariableUpdate.getName().equals(variableName)) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskDelegateExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskDelegateExpressionTest.java
@@ -62,20 +62,20 @@ public class ServiceTaskDelegateExpressionTest extends PluggableFlowableTestCase
                 ActivityInstanceEntityManager activityInstanceEntityManager = processEngineConfiguration.getActivityInstanceEntityManager();
                 
                 List<ActivityInstanceEntity> activityInstances = activityInstanceEntityManager.findActivityInstancesByProcessInstanceId(processId, true);
-                assertThat(activityInstances.size()).isEqualTo(5);
+                assertThat(activityInstances).hasSize(5);
                 Map<String, List<ActivityInstanceEntity>> activityInstanceMap = activityInstances.stream().collect(Collectors.groupingBy(ActivityInstanceEntity::getActivityId));
                 assertThat(activityInstanceMap.containsKey("theStart")).isTrue();
-                assertThat(activityInstanceMap.get("theStart").size()).isEqualTo(1);
+                assertThat(activityInstanceMap.get("theStart")).hasSize(1);
                 assertThat(activityInstanceMap.get("theStart").get(0).getEndTime()).isNotNull();
                 assertThat(activityInstanceMap.get("theStart").get(0).getTransactionOrder()).isEqualTo(1);
                 
                 assertThat(activityInstanceMap.containsKey("service1")).isTrue();
-                assertThat(activityInstanceMap.get("service1").size()).isEqualTo(1);
+                assertThat(activityInstanceMap.get("service1")).hasSize(1);
                 assertThat(activityInstanceMap.get("service1").get(0).getEndTime()).isNotNull();
                 assertThat(activityInstanceMap.get("service1").get(0).getTransactionOrder()).isEqualTo(3);
                 
                 assertThat(activityInstanceMap.containsKey("usertask1")).isTrue();
-                assertThat(activityInstanceMap.get("usertask1").size()).isEqualTo(1);
+                assertThat(activityInstanceMap.get("usertask1")).hasSize(1);
                 assertThat(activityInstanceMap.get("usertask1").get(0).getEndTime()).isNull();
                 assertThat(activityInstanceMap.get("usertask1").get(0).getTransactionOrder()).isEqualTo(5);
                 
@@ -99,15 +99,15 @@ public class ServiceTaskDelegateExpressionTest extends PluggableFlowableTestCase
                 ActivityInstanceEntityManager activityInstanceEntityManager = processEngineConfiguration.getActivityInstanceEntityManager();
                 
                 List<ActivityInstanceEntity> activityInstances = activityInstanceEntityManager.findActivityInstancesByProcessInstanceId(processId, true);
-                assertThat(activityInstances.size()).isEqualTo(7);
+                assertThat(activityInstances).hasSize(7);
                 Map<String, List<ActivityInstanceEntity>> activityInstanceMap = activityInstances.stream().collect(Collectors.groupingBy(ActivityInstanceEntity::getActivityId));
                 assertThat(activityInstanceMap.containsKey("usertask1")).isTrue();
-                assertThat(activityInstanceMap.get("usertask1").size()).isEqualTo(1);
+                assertThat(activityInstanceMap.get("usertask1")).hasSize(1);
                 assertThat(activityInstanceMap.get("usertask1").get(0).getEndTime()).isNotNull();
                 assertThat(activityInstanceMap.get("usertask1").get(0).getTransactionOrder()).isEqualTo(5);
                 
                 assertThat(activityInstanceMap.containsKey("theEnd")).isTrue();
-                assertThat(activityInstanceMap.get("theEnd").size()).isEqualTo(1);
+                assertThat(activityInstanceMap.get("theEnd")).hasSize(1);
                 assertThat(activityInstanceMap.get("theEnd").get(0).getEndTime()).isNotNull();
                 assertThat(activityInstanceMap.get("theEnd").get(0).getTransactionOrder()).isEqualTo(2);
                 
@@ -133,7 +133,7 @@ public class ServiceTaskDelegateExpressionTest extends PluggableFlowableTestCase
                 ActivityInstanceEntityManager activityInstanceEntityManager = processEngineConfiguration.getActivityInstanceEntityManager();
                 
                 List<ActivityInstanceEntity> activityInstances = activityInstanceEntityManager.findActivityInstancesByProcessInstanceId(processId, true);
-                assertThat(activityInstances.size()).isEqualTo(5);
+                assertThat(activityInstances).hasSize(5);
                 
                 ActivityInstanceEntity activityInstance = activityInstances.get(0);
                 assertThat(activityInstance.getActivityId()).isEqualTo("theStart");
@@ -172,7 +172,7 @@ public class ServiceTaskDelegateExpressionTest extends PluggableFlowableTestCase
                 ActivityInstanceEntityManager activityInstanceEntityManager = processEngineConfiguration.getActivityInstanceEntityManager();
                 
                 List<ActivityInstanceEntity> activityInstances = activityInstanceEntityManager.findActivityInstancesByProcessInstanceId(processId, true);
-                assertThat(activityInstances.size()).isEqualTo(0);
+                assertThat(activityInstances).isEmpty();
                 
                 return null;
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
@@ -57,7 +57,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertThat(historicActivityInstance.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(historicActivityInstance.getStartTime()).isNotNull();
         assertThat(historicActivityInstance.getEndTime()).isNotNull();
-        assertThat(historicActivityInstance.getDurationInMillis() >= 0).isTrue();
+        assertThat(historicActivityInstance.getDurationInMillis()).isGreaterThanOrEqualTo(0);
     }
     
     @Test
@@ -166,7 +166,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertThat(historicActivityInstance.getActivityId()).isEqualTo("receive");
         assertThat(historicActivityInstance.getActivityType()).isEqualTo("receiveTask");
         assertThat(historicActivityInstance.getEndTime()).isNotNull();
-        assertThat(historicActivityInstance.getDurationInMillis() >= 0).isTrue();
+        assertThat(historicActivityInstance.getDurationInMillis()).isGreaterThanOrEqualTo(0);
         assertThat(historicActivityInstance.getProcessDefinitionId()).isNotNull();
         assertThat(historicActivityInstance.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(historicActivityInstance.getStartTime()).isNotNull();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -523,7 +523,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
              * 
              * execution id: On which execution it was set activity id: in which activity was the process instance when setting the variable
              */
-            assertThat(historicActivityInstance2.getExecutionId().equals(update2.getExecutionId())).isFalse();
+            assertThat(historicActivityInstance2).isNotEqualTo(update2.getExecutionId());
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/json/JsonTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/json/JsonTest.java
@@ -514,11 +514,11 @@ public class JsonTest extends PluggableFlowableTestCase {
 
         value = (ObjectNode) runtimeService.getVariable(processInstance.getId(), BIG_JSON_OBJ);
         assertThat(value).isNotNull();
-        assertThat(value.toString()).isEqualTo(createBigJsonObject().toString());
+        assertThat(value).hasToString(createBigJsonObject().toString());
 
         VariableInstance variableInstance = runtimeService.getVariableInstance(processInstance.getId(), BIG_JSON_OBJ);
         assertThat(variableInstance).isNotNull();
-        assertThat(variableInstance.getValue().toString()).isEqualTo(createBigJsonObject().toString());
+        assertThat(variableInstance.getValue()).hasToString(createBigJsonObject().toString());
 
         task = taskService.createTaskQuery().active().singleResult();
         assertThat(task).isNotNull();
@@ -532,7 +532,7 @@ public class JsonTest extends PluggableFlowableTestCase {
             assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo(BIG_JSON_OBJ);
             value = (ObjectNode) historicVariableInstances.get(0).getValue();
             assertThat(value).isNotNull();
-            assertThat(value.toString()).isEqualTo(createBigJsonObject().toString());
+            assertThat(value).hasToString(createBigJsonObject().toString());
 
             assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo(MY_JSON_OBJ);
             value = (ObjectNode) historicVariableInstances.get(1).getValue();
@@ -550,7 +550,7 @@ public class JsonTest extends PluggableFlowableTestCase {
                     .singleResult();
 
             assertThat(historicVariableInstance).isNotNull();
-            assertThat(historicVariableInstance.getValue().toString()).isEqualTo(createBigJsonObject().toString());
+            assertThat(historicVariableInstance.getValue()).hasToString(createBigJsonObject().toString());
         }
 
         // It should be possible do remove a json variable

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/ServiceTaskLoggingTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/ServiceTaskLoggingTest.java
@@ -211,7 +211,7 @@ public class ServiceTaskLoggingTest extends ResourceFlowableTestCase {
 
         ObjectNode loggingNode = FlowableLoggingListener.TEST_LOGGING_NODES.get(0);
         assertThat(loggingNode.get("type").asText()).isEqualTo(LoggingSessionConstants.TYPE_PROCESS_STARTED);
-        assertThat(loggingNode.get("message").asText().contains("Started process instance with id ")).isTrue();
+        assertThat(loggingNode.get("message").asText()).contains("Started process instance with id ");
         assertThat(loggingNode.get("scopeId").asText()).isEqualTo(processInstance.getId());
         assertThat(loggingNode.get("scopeType").asText()).isEqualTo(ScopeTypes.BPMN);
         assertThat(loggingNode.get("scopeDefinitionId").asText()).isEqualTo(processDefinition.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/DurationHelperTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/calendar/DurationHelperTest.java
@@ -116,7 +116,7 @@ public class DurationHelperTest {
         DurationHelper dh = new DurationHelper("R2/2013-11-03T00:45:00-04:00/PT1H", testingClock);
         Calendar expected = parseCalendarWithOffset("20131103-01:45:00-04:00", TimeZone.getTimeZone("US/Eastern"));
 
-        assertThat(expected.compareTo(dh.getCalendarAfter())).isZero();
+        assertThat(expected).isEqualByComparingTo(dh.getCalendarAfter());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class DurationHelperTest {
         DurationHelper dh = new DurationHelper("R2/2013-11-03T00:45:00-04:00/PT2H", testingClock);
         Calendar expected = parseCalendarWithOffset("20131103-01:45:00-05:00", TimeZone.getTimeZone("US/Eastern"));
 
-        assertThat(expected.compareTo(dh.getCalendarAfter())).isZero();
+        assertThat(expected).isEqualByComparingTo(dh.getCalendarAfter());
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/rules/RulesDeployerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/rules/RulesDeployerTest.java
@@ -44,7 +44,7 @@ public class RulesDeployerTest extends ResourceFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("rulesDeployment", variableMap);
         assertThat(processInstance).isNotNull();
-        assertThat(processInstance.getProcessDefinitionId().startsWith("rulesDeployment:1")).isTrue();
+        assertThat(processInstance.getProcessDefinitionId()).startsWith("rulesDeployment:1");
 
         runtimeService.getVariable(processInstance.getId(), "order");
         assertThat(order.isValid()).isTrue();


### PR DESCRIPTION
After further review of recent changes found small idiomatic changes to assertj style.
