### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/callactivity/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/callactivity/CallActivityTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.examples.bpmn.callactivity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,18 +39,18 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("orderProcess");
         TaskQuery taskQuery = taskService.createTaskQuery();
         org.flowable.task.api.Task verifyCreditTask = taskQuery.singleResult();
-        assertEquals("Verify credit history", verifyCreditTask.getName());
+        assertThat(verifyCreditTask.getName()).isEqualTo("Verify credit history");
 
         // Verify with Query API
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertNotNull(subProcessInstance);
-        assertEquals(pi.getId(), runtimeService.createProcessInstanceQuery().subProcessInstanceId(subProcessInstance.getId()).singleResult().getId());
+        assertThat(subProcessInstance).isNotNull();
+        assertThat(runtimeService.createProcessInstanceQuery().subProcessInstanceId(subProcessInstance.getId()).singleResult().getId()).isEqualTo(pi.getId());
 
         // Completing the task with approval, will end the subprocess and
         // continue the original process
         taskService.complete(verifyCreditTask.getId(), CollectionUtil.singletonMap("creditApproved", true));
         org.flowable.task.api.Task prepareAndShipTask = taskQuery.singleResult();
-        assertEquals("Prepare and Ship", prepareAndShipTask.getName());
+        assertThat(prepareAndShipTask.getName()).isEqualTo("Prepare and Ship");
     }
 
     @Test
@@ -58,14 +60,14 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("mainProcess");
         TaskQuery taskQuery = taskService.createTaskQuery();
         org.flowable.task.api.Task verifyCreditTask = taskQuery.singleResult();
-        assertEquals("User Task 1", verifyCreditTask.getName());
+        assertThat(verifyCreditTask.getName()).isEqualTo("User Task 1");
 
         // Verify with Query API
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertNotNull(subProcessInstance);
-        assertEquals(pi.getId(), runtimeService.createProcessInstanceQuery().subProcessInstanceId(subProcessInstance.getId()).singleResult().getId());
+        assertThat(subProcessInstance).isNotNull();
+        assertThat(runtimeService.createProcessInstanceQuery().subProcessInstanceId(subProcessInstance.getId()).singleResult().getId()).isEqualTo(pi.getId());
 
-        assertEquals("Batman", runtimeService.getVariable(subProcessInstance.getId(), "Name"));
+        assertThat(runtimeService.getVariable(subProcessInstance.getId(), "Name")).isEqualTo("Batman");
     }
 
     @Test
@@ -77,19 +79,19 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         // No use of business key attributes
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("mainProcess");
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertNull(subProcessInstance.getBusinessKey());
+        assertThat(subProcessInstance.getBusinessKey()).isNull();
 
         // Modeled using expression: businessKey="${busKey}"
         Map<String, Object> variables = new HashMap<>();
         variables.put("busKey", "123");
         pi = runtimeService.startProcessInstanceByKey("mainProcessBusinessKey", variables);
         subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertEquals("123", subProcessInstance.getBusinessKey());
+        assertThat(subProcessInstance.getBusinessKey()).isEqualTo("123");
 
         // Inherit business key
         pi = runtimeService.startProcessInstanceByKey("mainProcessInheritBusinessKey", "123");
         subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
-        assertEquals("123", subProcessInstance.getBusinessKey());
+        assertThat(subProcessInstance.getBusinessKey()).isEqualTo("123");
     }
 
     @Test
