### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/CustomTaskAssignmentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/CustomTaskAssignmentTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.bpmn.tasklistener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,36 +54,36 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
     @Deployment
     public void testCandidateGroupAssignment() {
         runtimeService.startProcessInstanceByKey("customTaskAssignment");
-        assertEquals(1, taskService.createTaskQuery().taskCandidateGroup("management").count());
-        assertEquals(1, taskService.createTaskQuery().taskCandidateUser("kermit").count());
-        assertEquals(0, taskService.createTaskQuery().taskCandidateUser("fozzie").count());
+        assertThat(taskService.createTaskQuery().taskCandidateGroup("management").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskCandidateUser("kermit").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskCandidateUser("fozzie").count()).isZero();
     }
 
     @Test
     @Deployment
     public void testCandidateUserAssignment() {
         runtimeService.startProcessInstanceByKey("customTaskAssignment");
-        assertEquals(1, taskService.createTaskQuery().taskCandidateUser("kermit").count());
-        assertEquals(1, taskService.createTaskQuery().taskCandidateUser("fozzie").count());
-        assertEquals(0, taskService.createTaskQuery().taskCandidateUser("gonzo").count());
+        assertThat(taskService.createTaskQuery().taskCandidateUser("kermit").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskCandidateUser("fozzie").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().taskCandidateUser("gonzo").count()).isZero();
     }
 
     @Test
     @Deployment
     public void testAssigneeAssignment() {
         runtimeService.startProcessInstanceByKey("setAssigneeInListener");
-        assertNotNull(taskService.createTaskQuery().taskAssignee("kermit").singleResult());
-        assertEquals(0, taskService.createTaskQuery().taskAssignee("fozzie").count());
-        assertEquals(0, taskService.createTaskQuery().taskAssignee("gonzo").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("kermit").singleResult()).isNotNull();
+        assertThat(taskService.createTaskQuery().taskAssignee("fozzie").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskAssignee("gonzo").count()).isZero();
     }
 
     @Test
     @Deployment
     public void testOverwriteExistingAssignments() {
         runtimeService.startProcessInstanceByKey("overrideAssigneeInListener");
-        assertNotNull(taskService.createTaskQuery().taskAssignee("kermit").singleResult());
-        assertEquals(0, taskService.createTaskQuery().taskAssignee("fozzie").count());
-        assertEquals(0, taskService.createTaskQuery().taskAssignee("gonzo").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("kermit").singleResult()).isNotNull();
+        assertThat(taskService.createTaskQuery().taskAssignee("fozzie").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskAssignee("gonzo").count()).isZero();
     }
 
     @Test
@@ -98,9 +100,9 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("customTaskAssignment", variables);
 
         // check task lists
-        assertNotNull(taskService.createTaskQuery().taskAssignee("gonzo").singleResult());
-        assertEquals(0, taskService.createTaskQuery().taskAssignee("fozzie").count());
-        assertEquals(0, taskService.createTaskQuery().taskAssignee("kermit").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("gonzo").singleResult()).isNotNull();
+        assertThat(taskService.createTaskQuery().taskAssignee("fozzie").count()).isZero();
+        assertThat(taskService.createTaskQuery().taskAssignee("kermit").count()).isZero();
     }
 
     @Test
