### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.engine.test.cfg;
 
-import static org.flowable.engine.impl.test.AbstractTestCase.assertEquals;
-import static org.flowable.engine.impl.test.AbstractTestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
@@ -40,14 +39,14 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemProcessEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
 
         // then
         // if the process engine is closed
         processEngine.close();
 
         // the idle connections are closed
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
     @Test
@@ -62,17 +61,17 @@ public class ForceCloseMybatisConnectionPoolTest {
 
         PooledDataSource pooledDataSource = (PooledDataSource) standaloneInMemProcessEngineConfiguration.getDataSource();
         PoolState state = pooledDataSource.getPoolState();
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
 
         // then
         // if the process engine is closed
         processEngine.close();
 
         // the idle connections are not closed
-        assertTrue(state.getIdleConnectionCount() > 0);
+        assertThat(state.getIdleConnectionCount()).isGreaterThan(0);
 
         pooledDataSource.forceCloseAll();
-        assertEquals(0, state.getIdleConnectionCount());
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/RetryInterceptorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/RetryInterceptorTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.cfg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -63,10 +65,10 @@ public class RetryInterceptorTest {
             processEngine.getManagementService().executeCommand(new CommandThrowingOptimisticLockingException());
             Assert.fail("ActivitiException expected.");
         } catch (FlowableException e) {
-            Assert.assertTrue(e.getMessage().contains(retryInterceptor.getNumOfRetries() + " retries failed"));
+            assertThat(e.getMessage()).contains(retryInterceptor.getNumOfRetries() + " retries failed");
         }
 
-        Assert.assertEquals(retryInterceptor.getNumOfRetries() + 1, counter.get()); // +1, we retry 3 times, so one extra for the regular execution
+        assertThat(counter.get()).isEqualTo(retryInterceptor.getNumOfRetries() + 1); // +1, we retry 3 times, so one extra for the regular execution
     }
 
     public static AtomicInteger counter = new AtomicInteger();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/ChangeConfigAndRebootEngineTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/ChangeConfigAndRebootEngineTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.cfg.executioncount;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.common.engine.impl.interceptor.Command;
@@ -116,18 +118,18 @@ public class ChangeConfigAndRebootEngineTest extends ResourceFlowableTestCase {
                         ValidateExecutionRelatedEntityCountCfgCmd.PROPERTY_EXECUTION_RELATED_ENTITY_COUNT);
             }
         });
-        assertEquals(expectedValue, Boolean.parseBoolean(propertyEntity.getValue()));
+        assertThat(Boolean.parseBoolean(propertyEntity.getValue())).isEqualTo(expectedValue);
     }
 
     protected void assertExecutions(ProcessInstance processInstance, boolean expectedCountIsEnabledFlag) {
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         for (Execution execution : executions) {
             CountingExecutionEntity countingExecutionEntity = (CountingExecutionEntity) execution;
-            assertEquals(expectedCountIsEnabledFlag, countingExecutionEntity.isCountEnabled());
+            assertThat(countingExecutionEntity.isCountEnabled()).isEqualTo(expectedCountIsEnabledFlag);
 
             if (expectedCountIsEnabledFlag && execution.getParentId() != null) {
-                assertEquals(1, countingExecutionEntity.getTaskCount());
+                assertThat(countingExecutionEntity.getTaskCount()).isEqualTo(1);
             }
         }
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.cfg.executioncount;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -126,8 +128,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         // Validate (cause this tended to be screwed up)
         List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().list();
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
-            Assert.assertNotNull(historicActivityInstance.getStartTime());
-            Assert.assertNotNull(historicActivityInstance.getEndTime());
+            assertThat(historicActivityInstance.getStartTime()).isNotNull();
+            assertThat(historicActivityInstance.getEndTime()).isNotNull();
         }
 
         FlowableProfiler.getInstance().reset();
@@ -136,7 +138,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
 
-        assertEquals(runtimeService.createActivityInstanceQuery().count(), 0L);
+        assertThat(runtimeService.createActivityInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -155,8 +157,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
 
             assertNoUpdatesAndDeletes("StartProcessInstanceCmd");
 
-            Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-            Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1);
         }
     }
 
@@ -175,8 +177,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                     "HistoricActivityInstanceEntityImpl-bulk-with-17", 1L);
             assertNoUpdatesAndDeletes("StartProcessInstanceCmd");
 