@@ -98,10 +100,9 @@ public class CallActivityTest extends PluggableFlowableTestCase {
             "org/flowable/examples/bpmn/callactivity/dynamicallyCalledChildProcess.bpmn20.xml"})
     public void testCallActivityDynamicChange(){
         // Call original CallActivity
-        ProcessInstance pi = runtimeService.startProcessInstanceByKey("processWithDynamicCallActivity");
+        runtimeService.startProcessInstanceByKey("processWithDynamicCallActivity");
         taskService.complete(taskService.createTaskQuery().singleResult().getId());
-        assertEquals("Original Child Process User Task",
-                taskService.createTaskQuery().singleResult().getName());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("Original Child Process User Task");
         taskService.complete(taskService.createTaskQuery().singleResult().getId());
 
         // Dynamically change CallActivity
@@ -110,8 +111,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         dynamicBpmnService.saveProcessDefinitionInfo(dynamicallyChangedInstance.getProcessDefinitionId(), infoNode);
         taskService.complete(taskService.createTaskQuery().processInstanceId(dynamicallyChangedInstance.getProcessInstanceId()).singleResult().getId());
 
-        assertEquals("Dynamically Changed Call Activity User Task",
-                taskService.createTaskQuery().singleResult().getName());
+        assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("Dynamically Changed Call Activity User Task");
 
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.bpmn.event.timer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
@@ -32,7 +34,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
 
         // There should be one task, with a timer : first line support
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertEquals("First line support", task.getName());
+        assertThat(task.getName()).isEqualTo("First line support");
 
         // Manually execute the job
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -41,7 +43,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
 
         // The timer has fired, and the second task (second line support) now exists
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertEquals("Handle escalated issue", task.getName());
+        assertThat(task.getName()).isEqualTo("Handle escalated issue");
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/CustomFlowExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/CustomFlowExecutionListenerTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.bpmn.executionlistener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,12 +39,11 @@ public class CustomFlowExecutionListenerTest extends ResourceFlowableTestCase {
         variableMap.put("customFlowBean", new CustomFlowBean());
         runtimeService.startProcessInstanceByKey("scriptExecutionListenerProcess", variableMap);
         HistoricVariableInstance variable = historyService.createHistoricVariableInstanceQuery().variableName("flow1_activiti_conditions").singleResult();
-        assertNotNull(variable);
-        assertEquals("flow1_activiti_conditions", variable.getVariableName());
+        assertThat(variable).isNotNull();
+        assertThat(variable.getVariableName()).isEqualTo("flow1_activiti_conditions");
         @SuppressWarnings("unchecked")
         List<String> conditions = (List<String>) variable.getValue();
-        assertEquals(2, conditions.size());
-        assertEquals("hello", conditions.get(0));
-        assertEquals("world", conditions.get(1));
+        assertThat(conditions)
+                .containsExactly("hello", "world");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
@@ -13,6 +13,9 @@
 
 package org.flowable.examples.bpmn.executionlistener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,47 +43,47 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersProcess", "businessKey123");
 
         String varSetInExecutionListener = (String) runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
-        assertNotNull(varSetInExecutionListener);
-        assertEquals("firstValue", varSetInExecutionListener);
+        assertThat(varSetInExecutionListener).isNotNull();
+        assertThat(varSetInExecutionListener).isEqualTo("firstValue");
 
         // Check if business key was available in execution listener
         String businessKey = (String) runtimeService.getVariable(processInstance.getId(), "businessKeyInExecution");
-        assertNotNull(businessKey);
-        assertEquals("businessKey123", businessKey);
+        assertThat(businessKey).isNotNull();
+        assertThat(businessKey).isEqualTo("businessKey123");
 
         // Transition take executionListener will set 2 variables
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         varSetInExecutionListener = (String) runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
 
-        assertNotNull(varSetInExecutionListener);
-        assertEquals("secondValue", varSetInExecutionListener);
+        assertThat(varSetInExecutionListener).isNotNull();
+        assertThat(varSetInExecutionListener).isEqualTo("secondValue");
 
         ExampleExecutionListenerPojo myPojo = new ExampleExecutionListenerPojo();
         runtimeService.setVariable(processInstance.getId(), "myPojo", myPojo);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         // First usertask uses a method-expression as executionListener:
         // ${myPojo.myMethod(execution.eventName)}
         ExampleExecutionListenerPojo pojoVariable = (ExampleExecutionListenerPojo) runtimeService.getVariable(processInstance.getId(), "myPojo");
-        assertNotNull(pojoVariable.getReceivedEventName());
-        assertEquals("end", pojoVariable.getReceivedEventName());
+        assertThat(pojoVariable.getReceivedEventName()).isNotNull();
+        assertThat(pojoVariable.getReceivedEventName()).isEqualTo("end");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
 
         List<RecordedEvent> events = RecorderExecutionListener.getRecordedEvents();
-        assertEquals(1, events.size());
-        RecordedEvent event = events.get(0);
-        assertEquals("End Process Listener", event.getParameter());
+        assertThat(events)
+                .extracting(RecordedEvent::getParameter)
+                .containsExactly("End Process Listener");
     }
 
     @Test
@@ -92,28 +95,14 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
 
         List<RecordedEvent> recordedEvents = RecorderExecutionListener.getRecordedEvents();
-        assertEquals(4, recordedEvents.size());
-
-        assertEquals("theStart", recordedEvents.get(0).getActivityId());
-        assertEquals("Start Event", recordedEvents.get(0).getActivityName());
-        assertEquals("Start Event Listener", recordedEvents.get(0).getParameter());
-        assertEquals("end", recordedEvents.get(0).getEventName());
-
-        assertEquals("noneEvent", recordedEvents.get(1).getActivityId());
-        assertEquals("None Event", recordedEvents.get(1).getActivityName());
-        assertEquals("Intermediate Catch Event Listener", recordedEvents.get(1).getParameter());
-        assertEquals("end", recordedEvents.get(1).getEventName());
-
-        assertEquals("signalEvent", recordedEvents.get(2).getActivityId());
-        assertEquals("Signal Event", recordedEvents.get(2).getActivityName());
-        assertEquals("Intermediate Throw Event Listener", recordedEvents.get(2).getParameter());
-        assertEquals("start", recordedEvents.get(2).getEventName());
-
-        assertEquals("theEnd", recordedEvents.get(3).getActivityId());
-        assertEquals("End Event", recordedEvents.get(3).getActivityName());
-        assertEquals("End Event Listener", recordedEvents.get(3).getParameter());
-        assertEquals("start", recordedEvents.get(3).getEventName());
-
+        assertThat(recordedEvents)
+                .extracting(RecordedEvent::getActivityId, RecordedEvent::getActivityName, RecordedEvent::getParameter, RecordedEvent::getEventName)
+                .containsExactly(
+                        tuple("theStart", "Start Event", "Start Event Listener", "end"),
+                        tuple("noneEvent", "None Event", "Intermediate Catch Event Listener", "end"),
+                        tuple("signalEvent", "Signal Event", "Intermediate Throw Event Listener", "start"),
+                        tuple("theEnd", "End Event", "End Event Listener", "start")
+                );
     }
 
     @Test
