### PR TITLE
Update assertj fluent style in flowable-bpmn-converter module.

### DIFF
--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/AsyncEndEventConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/AsyncEndEventConverterTest.java
@@ -15,8 +15,6 @@ package org.flowable.editor.language.xml;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import java.util.List;
-
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.EndEvent;
 import org.flowable.bpmn.model.FlowElement;
@@ -46,16 +44,13 @@ public class AsyncEndEventConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("endEvent");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(EndEvent.class);
-        assertThat(flowElement.getId()).isEqualTo("endEvent");
-        EndEvent endEvent = (EndEvent) flowElement;
-        assertThat(endEvent.getId()).isEqualTo("endEvent");
-        assertThat(endEvent.isAsynchronous()).isTrue();
-
-        List<FlowableListener> listeners = endEvent.getExecutionListeners();
-        assertThat(listeners)
-                .extracting(FlowableListener::getImplementationType, FlowableListener::getImplementation, FlowableListener::getEvent)
-                .containsExactly(tuple(ImplementationType.IMPLEMENTATION_TYPE_CLASS, "org.test.TestClass", "start"));
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(EndEvent.class, endEvent -> {
+                    assertThat(endEvent.getId()).isEqualTo("endEvent");
+                    assertThat(endEvent.isAsynchronous()).isTrue();
+                    assertThat(endEvent.getExecutionListeners())
+                            .extracting(FlowableListener::getImplementationType, FlowableListener::getImplementation, FlowableListener::getEvent)
+                            .containsExactly(tuple(ImplementationType.IMPLEMENTATION_TYPE_CLASS, "org.test.TestClass", "start"));
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CallActivityConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CallActivityConverterTest.java
@@ -15,8 +15,6 @@ package org.flowable.editor.language.xml;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import java.util.List;
-
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.CallActivity;
 import org.flowable.bpmn.model.FlowElement;
@@ -45,29 +43,24 @@ public class CallActivityConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("callactivity");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(CallActivity.class);
-        CallActivity callActivity = (CallActivity) flowElement;
-        assertThat(callActivity.getId()).isEqualTo("callactivity");
-        assertThat(callActivity.getName()).isEqualTo("Call activity");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(CallActivity.class, callActivity -> {
+                    assertThat(callActivity.getId()).isEqualTo("callactivity");
+                    assertThat(callActivity.getName()).isEqualTo("Call activity");
+                    assertThat(callActivity.getCalledElement()).isEqualTo("processId");
+                    assertThat(callActivity.getFallbackToDefaultTenant()).isTrue();
+                    assertThat(callActivity.getInParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
+                            .containsExactly(
+                                    tuple("test", "test", null),
+                                    tuple(null, "test", "${test}")
+                            );
+                    assertThat(callActivity.getOutParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget)
+                            .containsExactly(
+                                    tuple("test", "test")
+                            );
 
-        assertThat(callActivity.getCalledElement()).isEqualTo("processId");
-
-        assertThat(callActivity.getFallbackToDefaultTenant()).isTrue();
-
-        List<IOParameter> parameters = callActivity.getInParameters();
-        assertThat(parameters)
-                .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
-                .containsExactly(
-                        tuple("test", "test", null),
-                        tuple(null, "test", "${test}")
-                );
-
-        parameters = callActivity.getOutParameters();
-        assertThat(parameters)
-                .extracting(IOParameter::getSource, IOParameter::getTarget)
-                .containsExactly(
-                        tuple("test", "test")
-                );
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CallActivityWithFallbackValueFalseConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CallActivityWithFallbackValueFalseConverterTest.java
@@ -15,8 +15,6 @@ package org.flowable.editor.language.xml;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import java.util.List;
-
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.CallActivity;
 import org.flowable.bpmn.model.FlowElement;
@@ -45,29 +43,23 @@ public class CallActivityWithFallbackValueFalseConverterTest extends AbstractCon
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("callactivity");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(CallActivity.class);
-        CallActivity callActivity = (CallActivity) flowElement;
-        assertThat(callActivity.getId()).isEqualTo("callactivity");
-        assertThat(callActivity.getName()).isEqualTo("Call activity");
-
-        assertThat(callActivity.getCalledElement()).isEqualTo("processId");
-
-        assertThat(callActivity.getFallbackToDefaultTenant()).isFalse();
-
-        List<IOParameter> parameters = callActivity.getInParameters();
-        assertThat(parameters)
-                .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
-                .containsExactly(
-                        tuple("test", "test", null),
-                        tuple(null, "test", "${test}")
-                );
-
-        parameters = callActivity.getOutParameters();
-        assertThat(parameters)
-                .extracting(IOParameter::getSource, IOParameter::getTarget)
-                .containsExactly(
-                        tuple("test", "test")
-                );
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(CallActivity.class, callActivity -> {
+                    assertThat(callActivity.getId()).isEqualTo("callactivity");
+                    assertThat(callActivity.getName()).isEqualTo("Call activity");
+                    assertThat(callActivity.getCalledElement()).isEqualTo("processId");
+                    assertThat(callActivity.getFallbackToDefaultTenant()).isFalse();
+                    assertThat(callActivity.getInParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
+                            .containsExactly(
+                                    tuple("test", "test", null),
+                                    tuple(null, "test", "${test}")
+                            );
+                    assertThat(callActivity.getOutParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget)
+                            .containsExactly(
+                                    tuple("test", "test")
+                            );
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CallActivityWithNoFallbackConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CallActivityWithNoFallbackConverterTest.java
@@ -15,8 +15,6 @@ package org.flowable.editor.language.xml;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import java.util.List;
-
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.CallActivity;
 import org.flowable.bpmn.model.FlowElement;
@@ -45,29 +43,23 @@ public class CallActivityWithNoFallbackConverterTest extends AbstractConverterTe
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("callactivity");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(CallActivity.class);
-        CallActivity callActivity = (CallActivity) flowElement;
-        assertThat(callActivity.getId()).isEqualTo("callactivity");
-        assertThat(callActivity.getName()).isEqualTo("Call activity");
-
-        assertThat(callActivity.getCalledElement()).isEqualTo("processId");
-
-        assertThat(callActivity.getFallbackToDefaultTenant()).isNull();
-
-        List<IOParameter> parameters = callActivity.getInParameters();
-        assertThat(parameters)
-                .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
-                .containsExactly(
-                        tuple("test", "test", null),
-                        tuple(null, "test", "${test}")
-                );
-
-        parameters = callActivity.getOutParameters();
-        assertThat(parameters)
-                .extracting(IOParameter::getSource, IOParameter::getTarget)
-                .containsExactly(
-                        tuple("test", "test")
-                );
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(CallActivity.class, callActivity -> {
+                    assertThat(callActivity.getId()).isEqualTo("callactivity");
+                    assertThat(callActivity.getName()).isEqualTo("Call activity");
+                    assertThat(callActivity.getCalledElement()).isEqualTo("processId");
+                    assertThat(callActivity.getFallbackToDefaultTenant()).isNull();
+                    assertThat(callActivity.getInParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
+                            .containsExactly(
+                                    tuple("test", "test", null),
+                                    tuple(null, "test", "${test}")
+                            );
+                    assertThat(callActivity.getOutParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget)
+                            .containsExactly(
+                                    tuple("test", "test")
+                            );
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CaseServiceTaskConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CaseServiceTaskConverterTest.java
@@ -15,8 +15,6 @@ package org.flowable.editor.language.xml;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import java.util.List;
-
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.CaseServiceTask;
 import org.flowable.bpmn.model.FlowElement;
@@ -45,30 +43,24 @@ public class CaseServiceTaskConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("caseServiceTask");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(CaseServiceTask.class);
-        CaseServiceTask caseServiceTask = (CaseServiceTask) flowElement;
-        assertThat(caseServiceTask.getId()).isEqualTo("caseServiceTask");
-        assertThat(caseServiceTask.getName()).isEqualTo("Case task");
-
-        assertThat(caseServiceTask.getCaseDefinitionKey()).isEqualTo("caseId");
-
-        assertThat(caseServiceTask.isFallbackToDefaultTenant()).isTrue();
-        assertThat(caseServiceTask.isSameDeployment()).isFalse();
-
-        List<IOParameter> parameters = caseServiceTask.getInParameters();
-        assertThat(parameters)
-                .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
-                .containsExactly(
-                        tuple("test", "test", null),
-                        tuple(null, "test", "${test}")
-                );
-
-        parameters = caseServiceTask.getOutParameters();
-        assertThat(parameters)
-                .extracting(IOParameter::getSource, IOParameter::getTarget)
-                .containsExactly(
-                        tuple("test", "test")
-                );
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(CaseServiceTask.class, caseServiceTask -> {
+                    assertThat(caseServiceTask.getId()).isEqualTo("caseServiceTask");
+                    assertThat(caseServiceTask.getName()).isEqualTo("Case task");
+                    assertThat(caseServiceTask.getCaseDefinitionKey()).isEqualTo("caseId");
+                    assertThat(caseServiceTask.isFallbackToDefaultTenant()).isTrue();
+                    assertThat(caseServiceTask.isSameDeployment()).isFalse();
+                    assertThat(caseServiceTask.getInParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget, IOParameter::getSourceExpression)
+                            .containsExactly(
+                                    tuple("test", "test", null),
+                                    tuple(null, "test", "${test}")
+                            );
+                    assertThat(caseServiceTask.getOutParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget)
+                            .containsExactly(
+                                    tuple("test", "test")
+                            );
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CollapsedSubProcessConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CollapsedSubProcessConverterTest.java
@@ -13,6 +13,7 @@
 package org.flowable.editor.language.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,10 +61,8 @@ public class CollapsedSubProcessConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel bpmnModel) {
         //temp vars
-        GraphicInfo gi = null;
-        GraphicInfo start = null;
-        GraphicInfo end = null;
-        List<GraphicInfo> flowLocationGraphicInfo = null;
+        GraphicInfo gi;
+        List<GraphicInfo> flowLocationGraphicInfo;
 
         //validate parent
         gi = bpmnModel.getGraphicInfo(START_EVENT);
@@ -74,19 +73,17 @@ public class CollapsedSubProcessConverterTest extends AbstractConverterTest {
         assertThat(gi.getExpanded()).isNull();
 
         flowLocationGraphicInfo = bpmnModel.getFlowLocationGraphicInfo(SEQUENCEFLOW_TO_COLLAPSEDSUBPROCESS);
-        assertThat(flowLocationGraphicInfo).hasSize(2);
 
         gi = bpmnModel.getGraphicInfo(COLLAPSEDSUBPROCESS);
         assertThat(gi.getExpanded()).isFalse();
 
         //intersection points traversed from xml are full points it seems...
-        start = flowLocationGraphicInfo.get(0);
-        assertThat(start.getX()).isEqualTo(102.0);
-        assertThat(start.getY()).isEqualTo(111.0);
-
-        end = flowLocationGraphicInfo.get(1);
-        assertThat(end.getX()).isEqualTo(165.0);
-        assertThat(end.getY()).isEqualTo(112.0);
+        assertThat(flowLocationGraphicInfo)
+                .extracting(GraphicInfo::getX, GraphicInfo::getY)
+                .containsExactly(
+                        tuple(102.0, 111.0),
+                        tuple(165.0, 112.0)
+                );
 
         //validate graphic infos
         FlowElement flowElement = bpmnModel.getFlowElement(IN_CSB_START_EVENT);
@@ -99,23 +96,24 @@ public class CollapsedSubProcessConverterTest extends AbstractConverterTest {
         assertThat(gi.getHeight()).isEqualTo(30.0);
 
         flowElement = bpmnModel.getFlowElement(IN_CSB_SEQUENCEFLOW_TO_USERTASK);
-        assertThat(flowElement).isInstanceOf(SequenceFlow.class);
-        assertThat(flowElement.getName()).isEqualTo("to ut");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(SequenceFlow.class, sequenceFlow -> {
+                            assertThat(sequenceFlow.getName()).isEqualTo("to ut");
+                        });
 
         flowLocationGraphicInfo = bpmnModel.getFlowLocationGraphicInfo(IN_CSB_SEQUENCEFLOW_TO_USERTASK);
-        assertThat(flowLocationGraphicInfo).hasSize(2);
-
-        start = flowLocationGraphicInfo.get(0);
-        assertThat(start.getX()).isEqualTo(120.0);
-        assertThat(start.getY()).isEqualTo(150.0);
-
-        end = flowLocationGraphicInfo.get(1);
-        assertThat(end.getX()).isEqualTo(232.0);
-        assertThat(end.getY()).isEqualTo(150.0);
+        assertThat(flowLocationGraphicInfo)
+                .extracting(GraphicInfo::getX, GraphicInfo::getY)
+                .containsExactly(
+                        tuple(120.0, 150.0),
+                        tuple(232.0, 150.0)
+                );
 
         flowElement = bpmnModel.getFlowElement(IN_CSB_USERTASK);
-        assertThat(flowElement).isInstanceOf(UserTask.class);
-        assertThat(flowElement.getName()).isEqualTo("User task 1");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(UserTask.class, userTask -> {
+                    assertThat(userTask.getName()).isEqualTo("User task 1");
+                });
 
         gi = bpmnModel.getGraphicInfo(IN_CSB_USERTASK);
         assertThat(gi.getX()).isEqualTo(232.0);
@@ -124,19 +122,19 @@ public class CollapsedSubProcessConverterTest extends AbstractConverterTest {
         assertThat(gi.getHeight()).isEqualTo(80.0);
 
         flowElement = bpmnModel.getFlowElement(IN_CSB_SEQUENCEFLOW_TO_END);
-        assertThat(flowElement).isInstanceOf(SequenceFlow.class);
-        assertThat(flowElement.getName()).isEqualTo("to end");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(SequenceFlow.class, sequenceFlow -> {
+                    assertThat(sequenceFlow.getName()).isEqualTo("to end");
+                });
 
         flowLocationGraphicInfo = bpmnModel.getFlowLocationGraphicInfo(IN_CSB_SEQUENCEFLOW_TO_END);
-        assertThat(flowLocationGraphicInfo).hasSize(2);
+        assertThat(flowLocationGraphicInfo)
+                .extracting(GraphicInfo::getX, GraphicInfo::getY)
+                .containsExactly(
+                        tuple(332.0, 150.0),
+                        tuple(435.0, 150.0)
+                );
 
-        start = flowLocationGraphicInfo.get(0);
-        assertThat(start.getX()).isEqualTo(332.0);
-        assertThat(start.getY()).isEqualTo(150.0);
-
-        end = flowLocationGraphicInfo.get(1);
-        assertThat(end.getX()).isEqualTo(435.0);
-        assertThat(end.getY()).isEqualTo(150.0);
     }
 
     @Override
@@ -192,7 +190,7 @@ public class CollapsedSubProcessConverterTest extends AbstractConverterTest {
             if (diInfo == null) {
                 diInfo = multiSubEdgeMap.get(id);
             }
-            assertThat(diInfo).hasSize(info.size());
+            assertThat(diInfo).hasSameSizeAs(info);
             compareCollections(info, diInfo);
         }
 
@@ -208,4 +206,5 @@ public class CollapsedSubProcessConverterTest extends AbstractConverterTest {
             assertThat(locationMap.get(id).equals(shapeInfo));
         }
     }
+
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CommaSplitterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CommaSplitterTest.java
@@ -29,7 +29,6 @@ public class CommaSplitterTest {
     public void testNoComma() {
         String testString = "Test String";
         List<String> result = CommaSplitter.splitCommas(testString);
-        assertThat(result).isNotNull();
         assertThat(result).containsExactly(testString);
     }
 
@@ -37,7 +36,6 @@ public class CommaSplitterTest {
     public void testOneComa() {
         String testString = "Test,String";
         List<String> result = CommaSplitter.splitCommas(testString);
-        assertThat(result).isNotNull();
         assertThat(result).containsExactly("Test", "String");
     }
 
@@ -45,7 +43,6 @@ public class CommaSplitterTest {
     public void testManyCommas() {
         String testString = "does,anybody,really,read,this,nonsense";
         List<String> result = CommaSplitter.splitCommas(testString);
-        assertThat(result).isNotNull();
         assertThat(result).containsExactly("does", "anybody", "really", "read", "this", "nonsense");
     }
 
@@ -53,7 +50,6 @@ public class CommaSplitterTest {
     public void testCommaAtStart() {
         String testString = ",first,second";
         List<String> result = CommaSplitter.splitCommas(testString);
-        assertThat(result).isNotNull();
         assertThat(result).containsExactly("first", "second");
     }
 
@@ -61,7 +57,6 @@ public class CommaSplitterTest {
     public void testCommaAtEnd() {
         String testString = "first,second,";
         List<String> result = CommaSplitter.splitCommas(testString);
-        assertThat(result).isNotNull();
         assertThat(result).containsExactly("first", "second");
     }
 
@@ -69,7 +64,6 @@ public class CommaSplitterTest {
     public void testCommaAtStartAndEnd() {
         String testString = ",first,second,";
         List<String> result = CommaSplitter.splitCommas(testString);
-        assertThat(result).isNotNull();
         assertThat(result).containsExactly("first", "second");
     }
 
@@ -77,7 +71,6 @@ public class CommaSplitterTest {
     public void testOneComaInExpression() {
         String testString = "${first,second}";
         List<String> result = CommaSplitter.splitCommas(testString);
-        assertThat(result).isNotNull();
         assertThat(result).containsExactly(testString);
     }
 
@@ -85,7 +78,6 @@ public class CommaSplitterTest {
     public void testOManyComaInExpression() {
         String testString = "${Everything,should,be,made,as,simple,as,possible},but,no,simpler";
         List<String> result = CommaSplitter.splitCommas(testString);
-        assertThat(result).isNotNull();
         assertThat(result).containsExactly("${Everything,should,be,made,as,simple,as,possible}", "but", "no", "simpler");
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CompleteConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CompleteConverterTest.java
@@ -45,29 +45,30 @@ public class CompleteConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("userTask1");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(UserTask.class);
-        assertThat(flowElement.getId()).isEqualTo("userTask1");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(UserTask.class, userTask -> {
+                    assertThat(userTask.getId()).isEqualTo("userTask1");
+                });
 
         flowElement = model.getMainProcess().getFlowElement("catchsignal");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(IntermediateCatchEvent.class);
-        assertThat(flowElement.getId()).isEqualTo("catchsignal");
-        IntermediateCatchEvent catchEvent = (IntermediateCatchEvent) flowElement;
-        assertThat(catchEvent.getEventDefinitions()).hasSize(1);
-        assertThat(catchEvent.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);
-        SignalEventDefinition signalEvent = (SignalEventDefinition) catchEvent.getEventDefinitions().get(0);
-        assertThat(signalEvent.getSignalRef()).isEqualTo("testSignal");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(IntermediateCatchEvent.class, intermediateCatchEvent -> {
+                    assertThat(intermediateCatchEvent.getId()).isEqualTo("catchsignal");
+                    assertThat(intermediateCatchEvent.getEventDefinitions()).hasSize(1);
+                    assertThat(intermediateCatchEvent.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);
+                    SignalEventDefinition signalEvent = (SignalEventDefinition) intermediateCatchEvent.getEventDefinitions().get(0);
+                    assertThat(signalEvent.getSignalRef()).isEqualTo("testSignal");
+                });
 
         flowElement = model.getMainProcess().getFlowElement("subprocess");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(SubProcess.class);
-        assertThat(flowElement.getId()).isEqualTo("subprocess");
-        SubProcess subProcess = (SubProcess) flowElement;
-
-        flowElement = subProcess.getFlowElement("receiveTask");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(ReceiveTask.class);
-        assertThat(flowElement.getId()).isEqualTo("receiveTask");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(SubProcess.class, subProcess -> {
+                    assertThat(subProcess.getId()).isEqualTo("subprocess");
+                    FlowElement task = subProcess.getFlowElement("receiveTask");
+                    assertThat(task)
+                            .isInstanceOfSatisfying(ReceiveTask.class, receiveTask -> {
+                                assertThat(receiveTask.getId()).isEqualTo("receiveTask");
+                            });
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CustomNamespaceAttributeConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/CustomNamespaceAttributeConverterTest.java
@@ -55,25 +55,23 @@ public class CustomNamespaceAttributeConverterTest extends AbstractConverterTest
                 .containsExactly(tuple("http://custom.org/bpmn", "custom", "version", "9"));
 
         FlowElement flowElement = model.getMainProcess().getFlowElement("usertask");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(UserTask.class);
-        assertThat(flowElement.getId()).isEqualTo("usertask");
-        UserTask userTask = (UserTask) flowElement;
-        assertThat(userTask.getId()).isEqualTo("usertask");
-        assertThat(userTask.getName()).isEqualTo("User Task");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(UserTask.class, userTask -> {
+                    assertThat(userTask.getId()).isEqualTo("usertask");
+                    assertThat(userTask.getName()).isEqualTo("User Task");
 
-        Map<String, List<ExtensionAttribute>> attributesMap = userTask.getAttributes();
-        assertThat(attributesMap).isNotNull();
-        assertThat(attributesMap).hasSize(2);
+                    Map<String, List<ExtensionAttribute>> attributesMap = userTask.getAttributes();
+                    assertThat(attributesMap).hasSize(2);
 
-        attributes = attributesMap.get("id");
-        assertThat(attributes)
-                .extracting(ExtensionAttribute::getName, ExtensionAttribute::getValue, ExtensionAttribute::getNamespacePrefix, ExtensionAttribute::getNamespace)
-                .containsExactly(tuple("id", "test", "custom2", "http://custom2.org/bpmn"));
+                    List<ExtensionAttribute> attr = attributesMap.get("id");
+                    assertThat(attr)
+                            .extracting(ExtensionAttribute::getName, ExtensionAttribute::getValue, ExtensionAttribute::getNamespacePrefix, ExtensionAttribute::getNamespace)
+                            .containsExactly(tuple("id", "test", "custom2", "http://custom2.org/bpmn"));
 
-        attributes = attributesMap.get("attr");
-        assertThat(attributes)
-                .extracting(ExtensionAttribute::getName, ExtensionAttribute::getValue, ExtensionAttribute::getNamespacePrefix, ExtensionAttribute::getNamespace)
-                .containsExactly(tuple("attr", "attrValue", "custom2", "http://custom2.org/bpmn"));
+                    attr = attributesMap.get("attr");
+                    assertThat(attr)
+                            .extracting(ExtensionAttribute::getName, ExtensionAttribute::getValue, ExtensionAttribute::getNamespacePrefix, ExtensionAttribute::getNamespace)
+                            .containsExactly(tuple("attr", "attrValue", "custom2", "http://custom2.org/bpmn"));
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/DataObjectConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/DataObjectConverterTest.java
@@ -51,9 +51,10 @@ public class DataObjectConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("start1");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(StartEvent.class);
-        assertThat(flowElement.getId()).isEqualTo("start1");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(StartEvent.class, startEvent -> {
+                    assertThat(startEvent.getId()).isEqualTo("start1");
+                });
 
         // verify the main process data objects
         List<ValuedDataObject> dataObjects = model.getMainProcess().getDataObjects();
@@ -98,16 +99,17 @@ public class DataObjectConverterTest extends AbstractConverterTest {
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:string");
 
         flowElement = model.getMainProcess().getFlowElement("userTask1");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(UserTask.class);
-        assertThat(flowElement.getId()).isEqualTo("userTask1");
-        UserTask userTask = (UserTask) flowElement;
-        assertThat(userTask.getAssignee()).isEqualTo("kermit");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(UserTask.class, userTask -> {
+                    assertThat(userTask.getId()).isEqualTo("userTask1");
+                    assertThat(userTask.getAssignee()).isEqualTo("kermit");
+                });
 
         flowElement = model.getMainProcess().getFlowElement("subprocess1");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(SubProcess.class);
-        assertThat(flowElement.getId()).isEqualTo("subprocess1");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(SubProcess.class, subProcess -> {
+                    assertThat(subProcess.getId()).isEqualTo("subprocess1");
+                });
         SubProcess subProcess = (SubProcess) flowElement;
         assertThat(subProcess.getFlowElements()).hasSize(12);
 

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/DataStoreConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/DataStoreConverterTest.java
@@ -52,7 +52,6 @@ public class DataStoreConverterTest extends AbstractConverterTest {
         assertThat(dataStore.getItemSubjectRef()).isEqualTo("test");
 
         FlowElement refElement = model.getFlowElement("DataStoreReference_1");
-        assertThat(refElement).isNotNull();
         assertThat(refElement).isInstanceOf(DataStoreReference.class);
 
         assertThat(model.getPools())

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/EncodingConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/EncodingConverterTest.java
@@ -36,12 +36,11 @@ public class EncodingConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("writeReportTask");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(UserTask.class);
-        assertThat(flowElement.getId()).isEqualTo("writeReportTask");
-        UserTask userTask = (UserTask) flowElement;
-        assertThat(userTask.getId()).isEqualTo("writeReportTask");
-        assertThat(userTask.getName()).isEqualTo("Fazer relatório");
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(UserTask.class, userTask -> {
+                    assertThat(userTask.getId()).isEqualTo("writeReportTask");
+                    assertThat(userTask.getName()).isEqualTo("Fazer relatório");
+                });
     }
 
     @Override

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/EventBasedGatewayConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/EventBasedGatewayConverterTest.java
@@ -44,13 +44,12 @@ public class EventBasedGatewayConverterTest extends AbstractConverterTest {
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("eventBasedGateway");
-        assertThat(flowElement).isNotNull();
-        assertThat(flowElement).isInstanceOf(EventGateway.class);
-
-        EventGateway gateway = (EventGateway) flowElement;
-        List<FlowableListener> listeners = gateway.getExecutionListeners();
-        assertThat(listeners)
-                .extracting(FlowableListener::getImplementationType, FlowableListener::getImplementation, FlowableListener::getEvent)
-                .containsExactly(tuple(ImplementationType.IMPLEMENTATION_TYPE_CLASS, "org.test.TestClass", "start"));
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(EventGateway.class, eventGateway -> {
+                    List<FlowableListener> listeners = eventGateway.getExecutionListeners();
+                    assertThat(listeners)
+                            .extracting(FlowableListener::getImplementationType, FlowableListener::getImplementation, FlowableListener::getEvent)
+                            .containsExactly(tuple(ImplementationType.IMPLEMENTATION_TYPE_CLASS, "org.test.TestClass", "start"));
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ExternalWorkerServiceTaskConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ExternalWorkerServiceTaskConverterTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.editor.language.xml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.ExternalWorkerServiceTask;
@@ -43,15 +41,14 @@ public class ExternalWorkerServiceTaskConverterTest extends AbstractConverterTes
 
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("externalWorkerServiceTask");
-        assertNotNull(flowElement);
-        assertTrue(flowElement instanceof ExternalWorkerServiceTask);
-        ExternalWorkerServiceTask externalWorkerServiceTask = (ExternalWorkerServiceTask) flowElement;
-        assertEquals("externalWorkerServiceTask", externalWorkerServiceTask.getId());
-        assertEquals("External worker task", externalWorkerServiceTask.getName());
+        assertThat(flowElement)
+                .isInstanceOfSatisfying(ExternalWorkerServiceTask.class, externalWorkerServiceTask -> {
+                    assertThat(externalWorkerServiceTask.getId()).isEqualTo("externalWorkerServiceTask");
+                    assertThat(externalWorkerServiceTask.getName()).isEqualTo("External worker task");
 
-        assertEquals("topic", externalWorkerServiceTask.getTopic());
-        assertEquals("skipExpression", externalWorkerServiceTask.getSkipExpression());
-        assertTrue(externalWorkerServiceTask.isExclusive());
-
+                    assertThat(externalWorkerServiceTask.getTopic()).isEqualTo("topic");
+                    assertThat(externalWorkerServiceTask.getSkipExpression()).isEqualTo("skipExpression");
+                    assertThat(externalWorkerServiceTask.isExclusive()).isTrue();
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ExternalWorkerServiceTaskWithExtensionElementsConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ExternalWorkerServiceTaskWithExtensionElementsConverterTest.java
@@ -44,23 +44,22 @@ public class ExternalWorkerServiceTaskWithExtensionElementsConverterTest extends
     private void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("externalWorkerServiceTask");
         assertThat(flowElement)
-                .isNotNull()
-                .isInstanceOf(ExternalWorkerServiceTask.class);
-        ExternalWorkerServiceTask externalWorkerServiceTask = (ExternalWorkerServiceTask) flowElement;
-        assertThat(externalWorkerServiceTask.getId()).isEqualTo("externalWorkerServiceTask");
-        assertThat(externalWorkerServiceTask.getName()).isEqualTo("External worker task");
+                .isInstanceOfSatisfying(ExternalWorkerServiceTask.class, externalWorkerServiceTask -> {
+                    assertThat(externalWorkerServiceTask.getId()).isEqualTo("externalWorkerServiceTask");
+                    assertThat(externalWorkerServiceTask.getName()).isEqualTo("External worker task");
 
-        assertThat(externalWorkerServiceTask.getTopic()).isEqualTo("topic");
-        assertThat(externalWorkerServiceTask.getSkipExpression()).isEqualTo("skipExpression");
-        assertThat(externalWorkerServiceTask.isExclusive()).isTrue();
+                    assertThat(externalWorkerServiceTask.getTopic()).isEqualTo("topic");
+                    assertThat(externalWorkerServiceTask.getSkipExpression()).isEqualTo("skipExpression");
+                    assertThat(externalWorkerServiceTask.isExclusive()).isTrue();
 
-        assertThat(externalWorkerServiceTask.getExtensionElements())
-                .containsOnlyKeys("customValue");
+                    assertThat(externalWorkerServiceTask.getExtensionElements())
+                            .containsOnlyKeys("customValue");
 
-        assertThat(externalWorkerServiceTask.getExtensionElements().get("customValue"))
-                .extracting(ExtensionElement::getNamespacePrefix, ExtensionElement::getName, ExtensionElement::getElementText)
-                .containsOnly(
-                        tuple("flowable", "customValue", "test")
-                );
+                    assertThat(externalWorkerServiceTask.getExtensionElements().get("customValue"))
+                            .extracting(ExtensionElement::getNamespacePrefix, ExtensionElement::getName, ExtensionElement::getElementText)
+                            .containsOnly(
+                                    tuple("flowable", "customValue", "test")
+                            );
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/FormPropertiesConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/FormPropertiesConverterTest.java
@@ -54,54 +54,59 @@ public class FormPropertiesConverterTest extends AbstractConverterTest {
         assertThat(model.getMainProcess().isExecutable()).isTrue();
 
         FlowElement startFlowElement = model.getMainProcess().getFlowElement("startNode");
-        assertThat(startFlowElement).isNotNull();
-        assertThat(startFlowElement).isInstanceOf(StartEvent.class);
-        StartEvent startEvent = (StartEvent) startFlowElement;
-
-        for (FormProperty formProperty : startEvent.getFormProperties()) {
-            assertThat(formProperty.isRequired()).isTrue();
-        }
+        assertThat(startFlowElement)
+                .isInstanceOfSatisfying(StartEvent.class, startEvent -> {
+                            for (FormProperty formProperty : startEvent.getFormProperties()) {
+                                assertThat(formProperty.isRequired()).isTrue();
+                            }
+                        });
 
         FlowElement userFlowElement = model.getMainProcess().getFlowElement("userTask");
-        assertThat(userFlowElement).isNotNull();
-        assertThat(userFlowElement).isInstanceOf(UserTask.class);
-        UserTask userTask = (UserTask) userFlowElement;
+        assertThat(userFlowElement)
+                .isInstanceOfSatisfying(UserTask.class, userTask -> {
 
-        List<FormProperty> formProperties = userTask.getFormProperties();
+                    List<FormProperty> formProperties = userTask.getFormProperties();
+                    assertThat(formProperties).as("Invalid form properties list: ").hasSize(8);
 
-        assertThat(formProperties).isNotNull();
-        assertThat(formProperties).as("Invalid form properties list: ").hasSize(8);
+                    for (FormProperty formProperty : formProperties) {
+                        switch (formProperty.getId()) {
+                            case "new_property_1":
+                                checkFormProperty(formProperty, false, false, false);
+                                break;
+                            case "new_property_2":
+                                checkFormProperty(formProperty, false, false, true);
+                                break;
+                            case "new_property_3":
+                                checkFormProperty(formProperty, false, true, false);
+                                break;
+                            case "new_property_4":
+                                checkFormProperty(formProperty, false, true, true);
+                                break;
+                            case "new_property_5":
+                                checkFormProperty(formProperty, true, false, false);
 
-        for (FormProperty formProperty : formProperties) {
-            if (formProperty.getId().equals("new_property_1")) {
-                checkFormProperty(formProperty, false, false, false);
-            } else if (formProperty.getId().equals("new_property_2")) {
-                checkFormProperty(formProperty, false, false, true);
-            } else if (formProperty.getId().equals("new_property_3")) {
-                checkFormProperty(formProperty, false, true, false);
-            } else if (formProperty.getId().equals("new_property_4")) {
-                checkFormProperty(formProperty, false, true, true);
-            } else if (formProperty.getId().equals("new_property_5")) {
-                checkFormProperty(formProperty, true, false, false);
+                                List<Map<String, Object>> formValues = new ArrayList<>();
+                                for (FormValue formValue : formProperty.getFormValues()) {
+                                    Map<String, Object> formValueMap = new HashMap<>();
+                                    formValueMap.put("id", formValue.getId());
+                                    formValueMap.put("name", formValue.getName());
+                                    formValues.add(formValueMap);
+                                }
+                                checkFormPropertyFormValues(formValues);
 
-                List<Map<String, Object>> formValues = new ArrayList<>();
-                for (FormValue formValue : formProperty.getFormValues()) {
-                    Map<String, Object> formValueMap = new HashMap<>();
-                    formValueMap.put("id", formValue.getId());
-                    formValueMap.put("name", formValue.getName());
-                    formValues.add(formValueMap);
-                }
-                checkFormPropertyFormValues(formValues);
-
-            } else if (formProperty.getId().equals("new_property_6")) {
-                checkFormProperty(formProperty, true, false, true);
-            } else if (formProperty.getId().equals("new_property_7")) {
-                checkFormProperty(formProperty, true, true, false);
-            } else if (formProperty.getId().equals("new_property_8")) {
-                checkFormProperty(formProperty, true, true, true);
-            }
-        }
-
+                                break;
+                            case "new_property_6":
+                                checkFormProperty(formProperty, true, false, true);
+                                break;
+                            case "new_property_7":
+                                checkFormProperty(formProperty, true, true, false);
+                                break;
+                            case "new_property_8":
+                                checkFormProperty(formProperty, true, true, true);
+                                break;
+                        }
+                    }
+                });
     }
 
     private void checkFormProperty(FormProperty formProperty, boolean shouldBeRequired, boolean shouldBeReadable, boolean shouldBeWritable) {

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/InCompleteSignalConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/InCompleteSignalConverterTest.java
@@ -46,7 +46,6 @@ public class InCompleteSignalConverterTest extends AbstractConverterTest {
 
         ProcessValidator processValidator = new ProcessValidatorFactory().createDefaultProcessValidator();
         List<ValidationError> errors = processValidator.validate(model);
-        assertThat(errors).isNotNull();
         assertThat(errors).hasSize(2);
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/SubProcessMultiDiagramConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/SubProcessMultiDiagramConverterTest.java
@@ -164,7 +164,7 @@ public class SubProcessMultiDiagramConverterTest extends AbstractConverterTest {
             if (diInfo == null) {
                 diInfo = multiSubEdgeMap.get(id);
             }
-            assertThat(diInfo).hasSize(info.size());
+            assertThat(diInfo).hasSameSizeAs(info);
             compareCollections(info, diInfo);
         }
 

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ValuedDataObjectConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ValuedDataObjectConverterTest.java
@@ -13,6 +13,7 @@
 package org.flowable.editor.language.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -76,50 +77,61 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
         assertThat(dataObj.getId()).isEqualTo("dObj1");
         assertThat(dataObj.getName()).isEqualTo("StringTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:string");
-        assertThat(dataObj.getValue()).isInstanceOf(String.class);
-        assertThat(dataObj.getValue()).isEqualTo("Testing1&2&3");
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(String.class, value -> {
+                    assertThat(value).isEqualTo("Testing1&2&3");
+                });
 
         dataObj = objectMap.get("dObj2");
         assertThat(dataObj.getId()).isEqualTo("dObj2");
         assertThat(dataObj.getName()).isEqualTo("BooleanTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:boolean");
-        assertThat(dataObj.getValue()).isInstanceOf(Boolean.class);
-        assertThat(dataObj.getValue()).isEqualTo(Boolean.TRUE);
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Boolean.class, value -> {
+                    assertThat(value).isTrue();
+                });
 
         dataObj = objectMap.get("dObj3");
         assertThat(dataObj.getId()).isEqualTo("dObj3");
         assertThat(dataObj.getName()).isEqualTo("DateTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:datetime");
-        assertThat(dataObj.getValue()).isInstanceOf(Date.class);
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        assertThat(sdf.format(dataObj.getValue())).isEqualTo("2013-09-16T11:23:00");
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Date.class, value -> {
+                    assertThat(sdf.format(value)).isEqualTo("2013-09-16T11:23:00");
+                });
 
         dataObj = objectMap.get("dObj4");
         assertThat(dataObj.getId()).isEqualTo("dObj4");
         assertThat(dataObj.getName()).isEqualTo("DoubleTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:double");
-        assertThat(dataObj.getValue()).isInstanceOf(Double.class);
-        assertThat(dataObj.getValue()).isEqualTo(123456789d);
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Double.class, value -> {
+                    assertThat(value).isEqualTo(123456789d);
+                });
 
         dataObj = objectMap.get("dObj5");
         assertThat(dataObj.getId()).isEqualTo("dObj5");
         assertThat(dataObj.getName()).isEqualTo("IntegerTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:int");
-        assertThat(dataObj.getValue()).isInstanceOf(Integer.class);
-        assertThat(dataObj.getValue()).isEqualTo(123);
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Integer.class, value -> {
+                    assertThat(value).isEqualTo(123);
+                });
 
         dataObj = objectMap.get("dObj6");
         assertThat(dataObj.getId()).isEqualTo("dObj6");
         assertThat(dataObj.getName()).isEqualTo("LongTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:long");
-        assertThat(dataObj.getValue()).isInstanceOf(Long.class);
-        assertThat(dataObj.getValue()).isEqualTo(-123456L);
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Long.class, value -> {
+                    assertThat(value).isEqualTo(-123456L);
+                });
         assertThat(dataObj.getExtensionElements()).hasSize(1);
         List<ExtensionElement> testValues = dataObj.getExtensionElements().get("testvalue");
-        assertThat(testValues).isNotNull();
-        assertThat(testValues).hasSize(1);
-        assertThat(testValues.get(0).getName()).isEqualTo("testvalue");
-        assertThat(testValues.get(0).getElementText()).isEqualTo("test");
+        assertThat(testValues)
+                .extracting(ExtensionElement::getName, ExtensionElement::getElementText)
+                .containsExactly(tuple("testvalue", "test"));
 
         dataObj = objectMap.get("dObjJson");
         assertThat(dataObj.getId()).isEqualTo("dObjJson");
@@ -164,42 +176,53 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
         assertThat(dataObj.getId()).isEqualTo("dObj7");
         assertThat(dataObj.getName()).isEqualTo("StringSubTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:string");
-        assertThat(dataObj.getValue()).isInstanceOf(String.class);
-        assertThat(dataObj.getValue()).isEqualTo("Testing456");
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(String.class, value -> {
+                    assertThat(value).isEqualTo("Testing456");
+                });
 
         dataObj = objectMap.get("dObj8");
         assertThat(dataObj.getId()).isEqualTo("dObj8");
         assertThat(dataObj.getName()).isEqualTo("BooleanSubTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:boolean");
-        assertThat(dataObj.getValue()).isInstanceOf(Boolean.class);
-        assertThat(dataObj.getValue()).isEqualTo(Boolean.FALSE);
-
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Boolean.class, value -> {
+                    assertThat(value).isFalse();
+                });
         dataObj = objectMap.get("dObj9");
         assertThat(dataObj.getId()).isEqualTo("dObj9");
         assertThat(dataObj.getName()).isEqualTo("DateSubTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:datetime");
-        assertThat(dataObj.getValue()).isInstanceOf(Date.class);
-        assertThat(sdf.format(dataObj.getValue())).isEqualTo("2013-11-11T22:00:00");
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Date.class, value -> {
+                    assertThat(sdf.format(value)).isEqualTo("2013-11-11T22:00:00");
+                });
 
         dataObj = objectMap.get("dObj10");
         assertThat(dataObj.getId()).isEqualTo("dObj10");
         assertThat(dataObj.getName()).isEqualTo("DoubleSubTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:double");
-        assertThat(dataObj.getValue()).isInstanceOf(Double.class);
-        assertThat(dataObj.getValue()).isEqualTo(678912345d);
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Double.class, value -> {
+                    assertThat(value).isEqualTo(678912345d);
+                });
 
         dataObj = objectMap.get("dObj11");
         assertThat(dataObj.getId()).isEqualTo("dObj11");
         assertThat(dataObj.getName()).isEqualTo("IntegerSubTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:int");
-        assertThat(dataObj.getValue()).isInstanceOf(Integer.class);
-        assertThat(dataObj.getValue()).isEqualTo(45);
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Integer.class, value -> {
+                    assertThat(value).isEqualTo(45);
+                });
 
         dataObj = objectMap.get("dObj12");
         assertThat(dataObj.getId()).isEqualTo("dObj12");
         assertThat(dataObj.getName()).isEqualTo("LongSubTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:long");
-        assertThat(dataObj.getValue()).isInstanceOf(Long.class);
-        assertThat(dataObj.getValue()).isEqualTo(456123L);
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Long.class, value -> {
+                    assertThat(value).isEqualTo(456123L);
+                });
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ValuedDataObjectWithExtensionsConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ValuedDataObjectWithExtensionsConverterTest.java
@@ -147,8 +147,10 @@ public class ValuedDataObjectWithExtensionsConverterTest extends AbstractConvert
         assertThat(dataObj.getId()).isEqualTo("dObj1");
         assertThat(dataObj.getName()).isEqualTo("StringTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:string");
-        assertThat(dataObj.getValue()).isInstanceOf(String.class);
-        assertThat(dataObj.getValue()).isEqualTo("Testing123");
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(String.class, value -> {
+                    assertThat(value).isEqualTo("Testing123");
+                });
 
         /*
          * Verify DataObject attributes extension
@@ -187,8 +189,10 @@ public class ValuedDataObjectWithExtensionsConverterTest extends AbstractConvert
         assertThat(dataObj.getId()).isEqualTo("dObj2");
         assertThat(dataObj.getName()).isEqualTo("BooleanTest");
         assertThat(dataObj.getItemSubjectRef().getStructureRef()).isEqualTo("xsd:boolean");
-        assertThat(dataObj.getValue()).isInstanceOf(Boolean.class);
-        assertThat(dataObj.getValue()).isEqualTo(Boolean.TRUE);
+        assertThat(dataObj.getValue())
+                .isInstanceOfSatisfying(Boolean.class, value -> {
+                    assertThat(value).isTrue();
+                });
 
         /*
          * Verify DataObject attributes extension


### PR DESCRIPTION
Updates to the `org.flowable.editor.language.xml` package to use more natural assertj style coding and remove unnecessary duplicate tests (e.g., testing for null by `isInstanceOf` or null before `hasSize`).
Also found one file that was added in April (`org.flowable.editor.language.xml.ExternalWorkerServiceTaskConverterTest`) that needed to be converted to assertj.

Originally thought there would be multiple PRs but the second half of the module was in much better shape so I just added the 4 additional files to this PR.