@@ -109,18 +111,18 @@ public class CustomTaskAssignmentTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("releaseTaskProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskAssignee("fozzie").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         String taskId = task.getId();
 
         // Set assignee to null
         taskService.setAssignee(taskId, null);
 
         task = taskService.createTaskQuery().taskAssignee("fozzie").singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
 
         task = taskService.createTaskQuery().taskId(taskId).singleResult();
-        assertNotNull(task);
-        assertNull(task.getAssignee());
+        assertThat(task).isNotNull();
+        assertThat(task.getAssignee()).isNull();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.examples.bpmn.tasklistener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -30,23 +32,23 @@ public class ScriptTaskListenerTest extends PluggableFlowableTestCase {
     public void testScriptTaskListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("scriptTaskListenerProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Name does not match", "All your base are belong to us", task.getName());
+        assertThat(task.getName()).as("Name does not match").isEqualTo("All your base are belong to us");
 
         taskService.complete(task.getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
-            assertEquals("kermit", historicTask.getOwner());
+            assertThat(historicTask.getOwner()).isEqualTo("kermit");
 
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("Task name not set with 'bar' variable", "BAR", task.getName());
+            assertThat(task.getName()).as("Task name not set with 'bar' variable").isEqualTo("BAR");
         }
 
         Object bar = runtimeService.getVariable(processInstance.getId(), "bar");
-        assertNull("Expected 'bar' variable to be local to script", bar);
+        assertThat(bar).as("Expected 'bar' variable to be local to script").isNull();
 
         Object foo = runtimeService.getVariable(processInstance.getId(), "foo");
-        assertEquals("Could not find the 'foo' variable in variable scope", "FOO", foo);
+        assertThat(foo).as("Could not find the 'foo' variable in variable scope").isEqualTo("FOO");
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerOnTransactionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerOnTransactionTest.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.examples.bpmn.tasklistener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +26,7 @@ import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -49,12 +54,13 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         List<CurrentTaskTransactionDependentTaskListener.CurrentTask> currentTasks = CurrentTaskTransactionDependentTaskListener.getCurrentTasks();
-        assertEquals(1, currentTasks.size());
-
-        assertEquals("usertask1", currentTasks.get(0).getTaskId());
-        assertEquals("User Task 1", currentTasks.get(0).getTaskName());
-        assertEquals(processInstance.getId(), currentTasks.get(0).getProcessInstanceId());
-        assertNotNull(currentTasks.get(0).getProcessInstanceId());
+        assertThat(currentTasks)
+                .extracting(CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskId,
+                        CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskName,
+                        CurrentTaskTransactionDependentTaskListener.CurrentTask::getProcessInstanceId)
+                .containsExactly(
+                        tuple("usertask1", "User Task 1", processInstance.getId())
+                );
     }
 
     @Test
@@ -87,17 +93,14 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         }
 
         List<CurrentTaskTransactionDependentTaskListener.CurrentTask> currentTasks = CurrentTaskTransactionDependentTaskListener.getCurrentTasks();
-        assertEquals(2, currentTasks.size());
-
-        assertEquals("usertask1", currentTasks.get(0).getTaskId());
-        assertEquals("User Task 1", currentTasks.get(0).getTaskName());
-        assertEquals(processInstance.getId(), currentTasks.get(0).getProcessInstanceId());
-        assertNotNull(currentTasks.get(0).getProcessInstanceId());
-
-        assertEquals("usertask3", currentTasks.get(1).getTaskId());
-        assertEquals("User Task 3", currentTasks.get(1).getTaskName());
-        assertEquals(processInstance.getId(), currentTasks.get(1).getProcessInstanceId());
-        assertNotNull(currentTasks.get(1).getProcessInstanceId());
+        assertThat(currentTasks)
+                .extracting(CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskId,
+                        CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskName,
+                        CurrentTaskTransactionDependentTaskListener.CurrentTask::getProcessInstanceId)
+                .containsExactly(
+                        tuple("usertask1", "User Task 1", processInstance.getId()),
+                        tuple("usertask3", "User Task 3", processInstance.getId())
+                );
     }
 
     @Test
@@ -109,7 +112,7 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("taskListenersOnCompleteExecutionVariables");
 
         // task 1 has committed listener
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        Task task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
 
         // task 2 has committed listener
@@ -117,17 +120,21 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         List<CurrentTaskTransactionDependentTaskListener.CurrentTask> currentTasks = CurrentTaskTransactionDependentTaskListener.getCurrentTasks();
-        assertEquals(2, currentTasks.size());
+        assertThat(currentTasks)
+                .extracting(CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskId,
+                        CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskName)
+                .containsExactly(
+                        tuple("usertask1", "User Task 1"),
+                        tuple("usertask2", "User Task 2")
+                );
 
-        assertEquals("usertask1", currentTasks.get(0).getTaskId());
-        assertEquals("User Task 1", currentTasks.get(0).getTaskName());
-        assertEquals(1, currentTasks.get(1).getExecutionVariables().size());
-        assertEquals("test1", currentTasks.get(0).getExecutionVariables().get("injectedExecutionVariable"));
+        assertThat(currentTasks.get(0).getExecutionVariables())
+                .hasSize(1)
+                .containsEntry("injectedExecutionVariable", "test1");
 
-        assertEquals("usertask2", currentTasks.get(1).getTaskId());
-        assertEquals("User Task 2", currentTasks.get(1).getTaskName());
-        assertEquals(1, currentTasks.get(1).getExecutionVariables().size());
-        assertEquals("test2", currentTasks.get(1).getExecutionVariables().get("injectedExecutionVariable"));
+        assertThat(currentTasks.get(1).getExecutionVariables())
+                .hasSize(1)
+                .containsEntry("injectedExecutionVariable", "test2");
     }
 
     @Test