@@ -125,12 +114,11 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersProcess", variables);
 
         Object varSetByListener = runtimeService.getVariable(processInstance.getId(), "var");
-        assertNotNull(varSetByListener);
-        assertTrue(varSetByListener instanceof String);
+        assertThat(varSetByListener).isNotNull();
+        assertThat(varSetByListener).isInstanceOf(String.class);
 
-        // Result is a concatenation of fixed injected field and injected
-        // expression
-        assertEquals("Yes, I am listening!", varSetByListener);
+        // Result is a concatenation of fixed injected field and injected expression
+        assertThat(varSetByListener).isEqualTo("Yes, I am listening!");
     }
 
     @Test
@@ -143,16 +131,13 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
 
         List<CurrentActivity> currentActivities = CurrentActivityExecutionListener.getCurrentActivities();
-        assertEquals(3, currentActivities.size());
-
-        assertEquals("theStart", currentActivities.get(0).getActivityId());
-        assertEquals("Start Event", currentActivities.get(0).getActivityName());
-
-        assertEquals("noneEvent", currentActivities.get(1).getActivityId());
-        assertEquals("None Event", currentActivities.get(1).getActivityName());
-
-        assertEquals("theEnd", currentActivities.get(2).getActivityId());
-        assertEquals("End Event", currentActivities.get(2).getActivityName());
+        assertThat(currentActivities)
+                .extracting(CurrentActivity::getActivityId, CurrentActivity::getActivityName)
+                .containsExactly(
+                        tuple("theStart", "Start Event"),
+                        tuple("noneEvent", "None Event"),
+                        tuple("theEnd", "End Event")
+                );
     }
 
     @Test
@@ -163,8 +148,9 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersProcess");
 
         List<RecordedEvent> recordedEvents = RecorderExecutionListener.getRecordedEvents();
-        assertEquals(1, recordedEvents.size());
-        assertEquals("Process Start", recordedEvents.get(0).getParameter());
+        assertThat(recordedEvents)
+                .extracting(RecordedEvent::getParameter)
+                .containsExactly("Process Start");
 
         RecorderExecutionListener.clear();
 
@@ -174,11 +160,9 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         assertProcessEnded(processInstance.getId());
 
         recordedEvents = RecorderExecutionListener.getRecordedEvents();
-
-        assertEquals(3, recordedEvents.size());
-        assertEquals("Subprocess Start", recordedEvents.get(0).getParameter());
-        assertEquals("Subprocess End", recordedEvents.get(1).getParameter());
-        assertEquals("Process End", recordedEvents.get(2).getParameter());
+        assertThat(recordedEvents)
+                .extracting(RecordedEvent::getParameter)
+                .containsExactly("Subprocess Start", "Subprocess End", "Process End");
     }
 
     @Test
@@ -190,20 +174,20 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
             businessKey("businessKey123").startAsync();
         String varSetInExecutionListener = (String) runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
         // ProcessStartExecutionListeners are executed from the asynchronous job
