### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailSendTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailSendTaskTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.examples.bpmn.mail;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -85,14 +87,14 @@ public class EmailSendTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("sendMailExample", vars);
 
         List<WiserMessage> messages = wiser.getMessages();
-        assertEquals(1, messages.size());
+        assertThat(messages).hasSize(1);
 
         WiserMessage message = messages.get(0);
         MimeMessage mimeMessage = message.getMimeMessage();
 
-        assertEquals("Your order " + orderId + " has been shipped", mimeMessage.getHeader("Subject", null));
-        assertEquals(from, mimeMessage.getHeader("From", null));
-        assertTrue(mimeMessage.getHeader("To", null).contains(recipient));
+        assertThat(mimeMessage.getHeader("Subject", null)).isEqualTo("Your order " + orderId + " has been shipped");
+        assertThat(mimeMessage.getHeader("From", null)).isEqualTo(from);
+        assertThat(mimeMessage.getHeader("To", null)).contains(recipient);
     }
 
     @Test
@@ -109,16 +111,16 @@ public class EmailSendTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("sendMailWithStaticHeaderExample", vars);
 
         List<WiserMessage> messages = wiser.getMessages();
-        assertEquals(1, messages.size());
+        assertThat(messages).hasSize(1);
 
         WiserMessage message = messages.get(0);
         MimeMessage mimeMessage = message.getMimeMessage();
 
-        assertEquals(from, mimeMessage.getHeader("From", null));
-        assertTrue(mimeMessage.getHeader("To", null).contains(recipient));
-        assertEquals("value1", mimeMessage.getHeader("X-Attribute1", null));
-        assertEquals("value2", mimeMessage.getHeader("X-Attribute2", null));
-        assertEquals("value3", mimeMessage.getHeader("X-Attribute3", null));
+        assertThat(mimeMessage.getHeader("From", null)).isEqualTo(from);
+        assertThat(mimeMessage.getHeader("To", null)).contains(recipient);
+        assertThat(mimeMessage.getHeader("X-Attribute1", null)).isEqualTo("value1");
+        assertThat(mimeMessage.getHeader("X-Attribute2", null)).isEqualTo("value2");
+        assertThat(mimeMessage.getHeader("X-Attribute3", null)).isEqualTo("value3");
     }
 
     @Test
@@ -139,16 +141,16 @@ public class EmailSendTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("sendMailWithVariableHeaderExample", vars);
 
         List<WiserMessage> messages = wiser.getMessages();
-        assertEquals(1, messages.size());
+        assertThat(messages).hasSize(1);
 
         WiserMessage message = messages.get(0);
         MimeMessage mimeMessage = message.getMimeMessage();
 
-        assertEquals(from, mimeMessage.getHeader("From", null));
-        assertTrue(mimeMessage.getHeader("To", null).contains(recipient));
-        assertEquals("value1", mimeMessage.getHeader("X-Attribute1", null));
-        assertEquals("value2", mimeMessage.getHeader("X-Attribute2", null));
-        assertEquals("value3", mimeMessage.getHeader("X-Attribute3", null));
+        assertThat(mimeMessage.getHeader("From", null)).isEqualTo(from);
+        assertThat(mimeMessage.getHeader("To", null)).contains(recipient);
+        assertThat(mimeMessage.getHeader("X-Attribute1", null)).isEqualTo("value1");
+        assertThat(mimeMessage.getHeader("X-Attribute2", null)).isEqualTo("value2");
+        assertThat(mimeMessage.getHeader("X-Attribute3", null)).isEqualTo("value3");
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/mail/EmailServiceTaskTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.examples.bpmn.mail;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -82,14 +84,14 @@ public class EmailServiceTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("sendMailExample", vars);
 
         List<WiserMessage> messages = wiser.getMessages();
-        assertEquals(1, messages.size());
+        assertThat(messages).hasSize(1);
 
         WiserMessage message = messages.get(0);
         MimeMessage mimeMessage = message.getMimeMessage();
 