-            Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-            Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1);
         }
     }
 
@@ -195,8 +197,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                     "HistoricActivityInstanceEntityImpl-bulk-with-17", 1L);
             assertNoUpdatesAndDeletes("StartProcessInstanceCmd");
 
-            Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-            Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1);
         }
     }
 
@@ -214,8 +216,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                     "HistoricProcessInstanceEntityImpl", 1L);
             assertNoUpdatesAndDeletes("StartProcessInstanceCmd");
 
-            Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-            Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1);
         }
     }
 
@@ -233,8 +235,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                     "HistoricProcessInstanceEntityImpl", 1L);
             assertNoUpdatesAndDeletes("StartProcessInstanceCmd");
 
-            Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-            Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1);
         }
     }
 
@@ -253,8 +255,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                     "HistoricProcessInstanceEntityImpl", 1L);
             assertNoUpdatesAndDeletes("StartProcessInstanceCmd");
 
-            Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-            Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1);
         }
     }
 
@@ -273,8 +275,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                     "HistoricVariableInstanceEntityImpl", 1L);
             assertNoUpdatesAndDeletes("StartProcessInstanceCmd");
 
-            Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-            Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1);
         }
     }
 
@@ -308,8 +310,8 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                             "Bulk-delete-deleteTasksByExecutionId", 1L,
                             "Bulk-delete-deleteActivityInstancesByProcessInstanceId", 1L);
 
-            Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-            Assert.assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1);
         }
     }
 
@@ -614,35 +616,39 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                 System.out.println(command);
             }
         }
-        Assert.assertEquals(commands.length, allStats.size());
+        assertThat(allStats).hasSameSizeAs(commands);
 
         for (String command : commands) {
-            Assert.assertNotNull("Could not get stats for " + command, getStatsForCommand(command, allStats));
+            assertThat(getStatsForCommand(command, allStats)).as("Could not get stats for " + command).isNotNull();
         }
     }
 
     protected void assertDatabaseSelects(String commandClass, Object... expectedSelects) {
         CommandStats stats = getStats(commandClass);
 
-        Assert.assertEquals("Unexpected number of database selects for " + commandClass + ". ", expectedSelects.length / 2, stats.getDbSelects().size());
+        assertThat(stats.getDbSelects()).as("Unexpected number of database selects for " + commandClass + ". ").hasSize(expectedSelects.length / 2);
 
         for (int i = 0; i < expectedSelects.length; i += 2) {
             String dbSelect = (String) expectedSelects[i];
             Long count = (Long) expectedSelects[i + 1];
 
-            Assert.assertEquals("Wrong select count for " + dbSelect, count, stats.getDbSelects().get(dbSelect));
+            assertThat(stats.getDbSelects())
+                    .as("Wrong select count for " + dbSelect)
+                    .containsEntry(dbSelect, count);
         }
     }
 
     protected void assertDatabaseUpdates(String commandClass, Object... expectedUpdates) {
         CommandStats stats = getStats(commandClass);
-        Assert.assertEquals("Unexpected number of database updates for " + commandClass + ". ", expectedUpdates.length / 2, stats.getDbUpdates().size());
+        assertThat(stats.getDbUpdates()).as("Unexpected number of database updates for " + commandClass + ". ").hasSize(expectedUpdates.length / 2);
 
         for (int i = 0; i < expectedUpdates.length; i += 2) {
             String dbUpdate = (String) expectedUpdates[i];
             Long count = (Long) expectedUpdates[i + 1];
 
-            Assert.assertEquals("Wrong update count for " + dbUpdate, count, stats.getDbUpdates().get(dbUpdate));
+            assertThat(stats.getDbUpdates())
+                    .as("Wrong update count for " + dbUpdate)
+                    .containsEntry(dbUpdate, count);
         }
     }
 
@@ -657,7 +663,9 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
             String dbInsert = (String) expectedInserts[i];
             Long count = (Long) expectedInserts[i + 1];
 
-            Assert.assertEquals("Insert count for " + dbInsert + " not correct", count, stats.getDbInserts().get(getQualifiedClassName(dbInsert)));
+            assertThat(stats.getDbInserts())
+                    .as("Insert count for " + dbInsert + " not correct")
+                    .containsEntry(getQualifiedClassName(dbInsert), count);
         }
     }
 