-        assertNull(varSetInExecutionListener);
+        assertThat(varSetInExecutionListener).isNull();
 
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 2000, 200);
 
         // Process start executionListener will have executionListener class
         // that sets 2 variables
         varSetInExecutionListener = (String) runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
-        assertNotNull(varSetInExecutionListener);
-        assertEquals("firstValue", varSetInExecutionListener);
+        assertThat(varSetInExecutionListener).isNotNull();
+        assertThat(varSetInExecutionListener).isEqualTo("firstValue");
 
         // Check if business key was available in execution listener
         String businessKey = (String) runtimeService.getVariable(processInstance.getId(), "businessKeyInExecution");
-        assertNotNull(businessKey);
-        assertEquals("businessKey123", businessKey);
+        assertThat(businessKey).isNotNull();
+        assertThat(businessKey).isEqualTo("businessKey123");
 
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptExecutionListenerTest.java
@@ -12,9 +12,10 @@
  */
 package org.flowable.examples.bpmn.executionlistener;
 
-import java.util.HashMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.util.List;
-import java.util.Map;
 
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
@@ -36,18 +37,13 @@ public class ScriptExecutionListenerTest extends PluggableFlowableTestCase {
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricVariableInstance> historicVariables = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list();
-            Map<String, Object> varMap = new HashMap<>();
-            for (HistoricVariableInstance historicVariableInstance : historicVariables) {
-                varMap.put(historicVariableInstance.getVariableName(), historicVariableInstance.getValue());
-            }
-
-            assertTrue(varMap.containsKey("foo"));
-            assertEquals("FOO", varMap.get("foo"));
-            assertTrue(varMap.containsKey("var1"));
-            assertEquals("test", varMap.get("var1"));
-            assertFalse(varMap.containsKey("bar"));
-            assertTrue(varMap.containsKey("myVar"));
-            assertEquals("BAR", varMap.get("myVar"));
+            assertThat(historicVariables)
+                    .extracting(HistoricVariableInstance::getVariableName, HistoricVariableInstance::getValue)
+                    .containsExactlyInAnyOrder(
+                            tuple("foo", "FOO"),
+                            tuple("var1", "test"),
+                            tuple("myVar", "BAR")
+                    );
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/expression/UelExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/expression/UelExpressionTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.examples.bpmn.expression;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -32,14 +34,14 @@ public class UelExpressionTest extends PluggableFlowableTestCase {
         UelExpressionTestOrder order = new UelExpressionTestOrder(150);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("uelExpressions", CollectionUtil.singletonMap("order", order));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Standard service", task.getName());
+        assertThat(task.getName()).isEqualTo("Standard service");
 
         // While an order of 300, gives us a premium service (goes through an
         // UEL method expression)
         order = new UelExpressionTestOrder(300);
         processInstance = runtimeService.startProcessInstanceByKey("uelExpressions", CollectionUtil.singletonMap("order", order));
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Premium service", task.getName());
+        assertThat(task.getName()).isEqualTo("Premium service");
 
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/ExclusiveGatewayTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.examples.bpmn.gateway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,29 +45,25 @@ public class ExclusiveGatewayTest extends PluggableFlowableTestCase {
         variables.put("input", 1);
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("exclusiveGateway", variables);
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertEquals("Send e-mail for more information", task.getName());
+        assertThat(task.getName()).isEqualTo("Send e-mail for more information");
 
         // Test with input == 2
         variables.put("input", 2);
         pi = runtimeService.startProcessInstanceByKey("exclusiveGateway", variables);
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertEquals("Check account balance", task.getName());
+        assertThat(task.getName()).isEqualTo("Check account balance");
 
         // Test with input == 3
         variables.put("input", 3);
         pi = runtimeService.startProcessInstanceByKey("exclusiveGateway", variables);
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        assertEquals("Call customer", task.getName());
+        assertThat(task.getName()).isEqualTo("Call customer");
 
         // Test with input == 4
         variables.put("input", 4);
-        try {
-            runtimeService.startProcessInstanceByKey("exclusiveGateway", variables);
-            fail();
-        } catch (FlowableException e) {
-            // Exception is expected since no outgoing sequence flow matches
-        }
-
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("exclusiveGateway", variables))
+                .as("Exception is expected since no outgoing sequence flow matches")
+                .isInstanceOf(FlowableException.class);
     }
 
 }


### PR DESCRIPTION
This is part 1 for the `org.flowable.examples.bpmn` package.  The files converted are up to and include those in the `gateway` subpackage.   More to come.....