-        assertEquals("Your order " + orderId + " has been shipped", mimeMessage.getHeader("Subject", null));
-        assertEquals(from, mimeMessage.getHeader("From", null));
-        assertTrue(mimeMessage.getHeader("To", null).contains(recipient));
+        assertThat(mimeMessage.getHeader("Subject", null)).isEqualTo("Your order " + orderId + " has been shipped");
+        assertThat(mimeMessage.getHeader("From", null)).isEqualTo(from);
+        assertThat(mimeMessage.getHeader("To", null)).contains(recipient);
     }
 
     @Test
@@ -106,16 +108,16 @@ public class EmailServiceTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("sendMailWithStaticHeaderExample", vars);
 
         List<WiserMessage> messages = wiser.getMessages();
-        assertEquals(1, messages.size());
+        assertThat(messages).hasSize(1);
 
         WiserMessage message = messages.get(0);
         MimeMessage mimeMessage = message.getMimeMessage();
 
-        assertEquals(from, mimeMessage.getHeader("From", null));
-        assertTrue(mimeMessage.getHeader("To", null).contains(recipient));
-        assertEquals("value1", mimeMessage.getHeader("X-Attribute1", null));
-        assertEquals("value2", mimeMessage.getHeader("X-Attribute2", null));
-        assertEquals("value3", mimeMessage.getHeader("X-Attribute3", null));
+        assertThat(mimeMessage.getHeader("From", null)).isEqualTo(from);
+        assertThat(mimeMessage.getHeader("To", null)).contains(recipient);
+        assertThat(mimeMessage.getHeader("X-Attribute1", null)).isEqualTo("value1");
+        assertThat(mimeMessage.getHeader("X-Attribute2", null)).isEqualTo("value2");
+        assertThat(mimeMessage.getHeader("X-Attribute3", null)).isEqualTo("value3");
     }
 
     @Test
@@ -136,16 +138,16 @@ public class EmailServiceTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("sendMailWithVariableHeaderExample", vars);
 
         List<WiserMessage> messages = wiser.getMessages();
-        assertEquals(1, messages.size());
+        assertThat(messages).hasSize(1);
 
         WiserMessage message = messages.get(0);
         MimeMessage mimeMessage = message.getMimeMessage();
 
-        assertEquals(from, mimeMessage.getHeader("From", null));
-        assertTrue(mimeMessage.getHeader("To", null).contains(recipient));
-        assertEquals("value1", mimeMessage.getHeader("X-Attribute1", null));
-        assertEquals("value2", mimeMessage.getHeader("X-Attribute2", null));
-        assertEquals("value3", mimeMessage.getHeader("X-Attribute3", null));
+        assertThat(mimeMessage.getHeader("From", null)).isEqualTo(from);
+        assertThat(mimeMessage.getHeader("To", null)).contains(recipient);
+        assertThat(mimeMessage.getHeader("X-Attribute1", null)).isEqualTo("value1");
+        assertThat(mimeMessage.getHeader("X-Attribute2", null)).isEqualTo("value2");
+        assertThat(mimeMessage.getHeader("X-Attribute3", null)).isEqualTo("value3");
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/receivetask/ReceiveTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/receivetask/ReceiveTaskTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.examples.bpmn.receivetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -29,7 +31,7 @@ public class ReceiveTaskTest extends PluggableFlowableTestCase {
     public void testWaitStateBehavior() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("receiveTask");
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).activityId("waitState").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         runtimeService.trigger(execution.getId());
         assertProcessEnded(pi.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import groovy.lang.MissingPropertyException;
+
 /**
  * @author Joram Barrez
  * @author Christian Stettler
@@ -51,14 +53,14 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
     @Deployment
     public void testFailingScript() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("failingScript"))
-                .hasStackTraceContaining("MissingPropertyException");
+                .hasRootCauseInstanceOf(MissingPropertyException.class);
     }
 
     @Test
     @Deployment
     public void testExceptionThrownInScript() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("failingScript"))
-                .hasStackTraceContaining("IllegalStateException");
+                .hasRootCauseInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
@@ -12,8 +12,13 @@
  */
 package org.flowable.examples.bpmn.scripttask;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import groovy.lang.MissingPropertyException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -21,8 +26,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Joram Barrez
@@ -39,35 +43,22 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setScriptResultToProcessVariable", variables);
 
-        assertEquals("hello", runtimeService.getVariable(pi.getId(), "existingProcessVariableName"));
-        assertEquals(pi.getId(), runtimeService.getVariable(pi.getId(), "newProcessVariableName"));
+        assertThat(runtimeService.getVariable(pi.getId(), "existingProcessVariableName")).isEqualTo("hello");
+        assertThat(runtimeService.getVariable(pi.getId(), "newProcessVariableName")).isEqualTo(pi.getId());
     }
 
     @Test
     @Deployment
     public void testFailingScript() {
-        Exception expectedException = null;
-        try {
-            runtimeService.startProcessInstanceByKey("failingScript");
-        } catch (Exception e) {
-            expectedException = e;
-        }
-
-        // Check if correct exception is found in the stacktrace
-        verifyExceptionInStacktrace(expectedException, MissingPropertyException.class);
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("failingScript"))
+                .hasStackTraceContaining("MissingPropertyException");
     }
 
     @Test
     @Deployment
     public void testExceptionThrownInScript() {
-        Exception expectedException = null;
-        try {
-            runtimeService.startProcessInstanceByKey("failingScript");
-        } catch (Exception e) {
-            expectedException = e;
-        }
-
-        verifyExceptionInStacktrace(expectedException, IllegalStateException.class);
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("failingScript"))
+                .hasStackTraceContaining("IllegalStateException");
     }
 
     @Test
