### PR TITLE
Update assertj fluent style in flowable-app-engine module.

### DIFF
--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -47,7 +47,7 @@ public class ForceCloseMybatisConnectionPoolTest {
         appEngine.close();
 
         // the idle connections are closed
-        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
     @Test
@@ -73,7 +73,7 @@ public class ForceCloseMybatisConnectionPoolTest {
         assertThat(state.getIdleConnectionCount()).isPositive();
 
         pooledDataSource.forceCloseAll();
-        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
 }

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/persistence/EntitiesTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/persistence/EntitiesTest.java
@@ -47,10 +47,12 @@ public class EntitiesTest {
     public void verifyEntitiesInEntityDependencyOrder() {
         Set<String> mappedResources = getMappedResources();
         for (String mappedResource : mappedResources) {
-            assertThat(EntityDependencyOrder.INSERT_ORDER.contains(getAndAssertEntityImplClass(mappedResource)))
-                .as("No insert entry in EntityDependencyOrder for " + mappedResource).isTrue();
-            assertThat(EntityDependencyOrder.DELETE_ORDER.contains(getAndAssertEntityImplClass(mappedResource)))
-                .as("No delete entry in EntityDependencyOrder for " + mappedResource).isTrue();
+            assertThat(EntityDependencyOrder.INSERT_ORDER)
+                    .as("No insert entry in EntityDependencyOrder for " + mappedResource)
+                    .contains(getAndAssertEntityImplClass(mappedResource));
+            assertThat(EntityDependencyOrder.DELETE_ORDER)
+                    .as("No delete entry in EntityDependencyOrder for " + mappedResource)
+                    .contains(getAndAssertEntityImplClass(mappedResource));
         }
     }
     
@@ -58,8 +60,9 @@ public class EntitiesTest {
     public void verifyEntitiesInTableDataManager() {
         Set<String> mappedResources = getMappedResources();
         for (String mappedResource : mappedResources) {
-            assertThat(EntityToTableMap.entityToTableNameMap.containsKey(getAndAssertEntityInterfaceClass(mappedResource)))
-                .as("No entry in TableDataManagerImpl for " + mappedResource).isTrue();
+            assertThat(EntityToTableMap.entityToTableNameMap)
+                    .as("No entry in TableDataManagerImpl for " + mappedResource)
+                    .containsKey(getAndAssertEntityInterfaceClass(mappedResource));
         }
     }
     

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CaseDefinitionQueryTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CaseDefinitionQueryTest.java
@@ -103,8 +103,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidDeploymentId() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId("invalid").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId("invalid").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId("invalid").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentId("invalid").count()).isZero();
     }
 
     @Test
@@ -127,8 +127,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidDeploymentIds() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).count()).isZero();
     }
 
     @Test
@@ -158,8 +158,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionId() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId("invalid").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId("invalid").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId("invalid").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionId("invalid").count()).isZero();
     }
 
     @Test
@@ -182,8 +182,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionIds() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).count()).isZero();
     }
 
     @Test
@@ -194,8 +194,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionCategory() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("invalid").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("invalid").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("invalid").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategory("invalid").count()).isZero();
     }
 
     @Test
@@ -206,8 +206,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionCategoryLike() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("invalid%").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("invalid%n").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("invalid%").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryLike("invalid%n").count()).isZero();
     }
 
     @Test
@@ -215,8 +215,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("another").list()).hasSize(4);
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("another").count()).isEqualTo(4);
 
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("http://flowable.org/app").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("http://flowable.org/app").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("http://flowable.org/app").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionCategoryNotEquals("http://flowable.org/app").count()).isZero();
     }
 
     @Test
@@ -233,8 +233,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionName() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Case 3").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Case 3").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Case 3").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionName("Case 3").count()).isZero();
     }
 
     @Test
@@ -245,8 +245,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("Full%").list()).hasSize(1);
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("Full%").count()).isEqualTo(1);
 
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("invalid%").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("invalid%").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("invalid%").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionNameLike("invalid%").count()).isZero();
     }
 
     @Test
@@ -260,8 +260,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionKey() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("invalid").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("invalid").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("invalid").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKey("invalid").count()).isZero();
     }
 
     @Test