@@ -140,8 +147,9 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
-            assertEquals(1, historicProcessInstances.size());
-            assertEquals("transactionDependentTaskListenerProcess", historicProcessInstances.get(0).getProcessDefinitionKey());
+            assertThat(historicProcessInstances)
+                    .extracting(HistoricProcessInstance::getProcessDefinitionKey)
+                    .containsExactly("transactionDependentTaskListenerProcess");
         }
 
         ProcessInstance secondProcessInstance = runtimeService.startProcessInstanceByKey("secondTransactionDependentTaskListenerProcess");
@@ -154,15 +162,18 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // first historic process instance was deleted by task listener
             List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
-            assertEquals(1, historicProcessInstances.size());
-            assertEquals("secondTransactionDependentTaskListenerProcess", historicProcessInstances.get(0).getProcessDefinitionKey());
+            assertThat(historicProcessInstances)
+                    .extracting(HistoricProcessInstance::getProcessDefinitionKey)
+                    .containsExactly("secondTransactionDependentTaskListenerProcess");
         }
 
         List<MyTransactionalOperationTransactionDependentTaskListener.CurrentTask> currentTasks = MyTransactionalOperationTransactionDependentTaskListener.getCurrentTasks();
-        assertEquals(1, currentTasks.size());
-
-        assertEquals("usertask1", currentTasks.get(0).getTaskId());
-        assertEquals("User Task 1", currentTasks.get(0).getTaskName());
+        assertThat(currentTasks)
+                .extracting(CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskId,
+                        CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskName)
+                .containsExactly(
+                        tuple("usertask1", "User Task 1")
+                );
     }
 
     @Test
@@ -176,12 +187,14 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         List<CurrentTaskTransactionDependentTaskListener.CurrentTask> currentTasks = CurrentTaskTransactionDependentTaskListener.getCurrentTasks();
-        assertEquals(1, currentTasks.size());
-
-        assertEquals("usertask1", currentTasks.get(0).getTaskId());
-        assertEquals("User Task 1", currentTasks.get(0).getTaskName());
-        assertEquals(1, currentTasks.get(0).getCustomPropertiesMap().size());
-        assertEquals("usertask1", currentTasks.get(0).getCustomPropertiesMap().get("customProp1"));
+        assertThat(currentTasks)
+                .extracting(CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskId,
+                        CurrentTaskTransactionDependentTaskListener.CurrentTask::getTaskName)
+                .containsExactly(
+                        tuple("usertask1", "User Task 1")
+                );
+        assertThat(currentTasks.get(0).getCustomPropertiesMap())
+                .containsExactly(entry("customProp1", "usertask1"));
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
@@ -158,8 +158,8 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testTaskCompleteListener() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
-        assertNull(runtimeService.getVariable(processInstance.getId(), "greeting"));
-        assertNull(runtimeService.getVariable(processInstance.getId(), "expressionValue"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "greeting")).isNull();
+        assertThat(runtimeService.getVariable(processInstance.getId(), "expressionValue")).isNull();
 
         // Completing first task will change the description
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
@@ -173,7 +173,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTest.bpmn20.xml" })
     public void testTaskListenerWithExpression() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
-        assertNull(runtimeService.getVariable(processInstance.getId(), "greeting2"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "greeting2")).isNull();
 
         // Completing first task will change the description
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskassignee/TaskAssigneeTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskassignee/TaskAssigneeTest.java
@@ -12,11 +12,15 @@
  */
 package org.flowable.examples.bpmn.usertask.taskassignee;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.util.List;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,13 +39,12 @@ public class TaskAssigneeTest extends PluggableFlowableTestCase {
 
         // Get task list
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
-        assertEquals(1, tasks.size());
-        org.flowable.task.api.Task myTask = tasks.get(0);
-        assertEquals("Schedule meeting", myTask.getName());
-        assertEquals("Schedule an engineering meeting for next week with the new hire.", myTask.getDescription());
+        assertThat(tasks)
+                .extracting(Task::getName, Task::getDescription)
+                .containsExactly(tuple("Schedule meeting", "Schedule an engineering meeting for next week with the new hire."));
 
         // Complete task. Process is now finished
-        taskService.complete(myTask.getId());
+        taskService.complete(tasks.get(0).getId());
         // assert if the process instance completed
         assertProcessEnded(processInstance.getId());
     }


### PR DESCRIPTION
This is part 3 (of 3) for the `org.flowable.examples.bpmn` package. The files converted are in the `tasklistener` and `usertask` subpackages.