@@ -75,48 +66,40 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
     public void testAutoStoreVariables() {
         // The first script should NOT store anything as 'autoStoreVariables' is set to false
         String id = runtimeService.startProcessInstanceByKey("testAutoStoreVariables", CollectionUtil.map("a", 20, "b", 22)).getId();
-        assertNull(runtimeService.getVariable(id, "sum"));
+        assertThat(runtimeService.getVariable(id, "sum")).isNull();
 
         // The second script, after the user task will set the variable
         taskService.complete(taskService.createTaskQuery().singleResult().getId());
-        assertEquals(42, ((Number) runtimeService.getVariable(id, "sum")).intValue());
+        assertThat(((Number) runtimeService.getVariable(id, "sum")).intValue()).isEqualTo(42);
     }
 
     @Test
     public void testNoScriptProvided() {
-        try {
-            deploymentIdsForAutoCleanup.add(
+        assertThatThrownBy(() ->  deploymentIdsForAutoCleanup.add(
                 repositoryService.createDeployment().addClasspathResource("org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testNoScriptProvided.bpmn20.xml").deploy().getId()
-            );
-            fail("Deployment should not have worked");
-        } catch (FlowableException e) {
-            assertTextPresent("No script provided", e.getMessage());
-        }
+        ))
+                .as("Deployment should not have worked")
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("No script provided");
     }
 
     @Test
     @Deployment
     public void testErrorInScript() {
-        try {
-            runtimeService.startProcessInstanceByKey("testErrorInScript");
-            fail("Starting process should result in error in script");
-        } catch (FlowableException e) {
-            assertTextPresent("Error in Script", e.getMessage());
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testErrorInScript"))
+                .as("Starting process should result in error in script")
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("Error in Script");
     }
 
     @Test
     @Deployment
     public void testNoErrorInScript() {
-        boolean noError = true;
-        try {
+        assertThatCode(() -> {
             Map<String, Object> variables = new HashMap<>();
             variables.put("scriptVar", "1212");
             runtimeService.startProcessInstanceByKey("testNoErrorInScript", variables);
-        } catch (FlowableException e) {
-            noError = false;
-        }
-        assertTrue(noError);
+        }).doesNotThrowAnyException();
     }
 
     @Test
@@ -128,15 +111,15 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setScriptResultToProcessVariable", variables);
 
-        assertEquals("hello", runtimeService.getVariable(pi.getId(), "existingProcessVariableName"));
-        assertEquals(pi.getId(), runtimeService.getVariable(pi.getId(), "newProcessVariableName"));
+        assertThat(runtimeService.getVariable(pi.getId(), "existingProcessVariableName")).isEqualTo("hello");
+        assertThat(runtimeService.getVariable(pi.getId(), "newProcessVariableName")).isEqualTo(pi.getId());
     }
 
     @Test
     @Deployment
     public void testDynamicScript() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testDynamicScript", CollectionUtil.map("a", 20, "b", 22));