@@ -275,8 +275,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionKeyLike() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%invalid").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%invalid").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%invalid").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionKeyLike("%invalid").count()).isZero();
     }
 
     @Test
@@ -290,8 +290,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).list()).hasSize(1);
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(2).count()).isEqualTo(1);
 
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(4).list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(4).count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(4).list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersion(4).count()).isZero();
     }
 
     @Test
@@ -299,8 +299,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(2).list()).hasSize(1);
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(2).count()).isEqualTo(1);
 
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(3).list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(3).count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(3).list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThan(3).count()).isZero();
     }
 
     @Test
@@ -311,8 +311,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(3).list()).hasSize(1);
         assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(3).count()).isEqualTo(1);
 
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(4).list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(4).count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(4).list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionVersionGreaterThanOrEquals(4).count()).isZero();
     }
 
     @Test
@@ -368,8 +368,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionResourceName() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("invalid.app").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("invalid.app").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("invalid.app").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceName("invalid.app").count()).isZero();
     }
 
     @Test
@@ -383,8 +383,8 @@ public class CaseDefinitionQueryTest extends FlowableAppTestCase {
 
     @Test
     public void testQueryByInvalidAppDefinitionResourceNameLike() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%invalid%").list()).hasSize(0);
-        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%invalid%").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%invalid%").list()).isEmpty();
+        assertThat(appRepositoryService.createAppDefinitionQuery().appDefinitionResourceNameLike("%invalid%").count()).isZero();
     }
 
     @Test

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CustomAppModelTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/CustomAppModelTest.java
@@ -40,9 +40,7 @@ public class CustomAppModelTest extends FlowableAppTestCase {
             AppDefinition appDefinition = appRepositoryService.createAppDefinitionQuery().appDefinitionKey("extraInfoApp").singleResult();
             
             AppModel appModel = appRepositoryService.getAppModel(appDefinition.getId());
-            assertThat(appModel)
-                .isNotNull()
-                .isInstanceOf(CustomAppModel.class);
+            assertThat(appModel).isInstanceOf(CustomAppModel.class);
             
             CustomAppModel customAppModel = (CustomAppModel) appModel;
             assertThat(customAppModel.getKey()).isEqualTo("extraInfoApp");

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentQueryTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/repository/DeploymentQueryTest.java
@@ -77,8 +77,8 @@ public class DeploymentQueryTest extends FlowableAppTestCase {
     @Test
     public void testQueryByInvalidDeploymentId() {
         assertThat(appRepositoryService.createDeploymentQuery().deploymentId("invalid").singleResult()).isNull();
-        assertThat(appRepositoryService.createDeploymentQuery().deploymentId("invalid").list()).hasSize(0);
-        assertThat(appRepositoryService.createDeploymentQuery().deploymentId("invalid").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId("invalid").list()).isEmpty();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentId("invalid").count()).isZero();
     }
     
     @Test
@@ -92,8 +92,8 @@ public class DeploymentQueryTest extends FlowableAppTestCase {
     @Test
     public void testQueryByInvalidDeploymentName() {
         assertThat(appRepositoryService.createDeploymentQuery().deploymentName("invalid").singleResult()).isNull();
-        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("invalid").list()).hasSize(0);
-        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("invalid").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("invalid").list()).isEmpty();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentName("invalid").count()).isZero();
     }
     
     @Test
@@ -104,8 +104,8 @@ public class DeploymentQueryTest extends FlowableAppTestCase {
         assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("test%").count()).isEqualTo(1);
         
         assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").singleResult()).isNull();
-        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").list()).hasSize(0);
-        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").list()).isEmpty();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").count()).isZero();
     }
     
     @Test
@@ -119,8 +119,8 @@ public class DeploymentQueryTest extends FlowableAppTestCase {
     @Test
     public void testQueryByInvalidDeploymentCategory() {
         assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").singleResult()).isNull();
-        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").list()).hasSize(0);
-        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").count()).isEqualTo(0);
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").list()).isEmpty();
+        assertThat(appRepositoryService.createDeploymentQuery().deploymentCategory("invalid").count()).isZero();
     }
     
     @Test


### PR DESCRIPTION
Update assertj code in `org.flowable.app.engine.test` package to use more idiomatic and less redudant assertj constructs.

For example, there is no need to test for `notNull` before `isInstanceOf` as the latter includes the former.
