### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.examples.groovy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.common.engine.impl.util.CollectionUtil;
@@ -35,7 +37,7 @@ public class GroovyScriptTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("scriptExecution", CollectionUtil.singletonMap("inputArray", inputArray));
 
         Integer result = (Integer) runtimeService.getVariable(pi.getId(), "sum");
-        assertEquals(15, result.intValue());
+        assertThat(result.intValue()).isEqualTo(15);
     }
 
     @Test
@@ -45,8 +47,8 @@ public class GroovyScriptTest extends PluggableFlowableTestCase {
 
         // Since 'def' is used, the 'scriptVar' will be script local
         // and not automatically stored as a process variable.
-        assertNull(runtimeService.getVariable(pi.getId(), "scriptVar"));
-        assertEquals("test123", runtimeService.getVariable(pi.getId(), "myVar"));
+        assertThat(runtimeService.getVariable(pi.getId(), "scriptVar")).isNull();
+        assertThat(runtimeService.getVariable(pi.getId(), "myVar")).isEqualTo("test123");
     }
 
     @Test
@@ -56,10 +58,10 @@ public class GroovyScriptTest extends PluggableFlowableTestCase {
 
         JobQuery jobQuery = managementService.createJobQuery().processInstanceId(processInstance.getId());
         List<Job> jobs = jobQuery.list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
 
         waitForJobExecutorToProcessAllJobs(7000L, 100L);
-        assertEquals(0L, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/ManagementServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/ManagementServiceTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.mgmt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -58,16 +60,16 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
             
         });
 
-        assertEquals(Long.valueOf(13), tableCount.get(tablePrefix + "ACT_GE_PROPERTY"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_GE_BYTEARRAY"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_RE_DEPLOYMENT"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_RU_EXECUTION"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_ID_GROUP"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_ID_MEMBERSHIP"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_ID_USER"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_RE_PROCDEF"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_RU_TASK"));
-        assertEquals(Long.valueOf(0), tableCount.get(tablePrefix + "ACT_RU_IDENTITYLINK"));
+        assertThat(tableCount.get(tablePrefix + "ACT_GE_PROPERTY")).isEqualTo(Long.valueOf(13));
+        assertThat(tableCount.get(tablePrefix + "ACT_GE_BYTEARRAY")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_RE_DEPLOYMENT")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_RU_EXECUTION")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_ID_GROUP")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_ID_MEMBERSHIP")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_ID_USER")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_RE_PROCDEF")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_RU_TASK")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_RU_IDENTITYLINK")).isZero();
     }
 
     @Test
@@ -76,14 +78,14 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         String tablePrefix = processEngineConfiguration.getDatabaseTablePrefix();
 
         TableMetaData tableMetaData = managementService.getTableMetaData(tablePrefix + "ACT_RU_TASK");
-        assertEquals(tableMetaData.getColumnNames().size(), tableMetaData.getColumnTypes().size());
-        assertEquals(30, tableMetaData.getColumnNames().size());
+        assertThat(tableMetaData.getColumnTypes()).hasSameSizeAs(tableMetaData.getColumnNames());
+        assertThat(tableMetaData.getColumnNames()).hasSize(30);
  
         int assigneeIndex = tableMetaData.getColumnNames().indexOf("ASSIGNEE_");
         int createTimeIndex = tableMetaData.getColumnNames().indexOf("CREATE_TIME_");
 