-        assertEquals(42, ((Number) runtimeService.getVariable(processInstance.getId(), "test")).intValue());
+        assertThat(((Number) runtimeService.getVariable(processInstance.getId(), "test")).intValue()).isEqualTo(42);
         taskService.complete(taskService.createTaskQuery().singleResult().getId());
         assertProcessEnded(processInstance.getId());
 
@@ -145,23 +128,9 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
         dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId, infoNode);
 
         processInstance = runtimeService.startProcessInstanceByKey("testDynamicScript", CollectionUtil.map("c", 10, "d", 12));
-        assertEquals(22, ((Number) runtimeService.getVariable(processInstance.getId(), "test2")).intValue());
+        assertThat(((Number) runtimeService.getVariable(processInstance.getId(), "test2")).intValue()).isEqualTo(22);
         taskService.complete(taskService.createTaskQuery().singleResult().getId());
         assertProcessEnded(processInstance.getId());
-    }
-
-    protected void verifyExceptionInStacktrace(Exception rootException, Class<?> expectedExceptionClass) {
-        Throwable expectedException = rootException;
-        boolean found = false;
-        while (!found && expectedException != null) {
-            if (expectedException.getClass().equals(expectedExceptionClass)) {
-                found = true;
-            } else {
-                expectedException = expectedException.getCause();
-            }
-        }
-
-        assertEquals(expectedExceptionClass, expectedException.getClass());
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.examples.bpmn.servicetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,7 +39,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
     public void testJavaServiceDelegation() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("javaServiceDelegation", CollectionUtil.singletonMap("input", "Activiti BPM Engine"));
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).activityId("waitState").singleResult();
-        assertEquals("ACTIVITI BPM ENGINE", runtimeService.getVariable(execution.getId(), "input"));
+        assertThat(runtimeService.getVariable(execution.getId(), "input")).isEqualTo("ACTIVITI BPM ENGINE");
     }
 
     @Test
@@ -48,8 +51,8 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("fieldInjection");
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).activityId("waitState").singleResult();
 
-        assertEquals("HELLO WORLD", runtimeService.getVariable(execution.getId(), "var"));
-        assertEquals("HELLO SETTER", runtimeService.getVariable(execution.getId(), "setterVar"));
+        assertThat(runtimeService.getVariable(execution.getId(), "var")).isEqualTo("HELLO WORLD");
+        assertThat(runtimeService.getVariable(execution.getId(), "setterVar")).isEqualTo("HELLO SETTER");
     }
 
     @Test
@@ -63,8 +66,8 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("expressionFieldInjection", vars);
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).activityId("waitState").singleResult();
 
-        assertEquals("timrek .rM olleH", runtimeService.getVariable(execution.getId(), "var2"));
-        assertEquals("elam :si redneg ruoY", runtimeService.getVariable(execution.getId(), "var1"));
+        assertThat(runtimeService.getVariable(execution.getId(), "var2")).isEqualTo("timrek .rM olleH");
+        assertThat(runtimeService.getVariable(execution.getId(), "var1")).isEqualTo("elam :si redneg ruoY");
     }
     
     @Test
@@ -78,8 +81,8 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
       ProcessInstance pi = runtimeService.startProcessInstanceByKey("serviceTask", vars);
       
       Execution waitExecution = runtimeService.createExecutionQuery().processInstanceId(pi.getProcessInstanceId()).onlyChildExecutions().singleResult();
-      assertNotNull(waitExecution);
-      assertEquals("waitState", waitExecution.getActivityId());
+      assertThat(waitExecution).isNotNull();
+      assertThat(waitExecution.getActivityId()).isEqualTo("waitState");
     }
     
     @Test
@@ -90,7 +93,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
       
       ProcessInstance pi = runtimeService.startProcessInstanceByKey("asyncServiceTask", vars);
       Job job = managementService.createJobQuery().processInstanceId(pi.getProcessInstanceId()).singleResult();
-      assertNotNull(job);
+      assertThat(job).isNotNull();
       
       vars = new HashMap<>();
       vars.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", true);
@@ -100,8 +103,8 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
       managementService.executeJob(job.getId());
       
       Execution waitExecution = runtimeService.createExecutionQuery().processInstanceId(pi.getProcessInstanceId()).onlyChildExecutions().singleResult();
