### PR TITLE
Update assertj fluent style in flowable-cmmn-converter module.

### DIFF
--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseCustomExtensionElementXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseCustomExtensionElementXmlConverterTest.java
@@ -51,10 +51,11 @@ public class CaseCustomExtensionElementXmlConverterTest extends AbstractConverte
 
         List<ExtensionElement> customElements = primaryCase.getExtensionElements().get("customElement");
         assertThat(customElements)
-                .extracting(ExtensionElement::getElementText, ExtensionElement::getNamespacePrefix, ExtensionElement::getNamespace)
-                .containsExactly(tuple("Element text", "flowable", "http://flowable.org/cmmn"));
-
-        assertThat(customElements.get(0).getAttributeValue(null, "attribute")).isEqualTo("Value");
+                .extracting(ExtensionElement::getElementText,
+                        ExtensionElement::getNamespacePrefix,
+                        ExtensionElement::getNamespace,
+                        extensionElement -> extensionElement.getAttributeValue(null, "attribute"))
+                .containsExactly(tuple("Element text", "flowable", "http://flowable.org/cmmn", "Value"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CaseTaskCmmnXmlConverterTest.java
@@ -69,7 +69,6 @@ public class CaseTaskCmmnXmlConverterTest extends AbstractConverterTest {
                     assertThat(task1.getInParameters())
                             .extracting(IOParameter::getSource, IOParameter::getTarget)
                             .containsExactly(tuple("testSource", "testTarget"));
-
                 });
     }
 

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CmmnXmlConverterTest.java
@@ -129,7 +129,6 @@ public class CmmnXmlConverterTest extends AbstractConverterTest {
 
             if (!planItem.getId().equals("planItemTaskA")) {
                 assertThat(planItem.getEntryCriteria())
-                        .isNotNull()
                         .hasSize(1)
                         .extracting(Criterion::getSentry)
                         .isNotNull(); // Verify if sentry reference is resolved

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CompletionNeutralConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CompletionNeutralConverterTest.java
@@ -80,7 +80,6 @@ public class CompletionNeutralConverterTest extends AbstractConverterTest {
             planItemDefinitions.forEach(definition -> {
                 assertThat(definition.getDefaultControl()).isNotNull();
                 assertThat(definition.getDefaultControl().getCompletionNeutralRule()).isNotNull();
-                assertThat(definition.getDefaultControl().getCompletionNeutralRule().getCondition()).isNotNull();
                 assertThat(definition.getDefaultControl().getCompletionNeutralRule().getCondition()).isEqualTo("${" + definition.getId() + "}");
             });
 

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/EventListenerWithEventTypeXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/EventListenerWithEventTypeXmlConverterTest.java
@@ -46,16 +46,16 @@ public class EventListenerWithEventTypeXmlConverterTest extends AbstractConverte
 
     public void validateModel(CmmnModel cmmnModel) {
         PlanItemDefinition planItemDefinition = cmmnModel.findPlanItemDefinition("eventListener");
-        assertThat(planItemDefinition).isInstanceOf(GenericEventListener.class);
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(GenericEventListener.class, genericEventListener -> {
+                    assertThat(genericEventListener.getEventType()).isEqualTo("myEvent");
 
-        GenericEventListener genericEventListener = (GenericEventListener) planItemDefinition;
-        assertThat(genericEventListener.getEventType()).isEqualTo("myEvent");
-
-        List<ExtensionElement> correlationParameters = genericEventListener.getExtensionElements().getOrDefault("eventCorrelationParameter", new ArrayList<>());
-        assertThat(correlationParameters)
-                .extracting(extensionElement -> extensionElement.getAttributeValue(null, "name"),
-                        extensionElement -> extensionElement.getAttributeValue(null, "value"))
-                .containsExactly(tuple("customerId", "${customerIdVar}"));
+                    List<ExtensionElement> correlationParameters = genericEventListener.getExtensionElements().getOrDefault("eventCorrelationParameter", new ArrayList<>());
+                    assertThat(correlationParameters)
+                            .extracting(extensionElement -> extensionElement.getAttributeValue(null, "name"),
+                                    extensionElement -> extensionElement.getAttributeValue(null, "value"))
+                            .containsExactly(tuple("customerId", "${customerIdVar}"));
+                });
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExternalWorkerServiceTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExternalWorkerServiceTaskCmmnXmlConverterTest.java
@@ -68,32 +68,33 @@ public class ExternalWorkerServiceTaskCmmnXmlConverterTest extends AbstractConve
         PlanItem planItemTaskA = cmmnModel.findPlanItem("planItemTaskA");
         PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
         assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
-        assertThat(planItemDefinition).isInstanceOf(ExternalWorkerServiceTask.class);
-
-        ExternalWorkerServiceTask taskA = (ExternalWorkerServiceTask) planItemDefinition;
-        assertThat(taskA.getType()).isEqualTo(ExternalWorkerServiceTask.TYPE);
-        assertThat(taskA.getName()).isEqualTo("A");
-        assertThat(taskA.getTopic()).isEqualTo("simple");
-        assertThat(taskA.isAsync()).isFalse();
-        assertThat(taskA.isExclusive()).isFalse();
-        assertThat(taskA.getExtensionElements()).containsOnlyKeys("customValue");
-        assertThat(taskA.getExtensionElements().get("customValue"))
-                .extracting(ExtensionElement::getNamespacePrefix, ExtensionElement::getName, ExtensionElement::getElementText)
-                .containsOnly(
-                        tuple("flowable", "customValue", "test")
-                );
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ExternalWorkerServiceTask.class, externalWorkerServiceTask -> {
+                            assertThat(externalWorkerServiceTask.getType()).isEqualTo(ExternalWorkerServiceTask.TYPE);
+                            assertThat(externalWorkerServiceTask.getName()).isEqualTo("A");
+                            assertThat(externalWorkerServiceTask.getTopic()).isEqualTo("simple");
+                            assertThat(externalWorkerServiceTask.isAsync()).isFalse();
+                            assertThat(externalWorkerServiceTask.isExclusive()).isFalse();
+                            assertThat(externalWorkerServiceTask.getExtensionElements()).containsOnlyKeys("customValue");
+                            assertThat(externalWorkerServiceTask.getExtensionElements().get("customValue"))
+                                    .extracting(ExtensionElement::getNamespacePrefix, ExtensionElement::getName, ExtensionElement::getElementText)
+                                    .containsOnly(
+                                            tuple("flowable", "customValue", "test")
+                                    );
+                        });
 
         PlanItem planItemTaskB = cmmnModel.findPlanItem("planItemTaskB");
         planItemDefinition = planItemTaskB.getPlanItemDefinition();
         assertThat(planItemTaskB.getEntryCriteria()).hasSize(1);
-        assertThat(planItemDefinition).isInstanceOf(ExternalWorkerServiceTask.class);
-        ExternalWorkerServiceTask taskB = (ExternalWorkerServiceTask) planItemDefinition;
-        assertThat(taskB.getType()).isEqualTo(ExternalWorkerServiceTask.TYPE);
-        assertThat(taskB.getName()).isEqualTo("B");
-        assertThat(taskB.getTopic()).isNull();
-        assertThat(taskB.isAsync()).isFalse();
-        assertThat(taskB.isExclusive()).isTrue();
-        assertThat(taskB.getExtensionElements()).isEmpty();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ExternalWorkerServiceTask.class, externalWorkerServiceTask -> {
+                    assertThat(externalWorkerServiceTask.getType()).isEqualTo(ExternalWorkerServiceTask.TYPE);
+                    assertThat(externalWorkerServiceTask.getName()).isEqualTo("B");
+                    assertThat(externalWorkerServiceTask.getTopic()).isNull();
+                    assertThat(externalWorkerServiceTask.isAsync()).isFalse();
+                    assertThat(externalWorkerServiceTask.isExclusive()).isTrue();
+                    assertThat(externalWorkerServiceTask.getExtensionElements()).isEmpty();
+                });
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/NestedStagesCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/NestedStagesCmmnXmlConverterTest.java
@@ -53,7 +53,7 @@ public class NestedStagesCmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(nestedStage).isNotNull();
         assertThat(nestedStage.getName()).isEqualTo("Nested Stage");
 
-        // Nested stage has 3 plan items, and one of them refereces the rootTask from the plan model
+        // Nested stage has 3 plan items, and one of them references the rootTask from the plan model
         assertThat(nestedStage.getPlanItems()).hasSize(3);
         Stage nestedNestedStage = null;
         for (PlanItem planItem : nestedStage.getPlanItems()) {

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
@@ -57,11 +57,10 @@ public class ParentCompletionConverterTest extends AbstractConverterTest {
         Stage stageOne = (Stage) cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionInStageOrDownwards("stageOne");
         List<PlanItem> planItems1 = stageOne.getPlanItems();
         assertThat(planItems1).hasSize(1);
-        assertThat(planItems1)
-                .extracting(planItem2 -> planItem2.getItemControl(),
-                        planItem2 -> planItem2.getItemControl().getParentCompletionRule())
-                .doesNotContainNull();
-        assertThat(planItems1.get(0).getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE_AFTER_FIRST_COMPLETION);
+        PlanItem planItem = planItems1.get(0);
+        assertThat(planItem.getItemControl()).isNotNull();
+        assertThat(planItem.getItemControl().getParentCompletionRule()).isNotNull();
+        assertThat(planItem.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE_AFTER_FIRST_COMPLETION);
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ParentCompletionConverterTest.java
@@ -57,10 +57,11 @@ public class ParentCompletionConverterTest extends AbstractConverterTest {
         Stage stageOne = (Stage) cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionInStageOrDownwards("stageOne");
         List<PlanItem> planItems1 = stageOne.getPlanItems();
         assertThat(planItems1).hasSize(1);
-        PlanItem planItem = planItems1.get(0);
-        assertThat(planItem.getItemControl()).isNotNull();
-        assertThat(planItem.getItemControl().getParentCompletionRule()).isNotNull();
-        assertThat(planItem.getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE_AFTER_FIRST_COMPLETION);
+        assertThat(planItems1)
+                .extracting(planItem2 -> planItem2.getItemControl(),
+                        planItem2 -> planItem2.getItemControl().getParentCompletionRule())
+                .doesNotContainNull();
+        assertThat(planItems1.get(0).getItemControl().getParentCompletionRule().getType()).isEqualTo(ParentCompletionRule.IGNORE_AFTER_FIRST_COMPLETION);
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ProcessTaskCmmnXmlConverterTest.java
@@ -60,20 +60,22 @@ public class ProcessTaskCmmnXmlConverterTest extends AbstractConverterTest {
 
         PlanItem planItemTask1 = cmmnModel.findPlanItem("planItem1");
         PlanItemDefinition planItemDefinition = planItemTask1.getPlanItemDefinition();
-        assertThat(planItemDefinition).isInstanceOf(ProcessTask.class);
-        ProcessTask task1 = (ProcessTask) planItemDefinition;
-        assertThat(task1.getProcessRefExpression()).isEqualTo("${processDefinitionKey}");
-        assertThat((task1.isSameDeployment())).isNotNull();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ProcessTask.class, processTask -> {
+                    assertThat(processTask.getId()).isEqualTo("theProcess");
+                    assertThat(processTask.getProcessRefExpression()).isEqualTo("${processDefinitionKey}");
+                    assertThat((processTask.isSameDeployment())).isNotNull();
 
-        assertThat(task1.getInParameters())
-                .extracting(IOParameter::getSource, IOParameter::getTarget)
-                .containsExactly(tuple("num2", "num"));
+                    assertThat(processTask.getInParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget)
+                            .containsExactly(tuple("num2", "num"));
 
-        assertThat(task1.getOutParameters())
-                .extracting(IOParameter::getSource, IOParameter::getTarget)
-                .containsExactly(tuple("num", "num3"));
+                    assertThat(processTask.getOutParameters())
+                            .extracting(IOParameter::getSource, IOParameter::getTarget)
+                            .containsExactly(tuple("num", "num3"));
 
-        assertThat(task1.getFallbackToDefaultTenant()).isTrue();
+                    assertThat(processTask.getFallbackToDefaultTenant()).isTrue();
+                });
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/RepetitionRuleExtendedAttributesConverterTest.java
@@ -48,7 +48,6 @@ public class RepetitionRuleExtendedAttributesConverterTest extends AbstractConve
 
     public void validateModel(CmmnModel cmmnModel) {
         assertThat(cmmnModel).isNotNull();
-        assertThat(cmmnModel.getCases()).isNotNull();
         assertThat(cmmnModel.getCases()).hasSize(1);
 
         Map<String, CaseElement> caseElements = cmmnModel.getCases().get(0).getAllCaseElements();

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/SimpleCmmnXmlConverterTest.java
@@ -13,6 +13,7 @@
 package org.flowable.test.cmmn.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -49,18 +50,16 @@ public class SimpleCmmnXmlConverterTest extends AbstractConverterTest {
 
     public void validateModel(CmmnModel cmmnModel) {
         assertThat(cmmnModel).isNotNull();
-        assertThat(cmmnModel.getCases()).hasSize(1);
+        assertThat(cmmnModel.getCases())
+                .extracting(Case::getId, Case::getInitiatorVariableName)
+                .containsExactly(tuple("myCase", "test"));
 
         // Case
         Case caze = cmmnModel.getCases().get(0);
-        assertThat(caze.getId()).isEqualTo("myCase");
-        assertThat(caze.getInitiatorVariableName()).isEqualTo("test");
-        assertThat(caze.getCandidateStarterUsers()).hasSize(2);
-        assertThat(caze.getCandidateStarterUsers().contains("test")).isTrue();
-        assertThat(caze.getCandidateStarterUsers().contains("test2")).isTrue();
-        assertThat(caze.getCandidateStarterGroups()).hasSize(2);
-        assertThat(caze.getCandidateStarterGroups().contains("group")).isTrue();
-        assertThat(caze.getCandidateStarterGroups().contains("group2")).isTrue();
+        assertThat(caze.getCandidateStarterUsers())
+                .containsExactlyInAnyOrder("test", "test2");
+        assertThat(caze.getCandidateStarterGroups())
+                .containsExactlyInAnyOrder("group", "group2");
 
         // Plan model
         Stage planModel = caze.getPlanModel();
@@ -75,9 +74,9 @@ public class SimpleCmmnXmlConverterTest extends AbstractConverterTest {
         for (Sentry sentry : planModel.getSentries()) {
             List<SentryOnPart> onParts = sentry.getOnParts();
             assertThat(onParts)
-                .hasSize(1)
-                .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getSource, SentryOnPart::getStandardEvent)
-                .doesNotContainNull();
+                    .hasSize(1)
+                    .extracting(SentryOnPart::getId, SentryOnPart::getSourceRef, SentryOnPart::getSource, SentryOnPart::getStandardEvent)
+                    .doesNotContainNull();
         }
 
         // Plan items definitions
@@ -97,8 +96,8 @@ public class SimpleCmmnXmlConverterTest extends AbstractConverterTest {
         int nrOfMileStones = 0;
         for (PlanItem planItem : planItems) {
             assertThat(planItem)
-                .extracting(PlanItem::getId, PlanItem::getDefinitionRef, PlanItem::getPlanItemDefinition) // Verify plan item definition ref is resolved
-                .doesNotContainNull();
+                    .extracting(PlanItem::getId, PlanItem::getDefinitionRef, PlanItem::getPlanItemDefinition) // Verify plan item definition ref is resolved
+                    .doesNotContainNull();
 
             PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
             if (planItemDefinition instanceof Milestone) {
@@ -108,7 +107,6 @@ public class SimpleCmmnXmlConverterTest extends AbstractConverterTest {
             }
 
             if (!planItem.getId().equals("planItemTaskA")) {
-                assertThat(planItem.getEntryCriteria()).isNotNull();
                 assertThat(planItem.getEntryCriteria()).hasSize(1);
                 assertThat(planItem.getEntryCriteria().get(0).getSentry()).isNotNull(); // Verify if sentry reference is resolved
             }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/TimerEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/TimerEventListenerCmmnXmlConverterTest.java
@@ -41,9 +41,10 @@ public class TimerEventListenerCmmnXmlConverterTest extends AbstractConverterTes
 
         List<TimerEventListener> timerEventListeners = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(TimerEventListener.class, true);
         assertThat(timerEventListeners)
-                .extracting(TimerEventListener::getTimerExpression, TimerEventListener::getTimerStartTriggerStandardEvent)
-                .containsExactly(tuple("PT6H", PlanItemTransition.COMPLETE));
-        assertThat(timerEventListeners.get(0).getTimerStartTriggerPlanItem().getName()).isEqualTo("A");
+                .extracting(timerEventListener -> timerEventListener.getTimerExpression(),
+                        timerEventListener -> timerEventListener.getTimerStartTriggerStandardEvent(),
+                        timerEventListener -> timerEventListener.getTimerStartTriggerPlanItem().getName())
+                .containsExactly(tuple("PT6H", PlanItemTransition.COMPLETE, "A"));
     }
 
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/UserEventListenerCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/UserEventListenerCmmnXmlConverterTest.java
@@ -13,6 +13,7 @@
 package org.flowable.test.cmmn.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
@@ -48,11 +49,8 @@ public class UserEventListenerCmmnXmlConverterTest extends AbstractConverterTest
         assertThat(humanTasks).hasSize(2);
 
         List<UserEventListener> userEventListeners = cmmnModel.getPrimaryCase().getPlanModel().findPlanItemDefinitionsOfType(UserEventListener.class, true);
-        assertThat(userEventListeners).hasSize(1);
-
-        UserEventListener userEventListener = userEventListeners.get(0);
-        assertThat(userEventListener.getName()).isEqualTo("myUserEventListener");
-        assertThat(userEventListener.getId()).isEqualTo("userActionListener");
-        assertThat(userEventListener.getDocumentation()).isEqualTo("UserEventListener documentation");
+        assertThat(userEventListeners)
+                .extracting(UserEventListener::getName, UserEventListener::getId, UserEventListener::getDocumentation)
+                .containsExactly(tuple("myUserEventListener", "userActionListener", "UserEventListener documentation"));
     }
 }


### PR DESCRIPTION
Minor changes to file in the `org.flowable.test.cmmn.converter` directory to make the assertj statements more like the preferred style.