@@ -672,13 +680,15 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
             String dbDelete = (String) expectedDeletes[i];
             Long count = (Long) expectedDeletes[i + 1];
 
-            Assert.assertEquals("Delete count count for " + dbDelete + " not correct", count, stats.getDbDeletes().get(getQualifiedClassName(dbDelete)));
+            assertThat(stats.getDbDeletes())
+                    .as("Delete count count for " + dbDelete + " not correct")
+                    .containsEntry(getQualifiedClassName(dbDelete), count);
         }
     }
 
     protected void assertNoInserts(String commandClass) {
         CommandStats stats = getStats(commandClass);
-        Assert.assertEquals(0, stats.getDbInserts().size());
+        assertThat(stats.getDbInserts()).isEmpty();
     }
 
     protected void assertNoUpdatesAndDeletes(String commandClass) {
@@ -688,12 +698,12 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
 
     protected void assertNoDeletes(String commandClass) {
         CommandStats stats = getStats(commandClass);
-        Assert.assertEquals(0, stats.getDbDeletes().size());
+        assertThat(stats.getDbDeletes()).isEmpty();
     }
 
     protected void assertNoUpdates(String commandClass) {
         CommandStats stats = getStats(commandClass);
-        Assert.assertEquals(0, stats.getDbUpdates().size());
+        assertThat(stats.getDbUpdates()).isEmpty();
     }
 
     protected CommandStats getStats(String commandClass) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/multitenant/MultiTenantProcessEngineTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/multitenant/MultiTenantProcessEngineTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.cfg.multitenant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +29,6 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.job.service.impl.asyncexecutor.multitenant.ExecutorPerTenantAsyncExecutor;
 import org.flowable.job.service.impl.asyncexecutor.multitenant.SharedExecutorServiceAsyncExecutor;
 import org.h2.jdbcx.JdbcDataSource;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -186,9 +187,9 @@ public class MultiTenantProcessEngineTest {
     private void assertData(String userId, long nrOfActiveProcessInstances, long nrOfActiveJobs) {
         tenantInfoHolder.setCurrentUserId(userId);
 
-        Assert.assertEquals(nrOfActiveProcessInstances, processEngine.getRuntimeService().createExecutionQuery().onlyProcessInstanceExecutions().count());
-        Assert.assertEquals(nrOfActiveProcessInstances, processEngine.getHistoryService().createHistoricProcessInstanceQuery().unfinished().count());
-        Assert.assertEquals(nrOfActiveJobs, processEngine.getManagementService().createTimerJobQuery().count());
+        assertThat(processEngine.getRuntimeService().createExecutionQuery().onlyProcessInstanceExecutions().count()).isEqualTo(nrOfActiveProcessInstances);
+        assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery().unfinished().count()).isEqualTo(nrOfActiveProcessInstances);
+        assertThat(processEngine.getManagementService().createTimerJobQuery().count()).isEqualTo(nrOfActiveJobs);
 
         tenantInfoHolder.clearCurrentUserId();
         tenantInfoHolder.clearCurrentTenantId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/taskcount/ChangeTaskCountConfigAndRebootEngineTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/taskcount/ChangeTaskCountConfigAndRebootEngineTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.cfg.taskcount;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.common.engine.impl.persistence.entity.PropertyEntity;
@@ -158,11 +160,11 @@ public class ChangeTaskCountConfigAndRebootEngineTest extends ResourceFlowableTe
                         ValidateTaskRelatedEntityCountCfgCmd.PROPERTY_TASK_RELATED_ENTITY_COUNT);
             }
         });
-        assertEquals(expectedValue, Boolean.parseBoolean(propertyEntity.getValue()));
+        assertThat(Boolean.parseBoolean(propertyEntity.getValue())).isEqualTo(expectedValue);
     }
 
     protected void assertTaskCountFlag(org.flowable.task.api.Task task, boolean enableTaskCountFlag) {
-        assertEquals(((CountingTaskEntity) task).isCountEnabled(), enableTaskCountFlag);
+        assertThat(enableTaskCountFlag).isEqualTo(((CountingTaskEntity) task).isCountEnabled());
     }
 
     protected void finishProcessInstance(ProcessInstance processInstance) {


### PR DESCRIPTION
In the continuing quest to convert all of the `flowable-engine` module to assertj this PR converts the test files in the `org.flowable.engine.test.cfg` package.