-      assertNotNull(waitExecution);
-      assertEquals("waitState", waitExecution.getActivityId());
+      assertThat(waitExecution).isNotNull();
+      assertThat(waitExecution.getActivityId()).isEqualTo("waitState");
     }
 
     @Test
@@ -116,11 +119,11 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("expressionFieldInjectionWithSkipExpression", vars);
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).activityId("waitState").singleResult();
-        
-        assertNotNull(execution);
 
-        assertEquals("timrek .rM olleH", runtimeService.getVariable(execution.getId(), "var2"));
-        assertEquals("elam :si redneg ruoY", runtimeService.getVariable(execution.getId(), "var1"));
+        assertThat(execution).isNotNull();
+
+        assertThat(runtimeService.getVariable(execution.getId(), "var2")).isEqualTo("timrek .rM olleH");
+        assertThat(runtimeService.getVariable(execution.getId(), "var1")).isEqualTo("elam :si redneg ruoY");
 
         Map<String, Object> vars2 = new HashMap<>();
         vars2.put("name", "kermit");
@@ -132,36 +135,29 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         ProcessInstance pi2 = runtimeService.startProcessInstanceByKey("expressionFieldInjectionWithSkipExpression", vars2);
         Execution execution2 = runtimeService.createExecutionQuery().processInstanceId(pi2.getId()).activityId("waitState").singleResult();
 
-        assertNotNull(execution2);
+        assertThat(execution2).isNotNull();
 
         Map<String, Object> pi2VarMap = runtimeService.getVariables(pi2.getProcessInstanceId());
-        assertFalse(pi2VarMap.containsKey("var1"));
-        assertFalse(pi2VarMap.containsKey("var2"));
+        assertThat(pi2VarMap)
+                .doesNotContainKey("var1")
+                .doesNotContainKey("var2");
     }
 
     @Test
     @Deployment
     public void testUnexistingClassDelegation() {
-        try {
-            runtimeService.startProcessInstanceByKey("unexistingClassDelegation");
-            fail();
-        } catch (FlowableException e) {
-            assertTrue(e.getMessage().contains("couldn't instantiate class org.flowable.BogusClass"));
-            assertNotNull(e.getCause());
-            assertTrue(e.getCause() instanceof FlowableClassLoadingException);
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("unexistingClassDelegation"))
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("couldn't instantiate class org.flowable.BogusClass")
+                .hasCauseInstanceOf(FlowableClassLoadingException.class);
     }
 
     @Test
     public void testIllegalUseOfResultVariableName() {
-        try {
-            deploymentIdsForAutoCleanup.add(
-                repositoryService.createDeployment().addClasspathResource("org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.testIllegalUseOfResultVariableName.bpmn20.xml").deploy().getId()
-            );
-            fail();
-        } catch (FlowableException e) {
-            assertTrue(e.getMessage().contains("resultVariable"));
-        }
+        assertThatThrownBy(() -> deploymentIdsForAutoCleanup.add(
+                repositoryService.createDeployment().addClasspathResource("org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.testIllegalUseOfResultVariableName.bpmn20.xml").deploy().getId()))
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("resultVariable");
     }
 
     @Test
@@ -173,7 +169,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         Map<String, Object> vars = new HashMap<>();
         vars.put("var", "no-exception");
         runtimeService.startProcessInstanceByKey("exceptionHandling", vars);
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
 
         // If variable value == 'throw-exception', process executes
         // service task, which generates and catches exception,
@@ -181,19 +177,19 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         vars.put("var", "throw-exception");
         runtimeService.startProcessInstanceByKey("exceptionHandling", vars);
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Fix Exception", task.getName());
+        assertThat(task.getName()).isEqualTo("Fix Exception");
     }
 
     @Test
     @Deployment
     public void testGetBusinessKeyFromDelegateExecution() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("businessKeyProcess", "1234567890");
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey("businessKeyProcess").count());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("businessKeyProcess").count()).isEqualTo(1);
 
         // Check if business-key was available from the process
         String key = (String) runtimeService.getVariable(processInstance.getId(), "businessKeySetOnExecution");