-        assertTrue(assigneeIndex >= 0);
-        assertTrue(createTimeIndex >= 0);
+        assertThat(assigneeIndex).isGreaterThanOrEqualTo(0);
+        assertThat(createTimeIndex).isGreaterThanOrEqualTo(0);
 
         assertOneOf(new String[] { "VARCHAR", "NVARCHAR2", "nvarchar", "NVARCHAR" }, tableMetaData.getColumnTypes().get(assigneeIndex));
         assertOneOf(new String[] { "TIMESTAMP", "TIMESTAMP(6)", "datetime", "DATETIME" }, tableMetaData.getColumnTypes().get(createTimeIndex));

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/TablePageQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/mgmt/TablePageQueryTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.mgmt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,17 +36,17 @@ public class TablePageQueryTest extends PluggableFlowableTestCase {
 
         TablePage tablePage = managementService.createTablePageQuery().tableName(tablePrefix + "ACT_RU_TASK").listPage(0, 5);
 
-        assertEquals(0, tablePage.getFirstResult());
-        assertEquals(5, tablePage.getSize());
-        assertEquals(5, tablePage.getRows().size());
-        assertEquals(20, tablePage.getTotal());
+        assertThat(tablePage.getFirstResult()).isZero();
+        assertThat(tablePage.getSize()).isEqualTo(5);
+        assertThat(tablePage.getRows()).hasSize(5);
+        assertThat(tablePage.getTotal()).isEqualTo(20);
 
         tablePage = managementService.createTablePageQuery().tableName(tablePrefix + "ACT_RU_TASK").listPage(14, 10);
 
-        assertEquals(14, tablePage.getFirstResult());
-        assertEquals(6, tablePage.getSize());
-        assertEquals(6, tablePage.getRows().size());
-        assertEquals(20, tablePage.getTotal());
+        assertThat(tablePage.getFirstResult()).isEqualTo(14);
+        assertThat(tablePage.getSize()).isEqualTo(6);
+        assertThat(tablePage.getRows()).hasSize(6);
+        assertThat(tablePage.getTotal()).isEqualTo(20);
 
         taskService.deleteTasks(taskIds, true);
     }