-        assertNotNull(key);
-        assertEquals("1234567890", key);
+        assertThat(key).isNotNull();
+        assertThat(key).isEqualTo("1234567890");
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/MethodExpressionServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/MethodExpressionServiceTaskTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.bpmn.servicetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +35,7 @@ public class MethodExpressionServiceTaskTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariables", variables);
 
-        assertEquals("ok", runtimeService.getVariable(pi.getId(), "result"));
+        assertThat(runtimeService.getVariable(pi.getId(), "result")).isEqualTo("ok");
     }
 
     @Test
@@ -45,7 +47,7 @@ public class MethodExpressionServiceTaskTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables);
 
-        assertEquals("ok", runtimeService.getVariable(pi.getId(), "result"));
+        assertThat(runtimeService.getVariable(pi.getId(), "result")).isEqualTo("ok");
 
         Map<String, Object> variables2 = new HashMap<>();
         variables2.put("okReturningService", new OkReturningService());
@@ -54,7 +56,7 @@ public class MethodExpressionServiceTaskTest extends PluggableFlowableTestCase {
 
         ProcessInstance pi2 = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables2);
 
-        assertNull(runtimeService.getVariable(pi2.getId(), "result"));
+        assertThat(runtimeService.getVariable(pi2.getId(), "result")).isNull();
 
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/shell/ShellTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/shell/ShellTaskTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.bpmn.shell;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
@@ -49,7 +51,7 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
 
     @Test
     public void testOsDetection() throws Exception {
-        assertNotSame(OsType.UNKOWN, osType);
+        assertThat(osType).isNotSameAs(OsType.UNKOWN);
     }
 
     @Test
@@ -61,8 +63,8 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("echoShellWindows");
 
             String st = (String) runtimeService.getVariable(pi.getId(), "resultVar");
-            assertNotNull(st);
-            assertTrue(st.startsWith("EchoTest"));
+            assertThat(st).isNotNull();
+            assertThat(st).startsWith("EchoTest");
         }
     }
 
@@ -75,8 +77,8 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("echoShellLinux");
 
             String st = (String) runtimeService.getVariable(pi.getId(), "resultVar");
-            assertNotNull(st);
-            assertTrue(st.startsWith("EchoTest"));
+            assertThat(st).isNotNull();
+            assertThat(st).startsWith("EchoTest");
         }
     }
 
@@ -89,8 +91,8 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("echoShellMac");
 
             String st = (String) runtimeService.getVariable(pi.getId(), "resultVar");
-            assertNotNull(st);
-            assertTrue(st.startsWith("EchoTest"));
+            assertThat(st).isNotNull();
+            assertThat(st).startsWith("EchoTest");
         }
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/subprocess/SubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/subprocess/SubProcessTest.java
@@ -13,12 +13,14 @@
 
 package org.flowable.examples.bpmn.subprocess;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.ProcessInstance;
-import org.junit.Assert;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -37,19 +39,17 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).orderByTaskName().asc().list();
 
         // Tasks are ordered by name (see query)
-        Assert.assertEquals(2, tasks.size());
-        org.flowable.task.api.Task investigateHardwareTask = tasks.get(0);
-        org.flowable.task.api.Task investigateSoftwareTask = tasks.get(1);
-        Assert.assertEquals("Investigate hardware", investigateHardwareTask.getName());
-        Assert.assertEquals("Investigate software", investigateSoftwareTask.getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("Investigate hardware", "Investigate software");
 
         // Completing both the tasks finishes the subprocess and enables the
         // task after the subprocess
-        taskService.complete(investigateHardwareTask.getId());
-        taskService.complete(investigateSoftwareTask.getId());
+        taskService.complete(tasks.get(0).getId());
+        taskService.complete(tasks.get(1).getId());
 
         org.flowable.task.api.Task writeReportTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-        Assert.assertEquals("Write report", writeReportTask.getName());
+        assertThat(writeReportTask.getName()).isEqualTo("Write report");
 
         // Clean up
         repositoryService.deleteDeployment(deployment.getId(), true);


### PR DESCRIPTION
This is part 2 for the `org.flowable.examples.bpmn` package. The files converted are after the `gateway` subpackage through and including the `subprocess` package. There is one more part to come.....