@@ -68,7 +70,7 @@ public class TablePageQueryTest extends PluggableFlowableTestCase {
     }
 
     private void verifyTaskNames(String[] expectedTaskNames, List<Map<String, Object>> rowData) {
-        assertEquals(expectedTaskNames.length, rowData.size());
+        assertThat(rowData).hasSameSizeAs(expectedTaskNames);
         String columnKey = "NAME_";
 
         // mybatis will return the correct case for postgres table columns from
@@ -78,7 +80,7 @@ public class TablePageQueryTest extends PluggableFlowableTestCase {
         }
 
         for (int i = 0; i < expectedTaskNames.length; i++) {
-            assertEquals(expectedTaskNames[i], rowData.get(i).get(columnKey));
+            assertThat(rowData.get(i).get(columnKey)).isEqualTo(expectedTaskNames[i]);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/processdefinitions/ProcessDefinitionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/processdefinitions/ProcessDefinitionsTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.examples.processdefinitions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,73 +48,64 @@ public class ProcessDefinitionsTest extends PluggableFlowableTestCase {
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().orderByProcessDefinitionKey().asc().orderByProcessDefinitionVersion().desc().list();
 
-        assertNotNull(processDefinitions);
+        assertThat(processDefinitions).isNotNull();
 
-        assertEquals(5, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(5);
 
         ProcessDefinition processDefinition = processDefinitions.get(0);
-        assertEquals("EN", processDefinition.getKey());
-        assertEquals("Expense Note 2", processDefinition.getName());
-        assertTrue(processDefinition.getId().startsWith("EN:2"));
-        assertEquals(2, processDefinition.getVersion());
+        assertThat(processDefinition.getKey()).isEqualTo("EN");
+        assertThat(processDefinition.getName()).isEqualTo("Expense Note 2");
+        assertThat(processDefinition.getId()).startsWith("EN:2");
+        assertThat(processDefinition.getVersion()).isEqualTo(2);
 
         processDefinition = processDefinitions.get(1);
-        assertEquals("EN", processDefinition.getKey());
-        assertEquals("Expense Note 1", processDefinition.getName());
-        assertTrue(processDefinition.getId().startsWith("EN:1"));
-        assertEquals(1, processDefinition.getVersion());
+        assertThat(processDefinition.getKey()).isEqualTo("EN");
+        assertThat(processDefinition.getName()).isEqualTo("Expense Note 1");
+        assertThat(processDefinition.getId()).startsWith("EN:1");
+        assertThat(processDefinition.getVersion()).isEqualTo(1);
 
         processDefinition = processDefinitions.get(2);
-        assertEquals("IDR", processDefinition.getKey());
-        assertEquals("Insurance Damage Report 3", processDefinition.getName());
-        assertTrue(processDefinition.getId().startsWith("IDR:3"));
-        assertEquals(3, processDefinition.getVersion());
+        assertThat(processDefinition.getKey()).isEqualTo("IDR");
+        assertThat(processDefinition.getName()).isEqualTo("Insurance Damage Report 3");
+        assertThat(processDefinition.getId()).startsWith("IDR:3");
+        assertThat(processDefinition.getVersion()).isEqualTo(3);
 
         processDefinition = processDefinitions.get(3);
-        assertEquals("IDR", processDefinition.getKey());
-        assertEquals("Insurance Damage Report 2", processDefinition.getName());
-        assertTrue(processDefinition.getId().startsWith("IDR:2"));
-        assertEquals(2, processDefinition.getVersion());
+        assertThat(processDefinition.getKey()).isEqualTo("IDR");
+        assertThat(processDefinition.getName()).isEqualTo("Insurance Damage Report 2");
+        assertThat(processDefinition.getId()).startsWith("IDR:2");
+        assertThat(processDefinition.getVersion()).isEqualTo(2);
 
         processDefinition = processDefinitions.get(4);
-        assertEquals("IDR", processDefinition.getKey());
-        assertEquals("Insurance Damage Report 1", processDefinition.getName());
-        assertTrue(processDefinition.getId().startsWith("IDR:1"));
-        assertEquals(1, processDefinition.getVersion());
+        assertThat(processDefinition.getKey()).isEqualTo("IDR");
+        assertThat(processDefinition.getName()).isEqualTo("Insurance Damage Report 1");
+        assertThat(processDefinition.getId()).startsWith("IDR:1");
+        assertThat(processDefinition.getVersion()).isEqualTo(1);
 
         Set<String> queryDeploymentIds = new HashSet<>();
         queryDeploymentIds.add(processDefinitions.get(0).getDeploymentId());
         queryDeploymentIds.add(processDefinitions.get(1).getDeploymentId());
         List<ProcessDefinition> queryProcessDefinitions = repositoryService.createProcessDefinitionQuery().deploymentIds(queryDeploymentIds).orderByProcessDefinitionKey().asc()
                 .orderByProcessDefinitionVersion().desc().list();
-        assertEquals(2, queryProcessDefinitions.size());
-
-        processDefinition = queryProcessDefinitions.get(0);
-        assertEquals("EN", processDefinition.getKey());
-        assertEquals("Expense Note 2", processDefinition.getName());
-
-        processDefinition = queryProcessDefinitions.get(1);
-        assertEquals("EN", processDefinition.getKey());
-        assertEquals("Expense Note 1", processDefinition.getName());
+        assertThat(queryProcessDefinitions)
+                .extracting(ProcessDefinition::getKey, ProcessDefinition::getName)
+                .containsExactlyInAnyOrder(
+                        tuple("EN", "Expense Note 2"),
+                        tuple("EN", "Expense Note 1")
+                );
 
         queryDeploymentIds = new HashSet<>();
         queryDeploymentIds.add(processDefinitions.get(0).getDeploymentId());
         queryDeploymentIds.add(processDefinitions.get(3).getDeploymentId());
         queryDeploymentIds.add(processDefinitions.get(4).getDeploymentId());
         queryProcessDefinitions = repositoryService.createProcessDefinitionQuery().deploymentIds(queryDeploymentIds).list();
-        assertEquals(3, queryProcessDefinitions.size());
-
-        processDefinition = queryProcessDefinitions.get(0);
-        assertEquals("EN", processDefinition.getKey());
-        assertEquals("Expense Note 2", processDefinition.getName());
-
-        processDefinition = processDefinitions.get(3);
-        assertEquals("IDR", processDefinition.getKey());
-        assertEquals("Insurance Damage Report 2", processDefinition.getName());
-
-        processDefinition = processDefinitions.get(4);
-        assertEquals("IDR", processDefinition.getKey());
-        assertEquals("Insurance Damage Report 1", processDefinition.getName());
+        assertThat(queryProcessDefinitions)
+                .extracting(ProcessDefinition::getKey, ProcessDefinition::getName)
+                .containsExactlyInAnyOrder(
+                        tuple("EN", "Expense Note 2"),
+                        tuple("IDR", "Insurance Damage Report 1"),
+                        tuple("IDR", "Insurance Damage Report 2")
+                );
 
         deleteDeployments(deploymentIds);
     }
@@ -124,20 +118,15 @@ public class ProcessDefinitionsTest extends PluggableFlowableTestCase {
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().orderByProcessDefinitionKey().asc().orderByProcessDefinitionVersion().desc().list();
 
-        assertNotNull(processDefinitions);
-        assertEquals(2, processDefinitions.size());
-
-        ProcessDefinition processDefinition = processDefinitions.get(0);
-        assertEquals("IDR", processDefinition.getKey());
-        assertEquals("Insurance Damage Report", processDefinition.getName());
-        assertTrue(processDefinition.getId().startsWith("IDR:2"));
-        assertEquals(2, processDefinition.getVersion());
-
-        processDefinition = processDefinitions.get(1);
-        assertEquals("IDR", processDefinition.getKey());
-        assertEquals("Insurance Damage Report", processDefinition.getName());
-        assertTrue(processDefinition.getId().startsWith("IDR:1"));
-        assertEquals(1, processDefinition.getVersion());
+        assertThat(processDefinitions).isNotNull();
+        assertThat(processDefinitions)
+                .extracting(ProcessDefinition::getKey, ProcessDefinition::getName, ProcessDefinition::getVersion)
+                .containsExactly(
+                        tuple("IDR", "Insurance Damage Report", 2),
+                        tuple("IDR", "Insurance Damage Report", 1)
+                );
+        assertThat(processDefinitions.get(0).getId()).startsWith("IDR:2");
+        assertThat(processDefinitions.get(1).getId()).startsWith("IDR:1");
 
         deleteDeployments(deploymentIds);
     }
@@ -146,7 +135,7 @@ public class ProcessDefinitionsTest extends PluggableFlowableTestCase {
     public void testProcessDefinitionDescription() {
         String deploymentId = deployProcessString(("<definitions " + NAMESPACE + " " + TARGET_NAMESPACE + ">" + "  <process id='test' name='test'><documentation>This is a test</documentation></process></definitions>"));
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).singleResult();
-        assertEquals("This is a test", processDefinition.getDescription());
+        assertThat(processDefinition.getDescription()).isEqualTo("This is a test");
 
         deleteDeployments(Collections.singletonList(deploymentId));
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.examples.runtime;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
@@ -35,20 +35,15 @@ public class WatchDogAgendaTest extends ResourceFlowableTestCase {
         this.runtimeService.startProcessInstanceByKey("oneTaskProcess");
         org.flowable.task.api.Task task = this.taskService.createTaskQuery().singleResult();
         this.taskService.complete(task.getId());
-        assertThat(this.runtimeService.createProcessInstanceQuery().count(), is(0L));
+        assertThat(this.runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
     @Deployment(resources = "org/flowable/examples/runtime/WatchDogAgendaTest-endlessloop.bpmn20.xml")
     public void testWatchDogWithEndLessLoop() {
-        try {
-            this.runtimeService.startProcessInstanceByKey("endlessloop");
-            fail("ActivitiException with 'WatchDog limit exceeded.' message expected.");
-        } catch (FlowableException e) {
-            if (!"WatchDog limit exceeded.".equals(e.getMessage())) {
-                fail("Unexpected exception " + e);
-            }
-        }
+        assertThatThrownBy(() -> this.runtimeService.startProcessInstanceByKey("endlessloop"))
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("WatchDog limit exceeded.");
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/task/StandaloneTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/task/StandaloneTaskTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,6 +11,9 @@
  * limitations under the License.
  */
 package org.flowable.examples.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +24,7 @@ import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.task.api.Task;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.junit.jupiter.api.AfterEach;
@@ -59,35 +63,36 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
 
         // Retrieve task list for kermit
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskCandidateUser("kermit").list();
-        assertEquals(1, tasks.size());
-        assertEquals("testTask", tasks.get(0).getName());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("testTask");
 
         // Retrieve task list for gonzo
         tasks = taskService.createTaskQuery().taskCandidateUser("gonzo").list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         task = tasks.get(0);
-        assertEquals("testTask", task.getName());
+        assertThat(task.getName()).isEqualTo("testTask");
 
         task.setName("Update name");
         taskService.saveTask(task);
         tasks = taskService.createTaskQuery().taskCandidateUser("kermit").list();
-        assertEquals(1, tasks.size());
-        assertEquals("Update name", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Update name");
 
         // Claim task
         taskService.claim(taskId, "kermit");
 
         // Tasks shouldn't appear in the candidate tasklists anymore
-        assertTrue(taskService.createTaskQuery().taskCandidateUser("kermit").list().isEmpty());
-        assertTrue(taskService.createTaskQuery().taskCandidateUser("gonzo").list().isEmpty());
+        assertThat(taskService.createTaskQuery().taskCandidateUser("kermit").list()).isEmpty();
+        assertThat(taskService.createTaskQuery().taskCandidateUser("gonzo").list()).isEmpty();
 
         // Complete task
         taskService.deleteTask(taskId, true);
 
         // org.flowable.task.service.Task should be removed from runtime data
         // TODO: check for historic data when implemented!
-        assertNull(taskService.createTaskQuery().taskId(taskId).singleResult());
+        assertThat(taskService.createTaskQuery().taskId(taskId).singleResult()).isNull();
     }
 
     @Test
@@ -105,12 +110,9 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
 
         // second modification on the initial instance
         task2.setDescription("second modification");
-        try {
-            taskService.saveTask(task2);
-            fail("should get an exception here as the task was modified by someone else.");
-        } catch (FlowableOptimisticLockingException expected) {
-            // exception was thrown as expected
-        }
+        assertThatThrownBy(() -> taskService.saveTask(task2))
+                .as("should get an exception here as the task was modified by someone else.")
+                .isInstanceOf(FlowableOptimisticLockingException.class);
 
         taskService.deleteTask(taskId, true);
     }
@@ -120,15 +122,15 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
     public void testRevisionUpdatedOnSave() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
-        assertEquals(1, ((TaskEntity) task).getRevision());
+        assertThat(((TaskEntity) task).getRevision()).isEqualTo(1);
 
         task.setDescription("first modification");
         taskService.saveTask(task);
-        assertEquals(2, ((TaskEntity) task).getRevision());
+        assertThat(((TaskEntity) task).getRevision()).isEqualTo(2);
 
         task.setDescription("second modification");
         taskService.saveTask(task);
-        assertEquals(3, ((TaskEntity) task).getRevision());
+        assertThat(((TaskEntity) task).getRevision()).isEqualTo(3);
 
         taskService.deleteTask(task.getId(), true);
     }
@@ -138,19 +140,19 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
     public void testRevisionUpdatedOnSaveWhenFetchedUsingQuery() {
         org.flowable.task.api.Task task = taskService.newTask();
         taskService.saveTask(task);
-        assertEquals(1, ((TaskEntity) task).getRevision());
+        assertThat(((TaskEntity) task).getRevision()).isEqualTo(1);
 
         task.setAssignee("kermit");
         taskService.saveTask(task);
-        assertEquals(2, ((TaskEntity) task).getRevision());
+        assertThat(((TaskEntity) task).getRevision()).isEqualTo(2);
 
         // Now fetch the task through the query api
         task = taskService.createTaskQuery().singleResult();
-        assertEquals(2, ((TaskEntity) task).getRevision());
+        assertThat(((TaskEntity) task).getRevision()).isEqualTo(2);
         task.setPriority(1);
         taskService.saveTask(task);
 
-        assertEquals(3, ((TaskEntity) task).getRevision());
+        assertThat(((TaskEntity) task).getRevision()).isEqualTo(3);
 
         taskService.deleteTask(task.getId(), true);
     }
@@ -174,13 +176,14 @@ public class StandaloneTaskTest extends PluggableFlowableTestCase {
             Map<String, Object> finishVariables = new HashMap<>();
             finishVariables.put("finishedAmount", 40);
             taskService.complete(task.getId(), finishVariables);
-            
+
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // 4. get completed variable
             List<HistoricVariableInstance> hisVarList = historyService.createHistoricVariableInstanceQuery().taskId(task.getId()).list();
-            assertEquals(1, hisVarList.size());
-            assertEquals(40, hisVarList.get(0).getValue());
+            assertThat(hisVarList)
+                    .extracting(HistoricVariableInstance::getValue)
+                    .containsExactly(40);
 
             // Cleanup
             historyService.deleteHistoricTaskInstance(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/taskforms/TaskFormsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/taskforms/TaskFormsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.taskforms;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,11 +52,11 @@ public class TaskFormsTest extends PluggableFlowableTestCase {
         // Get start form
         String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
         Object startForm = formService.getRenderedStartForm(procDefId);
-        assertNotNull(startForm);
+        assertThat(startForm).isNotNull();
 
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
         String processDefinitionId = processDefinition.getId();
-        assertEquals("org/flowable/examples/taskforms/request.form", formService.getStartFormData(processDefinitionId).getFormKey());
+        assertThat(formService.getStartFormData(processDefinitionId).getFormKey()).isEqualTo("org/flowable/examples/taskforms/request.form");
 
         // Define variables that would be filled in through the form
         Map<String, String> formProperties = new HashMap<>();
@@ -65,25 +67,25 @@ public class TaskFormsTest extends PluggableFlowableTestCase {
 
         // Management should now have a task assigned to them
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskCandidateGroup("management").singleResult();
-        assertEquals("Vacation request by kermit", task.getDescription());
+        assertThat(task.getDescription()).isEqualTo("Vacation request by kermit");
         Object taskForm = formService.getRenderedTaskForm(task.getId());
-        assertNotNull(taskForm);
+        assertThat(taskForm).isNotNull();
 
         // Rejecting the task should put the process back to first task
         taskService.complete(task.getId(), CollectionUtil.singletonMap("vacationApproved", "false"));
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Adjust vacation request", task.getName());
+        assertThat(task.getName()).isEqualTo("Adjust vacation request");
     }
 
     @Test
     @Deployment
     public void testTaskFormUnavailable() {
         String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
-        assertNull(formService.getRenderedStartForm(procDefId));
+        assertThat(formService.getRenderedStartForm(procDefId)).isNull();
 
         runtimeService.startProcessInstanceByKey("noStartOrTaskForm");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNull(formService.getRenderedTaskForm(task.getId()));
+        assertThat(formService.getRenderedTaskForm(task.getId())).isNull();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/test/OneTaskProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/test/OneTaskProcessTest.java
@@ -12,8 +12,9 @@
  */
 package org.flowable.examples.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +72,7 @@ public class OneTaskProcessTest extends PluggableFlowableTestCase {
         this.taskService.complete(this.taskService.createTaskQuery().processInstanceId(oneTaskProcess.getProcessInstanceId()).singleResult().getId());
 
         // Assert -> process instance is finished
-        assertThat(this.runtimeService.createProcessInstanceQuery().processInstanceId(oneTaskProcess.getId()).count(), is(0L));
+        assertThat(this.runtimeService.createProcessInstanceQuery().processInstanceId(oneTaskProcess.getId()).count()).isZero();
     }
 
     @Test
@@ -89,19 +90,16 @@ public class OneTaskProcessTest extends PluggableFlowableTestCase {
         ProcessInstance pUnitTestProcessInstance = this.runtimeService.startProcessInstanceByKey(model.getMainProcess().getId());
 
         waitForJobExecutorToProcessAllJobs(15000, 200);
-        assertThat(this.runtimeService.createProcessInstanceQuery().processInstanceId(pUnitTestProcessInstance.getId()).count(), is(0L));
+        assertThat(this.runtimeService.createProcessInstanceQuery().processInstanceId(pUnitTestProcessInstance.getId()).count()).isZero();
     }
 
     @Test
     @Deployment(resources = {"org/flowable/engine/test/api/twoTasksProcess.bpmn20.xml"})
     public void testProcessModelFailure() {
         // deploy different process - test should fail
-        try {
-            testProcessModelByAnotherProcess(createTestProcessBpmnModel("twoTasksProcess"));
-            fail("Expected exception was not thrown.");
-        } catch (AssertionError e) {
-            assertThat(e.getMessage(), is("\nExpected: is <0L>\n     but: was <1L>"));
-        }
+        assertThatThrownBy(() -> testProcessModelByAnotherProcess(createTestProcessBpmnModel("twoTasksProcess")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("\nExpecting:\n <1L>\nto be equal to:\n <0L>");
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/DataObjectsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/DataObjectsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.variables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Map;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -29,54 +31,54 @@ public class DataObjectsTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("DataObjectsTest");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("usertask2", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("usertask2");
 
         Execution subProcess1 = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess1").singleResult();
         Execution subProcess2 = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess2").singleResult();
 
         Map<String, DataObject> dataObjects = runtimeService.getDataObjects(processInstance.getId());
-        assert 2 == dataObjects.size();
-        assertNotNull(dataObjects.get("VariableA"));
-        assertNotNull(dataObjects.get("VariableB"));
+        assertThat(dataObjects).hasSize(2);
+        assertThat(dataObjects.get("VariableA")).isNotNull();
+        assertThat(dataObjects.get("VariableB")).isNotNull();
 
-        assertNotNull(runtimeService.getDataObject(processInstance.getId(), "VariableA"));
-        assertNotNull(runtimeService.getDataObject(processInstance.getId(), "VariableB"));
+        assertThat(runtimeService.getDataObject(processInstance.getId(), "VariableA")).isNotNull();
+        assertThat(runtimeService.getDataObject(processInstance.getId(), "VariableB")).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subProcess1.getId());
-        assert 3 == dataObjects.size();
+        assertThat(dataObjects).hasSize(3);
 
-        assertNotNull(dataObjects.get("VariableA"));
-        assertNotNull(dataObjects.get("VariableB"));
-        assertNotNull(dataObjects.get("VariableC"));
+        assertThat(dataObjects.get("VariableA")).isNotNull();
+        assertThat(dataObjects.get("VariableB")).isNotNull();
+        assertThat(dataObjects.get("VariableC")).isNotNull();
 
-        assertNotNull(runtimeService.getDataObject(subProcess1.getId(), "VariableA"));
-        assertNotNull(runtimeService.getDataObject(subProcess1.getId(), "VariableB"));
-        assertNotNull(runtimeService.getDataObject(subProcess1.getId(), "VariableC"));
+        assertThat(runtimeService.getDataObject(subProcess1.getId(), "VariableA")).isNotNull();
+        assertThat(runtimeService.getDataObject(subProcess1.getId(), "VariableB")).isNotNull();
+        assertThat(runtimeService.getDataObject(subProcess1.getId(), "VariableC")).isNotNull();
 
         dataObjects = runtimeService.getDataObjects(subProcess2.getId());
-        assert 4 == dataObjects.size();
+        assertThat(dataObjects).hasSize(4);
 
-        assertNotNull(dataObjects.get("VariableA"));
-        assertNotNull(dataObjects.get("VariableB"));
-        assertNotNull(dataObjects.get("VariableC"));
-        assertNotNull(dataObjects.get("VariableD"));
+        assertThat(dataObjects.get("VariableA")).isNotNull();
+        assertThat(dataObjects.get("VariableB")).isNotNull();
+        assertThat(dataObjects.get("VariableC")).isNotNull();
+        assertThat(dataObjects.get("VariableD")).isNotNull();
 
-        assertNotNull(runtimeService.getDataObject(subProcess2.getId(), "VariableA"));
-        assertNotNull(runtimeService.getDataObject(subProcess2.getId(), "VariableB"));
-        assertNotNull(runtimeService.getDataObject(subProcess2.getId(), "VariableC"));
-        assertNotNull(runtimeService.getDataObject(subProcess2.getId(), "VariableD"));
+        assertThat(runtimeService.getDataObject(subProcess2.getId(), "VariableA")).isNotNull();
+        assertThat(runtimeService.getDataObject(subProcess2.getId(), "VariableB")).isNotNull();
+        assertThat(runtimeService.getDataObject(subProcess2.getId(), "VariableC")).isNotNull();
+        assertThat(runtimeService.getDataObject(subProcess2.getId(), "VariableD")).isNotNull();
 
         dataObjects = taskService.getDataObjects(task.getId());
-        assert 4 == dataObjects.size();
+        assertThat(dataObjects).hasSize(4);
 
-        assertNotNull(dataObjects.get("VariableA"));
-        assertNotNull(dataObjects.get("VariableB"));
-        assertNotNull(dataObjects.get("VariableC"));
-        assertNotNull(dataObjects.get("VariableD"));
+        assertThat(dataObjects.get("VariableA")).isNotNull();
+        assertThat(dataObjects.get("VariableB")).isNotNull();
+        assertThat(dataObjects.get("VariableC")).isNotNull();
+        assertThat(dataObjects.get("VariableD")).isNotNull();
 
-        assertNotNull(taskService.getDataObject(task.getId(), "VariableA"));
-        assertNotNull(taskService.getDataObject(task.getId(), "VariableB"));
-        assertNotNull(taskService.getDataObject(task.getId(), "VariableC"));
-        assertNotNull(taskService.getDataObject(task.getId(), "VariableD"));
+        assertThat(taskService.getDataObject(task.getId(), "VariableA")).isNotNull();
+        assertThat(taskService.getDataObject(task.getId(), "VariableB")).isNotNull();
+        assertThat(taskService.getDataObject(task.getId(), "VariableC")).isNotNull();
+        assertThat(taskService.getDataObject(task.getId(), "VariableD")).isNotNull();
     }
 }


### PR DESCRIPTION
Continuing the quest to convert all of `flowable-engine` to `assertj` this PR does all files in the `org.flowable.examples` directory except for the `org.flowable.examples.bpmn` subdirectory in order to keep the size of the PR down.

FWIW, in `StandaloneTaskTest` test file in lines 66-74 I reverted my changes using the `assertThat/extracting/contains` form because when it was there every time I ran the test it generated a concurrent modification exception and test failed. 
