### PR TITLE
Update assertj fluent style in flowable-cmmn-engine module.

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncCmmnHistoryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncCmmnHistoryTest.java
@@ -93,7 +93,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
                 .referenceId("someReferenceId")
                 .referenceType("someReferenceType")
                 .start();
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isZero();
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(1);
@@ -150,12 +150,12 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         cmmnTaskService.complete(task.getId());
         waitForAsyncHistoryExecutorToProcessAllJobs();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(1);
         cmmnHistoryService.deleteHistoricCaseInstance(caseInstance.getId());
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -176,7 +176,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
     public void testMilestoneReached() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("caseWithOneMilestone").start();
         assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isZero();
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
 
@@ -211,7 +211,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
     @CmmnDeployment
     public void testVariables() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneHumanTaskCase").start();
-        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         cmmnRuntimeService.setVariable(caseInstance.getId(), "test", "hello world");
         cmmnRuntimeService.setVariable(caseInstance.getId(), "test2", 2);
@@ -270,7 +270,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
     public void testHumanTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneHumanTaskCase").start();
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
         assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
@@ -308,7 +308,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         // Complete
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         cmmnTaskService.complete(task.getId());
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
         historicTaskInstance = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
@@ -418,8 +418,8 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
     public void testCasePageTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneCasePageTask").start();
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
         assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
@@ -469,7 +469,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         // Complete
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         cmmnTaskService.complete(task.getId());
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
         HistoricTaskInstance historicTaskInstance = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
@@ -489,7 +489,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testSimpleCaseFlow").start();
         List<PlanItemInstance> currentPlanItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
         assertThat(currentPlanItemInstances).hasSize(3);
-        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isZero();
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
         assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(3);
@@ -545,8 +545,8 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         cmmnRuntimeService.disablePlanItemInstance(task.getId());
         waitForAsyncHistoryExecutorToProcessAllJobs();
 
-        assertThat(cmmnManagementService.createHistoryJobQuery().scopeType(ScopeTypes.CMMN).count()).isEqualTo(0);
-        assertThat(cmmnManagementService.createDeadLetterJobQuery().scopeType(ScopeTypes.CMMN).count()).isEqualTo(0);
+        assertThat(cmmnManagementService.createHistoryJobQuery().scopeType(ScopeTypes.CMMN).count()).isZero();
+        assertThat(cmmnManagementService.createDeadLetterJobQuery().scopeType(ScopeTypes.CMMN).count()).isZero();
 
         HistoricPlanItemInstance historicPlanItemInstance = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(task.getId())
                 .singleResult();
@@ -680,9 +680,9 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
 
         HistoricTaskLogEntry historicTaskLogEntry = null;
         try {
-            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId("1").count()).isEqualTo(0l);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId("1").count()).isZero();
             waitForAsyncHistoryExecutorToProcessAllJobs();
-            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId("1").count()).isEqualTo(1l);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId("1").count()).isEqualTo(1);
 
             historicTaskLogEntry = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId("1").singleResult();
             assertThat(historicTaskLogEntry.getLogNumber()).isPositive();
@@ -722,56 +722,56 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         cmmnTaskService.deleteGroupIdentityLink(task.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnTaskService.complete(task.getId());
 
-        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().count()).isEqualTo(0l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().count()).isZero();
         assertThat(cmmnManagementService.createHistoryJobQuery().count()).isEqualTo(10l);
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
 
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(11l);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_CREATED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_NAME_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_PRIORITY_CHANGED.name())
                         .count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_ASSIGNEE_CHANGED.name())
                         .count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_OWNER_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_DUEDATE_CHANGED.name())
                         .count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_ADDED.name())
-                .count()).isEqualTo(2l);
+                .count()).isEqualTo(2);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_REMOVED.name())
-                        .count()).isEqualTo(2l);
+                        .count()).isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_COMPLETED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
     }
 
     @Test
     public void deleteAsynchUserTaskLogEntries() {
         CaseInstance caseInstance = deployAndStartOneHumanTaskCaseModel();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().count()).isEqualTo(0l);
-        assertThat(cmmnManagementService.createHistoryJobQuery().count()).isEqualTo(1l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().count()).isZero();
+        assertThat(cmmnManagementService.createHistoryJobQuery().count()).isEqualTo(1);
         waitForAsyncHistoryExecutorToProcessAllJobs();
         List<HistoricTaskLogEntry> historicTaskLogEntries = cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).list();
         assertThat(historicTaskLogEntries).hasSize(1);
 
         cmmnHistoryService.deleteHistoricTaskLogEntry(historicTaskLogEntries.get(0).getLogNumber());
 
-        assertThat(cmmnManagementService.createHistoryJobQuery().count()).isEqualTo(1l);
+        assertThat(cmmnManagementService.createHistoryJobQuery().count()).isEqualTo(1);
         waitForAsyncHistoryExecutorToProcessAllJobs();
-        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(0l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isZero();
     }
 
     @Test
@@ -782,7 +782,7 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
                 .name("someName")
                 .businessKey("someBusinessKey")
                 .start();
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isZero();
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().count()).isEqualTo(1);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncTaskTest.java
@@ -150,12 +150,12 @@ public class AsyncTaskTest extends FlowableCmmnTestCase {
         cmmnTaskService.complete(task.getId());
 
         // Now 3 async jobs should be created for the 3 async human tasks
-        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(3L);
+        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(3);
 
         List<Job> jobs = cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).list();
         assertThat(jobs).hasSize(3);
         for (Job job : jobs) {
-            assertThat(job.getElementId().startsWith("sid-")).isTrue();
+            assertThat(job.getElementId()).startsWith("sid-");
             assertThat(job.getElementName()).isIn("B", "C", "D");
         }
 
@@ -178,8 +178,8 @@ public class AsyncTaskTest extends FlowableCmmnTestCase {
 
         // Evaluation should not complete the case instance when the async task hasn't been processed yet
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testSingleAsyncTask").start();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         Job job = cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(job).isNotNull();
@@ -209,7 +209,7 @@ public class AsyncTaskTest extends FlowableCmmnTestCase {
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("A");
         cmmnTaskService.complete(task.getId());
-        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         waitForJobExecutorToProcessAllJobs();
         assertCaseInstanceEnded(caseInstance);
@@ -221,7 +221,7 @@ public class AsyncTaskTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTerminateCaseInstance").start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("Non-async");
-        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").singleResult().getState())
                 .isEqualTo(PlanItemInstanceState.ASYNC_ACTIVE);
 
@@ -230,13 +230,13 @@ public class AsyncTaskTest extends FlowableCmmnTestCase {
         // Triggering A should async-activate the three tasks after it
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("A").singleResult();
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(3L);
+        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(3);
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult().getName()).isEqualTo("Non-async");
 
         // Terminating the case should delete also the jobs
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -45,7 +45,7 @@ public class ForceCloseMybatisConnectionPoolTest {
         cmmnEngine.close();
 
         // the idle connections are closed
-        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ForceCloseMybatisConnectionPoolTest {
         assertThat(state.getIdleConnectionCount()).isPositive();
 
         pooledDataSource.forceCloseAll();
-        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/dynamic/ChangeStateActivateHumanTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/dynamic/ChangeStateActivateHumanTaskTest.java
@@ -32,7 +32,7 @@ public class ChangeStateActivateHumanTaskTest extends FlowableCmmnTestCase {
                 .variable("activateFirstTask", false)
                 .start();
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         cmmnRuntimeService.createChangePlanItemStateBuilder()
                 .caseInstanceId(caseInstance.getId())
@@ -87,7 +87,7 @@ public class ChangeStateActivateHumanTaskTest extends FlowableCmmnTestCase {
                 .variable("activateFirstTask", false)
                 .start();
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         cmmnRuntimeService.createChangePlanItemStateBuilder()
                 .caseInstanceId(caseInstance.getId())
@@ -152,7 +152,7 @@ public class ChangeStateActivateHumanTaskTest extends FlowableCmmnTestCase {
                 .variable("activateFirstTask", false)
                 .start();
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().onlyStages().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().onlyStages().caseInstanceId(caseInstance.getId()).singleResult();
@@ -188,7 +188,7 @@ public class ChangeStateActivateHumanTaskTest extends FlowableCmmnTestCase {
                 .variable("activateStage", false)
                 .start();
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().onlyStages().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().onlyStages().caseInstanceId(caseInstance.getId()).singleResult().getState())
                 .isEqualTo(PlanItemInstanceState.AVAILABLE);
@@ -234,7 +234,7 @@ public class ChangeStateActivateHumanTaskTest extends FlowableCmmnTestCase {
                 .changeToAvailableStateByPlanItemDefinitionId("task1")
                 .changeState();
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         PlanItemInstance dbPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/el/CmmnExpressionManagerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/el/CmmnExpressionManagerTest.java
@@ -107,7 +107,7 @@ public class CmmnExpressionManagerTest extends FlowableCmmnTestCase {
                 .variables(vars)
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("methodExpressionCase").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("methodExpressionCase").count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/el/PlanItemInstancesKeyWordInExpressionsTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/el/PlanItemInstancesKeyWordInExpressionsTest.java
@@ -264,7 +264,7 @@ public class PlanItemInstancesKeyWordInExpressionsTest extends FlowableCmmnTestC
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testPlanItemInstancesKeyWord").start();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateActive().count()).isZero();
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateEnabled().singleResult();
         assertThat(planItemInstance.getName()).isEqualTo("A");
@@ -295,7 +295,7 @@ public class PlanItemInstancesKeyWordInExpressionsTest extends FlowableCmmnTestC
 
         // The user event listeners should not be active after start
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
-                .planItemInstanceStateAvailable().count()).isEqualTo(0);
+                .planItemInstanceStateAvailable().count()).isZero();
 
         // Starting the human tasks should make the user event listeners available
         cmmnRuntimeService.startPlanItemInstance(
@@ -316,7 +316,7 @@ public class PlanItemInstancesKeyWordInExpressionsTest extends FlowableCmmnTestC
 
         cmmnRuntimeService.completeUserEventListenerInstance(cmmnRuntimeService.createUserEventListenerInstanceQuery().name("cancel 2").singleResult().getId());
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
-                .planItemInstanceStateAvailable().count()).isEqualTo(0);
+                .planItemInstanceStateAvailable().count()).isZero();
 
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/el/VariableFunctionDelegatesTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/el/VariableFunctionDelegatesTest.java
@@ -153,7 +153,7 @@ public class VariableFunctionDelegatesTest extends FlowableCmmnTestCase {
                 .variable("yesterday", yesterday)
                 .variable("tomorrow", tomorrow)
                 .start();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         Date myVar = new Date(yesterday.getTime() - (60 * 60 * 1000)); // day before yesterday
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myVar", myVar);
@@ -166,7 +166,7 @@ public class VariableFunctionDelegatesTest extends FlowableCmmnTestCase {
                 .variable("yesterday", yesterday)
                 .variable("tomorrow", tomorrow)
                 .start();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         myVar = new Date(tomorrow.getTime() + (60 * 60 * 1000)); // day after tomorrow
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myVar", myVar);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/MultiTenantCmmnEventRegistryConsumerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/MultiTenantCmmnEventRegistryConsumerTest.java
@@ -212,7 +212,7 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         deployCaseModel("startCaseInstanceTenantA.cmmn", TENANT_A);
         deployCaseModel("startCaseInstanceTenantB.cmmn", TENANT_B);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         assertThat(cmmnRuntimeService.createEventSubscriptionQuery().tenantId(TENANT_A).list())
                 .extracting(EventSubscription::getEventType, EventSubscription::getTenantId)
@@ -226,13 +226,13 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         // Note that #triggerEventWithoutTenantId doesn't have a tenantId set, but the channel has it hardcoded
 
         ((TestInboundChannelAdapter) tenantAChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("customerA");
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isZero();
 
         ((TestInboundChannelAdapter) tenantAChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("customerA");
         ((TestInboundChannelAdapter) tenantBChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("customerB");
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(2L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(2);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(1);
     }
 
     @Test
@@ -243,14 +243,14 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         InboundChannelModel tenantAChannelModel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("tenantAChannel", TENANT_A);
         InboundChannelModel tenantBChannelModel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("tenantBChannel", TENANT_B);
         ((TestInboundChannelAdapter) tenantAChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("customerA");
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isZero();
 
         ((TestInboundChannelAdapter) tenantAChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("customerA");
         ((TestInboundChannelAdapter) tenantBChannelModel.getInboundEventChannelAdapter()).triggerEventWithoutTenantId("customerA");
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1L); // no new instance for A started
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1); // no new instance for A started
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count())
-                .isEqualTo(1L); // but a new instance for B (different tenant)
+                .isEqualTo(1); // but a new instance for B (different tenant)
     }
 
     @Test
@@ -261,12 +261,12 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         InboundChannelModel sharedInboundChannelModel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("sharedChannel");
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_A);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isZero();
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_B);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(1);
 
         // The event definitions have the same key, but different payload handling
         CaseInstance tenantAInstance = cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).singleResult();
@@ -278,8 +278,8 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         assertThat(cmmnRuntimeService.getVariable(tenantBInstance.getId(), "tenantSpecificVar2")).isEqualTo("someMoreTenantBValue");
 
         ((TestInboundChannelAdapter) sharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_B);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(2);
     }
 
     @Test
@@ -292,16 +292,16 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         // The chanel has a tenant detector that will use the correct tenant to start the case instance
 
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_A);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isZero();
 
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_A);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(2L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(2);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isZero();
 
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_B);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(2L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(2);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_B).count()).isEqualTo(1);
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/CmmnHistoryServiceDisableTaskLogTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/CmmnHistoryServiceDisableTaskLogTest.java
@@ -41,7 +41,7 @@ public class CmmnHistoryServiceDisableTaskLogTest extends CustomCmmnConfiguratio
     @After
     public void deleteTasks() {
         if (task != null) {
-            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(0L);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isZero();
             cmmnHistoryService.deleteHistoricTaskInstance(task.getId());
             cmmnTaskService.deleteTask(task.getId());
         }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/CmmnHistoryServiceTaskLogTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/CmmnHistoryServiceTaskLogTest.java
@@ -590,7 +590,7 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
             assertThat(logEntries)
                     .extracting(HistoricTaskLogEntry::getTaskId)
                     .containsExactly(task.getId());
-            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(1l);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(1);
         } finally {
             deleteTaskWithLogEntries(anotherTask.getId());
         }
@@ -802,7 +802,7 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
                     .extracting(HistoricTaskLogEntry::getTaskId)
                     .containsExactly(anotherTask.getId(), task.getId(), task.getId());
 
-            assertThat(historicTaskLogEntryQuery.count()).isEqualTo(3l);
+            assertThat(historicTaskLogEntryQuery.count()).isEqualTo(3);
 
             List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
             assertThat(pagedLogEntries).hasSize(1);
@@ -858,10 +858,8 @@ public class CmmnHistoryServiceTaskLogTest extends CustomCmmnConfigurationFlowab
             cmmnRepositoryService.deleteDeployment(cmmnRepositoryService.createCaseDefinitionQuery()
                     .caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getDeploymentId(), true);
 
-            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count())
-                    .isEqualTo(0);
-            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count())
-                    .isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count()).isZero();
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceInvolvementTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceInvolvementTest.java
@@ -56,7 +56,7 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
     }
@@ -69,7 +69,7 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "gonzo", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
     }
@@ -82,7 +82,7 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "gonzo", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").list()).isEmpty();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("").singleResult()).isNull();
     }
@@ -94,7 +94,7 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("gonzo").count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("gonzo").count()).isZero();
     }
 
     @Test
@@ -137,7 +137,7 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId())
@@ -151,7 +151,7 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).list()).isEmpty();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("")).singleResult()).isNull();
     }
@@ -163,7 +163,7 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).list()).isEmpty();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("NonExisting")).singleResult()).isNull();
     }
@@ -178,7 +178,7 @@ public class HistoricCaseInstanceInvolvementTest extends FlowableCmmnTestCase {
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(
                 Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())).count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(
                 Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())).list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceQueryImplTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceQueryImplTest.java
@@ -62,7 +62,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").singleResult().getId())
                 .isEqualTo(caseInstance.getId());
@@ -73,7 +73,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceId("Undefined")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseDefinitionKey("oneTaskCase")
@@ -107,8 +107,8 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .name("nameTask3")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceNameLikeIgnoreCase("taskName%").count()).isEqualTo(2L);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceNameLikeIgnoreCase("%TASK3").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceNameLikeIgnoreCase("taskName%").count()).isEqualTo(2);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceNameLikeIgnoreCase("%TASK3").count()).isEqualTo(1);
     }
 
     public void getCaseInstanceByCaseDefinitionKeyIncludingVariables() {
@@ -116,7 +116,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKey("oneTaskCase").includeCaseVariables().singleResult().getId())
@@ -128,7 +128,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceId("Undefined")
                 .endOr()
                 .includeCaseVariables().count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseDefinitionKey("oneTaskCase")
@@ -151,7 +151,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).singleResult().getId())
@@ -163,7 +163,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKeys(Collections.singleton("oneTaskCase"))
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseInstanceId("undefined")
@@ -186,7 +186,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").count()).isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").list()).hasSize(2);
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
@@ -195,7 +195,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceId("undefined")
                 .endOr()
                 .count())
-                .isEqualTo(2L);
+                .isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseDefinitionCategory("http://flowable.org/cmmn")
@@ -211,7 +211,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").singleResult().getId())
@@ -223,7 +223,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceId("undefined")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseDefinitionName("oneTaskCaseName")
@@ -246,7 +246,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getId())
@@ -258,7 +258,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceId("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseDefinitionId(caseInstance.getCaseDefinitionId())
@@ -280,7 +280,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionVersion(1).count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionVersion(1).count()).isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseDefinitionVersion(1).list()).hasSize(2);
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
@@ -289,7 +289,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceId("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(2L);
+                .isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseDefinitionVersion(1)
@@ -305,7 +305,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId())
@@ -317,7 +317,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseInstanceId(caseInstance.getId())
@@ -341,7 +341,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .businessKey("businessKey")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceBusinessKey("businessKey").singleResult().getId())
@@ -353,7 +353,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseInstanceBusinessKey("businessKey")
@@ -379,7 +379,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         Calendar todayCal = new GregorianCalendar();
         Calendar dateCal = new GregorianCalendar(todayCal.get(Calendar.YEAR) + 1, todayCal.get(Calendar.MONTH), todayCal.get(Calendar.DAY_OF_YEAR));
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBefore(dateCal.getTime()).count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBefore(dateCal.getTime()).count()).isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBefore(dateCal.getTime()).list()).hasSize(2);
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
@@ -388,7 +388,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(2L);
+                .isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .startedBefore(dateCal.getTime())
@@ -406,7 +406,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
         Calendar todayCal = new GregorianCalendar();
         Calendar dateCal = new GregorianCalendar(todayCal.get(Calendar.YEAR) - 1, todayCal.get(Calendar.MONTH), todayCal.get(Calendar.DAY_OF_YEAR));
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedAfter(dateCal.getTime()).count()).isEqualTo(2L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedAfter(dateCal.getTime()).count()).isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedAfter(dateCal.getTime()).list()).hasSize(2);
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
@@ -415,7 +415,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(2L);
+                .isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .startedAfter(dateCal.getTime())
@@ -434,7 +434,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseDefinitionKey("oneTaskCase")
                     .start();
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").count()).isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").count()).isEqualTo(1);
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().startedBy("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -444,7 +444,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseDefinitionName("undefinedId")
                     .endOr()
                     .count())
-                    .isEqualTo(1L);
+                    .isEqualTo(1);
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                     .or()
                     .startedBy("kermit")
@@ -471,7 +471,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .callbackId("callBackId")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackId("callBackId").singleResult().getId())
@@ -483,7 +483,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseInstanceCallbackId("callBackId")
@@ -507,7 +507,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .callbackType("callBackType")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceCallbackType("callBackType").singleResult().getId())
@@ -519,7 +519,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseInstanceCallbackType("callBackType")
@@ -543,7 +543,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .referenceId("testReferenceId")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").singleResult().getId())
@@ -555,7 +555,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefined")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseInstanceReferenceId("testReferenceId")
@@ -579,7 +579,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .referenceType("testReferenceType")
                 .start();
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").singleResult().getId())
@@ -591,7 +591,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .caseInstanceReferenceType("testReferenceType")
@@ -619,7 +619,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         }
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceReferenceId("testReferenceId")
-                .caseInstanceReferenceType("testReferenceType").count()).isEqualTo(5L);
+                .caseInstanceReferenceType("testReferenceType").count()).isEqualTo(5);
     }
 
     @Test
@@ -636,7 +636,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .tenantId("tenantId")
                     .start();
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").count()).isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").count()).isEqualTo(1);
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").list().get(0).getId())
                     .isEqualTo(caseInstance.getId());
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceTenantId("tenantId").singleResult().getId())
@@ -648,7 +648,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseDefinitionName("undefinedId")
                     .endOr()
                     .count())
-                    .isEqualTo(1L);
+                    .isEqualTo(1);
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                     .or()
                     .caseInstanceTenantId("tenantId")
@@ -682,7 +682,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .tenantId("tenantId")
                     .start();
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().count()).isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().count()).isEqualTo(1);
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().list().get(0).getId())
                     .isNotEqualTo(caseInstance.getId());
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceWithoutTenantId().singleResult().getId())
@@ -694,7 +694,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseDefinitionName("undefinedId")
                     .endOr()
                     .count())
-                    .isEqualTo(1L);
+                    .isEqualTo(1);
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                     .or()
                     .caseInstanceWithoutTenantId()
@@ -721,7 +721,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit").singleResult().getId())
@@ -733,7 +733,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .involvedUser("kermit")
@@ -757,13 +757,13 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", "specialLink");
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit", "specialLink").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit", "specialLink").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit", "specialLink").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit", "specialLink").singleResult().getId())
                 .isEqualTo(caseInstance.getId());
         
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit", "wrongType").count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedUser("kermit", "wrongType").count()).isZero();
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
@@ -771,7 +771,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
@@ -779,7 +779,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
@@ -787,7 +787,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("wrongKey")
                 .endOr()
                 .count())
-                .isEqualTo(0L);
+                .isZero();
     }
 
     @Test
@@ -798,7 +798,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId())
@@ -810,7 +810,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .involvedGroups(Collections.singleton("testGroup"))
@@ -835,13 +835,13 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", "specialLink");
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", "extraLink");
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroup("testGroup", "specialLink").count()).isEqualTo(1L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroup("testGroup", "specialLink").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroup("testGroup", "specialLink").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroup("testGroup", "specialLink").singleResult().getId())
                 .isEqualTo(caseInstance.getId());
         
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroup("testGroup2", "wrongType").count()).isEqualTo(0L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroup("testGroup2", "wrongType").count()).isZero();
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
@@ -849,7 +849,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
@@ -857,7 +857,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
@@ -865,7 +865,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("wrongKey")
                 .endOr()
                 .count())
-                .isEqualTo(0L);
+                .isZero();
     }
 
     @Test
@@ -887,7 +887,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
                 .involvedUser("kermit").count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
                 .involvedUser("kermit").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
@@ -901,7 +901,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(2L);
+                .isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
@@ -917,7 +917,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(3L);
+                .isEqualTo(3);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
@@ -949,7 +949,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .variableValueEquals("queryVariable", "queryVariableValue")
                 .variableValueEquals("queryVariable2", "queryVariableValue2")
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .variableValueEquals("queryVariable", "queryVariableValue")
                 .variableValueEquals("queryVariable2", "queryVariableValue2")
@@ -968,7 +968,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(3L);
+                .isEqualTo(3);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .or()
                 .variableValueEquals("queryVariable", "queryVariableValue")
@@ -992,7 +992,7 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
 
         try {
             assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance1.getId()).caseInstanceWithoutTenantId().count())
-                    .isEqualTo(1L);
+                    .isEqualTo(1);
         } finally {
             cmmnRuntimeService.terminateCaseInstance(caseInstance2.getId());
             cmmnHistoryService.deleteHistoricCaseInstance(caseInstance2.getId());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricDataEngineDeleteTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricDataEngineDeleteTest.java
@@ -82,10 +82,9 @@ public class HistoricDataEngineDeleteTest {
                 for (int i = 0; i < 20; i++) {
                     if (i < 10) {
                         assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i))).isEmpty();
-                        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(0);
-                        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(0);
-                        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count())
-                                .isEqualTo(0);
+                        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isZero();
+                        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isZero();
+                        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count()).isZero();
 
                     } else {
                         assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i))).hasSize(1);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricPlanItemInstanceQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricPlanItemInstanceQueryTest.java
@@ -81,7 +81,7 @@ public class HistoricPlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(1);
         List<HistoricPlanItemInstance> planItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().list();
         for (HistoricPlanItemInstance planItemInstance : planItemInstances) {
-            assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).count()).isEqualTo(1L);
+            assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).count()).isEqualTo(1);
         }
     }
 
@@ -108,10 +108,8 @@ public class HistoricPlanItemInstanceQueryTest extends FlowableCmmnTestCase {
     @Test
     public void testByPlanItemDefinitionType() {
         startInstances(3);
-        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK).list().size())
-                .isEqualTo(6);
-        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.STAGE).list().size())
-                .isEqualTo(6);
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.HUMAN_TASK).list()).hasSize(6);
+        assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceDefinitionType(PlanItemDefinitionType.STAGE).list()).hasSize(6);
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoryDataDeleteTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoryDataDeleteTest.java
@@ -53,13 +53,13 @@ public class HistoryDataDeleteTest extends FlowableCmmnTestCase {
 
             query.deleteWithRelatedData();
 
-            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
-            assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
-            assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+            assertThat(cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).count()).isZero();
+            assertThat(cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
             assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId())).isEmpty();
             assertThat(cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId())).isEmpty();
-            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
-            assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+            assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         }
     }
 
@@ -97,11 +97,10 @@ public class HistoryDataDeleteTest extends FlowableCmmnTestCase {
             for (int i = 0; i < 20; i++) {
                 if (i < 10) {
                     assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i))).isEmpty();
-                    assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(0);
-                    assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(0);
+                    assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isZero();
+                    assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isZero();
                     assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstanceIds.get(i)).count())
-                            .isEqualTo(0);
-
+                            .isZero();
                 } else {
                     assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceIds.get(i))).hasSize(1);
                     assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().caseInstanceId(caseInstanceIds.get(i)).count()).isEqualTo(1);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoryServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoryServiceTest.java
@@ -48,23 +48,23 @@ public class HistoryServiceTest extends FlowableCmmnTestCase {
                 .start();
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var1", "test").count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var1", "test2").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var1", "test2").count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var1", "TEST").count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var1", "TEST2").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var1", "TEST2").count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var1", "te%").count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var1", "te2%").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLike("var1", "te2%").count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var1", "TE%").count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var1", "TE2%").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLikeIgnoreCase("var1", "TE2%").count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("var2", 5).count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("var2", 11).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueGreaterThan("var2", 11).count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("var2", 11).count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("var2", 8).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueLessThan("var2", 8).count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableExists("var1").count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableExists("var3").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableExists("var3").count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableNotExists("var3").count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableNotExists("var1").count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableNotExists("var1").count()).isZero();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -100,7 +100,7 @@ public class HistoryServiceTest extends FlowableCmmnTestCase {
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("startVar", "test").count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 11).count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 10).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("changeVar", 10).count()).isZero();
 
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -110,7 +110,7 @@ public class HistoryServiceTest extends FlowableCmmnTestCase {
         assertThat(planItemInstance.getName()).isEqualTo("Task B");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/MilestoneHistoryServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/MilestoneHistoryServiceTest.java
@@ -83,7 +83,7 @@ public class MilestoneHistoryServiceTest extends FlowableCmmnTestCase {
         //Milestone query is in sync with HistoricMilestone
         assertCaseInstanceNotEnded(caseInstance);
         assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().count()).isEqualTo(3);
-        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceName("1").milestoneInstanceWithoutTenantId().count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceName("1").milestoneInstanceWithoutTenantId().count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceName("1").milestoneInstanceWithoutTenantId().list()).hasSize(1);
         assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(3);
 
@@ -93,10 +93,10 @@ public class MilestoneHistoryServiceTest extends FlowableCmmnTestCase {
 
         //Milestone history is retained after the case ends
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(3);
         assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceName("1").milestoneInstanceWithoutTenantId().count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceName("1").milestoneInstanceWithoutTenantId().list()).hasSize(1);
 
         //There are two named milestones

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/PlanItemInstanceHistoryServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/PlanItemInstanceHistoryServiceTest.java
@@ -77,7 +77,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //one Task, one Stage, one Milestone
         List<PlanItemInstance> currentPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(currentPlanItems).isNotNull();
         assertThat(currentPlanItems).hasSize(3);
         assertThat(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase))
                 .isTrue();
@@ -88,7 +87,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
         //Milestone are just another planItem too, so it will appear in the planItemInstance History
         List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItems).isNotNull();
         assertThat(historicPlanItems).hasSize(3);
         assertThat(historicPlanItems.stream().map(HistoricPlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase))
                 .isTrue();
@@ -118,7 +116,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
         //Milestone history is only filled when the milestone occurs
         List<HistoricMilestoneInstance> historicMilestones = cmmnHistoryService.createHistoricMilestoneInstanceQuery()
                 .milestoneInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicMilestones).isNotNull();
         assertThat(historicMilestones).isEmpty();
 
         //////////////////////////////////////////////////////////////////
@@ -131,7 +128,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //Now there are 2 plan items in a non-final state, a Stage and its containing task (only 1 new planItem)
         currentPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(currentPlanItems).isNotNull();
         assertThat(currentPlanItems).hasSize(2);
         assertThat(currentPlanItems.stream().map(PlanItemInstance::getPlanItemDefinitionType).anyMatch(PlanItemDefinitionType.STAGE::equalsIgnoreCase))
                 .isTrue();
@@ -139,7 +135,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                 .anyMatch(p -> "task".equalsIgnoreCase(p.getPlanItemDefinitionType()) && "planItemTaskB".equalsIgnoreCase(p.getElementId()))).isTrue();
 
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItems).isNotNull();
         assertThat(historicPlanItems).hasSize(4);
         assertThat(
                 cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceId(historicPlanItems.get(0).getId()).planItemInstanceWithoutTenantId()
@@ -162,7 +157,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //Milestone appears now in the MilestoneHistory
         historicMilestones = cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicMilestones).isNotNull();
         assertThat(historicMilestones).hasSize(1);
 
         //////////////////////////////////////////////////
@@ -175,7 +169,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //History remains
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItems).isNotNull();
         assertThat(historicPlanItems).hasSize(4);
         historicPlanItems.forEach(assertCreateTimeHistoricPlanItemInstance
                 .andThen(assertStartedTimeHistoricPlanItemInstance)
@@ -184,7 +177,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
         );
 
         historicMilestones = cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicMilestones).isNotNull();
         assertThat(historicMilestones).hasSize(1);
     }
 
@@ -270,7 +262,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testEntryAndExitPropagate").start();
 
         List<PlanItemInstance> currentPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(currentPlanItems).isNotNull();
         assertThat(currentPlanItems).hasSize(3);
         assertThat(currentPlanItems.stream()
                 .filter(p -> PlanItemDefinitionType.STAGE.equalsIgnoreCase(p.getPlanItemDefinitionType()))
@@ -283,7 +274,6 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItems).isNotNull();
         assertThat(historicPlanItems).hasSize(3);
         checkHistoryCreateTimestamp(currentPlanItems, historicPlanItems, 1000L);
         assertThat(historicPlanItems.stream().filter(h -> PlanItemDefinitionType.STAGE.equalsIgnoreCase(h.getPlanItemDefinitionType()))
@@ -325,12 +315,10 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
 
         //A userEventListeners is removed and two human task are instanced
         currentPlanItems = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(currentPlanItems).isNotNull();
         assertThat(currentPlanItems).hasSize(4);
 
         //Two more planItemInstances in the history
         historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItems).isNotNull();
         assertThat(historicPlanItems).hasSize(5);
         checkHistoryCreateTimestamp(currentPlanItems, historicPlanItems, 1000L);
 
@@ -588,7 +576,7 @@ public class PlanItemInstanceHistoryServiceTest extends FlowableCmmnTestCase {
                     .findFirst()
                     .map(HistoricPlanItemInstance::getCreateTime)
                     .map(Date::getTime);
-            assertThat(createTimestamp.isPresent()).isTrue();
+            assertThat(createTimestamp).isPresent();
             long delta = createTimestamp.orElse(Long.MAX_VALUE) - p.getCreateTime().getTime();
             assertThat(delta).isLessThanOrEqualTo(threshold);
         });

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/CrossBoundaryActivationWithExitEventTypeCombinationTest.java
@@ -132,7 +132,7 @@ public class CrossBoundaryActivationWithExitEventTypeCombinationTest extends Flo
         assertThat(planItemInstances).isEmpty();
 
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/ManualActivationRuleTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/ManualActivationRuleTest.java
@@ -43,7 +43,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId());
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
@@ -63,7 +63,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         // Disabling the single plan item will terminate the case
         cmmnRuntimeService.disablePlanItemInstance(planItemInstance.getId());
@@ -82,13 +82,13 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         for (PlanItemInstance planItemInstance : planItemInstances) {
             assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.ENABLED);
         }
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         PlanItemInstance planItemInstance = planItemInstances.get(0);
         cmmnRuntimeService.disablePlanItemInstance(planItemInstance.getId());
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateDisabled().count()).isEqualTo(1);
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         cmmnRuntimeService.enablePlanItemInstance(planItemInstance.getId());
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(2);
@@ -98,7 +98,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testManualActivationWithSentries() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testManualActivationWithSentries").start();
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(1);
         
@@ -117,7 +117,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateActive().count()).isEqualTo(3);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateAvailable().count()).isZero();
         
         // Enabling the nested stage activates task D
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().singleResult();
@@ -148,7 +148,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
 
         // Completing task A will exit the enabled stage
         cmmnTaskService.complete(tasks.get(0).getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isZero();
         
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("C");
@@ -177,7 +177,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("testManuallyActivatedServiceTask")
                 .variable("manual", false)
                 .start();
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceStateEnabled().count()).isZero();
         assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "variable")).isEqualTo("test");
     }
     
@@ -188,7 +188,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("manualStage")
                 .start();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         cmmnEngineConfiguration.getCommandExecutor().execute(new Command<Void>() {
 
@@ -324,7 +324,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         assertThat(taskC.getName()).isEqualTo("C");
 
         cmmnTaskService.complete(taskC.getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -334,7 +334,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         cmmnTaskService.complete(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("A").singleResult().getId());
         assertCaseInstanceNotEnded(caseInstance);
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("B").count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskName("B").count()).isZero();
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ENABLED).singleResult();
         cmmnRuntimeService.startPlanItemInstance(planItemInstance.getId());
@@ -354,7 +354,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         PlanItemInstance stagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateEnabled().singleResult();
         assertThat(stagePlanItemInstance.getName()).isEqualTo("Stage one");
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(stagePlanItemInstance.getId()).start();
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
@@ -369,7 +369,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         PlanItemInstance stagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateEnabled().singleResult();
         assertThat(stagePlanItemInstance.getName()).isEqualTo("Stage one");
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         cmmnEngineConfiguration.getCommandExecutor().execute(new Command<Void>() {
             @Override
             public Void execute(CommandContext commandContext) {
@@ -397,7 +397,7 @@ public class ManualActivationRuleTest extends FlowableCmmnTestCase {
         assertThat(stagePlanItemInstance.getName()).isEqualTo("Stage with blocking task");
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateEnabled().count()).isEqualTo(0);
+            .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateEnabled().count()).isZero();
         cmmnRuntimeService.createPlanItemInstanceTransitionBuilder(stagePlanItemInstance.getId()).start();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
             .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateEnabled().count()).isEqualTo(1);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/OrphanEventListenerRemovalCombinedWithRepetitionTest.java
@@ -87,8 +87,8 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -123,8 +123,8 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "kill Stage A", AVAILABLE));
 
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -186,7 +186,7 @@ public class OrphanEventListenerRemovalCombinedWithRepetitionTest extends Flowab
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/RepetitionRuleTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/RepetitionRuleTest.java
@@ -151,7 +151,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         assertThat(planItemInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);
 
         // Task should not be created yet
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         // And one for the timer event listener
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult();
@@ -166,7 +166,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         setClockTo(currentTime);
         job = cmmnManagementService.moveTimerToExecutableJob(job.getId());
         cmmnManagementService.executeJob(job.getId());
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         // A plan item in state 'waiting for repetition' should exist for the yask
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -189,9 +189,9 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         for (Task task : cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list()) {
             cmmnTaskService.complete(task.getId());
         }
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
         // There should also still be a plan item instance in the 'wait for repetition' state
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
@@ -200,9 +200,9 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
 
         // Terminating the case instance should remove the timer
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
-        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         cmmnEngineConfiguration.resetClock();
     }
     
@@ -213,7 +213,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testRepeatingTimer").start();
 
         // Task should not be created yet
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         // Should have a timer job available
         Job job = cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).singleResult();
@@ -225,7 +225,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         setClockTo(currentTime);
         job = cmmnManagementService.moveTimerToExecutableJob(job.getId());
         cmmnManagementService.executeJob(job.getId());
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         // A plan item in state 'waiting for repetition' should exist for the yask
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -249,9 +249,9 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         for (Task task : cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list()) {
             cmmnTaskService.complete(task.getId());
         }
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
         // There should also still be a plan item instance in the 'wait for repetition' state
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
@@ -260,9 +260,9 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
 
         // Terminating the case instance should remove the timer
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
-        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         cmmnEngineConfiguration.resetClock();
     }
     
@@ -276,7 +276,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
                 .start();
 
         // Task should not be created yet
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         // Should have a timer job available
         Job job = cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).singleResult();
@@ -288,7 +288,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         setClockTo(currentTime);
         job = cmmnManagementService.moveTimerToExecutableJob(job.getId());
         cmmnManagementService.executeJob(job.getId());
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         // A plan item in state 'waiting for repetition' should exist for the yask
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -312,9 +312,9 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         for (Task task : cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list()) {
             cmmnTaskService.complete(task.getId());
         }
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
         // There should also still be a plan item instance in the 'wait for repetition' state
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
@@ -323,9 +323,9 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
 
         // Terminating the case instance should remove the timer
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
-        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         cmmnEngineConfiguration.resetClock();
     }
 
@@ -365,15 +365,15 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         // new timer should be scheduled
-        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         // Should only repeat two times
         currentTime = new Date(currentTime.getTime() + (5 * 60 * 60 * 1000) + 10000);
         setClockTo(currentTime);
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 10000L, 100L, true);
 
-        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
@@ -381,7 +381,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
                 .singleResult()).isNotNull();
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(tasks.size()).isEqualTo(2);
+        assertThat(tasks).hasSize(2);
         for (Task task : tasks) {
             cmmnTaskService.complete(task.getId());
         }
@@ -408,13 +408,13 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
         // new timer should NOT be scheduled. The orphan detection algorithm will take in account the waiting for repetition state and the fact its missing here
-        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
-        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnManagementService.createJobQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         // Ignoring second occur event
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
     }
 
     @Test
@@ -443,7 +443,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testRepeatingEventListener() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testRepeatingUserEventListener").start();
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
 
         for (int i = 0; i < 17; i++) {
             GenericEventListenerInstance genericEventListenerInstance = cmmnRuntimeService.createGenericEventListenerInstanceQuery()
@@ -461,7 +461,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("testRepeatingUserEventListener")
                 .variable("keepGoing", true)
                 .start();
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
 
         for (int i = 0; i < 3; i++) {
             UserEventListenerInstance userEventListenerInstance = cmmnRuntimeService.createUserEventListenerInstanceQuery()

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/RequiredRuleTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/RequiredRuleTest.java
@@ -177,7 +177,7 @@ public class RequiredRuleTest extends FlowableCmmnTestCase {
         stagePlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceId(stagePlanItemInstance.getId()).singleResult();
         assertThat(stagePlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         assertThat(stagePlanItemInstance.isCompletable()).isTrue();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         // Making the other task active, should disable the completeable flag again
         cmmnRuntimeService.setVariables(caseInstance.getId(), CollectionUtil.singletonMap("nonRequired", true));
@@ -214,7 +214,7 @@ public class RequiredRuleTest extends FlowableCmmnTestCase {
                 .singleResult();
         assertThat(stagePlanItemInstance2.getState()).isEqualTo(PlanItemInstanceState.ACTIVE);
         assertThat(stagePlanItemInstance2.isCompletable()).isTrue();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceCompletable().singleResult()).isNotNull();
         cmmnRuntimeService.completeStagePlanItemInstance(stagePlanItemInstance2.getId());
@@ -317,7 +317,7 @@ public class RequiredRuleTest extends FlowableCmmnTestCase {
 
         // D is required. But B is still active
         cmmnTaskService.complete(tasks.get(1).getId());
-        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isZero();
         cmmnTaskService.complete(tasks.get(0).getId());
         assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/jupiter/FlowableCmmnJupiterTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/jupiter/FlowableCmmnJupiterTest.java
@@ -48,7 +48,7 @@ class FlowableCmmnJupiterTest {
         assertThat(task.getName()).isEqualTo("The Task");
 
         taskService.complete(task.getId());
-        assertThat(runtimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(runtimeService.createCaseInstanceQuery().count()).isZero();
 
         assertThat(cmmnEngine.getName()).as("cmmn engine name").isEqualTo(CmmnEngines.NAME_DEFAULT);
     }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/listener/AvailableConditionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/listener/AvailableConditionTest.java
@@ -172,7 +172,7 @@ public class AvailableConditionTest extends FlowableCmmnTestCase {
             .caseDefinitionKey("testStageCompleteWithAvailableEventListener")
             .start();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceStateAvailable().count()).isZero();
 
         // Completing the task should make the available condition (cmmn:isStageCompletable()) true and make the eventlistener available)
         cmmnTaskService.complete(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult().getId());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/mgmt/CmmnManagementServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/mgmt/CmmnManagementServiceTest.java
@@ -48,14 +48,14 @@ public class CmmnManagementServiceTest extends FlowableCmmnTestCase {
             return suspendedJobEntity;
         });
 
-        assertThat(cmmnManagementService.createJobQuery().count()).isEqualTo(0);
+        assertThat(cmmnManagementService.createJobQuery().count()).isZero();
         assertThat(cmmnManagementService.createSuspendedJobQuery().count()).isEqualTo(1);
 
         Job executableJob = cmmnManagementService.moveSuspendedJobToExecutableJob(jobEntity.getId());
         assertThat(executableJob).isNotNull();
 
         assertThat(cmmnManagementService.createJobQuery().count()).isEqualTo(1);
-        assertThat(cmmnManagementService.createSuspendedJobQuery().count()).isEqualTo(0);
+        assertThat(cmmnManagementService.createSuspendedJobQuery().count()).isZero();
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/mgmt/ExternalWorkerJobQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/mgmt/ExternalWorkerJobQueryTest.java
@@ -79,7 +79,7 @@ public class ExternalWorkerJobQueryTest extends FlowableCmmnTestCase {
                 .containsOnly(caseInstance2.getId());
 
         query = cmmnManagementService.createExternalWorkerJobQuery().caseInstanceId("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }
@@ -100,7 +100,7 @@ public class ExternalWorkerJobQueryTest extends FlowableCmmnTestCase {
                 .containsOnly(caseInstance1.getId(), caseInstance2.getId());
 
         query = cmmnManagementService.createExternalWorkerJobQuery().caseDefinitionId("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }
@@ -132,7 +132,7 @@ public class ExternalWorkerJobQueryTest extends FlowableCmmnTestCase {
         assertThat(query.singleResult()).isNotNull();
 
         query = cmmnManagementService.createExternalWorkerJobQuery().planItemInstanceId("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }
@@ -154,7 +154,7 @@ public class ExternalWorkerJobQueryTest extends FlowableCmmnTestCase {
                 .containsExactlyInAnyOrder(caseInstance1.getId(), caseInstance2.getId());
 
         query = cmmnManagementService.createExternalWorkerJobQuery().elementId("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
 
     }
@@ -176,7 +176,7 @@ public class ExternalWorkerJobQueryTest extends FlowableCmmnTestCase {
                 .containsExactlyInAnyOrder(caseInstance1.getId(), caseInstance2.getId());
 
         query = cmmnManagementService.createExternalWorkerJobQuery().elementName("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
     }
 
@@ -192,7 +192,7 @@ public class ExternalWorkerJobQueryTest extends FlowableCmmnTestCase {
         assertThat(query.list()).hasSize(2);
 
         query = cmmnManagementService.createExternalWorkerJobQuery().handlerType("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
     }
 
@@ -252,7 +252,7 @@ public class ExternalWorkerJobQueryTest extends FlowableCmmnTestCase {
         assertThat(job.getExceptionMessage()).isEqualTo("Error message");
 
         query = cmmnManagementService.createExternalWorkerJobQuery().exceptionMessage("Error");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }
@@ -333,7 +333,7 @@ public class ExternalWorkerJobQueryTest extends FlowableCmmnTestCase {
         assertThat(job.getLockExpirationTime()).isNotNull();
 
         query = cmmnManagementService.createExternalWorkerJobQuery().lockOwner("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/migration/CaseInstanceMigrationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/migration/CaseInstanceMigrationTest.java
@@ -71,25 +71,25 @@ public class CaseInstanceMigrationTest extends AbstractCaseMigrationTest {
                 .containsOnly(PlanItemInstanceState.ACTIVE);
         
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(tasks.size()).isEqualTo(2);
+        assertThat(tasks).hasSize(2);
         for (Task task : tasks) {
             assertThat(task.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
             cmmnTaskService.complete(task.getId());
         }
         
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItemInstances.size()).isEqualTo(2);
+        assertThat(historicPlanItemInstances).hasSize(2);
         for (HistoricPlanItemInstance historicPlanItemInstance : historicPlanItemInstances) {
             assertThat(historicPlanItemInstance.getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
         
         List<HistoricTaskInstance> historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(historicTasks.size()).isEqualTo(2);
+        assertThat(historicTasks).hasSize(2);
         for (HistoricTaskInstance historicTask : historicTasks) {
             assertThat(historicTask.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
@@ -138,19 +138,19 @@ public class CaseInstanceMigrationTest extends AbstractCaseMigrationTest {
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         cmmnTaskService.complete(task.getId());
     
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItemInstances.size()).isEqualTo(2);
+        assertThat(historicPlanItemInstances).hasSize(2);
         for (HistoricPlanItemInstance historicPlanItemInstance : historicPlanItemInstances) {
             assertThat(historicPlanItemInstance.getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
         
         List<HistoricTaskInstance> historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(historicTasks.size()).isEqualTo(2);
+        assertThat(historicTasks).hasSize(2);
         for (HistoricTaskInstance historicTask : historicTasks) {
             assertThat(historicTask.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
@@ -189,25 +189,25 @@ public class CaseInstanceMigrationTest extends AbstractCaseMigrationTest {
                 .containsOnly(PlanItemInstanceState.ACTIVE);
         
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(tasks.size()).isEqualTo(2);
+        assertThat(tasks).hasSize(2);
         for (Task task : tasks) {
             assertThat(task.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
             cmmnTaskService.complete(task.getId());
         }
     
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItemInstances.size()).isEqualTo(2);
+        assertThat(historicPlanItemInstances).hasSize(2);
         for (HistoricPlanItemInstance historicPlanItemInstance : historicPlanItemInstances) {
             assertThat(historicPlanItemInstance.getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
         
         List<HistoricTaskInstance> historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(historicTasks.size()).isEqualTo(2);
+        assertThat(historicTasks).hasSize(2);
         for (HistoricTaskInstance historicTask : historicTasks) {
             assertThat(historicTask.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
@@ -256,19 +256,19 @@ public class CaseInstanceMigrationTest extends AbstractCaseMigrationTest {
         assertThat(task.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         cmmnTaskService.complete(task.getId());
     
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItemInstances.size()).isEqualTo(2);
+        assertThat(historicPlanItemInstances).hasSize(2);
         for (HistoricPlanItemInstance historicPlanItemInstance : historicPlanItemInstances) {
             assertThat(historicPlanItemInstance.getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
         
         List<HistoricTaskInstance> historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(historicTasks.size()).isEqualTo(2);
+        assertThat(historicTasks).hasSize(2);
         for (HistoricTaskInstance historicTask : historicTasks) {
             assertThat(historicTask.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
@@ -324,19 +324,19 @@ public class CaseInstanceMigrationTest extends AbstractCaseMigrationTest {
         assertThat(task.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         cmmnTaskService.complete(task.getId());
     
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItemInstances.size()).isEqualTo(4);
+        assertThat(historicPlanItemInstances).hasSize(4);
         for (HistoricPlanItemInstance historicPlanItemInstance : historicPlanItemInstances) {
             assertThat(historicPlanItemInstance.getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
         
         List<HistoricTaskInstance> historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(historicTasks.size()).isEqualTo(2);
+        assertThat(historicTasks).hasSize(2);
         for (HistoricTaskInstance historicTask : historicTasks) {
             assertThat(historicTask.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
@@ -484,19 +484,19 @@ public class CaseInstanceMigrationTest extends AbstractCaseMigrationTest {
         assertThat(task.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         cmmnTaskService.complete(task.getId());
     
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(caseInstance.getId()).list();
-        assertThat(historicPlanItemInstances.size()).isEqualTo(2);
+        assertThat(historicPlanItemInstances).hasSize(2);
         for (HistoricPlanItemInstance historicPlanItemInstance : historicPlanItemInstances) {
             assertThat(historicPlanItemInstance.getCaseDefinitionId()).isEqualTo(destinationDefinition.getId());
         }
         
         List<HistoricTaskInstance> historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).list();
-        assertThat(historicTasks.size()).isEqualTo(2);
+        assertThat(historicTasks).hasSize(2);
         for (HistoricTaskInstance historicTask : historicTasks) {
             assertThat(historicTask.getScopeDefinitionId()).isEqualTo(destinationDefinition.getId());
         }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/persistence/EntitiesTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/persistence/EntitiesTest.java
@@ -47,10 +47,12 @@ public class EntitiesTest {
     public void verifyEntitiesInEntityDependencyOrder() {
         Set<String> mappedResources = getMappedResources();
         for (String mappedResource : mappedResources) {
-            assertThat(EntityDependencyOrder.INSERT_ORDER.contains(getAndAssertEntityImplClass(mappedResource)))
-                    .as("No insert entry in EntityDependencyOrder for " + mappedResource).isTrue();
-            assertThat(EntityDependencyOrder.DELETE_ORDER.contains(getAndAssertEntityImplClass(mappedResource)))
-                    .as("No delete entry in EntityDependencyOrder for " + mappedResource).isTrue();
+            assertThat(EntityDependencyOrder.INSERT_ORDER)
+                    .as("No insert entry in EntityDependencyOrder for " + mappedResource)
+                    .contains(getAndAssertEntityImplClass(mappedResource));
+            assertThat(EntityDependencyOrder.DELETE_ORDER)
+                    .as("No delete entry in EntityDependencyOrder for " + mappedResource)
+                    .contains(getAndAssertEntityImplClass(mappedResource));
         }
     }
 
@@ -58,8 +60,9 @@ public class EntitiesTest {
     public void verifyEntitiesInTableDataManager() {
         Set<String> mappedResources = getMappedResources();
         for (String mappedResource : mappedResources) {
-            assertThat(EntityToTableMap.entityToTableNameMap.containsKey(getAndAssertEntityInterfaceClass(mappedResource)))
-                    .as("No entry in TableDataManagerImpl for " + mappedResource).isTrue();
+            assertThat(EntityToTableMap.entityToTableNameMap)
+                    .as("No entry in TableDataManagerImpl for " + mappedResource)
+                    .containsKey(getAndAssertEntityInterfaceClass(mappedResource));
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/prefix/CmmnPrefixTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/prefix/CmmnPrefixTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.cmmn.test.prefix;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,19 +65,19 @@ public class CmmnPrefixTest {
                     .caseDefinitionKey("oneHumanTaskCase")
                     .variable("testPrefix", "tested")
                     .start();
-            assertTrue(caseInstance.getId().startsWith("CAS-"));
+            assertThat(caseInstance.getId()).startsWith("CAS-");
             
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
-            assertTrue(task.getId().startsWith("TSK-"));
+            assertThat(task.getId()).startsWith("TSK-");
             cmmnTaskService.complete(task.getId());
 
             if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
                 HistoricTaskInstance historicTaskInstance = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-                assertTrue(historicTaskInstance.getId().startsWith("TSK-"));
+                assertThat(historicTaskInstance.getId()).startsWith("TSK-");
                 
                 if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
                     HistoricVariableInstance historicVariableInstance = cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult();
-                    assertTrue(historicVariableInstance.getId().startsWith("VAR-"));
+                    assertThat(historicVariableInstance.getId()).startsWith("VAR-");
                 }
             }
             

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/repository/CaseDefinitionQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/repository/CaseDefinitionQueryTest.java
@@ -89,7 +89,7 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
     @Test
     public void testQueryByInvalidDeploymentId() {
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().deploymentId("invalid").list()).isEmpty();
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().deploymentId("invalid").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().deploymentId("invalid").count()).isZero();
     }
 
     @Test
@@ -116,7 +116,7 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
     @Test
     public void testQueryByInvalidDeploymentIds() {
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).list()).isEmpty();
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().deploymentIds(new HashSet<>(Collections.singletonList("invalid"))).count()).isZero();
     }
 
     @Test
@@ -150,8 +150,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testQueryByInvalidCaseDefinitionId() {
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId("invalid").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId("invalid").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId("invalid").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionId("invalid").count()).isZero();
     }
 
     @Test
@@ -175,8 +175,7 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
     @Test
     public void testQueryByInvalidCaseDefinitionIds() {
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).list()).isEmpty();
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).count())
-                .isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionIds(new HashSet<>(Arrays.asList("invalid1", "invalid2"))).count()).isZero();
     }
 
     @Test
@@ -187,8 +186,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testQueryByInvalidCaseDefinitionCategory() {
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategory("invalid").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategory("invalid").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategory("invalid").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategory("invalid").count()).isZero();
     }
 
     @Test
@@ -199,8 +198,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testQueryByInvalidCaseDefinitionCategoryLike() {
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryLike("invalid%").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryLike("invalid%n").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryLike("invalid%").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryLike("invalid%n").count()).isZero();
     }
 
     @Test
@@ -208,8 +207,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("another").list()).hasSize(4);
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("another").count()).isEqualTo(4);
 
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("http://flowable.org/cmmn").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("http://flowable.org/cmmn").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("http://flowable.org/cmmn").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionCategoryNotEquals("http://flowable.org/cmmn").count()).isZero();
     }
 
     @Test
@@ -225,8 +224,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testQueryByInvalidCaseDefinitionName() {
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 3").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 3").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 3").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionName("Case 3").count()).isZero();
     }
 
     @Test
@@ -237,8 +236,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("%2").list()).hasSize(1);
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("%2").count()).isEqualTo(1);
 
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("invalid%").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("invalid%").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("invalid%").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionNameLike("invalid%").count()).isZero();
     }
 
     @Test
@@ -252,8 +251,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testQueryByInvalidCaseDefinitionKey() {
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("invalid").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("invalid").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("invalid").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("invalid").count()).isZero();
     }
 
     @Test
@@ -267,8 +266,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testQueryByInvalidCaseDefinitionKeyLike() {
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("%invalid").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("%invalid").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("%invalid").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKeyLike("%invalid").count()).isZero();
     }
 
     @Test
@@ -282,8 +281,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(2).list()).hasSize(1);
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(2).count()).isEqualTo(1);
 
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(4).list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(4).count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(4).list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersion(4).count()).isZero();
     }
 
     @Test
@@ -291,8 +290,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(2).list()).hasSize(1);
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(2).count()).isEqualTo(1);
 
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(3).list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(3).count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(3).list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThan(3).count()).isZero();
     }
 
     @Test
@@ -303,8 +302,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(3).list()).hasSize(1);
         assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(3).count()).isEqualTo(1);
 
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(4).list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(4).count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(4).list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionVersionGreaterThanOrEquals(4).count()).isZero();
     }
 
     @Test
@@ -364,8 +363,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testQueryByInvalidCaseDefinitionResourceName() {
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("invalid.cmmn").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("invalid.cmmn").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("invalid.cmmn").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceName("invalid.cmmn").count()).isZero();
     }
 
     @Test
@@ -379,8 +378,8 @@ public class CaseDefinitionQueryTest extends FlowableCmmnTestCase {
 
     @Test
     public void testQueryByInvalidCaseDefinitionResourceNameLike() {
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%invalid%").list()).hasSize(0);
-        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%invalid%").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%invalid%").list()).isEmpty();
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionResourceNameLike("%invalid%").count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/repository/DeploymentQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/repository/DeploymentQueryTest.java
@@ -78,7 +78,7 @@ public class DeploymentQueryTest extends FlowableCmmnTestCase {
     public void testQueryByInvalidDeploymentId() {
         assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentId("invalid").singleResult()).isNull();
         assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentId("invalid").list()).isEmpty();
-        assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentId("invalid").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentId("invalid").count()).isZero();
     }
 
     @Test
@@ -93,7 +93,7 @@ public class DeploymentQueryTest extends FlowableCmmnTestCase {
     public void testQueryByInvalidDeploymentName() {
         assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentName("invalid").singleResult()).isNull();
         assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentName("invalid").list()).isEmpty();
-        assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentName("invalid").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentName("invalid").count()).isZero();
     }
 
     @Test
@@ -105,7 +105,7 @@ public class DeploymentQueryTest extends FlowableCmmnTestCase {
 
         assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").singleResult()).isNull();
         assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").list()).isEmpty();
-        assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentNameLike("inval%").count()).isZero();
     }
 
     @Test
@@ -120,7 +120,7 @@ public class DeploymentQueryTest extends FlowableCmmnTestCase {
     public void testQueryByInvalidDeploymentCategory() {
         assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentCategory("invalid").singleResult()).isNull();
         assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentCategory("invalid").list()).isEmpty();
-        assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentCategory("invalid").count()).isEqualTo(0);
+        assertThat(cmmnRepositoryService.createDeploymentQuery().deploymentCategory("invalid").count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/repository/DeploymentTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/repository/DeploymentTest.java
@@ -115,8 +115,7 @@ public class DeploymentTest extends FlowableCmmnTestCase {
         
         String resourceName = "org/flowable/cmmn/test/repository/DeploymentTest.testCaseDefinitionDI.cmmn";
         String diagramResourceName = "org/flowable/cmmn/test/repository/DeploymentTest.testCaseDefinitionDI.caseB.png";
-        assertThat(resourceNames.contains(resourceName)).isTrue();
-        assertThat(resourceNames.contains(diagramResourceName)).isTrue();
+        assertThat(resourceNames).contains(resourceName, diagramResourceName);
         
         InputStream inputStream = cmmnRepositoryService.getResourceAsStream(cmmnDeployment.getId(), resourceName);
         assertThat(inputStream).isNotNull();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/AutoCompleteEvaluationTest.java
@@ -61,8 +61,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -119,8 +119,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -145,8 +145,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -206,8 +206,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         // complete Task C -> will complete the case
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -250,8 +250,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -307,8 +307,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -340,8 +340,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         // set the auto-complete flag on the case plan model which should directly complete the case
         cmmnRuntimeService.setVariable(caseInstance.getId(), "enablePlanModelAutoComplete", true);
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -403,8 +403,8 @@ public class AutoCompleteEvaluationTest extends FlowableCmmnTestCase {
         // complete Task C -> will complete the case
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletableReEvaluationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletableReEvaluationTest.java
@@ -56,8 +56,8 @@ public class CaseCompletableReEvaluationTest extends FlowableCmmnTestCase {
         // complete task A which will complete the case
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletionExitSentryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseCompletionExitSentryTest.java
@@ -53,8 +53,8 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
         // trigger the user event listener to manually complete the case (not forcing it though)
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Complete case if completable"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().finished().singleResult();
@@ -97,8 +97,8 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
         // trigger the user event listener again as the stage should not be completable
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances2, "Complete case"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().finished().singleResult();
@@ -133,8 +133,8 @@ public class CaseCompletionExitSentryTest extends FlowableCmmnTestCase {
         // trigger the user event listener to manually complete the case with a force to complete
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Force complete case"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().finished().singleResult();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceInvolvementTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceInvolvementTest.java
@@ -44,7 +44,7 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
             start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
     }
@@ -58,7 +58,7 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "gonzo", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
     }
@@ -72,7 +72,7 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "gonzo", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").count()).isZero();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").list()).isEmpty();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("").singleResult()).isNull();
     }
@@ -85,7 +85,7 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
             start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("gonzo").count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("gonzo").count()).isZero();
     }
 
     @Test
@@ -134,7 +134,7 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
             start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId())
@@ -149,7 +149,7 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
             start();
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).count()).isZero();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).list()).isEmpty();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("")).singleResult()).isNull();
     }
@@ -165,7 +165,7 @@ public class CaseInstanceInvolvementTest extends FlowableCmmnTestCase {
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(
                 Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
-        ).count()).isEqualTo(1L);
+        ).count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(
                 Stream.of("testGroup", "testGroup2", "testGroup3").collect(Collectors.toSet())
         ).list().get(0).getId()).isEqualTo(caseInstance.getId());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceQueryImplTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceQueryImplTest.java
@@ -70,12 +70,12 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").singleResult().getId()).isEqualTo(caseInstance.getId());
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().or().caseDefinitionKey("oneTaskCase").caseInstanceId("Undefined").endOr().list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(
@@ -89,7 +89,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKeys(Collections.singleton("oneTaskCase")).singleResult().getId())
@@ -100,7 +100,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceId("undefined")
                 .caseDefinitionKeys(Collections.singleton("oneTaskCase"))
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceId("undefined")
@@ -119,7 +119,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionCategory("http://flowable.org/cmmn").list()).hasSize(2);
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
@@ -127,7 +127,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionCategory("http://flowable.org/cmmn")
                 .caseInstanceId("undefined")
                 .endOr()
-                .count()).isEqualTo(2L);
+                .count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseDefinitionCategory("http://flowable.org/cmmn")
@@ -142,7 +142,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionName("oneTaskCaseName").singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -151,7 +151,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("oneTaskCaseName")
                 .caseInstanceId("undefined")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseDefinitionName("oneTaskCaseName")
@@ -172,10 +172,10 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).count()).isEqualTo(1);
         assertThat(
                 cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).caseInstanceId(caseInstance.getId()).count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionId(caseInstance.getCaseDefinitionId()).singleResult().getId())
@@ -186,7 +186,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionId(caseInstance.getCaseDefinitionId())
                 .caseInstanceId("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseDefinitionId(caseInstance.getCaseDefinitionId())
@@ -207,7 +207,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionVersion(1).count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionVersion(1).count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionVersion(1).list()).hasSize(2);
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
@@ -215,7 +215,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionVersion(1)
                 .caseInstanceId("undefinedId")
                 .endOr()
-                .count()).isEqualTo(2L);
+                .count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseDefinitionVersion(1)
@@ -230,7 +230,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -239,7 +239,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceId(caseInstance.getId())
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceId(caseInstance.getId())
@@ -261,7 +261,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .businessKey("businessKey")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceBusinessKey("businessKey").singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -270,7 +270,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceBusinessKey("businessKey")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceBusinessKey("businessKey")
@@ -294,7 +294,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         Calendar todayCal = new GregorianCalendar();
         Calendar dateCal = new GregorianCalendar(todayCal.get(Calendar.YEAR) + 1, todayCal.get(Calendar.MONTH), todayCal.get(Calendar.DAY_OF_YEAR));
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBefore(dateCal.getTime()).count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBefore(dateCal.getTime()).count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBefore(dateCal.getTime()).list()).hasSize(2);
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
@@ -302,7 +302,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceStartedBefore(dateCal.getTime())
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(2L);
+                .count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceStartedBefore(dateCal.getTime())
@@ -320,7 +320,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         Calendar todayCal = new GregorianCalendar();
         Calendar dateCal = new GregorianCalendar(todayCal.get(Calendar.YEAR) - 1, todayCal.get(Calendar.MONTH), todayCal.get(Calendar.DAY_OF_YEAR));
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedAfter(dateCal.getTime()).count()).isEqualTo(2L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedAfter(dateCal.getTime()).count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedAfter(dateCal.getTime()).list()).hasSize(2);
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
@@ -328,7 +328,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceStartedAfter(dateCal.getTime())
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(2L);
+                .count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceStartedAfter(dateCal.getTime())
@@ -346,7 +346,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseDefinitionKey("oneTaskCase")
                     .start();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").count()).isEqualTo(1);
             assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
             assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceStartedBy("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -355,7 +355,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseInstanceStartedBy("kermit")
                     .caseDefinitionName("undefinedId")
                     .endOr()
-                    .count()).isEqualTo(1L);
+                    .count()).isEqualTo(1);
             assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                     .or()
                     .caseInstanceStartedBy("kermit")
@@ -380,7 +380,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .callbackId("callBackId")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackId("callBackId").singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -389,7 +389,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceCallbackId("callBackId")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceCallbackId("callBackId")
@@ -411,7 +411,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .callbackType("callBackType")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceCallbackType("callBackType").singleResult().getId())
                 .isEqualTo(caseInstance.getId());
@@ -421,7 +421,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceCallbackType("callBackType")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceCallbackType("callBackType")
@@ -443,7 +443,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .referenceId("testReferenceId")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId").singleResult().getId())
@@ -454,7 +454,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceReferenceId("testReferenceId")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceReferenceId("testReferenceId")
@@ -476,7 +476,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .referenceType("testReferenceType")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceType("testReferenceType").singleResult().getId())
@@ -487,7 +487,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseInstanceReferenceType("testReferenceType")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .caseInstanceReferenceType("testReferenceType")
@@ -513,7 +513,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         }
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceReferenceId("testReferenceId")
-                .caseInstanceReferenceType("testReferenceType").count()).isEqualTo(4L);
+                .caseInstanceReferenceType("testReferenceType").count()).isEqualTo(4);
     }
 
     @Test
@@ -530,7 +530,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .tenantId("tenantId")
                     .start();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").count()).isEqualTo(1);
             assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").list().get(0).getId()).isEqualTo(caseInstance.getId());
             assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId("tenantId").singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -539,7 +539,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseInstanceTenantId("tenantId")
                     .caseDefinitionName("undefinedId")
                     .endOr()
-                    .count()).isEqualTo(1L);
+                    .count()).isEqualTo(1);
             assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                     .or()
                     .caseInstanceTenantId("tenantId")
@@ -571,7 +571,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .tenantId("tenantId")
                     .start();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").count()).isEqualTo(1);
             assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").list().get(0).getId()).isEqualTo(caseInstance.getId());
             assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantIdLike("ten%").singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -580,7 +580,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseInstanceTenantIdLike("ten%")
                     .caseDefinitionName("undefinedId")
                     .endOr()
-                    .count()).isEqualTo(1L);
+                    .count()).isEqualTo(1);
             assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                     .or()
                     .caseInstanceTenantIdLike("ten%")
@@ -612,7 +612,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .tenantId("tenantId")
                     .start();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().count()).isEqualTo(1);
             assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().list().get(0).getId()).isNotEqualTo(caseInstance.getId());
             assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceWithoutTenantId().singleResult().getId()).isNotEqualTo(caseInstance.getId());
 
@@ -621,7 +621,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                     .caseInstanceWithoutTenantId()
                     .caseDefinitionName("undefinedId")
                     .endOr()
-                    .count()).isEqualTo(1L);
+                    .count()).isEqualTo(1);
             assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                     .or()
                     .caseInstanceWithoutTenantId()
@@ -646,7 +646,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit").singleResult().getId()).isEqualTo(caseInstance.getId());
 
@@ -655,7 +655,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .involvedUser("kermit")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .involvedUser("kermit")
@@ -677,30 +677,30 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .start();
         cmmnRuntimeService.addUserIdentityLink(caseInstance.getId(), "kermit", "specialLink");
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit", "specialLink").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit", "specialLink").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit", "specialLink").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit", "specialLink").singleResult().getId()).isEqualTo(caseInstance.getId());
         
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit", "wrongType").count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedUser("kermit", "wrongType").count()).isZero();
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .involvedUser("kermit", "specialLink")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .involvedUser("kermit", "specialLink")
                 .caseDefinitionKey("oneTaskCase")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .involvedUser("kermit", "wrongType")
                 .caseDefinitionKey("undefined")
                 .endOr()
-                .count()).isEqualTo(0L);
+                .count()).isZero();
     }
 
     @Test
@@ -711,7 +711,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", IdentityLinkType.PARTICIPANT);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Collections.singleton("testGroup")).singleResult().getId())
@@ -722,7 +722,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .involvedGroups(Collections.singleton("testGroup"))
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .involvedGroups(Collections.singleton("testGroup"))
@@ -745,13 +745,13 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup", "specialLink");
         cmmnRuntimeService.addGroupIdentityLink(caseInstance.getId(), "testGroup2", "extraLink");
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroup("testGroup", "specialLink").count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroup("testGroup", "specialLink").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroup("testGroup", "specialLink").list().get(0).getId())
                 .isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroup("testGroup", "specialLink").singleResult().getId())
                 .isEqualTo(caseInstance.getId());
         
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroup("testGroup2", "wrongType").count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroup("testGroup2", "wrongType").count()).isZero();
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
@@ -759,7 +759,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionName("undefinedId")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
@@ -767,7 +767,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("oneTaskCase")
                 .endOr()
                 .count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
@@ -775,7 +775,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("wrongKey")
                 .endOr()
                 .count())
-                .isEqualTo(0L);
+                .isZero();
     }
 
     @Test
@@ -796,7 +796,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.addUserIdentityLink(caseInstance3.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
-                .involvedUser("kermit").count()).isEqualTo(1L);
+                .involvedUser("kermit").count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
                 .involvedUser("kermit").list().get(0).getId()).isEqualTo(caseInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
@@ -807,7 +807,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(2L);
+                .count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
@@ -821,7 +821,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .involvedUser("kermit")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(3L);
+                .count()).isEqualTo(3);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet()))
@@ -851,7 +851,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .variableValueEquals("queryVariable", "queryVariableValue")
                 .variableValueEquals("queryVariable2", "queryVariableValue2")
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .variableValueEquals("queryVariable", "queryVariableValue")
                 .variableValueEquals("queryVariable2", "queryVariableValue2")
@@ -867,7 +867,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .variableValueEquals("queryVariable2", "queryVariableValue2")
                 .caseDefinitionName("undefinedId")
                 .endOr()
-                .count()).isEqualTo(3L);
+                .count()).isEqualTo(3);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery()
                 .or()
                 .variableValueEquals("queryVariable", "queryVariableValue")
@@ -888,7 +888,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                 .name("caseInstance2")
                 .start();
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).caseInstanceWithoutTenantId().count()).isEqualTo(1L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).caseInstanceWithoutTenantId().count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).caseInstanceWithoutTenantId().list()).hasSize(1);
     }
 
@@ -951,7 +951,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         Assertions.assertThat(caseInstance).isNotNull();
         Assertions.assertThat(caseInstance.getId()).isEqualTo(caseInstance3.getId());
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("instantVar", nextYear).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("instantVar", nextYear).count()).isZero();
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("instantVar", oneYearAgo).count()).isEqualTo(3);
 
         // Test GREATER_THAN_OR_EQUAL
@@ -974,14 +974,14 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                         caseInstance2.getId()
                 );
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("instantVar", instant1).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("instantVar", instant1).count()).isZero();
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("instantVar", twoYearsLater).count()).isEqualTo(3);
 
         // Test LESS_THAN_OR_EQUAL
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("instantVar", nextYear).list();
         Assertions.assertThat(caseInstances).hasSize(3);
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("instantVar", oneYearAgo).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("instantVar", oneYearAgo).count()).isZero();
 
         // Test value-only matching
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(nextYear).singleResult();
@@ -1059,7 +1059,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         Assertions.assertThat(caseInstance).isNotNull();
         Assertions.assertThat(caseInstance.getId()).isEqualTo(caseInstance3.getId());
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("localDateVar", nextYear).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("localDateVar", nextYear).count()).isZero();
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("localDateVar", oneYearAgo).count()).isEqualTo(3);
 
         // Test GREATER_THAN_OR_EQUAL
@@ -1082,14 +1082,14 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                         caseInstance2.getId()
                 );
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateVar", localDate).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateVar", localDate).count()).isZero();
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateVar", twoYearsLater).count()).isEqualTo(3);
 
         // Test LESS_THAN_OR_EQUAL
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("localDateVar", nextYear).list();
         Assertions.assertThat(caseInstances).hasSize(3);
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("localDateVar", oneYearAgo).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("localDateVar", oneYearAgo).count()).isZero();
 
         // Test value-only matching
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(nextYear).singleResult();
@@ -1168,7 +1168,7 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         Assertions.assertThat(caseInstance).isNotNull();
         Assertions.assertThat(caseInstance.getId()).isEqualTo(caseInstance3.getId());
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("localDateTimeVar", nextYear).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("localDateTimeVar", nextYear).count()).isZero();
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueGreaterThan("localDateTimeVar", oneYearAgo).count()).isEqualTo(3);
 
         // Test GREATER_THAN_OR_EQUAL
@@ -1192,14 +1192,14 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
                         caseInstance2.getId()
                 );
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateTimeVar", localDateTime).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateTimeVar", localDateTime).count()).isZero();
         Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThan("localDateTimeVar", twoYearsLater).count()).isEqualTo(3);
 
         // Test LESS_THAN_OR_EQUAL
         caseInstances = cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("localDateTimeVar", nextYear).list();
         Assertions.assertThat(caseInstances).hasSize(3);
 
-        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("localDateTimeVar", oneYearAgo).count()).isEqualTo(0);
+        Assertions.assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueLessThanOrEqual("localDateTimeVar", oneYearAgo).count()).isZero();
 
         // Test value-only matching
         caseInstance = cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals(nextYear).singleResult();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CasePageTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CasePageTaskTest.java
@@ -87,8 +87,8 @@ public class CasePageTaskTest extends FlowableCmmnTestCase {
 
         // Finish case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         HistoricPlanItemInstance historicPlanItemInstance = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
@@ -128,8 +128,8 @@ public class CasePageTaskTest extends FlowableCmmnTestCase {
 
         // Finish case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -222,8 +222,8 @@ public class CasePageTaskTest extends FlowableCmmnTestCase {
 
         // Finish case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricIdentityLink> historicIdentityLinks = cmmnHistoryService.getHistoricIdentityLinksForPlanItemInstance(pagePlanItemInstance.getId());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseTaskTest.java
@@ -199,7 +199,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     protected void assertBlockingCaseTaskFlow(CaseInstance caseInstance) {
         assertThat(caseInstance).isNotNull();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -214,7 +214,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(2);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
@@ -248,8 +248,8 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
         assertThat(planItemInstance.getName()).isEqualTo("Task Two");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(2);
 
         List<HistoricEntityLink> historicEntityLinks = cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId());
@@ -295,7 +295,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
         assertThat(caseInstance).isNotNull();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -308,7 +308,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(2);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .orderByName().asc()
@@ -328,8 +328,8 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
         assertThat(planItemInstance.getName()).isEqualTo("The Task");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(2);
     }
 
@@ -338,7 +338,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     public void testRuntimeServiceTriggerCasePlanItemInstance() {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(2);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(2);
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -370,7 +370,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     public void testRuntimeServiceTriggerNonBlockingCasePlanItem() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(2);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(2);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -392,16 +392,16 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
                 .singleResult();
         assertThat(planItemInstance.getName()).isEqualTo("The Task");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(2);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
     }
 
     @Test
     @CmmnDeployment
     public void testTerminateCaseInstanceWithNonBlockingCaseTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(2);
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -412,7 +412,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
 
         // Terminating the parent case instance should not terminate the child (it's non-blocking)
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
 
@@ -425,7 +425,7 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.terminateCaseInstance(childCaseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(2);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
     }
 
     @Test
@@ -455,12 +455,12 @@ public class CaseTaskTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testTerminateCaseInstanceWithNestedCaseTasks() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(4);
 
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(4);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
 
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().list())
             .extracting(HistoricCaseInstance::getState)

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CmmnRuntimeServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CmmnRuntimeServiceTest.java
@@ -80,7 +80,7 @@ public class CmmnRuntimeServiceTest extends FlowableCmmnTestCase {
             }
         });
         
-        assertThat(planItemInstances.size()).isEqualTo(1);
+        assertThat(planItemInstances).hasSize(1);
         assertThat(planItemInstances.get(0).getPlanItemDefinitionId()).isEqualTo("theTask");
 
         // default values for callbacks are null
@@ -151,10 +151,10 @@ public class CmmnRuntimeServiceTest extends FlowableCmmnTestCase {
 
         assertThat(caseInstance).isNotNull();
         assertThat(this.cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count())
-                .as("Plan items are created asynchronously").isEqualTo(0l);
+                .as("Plan items are created asynchronously").isZero();
 
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200, true);
-        assertThat(this.cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1l);
+        assertThat(this.cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CompleteWithExitSentryByMilestoneTest.java
@@ -43,8 +43,8 @@ public class CompleteWithExitSentryByMilestoneTest extends FlowableCmmnTestCase 
         assertPlanItemInstanceState(planItemInstances, "Task", ACTIVE);
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/EntryCriteriaTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/EntryCriteriaTest.java
@@ -53,8 +53,8 @@ public class EntryCriteriaTest extends FlowableCmmnTestCase {
                 .caseInstanceId(caseInstance.getId())
                 .singleResult();
         assertThat(historicCaseInstance).isNotNull();
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -63,8 +63,8 @@ public class EntryCriteriaTest extends FlowableCmmnTestCase {
     public void testThreeEntryCriteriaOnPartsForWaitStates() {
         CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().singleResult();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionId(caseDefinition.getId()).start();
-        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isZero();
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -80,7 +80,7 @@ public class EntryCriteriaTest extends FlowableCmmnTestCase {
                 .milestoneInstanceCaseInstanceId(caseInstance.getId())
                 .singleResult();
         assertThat(mileStone.getName()).isEqualTo("PlanItem Milestone One");
-        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isZero();
 
         HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -132,8 +132,8 @@ public class EntryCriteriaTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(1).getId());
 
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ExitCriteriaTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ExitCriteriaTest.java
@@ -44,8 +44,8 @@ public class ExitCriteriaTest extends FlowableCmmnTestCase {
 
         // Completing A should trigger exit criteria of B. Case completes.
         cmmnRuntimeService.triggerPlanItemInstance(planItems.get(0).getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -53,8 +53,8 @@ public class ExitCriteriaTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testSimpleExitCriteriaNonBlocking() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).finished().count()).isEqualTo(1);
     }
@@ -74,8 +74,8 @@ public class ExitCriteriaTest extends FlowableCmmnTestCase {
             cmmnRuntimeService.triggerPlanItemInstance(planItems.get(i).getId());
         }
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -93,8 +93,8 @@ public class ExitCriteriaTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(planItems.get(0).getId());
         cmmnRuntimeService.triggerPlanItemInstance(planItems.get(1).getId());
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -125,8 +125,8 @@ public class ExitCriteriaTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(planItems.get(0).getId());
         cmmnRuntimeService.triggerPlanItemInstance(planItems.get(1).getId());
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -140,8 +140,8 @@ public class ExitCriteriaTest extends FlowableCmmnTestCase {
         assertThat(taskA).isNotNull();
         cmmnRuntimeService.triggerPlanItemInstance(taskA.getId());
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -156,15 +156,15 @@ public class ExitCriteriaTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(4);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
 
         // Trigger the plan item should satisfy the sentry of the plan model exit criteria
         PlanItemInstance taskA = cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Task A").singleResult();
         assertThat(taskA).isNotNull();
         cmmnRuntimeService.triggerPlanItemInstance(taskA.getId());
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(4);
 
         cmmnRepositoryService.deleteDeployment(oneTaskCaseDeploymentId, true);
@@ -182,7 +182,7 @@ public class ExitCriteriaTest extends FlowableCmmnTestCase {
                 .singleResult();
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ExitSentryCompletionExceptionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ExitSentryCompletionExceptionTest.java
@@ -48,8 +48,8 @@ public class ExitSentryCompletionExceptionTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -74,8 +74,8 @@ public class ExitSentryCompletionExceptionTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task C"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/GenericEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/GenericEventListenerTest.java
@@ -96,7 +96,7 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.completeGenericEventListenerInstance(listenerInstance.getId());
 
         //UserEventListener should be completed
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.GENERIC_EVENT_LISTENER).count()).isZero();
 
         //Only 2 PlanItems left
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
@@ -146,7 +146,7 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(listenerInstance.getId());
 
         //UserEventListener should be completed
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isZero();
 
         //Only 2 PlanItems left (1 stage & 1 active task)
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
@@ -268,7 +268,7 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
         // Completing the other task with the exit sentry should still keep the event, as it's reference by the entry of B
         cmmnTaskService.complete(tasks.get(0).getId());
         assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         // Firing the event listener should start B
         cmmnRuntimeService.completeGenericEventListenerInstance(
@@ -281,7 +281,7 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testMultipleEventListenersAsEntry() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testMultipleEventListenersAsEntry").start();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         List<GenericEventListenerInstance> eventListenerInstances = cmmnRuntimeService.createGenericEventListenerInstanceQuery()
                 .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
@@ -291,7 +291,7 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
 
         // Completing A should change nothing
         cmmnRuntimeService.completeGenericEventListenerInstance(eventListenerInstances.get(0).getId());
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         eventListenerInstances = cmmnRuntimeService.createGenericEventListenerInstanceQuery()
                 .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
         assertThat(eventListenerInstances)
@@ -301,7 +301,7 @@ public class GenericEventListenerTest extends FlowableCmmnTestCase {
         // Completing B should activate the stage and remove the orphan event listener C
         cmmnRuntimeService.completeGenericEventListenerInstance(eventListenerInstances.get(0).getId());
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createGenericEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/HumanTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/HumanTaskTest.java
@@ -98,7 +98,7 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
 
         cmmnTaskService.complete(task.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
             assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
@@ -167,7 +167,7 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
             assertThat(task.getTenantId()).isEqualTo("flowable");
             cmmnTaskService.complete(task.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         } finally {
             cmmnRepositoryService.deleteDeployment(deployment.getId(), true);
@@ -204,7 +204,7 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
             assertThat(task.getTenantId()).isEqualTo("flowable");
             cmmnTaskService.complete(task.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         } finally {
             cmmnRepositoryService.deleteDeployment(deployment.getId(), true);
             Authentication.setAuthenticatedUserId(null);
@@ -227,7 +227,7 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
 
         // Completing A should delete B and C
         cmmnTaskService.complete(tasks.get(0).getId());
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         assertCaseInstanceEnded(caseInstance);
 
         List<HistoricTaskInstance> historicTaskInstances = cmmnHistoryService.createHistoricTaskInstanceQuery().list();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MultiEntrySentryActivationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MultiEntrySentryActivationTest.java
@@ -69,8 +69,8 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage B Form", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -121,8 +121,8 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage B Form", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -164,7 +164,7 @@ public class MultiEntrySentryActivationTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Stage B Form", ACTIVE));
 
         assertCaseInstanceEnded(caseInstance);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemCompletionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemCompletionTest.java
@@ -62,8 +62,8 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         // trigger user listener to complete stage
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "User Listener A"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -94,8 +94,8 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         // trigger user listener to complete stage
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "User Listener A"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -121,8 +121,8 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.completeGenericEventListenerInstance(userEventListenerInstance.getId());
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -192,8 +192,8 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.startPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task E"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -278,8 +278,8 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         // complete Task B -> case must be completed now
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -304,8 +304,8 @@ public class PlanItemCompletionTest extends FlowableCmmnTestCase {
         runComplexCompletionTestScenario(true);
 
         // because autocompletion is on, the case will be completed
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInjectionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInjectionTest.java
@@ -78,7 +78,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
@@ -142,7 +141,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
@@ -171,8 +169,8 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task A", ACTIVE));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
@@ -228,7 +226,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
@@ -309,7 +306,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
@@ -338,8 +334,8 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task A", ACTIVE));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
@@ -398,7 +394,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
@@ -408,7 +403,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(derivedPlanItems).isNotNull();
         assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
@@ -438,7 +432,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(historicPlanItemInstances).isNotNull();
         assertThat(historicPlanItemInstances).hasSize(3);
     }
 
@@ -488,7 +481,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(2);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Injected Task A");
@@ -498,7 +490,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(derivedPlanItems).isNotNull();
         assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
@@ -526,15 +517,14 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Injected Task B", ACTIVE));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(historicPlanItemInstances).isNotNull();
         assertThat(historicPlanItemInstances).hasSize(3);
     }
 
@@ -586,7 +576,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(3);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Task X");
@@ -597,7 +586,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(derivedPlanItems).isNotNull();
         assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
@@ -672,7 +660,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(3);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Task X");
@@ -683,7 +670,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(derivedPlanItems).isNotNull();
         assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
@@ -711,15 +697,14 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task Y", ACTIVE));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(historicPlanItemInstances).isNotNull();
         assertThat(historicPlanItemInstances).hasSize(3);
     }
 
@@ -777,7 +762,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(3);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Task X");
@@ -788,7 +772,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(derivedPlanItems).isNotNull();
         assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
@@ -869,7 +852,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .active()
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(3);
         assertSingleTaskExists(tasks, "Task A");
         assertSingleTaskExists(tasks, "Task X");
@@ -880,7 +862,6 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
                 .derivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(derivedPlanItems).isNotNull();
         assertThat(derivedPlanItems).hasSize(3);
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task A", ACTIVE));
@@ -908,15 +889,14 @@ public class PlanItemInjectionTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByNameAndState(planItemInstances, "Task Y", ACTIVE));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricPlanItemInstance> historicPlanItemInstances = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
                 .planItemInstanceDerivedCaseDefinitionId(dynamicPlanItemCase.getId())
                 .list();
 
-        assertThat(historicPlanItemInstances).isNotNull();
         assertThat(historicPlanItemInstances).hasSize(3);
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.java
@@ -86,7 +86,7 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
         startInstances(1);
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().list();
         for (PlanItemInstance planItemInstance : planItemInstances) {
-            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).count()).isEqualTo(1L);
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceId(planItemInstance.getId()).count()).isEqualTo(1);
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/RuntimeServiceTest.java
@@ -75,8 +75,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         assertThat(caseInstance.getStartTime()).isNotNull();
         assertThat(caseInstance.getState()).isEqualTo(CaseInstanceState.COMPLETED);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
 
         List<HistoricMilestoneInstance> milestoneInstances = cmmnHistoryService.createHistoricMilestoneInstanceQuery()
@@ -95,7 +95,7 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionId(caseDefinition.getId()).start();
         assertThat(caseInstance.getState()).isEqualTo(CaseInstanceState.ACTIVE);
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(1);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(4);
 
@@ -129,8 +129,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         assertThat(planItemInstance.getName()).isEqualTo("Task B");
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().milestoneInstanceCaseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
 
@@ -371,13 +371,13 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
     }
 
     private void assertEmptyQuery(CaseInstanceQuery caseInstanceQuery, HistoricCaseInstanceQuery historicCaseInstanceQuery) {
-        assertThat(caseInstanceQuery.count()).isEqualTo(0);
+        assertThat(caseInstanceQuery.count()).isZero();
         assertThat(caseInstanceQuery.includeCaseVariables().singleResult()).isNull();
         List<CaseInstance> caseInstances = caseInstanceQuery.includeCaseVariables().list();
         assertThat(caseInstances).isEmpty();
 
         if (historicCaseInstanceQuery != null) {
-            assertThat(historicCaseInstanceQuery.count()).isEqualTo(0);
+            assertThat(historicCaseInstanceQuery.count()).isZero();
             assertThat(historicCaseInstanceQuery.includeCaseVariables().singleResult()).isNull();
             List<HistoricCaseInstance> historicCaseInstances = historicCaseInstanceQuery.includeCaseVariables().list();
             assertThat(historicCaseInstances).isEmpty();
@@ -394,25 +394,25 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .start();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("var", "test").count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("var", "test2").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("var", "test2").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEqualsIgnoreCase("var", "TEST").count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEqualsIgnoreCase("var", "TEST2").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEqualsIgnoreCase("var", "TEST2").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEquals("var", "test2").count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEquals("var", "test").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEquals("var", "test").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEqualsIgnoreCase("var", "TEST2").count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEqualsIgnoreCase("var", "TEST").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueNotEqualsIgnoreCase("var", "TEST").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLike("var", "te%").count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLike("var", "te2%").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLike("var", "te2%").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLikeIgnoreCase("var", "TE%").count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLikeIgnoreCase("var", "TE2%").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLikeIgnoreCase("var", "TE2%").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 5).count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 11).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 11).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 10).count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 11).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 11).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThan("numberVar", 20).count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThan("numberVar", 5).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThan("numberVar", 5).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThanOrEqual("numberVar", 10).count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThanOrEqual("numberVar", 9).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueLessThanOrEqual("numberVar", 9).count()).isZero();
 
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -431,39 +431,39 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setLocalVariables(planItemInstance.getId(), localVarMap);
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 10).count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 11).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThan("numberVar", 11).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 11).count()).isEqualTo(4);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 12).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueGreaterThanOrEqual("numberVar", 12).count()).isZero();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("localVar", "test").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseVariableValueEquals("localVar", "test").count()).isZero();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("localVar", "test").count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("localVar", "test2").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("localVar", "test2").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEqualsIgnoreCase("localVar", "TEST").count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEqualsIgnoreCase("localVar", "TEST2").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEqualsIgnoreCase("localVar", "TEST2").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("localVar", "test2").count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("localVar", "test").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("localVar", "test").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEqualsIgnoreCase("localVar", "TEST2").count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEqualsIgnoreCase("localVar", "TEST").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEqualsIgnoreCase("localVar", "TEST").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLike("localVar", "te%").count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLike("localVar", "te2%").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLike("localVar", "te2%").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLikeIgnoreCase("localVar", "TE%").count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLikeIgnoreCase("localVar", "TE2%").count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLikeIgnoreCase("localVar", "TE2%").count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThan("localNumberVar", 5).count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThan("localNumberVar", 17).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThan("localNumberVar", 17).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThanOrEqual("localNumberVar", 15).count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThanOrEqual("localNumberVar", 16).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueGreaterThanOrEqual("localNumberVar", 16).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThan("localNumberVar", 20).count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThan("localNumberVar", 5).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThan("localNumberVar", 5).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThanOrEqual("localNumberVar", 15).count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThanOrEqual("localNumberVar", 9).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueLessThanOrEqual("localNumberVar", 9).count()).isZero();
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE).singleResult();
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -499,7 +499,7 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -548,8 +548,8 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().unfinished().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -610,7 +610,7 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .extracting(CaseInstance::getCaseVariables)
                 .containsExactly(variablesA, variablesB, Collections.EMPTY_MAP);
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().count()).isEqualTo(3L);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().count()).isEqualTo(3);
 
         List<HistoricCaseInstance> historicCaseInstancesWithVariables = cmmnHistoryService.createHistoricCaseInstanceQuery().includeCaseVariables()
                 .orderByStartTime().asc().list();
@@ -618,7 +618,7 @@ public class RuntimeServiceTest extends FlowableCmmnTestCase {
                 .extracting(HistoricCaseInstance::getCaseVariables)
                 .containsExactly(variablesA, variablesB, Collections.EMPTY_MAP);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().count()).isEqualTo(3L);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().includeCaseVariables().orderByStartTime().asc().count()).isEqualTo(3);
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ServiceTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/ServiceTaskTest.java
@@ -59,7 +59,7 @@ public class ServiceTaskTest extends FlowableCmmnTestCase {
 
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -87,7 +87,7 @@ public class ServiceTaskTest extends FlowableCmmnTestCase {
 
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -118,7 +118,7 @@ public class ServiceTaskTest extends FlowableCmmnTestCase {
 
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -146,7 +146,7 @@ public class ServiceTaskTest extends FlowableCmmnTestCase {
 
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -174,7 +174,7 @@ public class ServiceTaskTest extends FlowableCmmnTestCase {
 
         // Triggering the task should start the child case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery()
                 .caseInstanceId(caseInstance.getId())

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/SignalEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/SignalEventListenerTest.java
@@ -95,7 +95,7 @@ public class SignalEventListenerTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(listenerInstance.getId());
 
         // SignalEventListener should be completed
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.SIGNAL_EVENT_LISTENER).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.SIGNAL_EVENT_LISTENER).count()).isZero();
 
         // Only 2 PlanItems left
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StageCompletionExitSentryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StageCompletionExitSentryTest.java
@@ -70,8 +70,8 @@ public class StageCompletionExitSentryTest extends FlowableCmmnTestCase {
         // complete Task B and the case will be completed
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -129,8 +129,8 @@ public class StageCompletionExitSentryTest extends FlowableCmmnTestCase {
         // complete Task B and the case will be completed
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -187,8 +187,8 @@ public class StageCompletionExitSentryTest extends FlowableCmmnTestCase {
         // complete Task B and the case will be completed
         cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StageTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StageTest.java
@@ -66,8 +66,8 @@ public class StageTest extends FlowableCmmnTestCase {
 
         // Finish case instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -75,8 +75,8 @@ public class StageTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testOneNestedStageNonBlocking() {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -110,8 +110,8 @@ public class StageTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testTwoNestedStagesNonBlocking() {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -166,8 +166,8 @@ public class StageTest extends FlowableCmmnTestCase {
                 .containsExactly(expectedNames);
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -175,8 +175,8 @@ public class StageTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testThreeNestedStagesNonBlocking() {
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -211,8 +211,8 @@ public class StageTest extends FlowableCmmnTestCase {
         // Triggering Task C should exit stage 2, which should also exit the inner nested stage
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(3).getId());
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -223,8 +223,8 @@ public class StageTest extends FlowableCmmnTestCase {
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(8);
 
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -377,7 +377,7 @@ public class StageTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService
                 .completeStagePlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Stage 1").singleResult().getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         stages = cmmnHistoryService.getStageOverview(caseInstance.getId());
         assertThat(stages).hasSize(3);
@@ -447,7 +447,7 @@ public class StageTest extends FlowableCmmnTestCase {
 
         cmmnRuntimeService
                 .completeStagePlanItemInstance(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Stage 1").singleResult().getId());
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         stages = cmmnHistoryService.getStageOverview(caseInstance.getId());
         assertThat(stages).hasSize(5);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/TimerEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/TimerEventListenerTest.java
@@ -50,11 +50,11 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).planItemInstanceStateAvailable()
                 .singleResult()).isNotNull();
 
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
-        assertThat(cmmnManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1);
+        assertThat(cmmnManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).count()).isEqualTo(1);
 
         // User task should not be active before the timer triggers
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
 
         Job timerJob = cmmnManagementService.createTimerJobQuery().scopeDefinitionId(caseInstance.getCaseDefinitionId()).singleResult();
         assertThat(timerJob).isNotNull();
@@ -65,7 +65,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         cmmnManagementService.executeJob(timerJob.getId());
 
         // User task should be active after the timer has triggered
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1);
     }
     
     @Test
@@ -75,8 +75,8 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         assertThat(caseInstance).isNotNull();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
-        assertThat(cmmnManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1);
+        assertThat(cmmnManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).count()).isEqualTo(1);
 
         Job timerJob = cmmnManagementService.createTimerJobQuery().scopeDefinitionId(caseInstance.getCaseDefinitionId()).singleResult();
         assertThat(timerJob).isNotNull();
@@ -86,7 +86,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         cmmnManagementService.executeJob(timerJob.getId());
 
         // User task should be active after the timer has triggered
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1);
     }
     
     @Test
@@ -99,8 +99,8 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         assertThat(caseInstance).isNotNull();
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
-        assertThat(cmmnManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1);
+        assertThat(cmmnManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).count()).isEqualTo(1);
 
         Job timerJob = cmmnManagementService.createTimerJobQuery().scopeDefinitionId(caseInstance.getCaseDefinitionId()).singleResult();
         assertThat(timerJob).isNotNull();
@@ -110,7 +110,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         cmmnManagementService.executeJob(timerJob.getId());
 
         // User task should be active after the timer has triggered
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1);
     }
 
     /**
@@ -131,7 +131,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         assertThat(planItemInstance).isNotNull();
 
         // User task should not be active before the timer triggers
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
 
         // Timer fires after 1 hour, so setting it to 1 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (60 * 60 * 1000 + 1)));
@@ -139,7 +139,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
 
         // User task should be active after the timer has triggered 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1);
     }
 
     @Test
@@ -155,7 +155,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .singleResult();
         assertThat(planItemInstance).isNotNull();
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
 
         // Timer fires after 1 day, so setting it to 1 day + 1 second
         setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
@@ -163,7 +163,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
 
         // User task should be active after the timer has triggered 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(2L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(2);
     }
 
     @Test
@@ -173,7 +173,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerInStage").start();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
@@ -181,7 +181,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .singleResult();
         assertThat(planItemInstance).isNotNull();
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1);
 
         // Timer fires after 3 hours, so setting it to 3 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (3 * 60 * 60 * 1000 + 1)));
@@ -202,22 +202,22 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStageExitOnTimerOccurrence").start();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count()).isEqualTo(3L);
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK).count()).isEqualTo(3);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(PlanItemDefinitionType.STAGE).count()).isEqualTo(1L);
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(PlanItemDefinitionType.STAGE).count()).isEqualTo(1);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).count()).isEqualTo(4L);
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).count()).isEqualTo(4);
 
         // Timer fires after 24 hours, so setting it to 24 hours + 1 second
         setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
 
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -239,27 +239,27 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count())
-                .isEqualTo(2L);
+                .isEqualTo(2);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count()).isEqualTo(0L);
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count()).isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count())
-                .isEqualTo(0L);
+                .isZero();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         setClockTo(new Date(dayBefore.getTime() + (24 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count())
-                .isEqualTo(0L);
+                .isZero();
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).list();
         assertThat(tasks).hasSize(3);
@@ -279,13 +279,13 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .variable("startTime", startTime)
                 .start();
 
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count()).isEqualTo(2L);
+                .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(Stage.class.getSimpleName().toLowerCase()).count()).isEqualTo(2);
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE).planItemDefinitionType(HumanTask.class.getSimpleName().toLowerCase()).count())
-                .isEqualTo(2L);
+                .isEqualTo(2);
 
         setClockTo(new Date(startTime.getTime() + (2 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
@@ -306,7 +306,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStartTrigger").start();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
-                .planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count()).isEqualTo(1L);
+                .planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count()).isEqualTo(1);
 
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("A");
@@ -319,7 +319,7 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE).planItemDefinitionType(TimerEventListener.class.getSimpleName().toLowerCase()).count())
-                .isEqualTo(1L);
+                .isEqualTo(1);
 
         setClockTo(new Date(startTime.getTime() + (3 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
@@ -332,13 +332,13 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         Date startTime = setClockFixedToCurrentTime();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testExitNestedStageThroughTimer").start();
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemDefinitionType(PlanItemDefinitionType.STAGE)
-                .count()).isEqualTo(3L);
+                .count()).isEqualTo(3);
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("The task");
 
         setClockTo(new Date(startTime.getTime() + (5 * 60 * 60 * 1000)));
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 10000L, 100L, true);
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0L);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         assertCaseInstanceEnded(caseInstance);
     }
 
@@ -356,14 +356,14 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
                 .extracting(Task::getName)
                 .containsExactly("A", "B");
 
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(0L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isZero();
 
         // Completing A activates the stage and the timer event listener
         cmmnTaskService.complete(tasks.get(0).getId());
         cmmnTaskService.complete(tasks.get(1).getId());
 
         // Timer event listener created a timer job
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1);
         tasks = cmmnTaskService.createTaskQuery()
                 .caseInstanceId(caseInstance.getId())
                 .orderByTaskName().asc()
@@ -402,14 +402,14 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
         assertThat(tasks).hasSize(1);
 
         // Should have a TimerJob
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1);
 
         for (Task task : tasks) {
             cmmnTaskService.complete(task.getId());
         }
 
         // TimerJob should be deleted after all tasks have completed in the stage
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(0L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isZero();
     }
 
     @Test
@@ -417,11 +417,11 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
     public void testTimerWithAvailableCondition() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerExpression").start();
 
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(0L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isZero();
 
         // Setting the variable should make the timer available and create the timer job
         cmmnRuntimeService.setVariable(caseInstance.getId(), "timerVar", true);
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1);
 
         PlanItemInstance timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER).singleResult();
@@ -429,13 +429,13 @@ public class TimerEventListenerTest extends FlowableCmmnTestCase {
 
         // Setting the variable to false again will dismiss the timer
         cmmnRuntimeService.setVariable(caseInstance.getId(), "timerVar", false);
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(0L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isZero();
         timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
                 .singleResult();
         assertThat(timerPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.UNAVAILABLE);
 
         cmmnRuntimeService.setVariable(caseInstance.getId(), "timerVar", true);
-        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1L);
+        assertThat(cmmnManagementService.createTimerJobQuery().count()).isEqualTo(1);
         timerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.TIMER_EVENT_LISTENER)
                 .singleResult();
         assertThat(timerPlanItemInstance.getState()).isEqualTo(PlanItemInstanceState.AVAILABLE);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/UserEventListenerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/UserEventListenerTest.java
@@ -95,7 +95,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.completeUserEventListenerInstance(listenerInstance.getId());
 
         //UserEventListener should be completed
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isZero();
 
         //Only 2 PlanItems left
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
@@ -142,7 +142,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(listenerInstance.getId());
 
         //UserEventListener should be completed
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isZero();
 
         //Only 2 PlanItems left (1 stage & 1 active task)
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().list()).hasSize(2);
@@ -236,7 +236,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.triggerPlanItemInstance(userEvent.getId());
 
         //UserEventListener is consumed
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER).count()).isZero();
 
         //Task is om Active state and a second task instance waiting for repetition
         Map<String, List<PlanItemInstance>> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -245,9 +245,9 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
                 .list().stream()
                 .collect(Collectors.groupingBy(PlanItemInstance::getState));
         assertThat(tasks).hasSize(2);
-        assertThat(tasks.containsKey(PlanItemInstanceState.ACTIVE)).isTrue();
+        assertThat(tasks).containsKey(PlanItemInstanceState.ACTIVE);
         assertThat(tasks.get(PlanItemInstanceState.ACTIVE)).hasSize(1);
-        assertThat(tasks.containsKey(PlanItemInstanceState.WAITING_FOR_REPETITION)).isTrue();
+        assertThat(tasks).containsKey(PlanItemInstanceState.WAITING_FOR_REPETITION);
         assertThat(tasks.get(PlanItemInstanceState.WAITING_FOR_REPETITION)).hasSize(1);
 
         //Complete active task
@@ -479,7 +479,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         // Completing the other task with the exit sentry should still keep the user event, as it's reference by the entry of B
         cmmnTaskService.complete(tasks.get(0).getId());
         assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNotNull();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         // Firing the user event listener should start B
         cmmnRuntimeService.completeUserEventListenerInstance(
@@ -508,7 +508,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
     @CmmnDeployment
     public void testMultipleEventListenersAsEntry() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testMultipleEventListenersAsEntry").start();
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         List<UserEventListenerInstance> userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery()
                 .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
@@ -518,7 +518,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
 
         // Completing A should change nothing
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstances.get(0).getId());
-        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         userEventListenerInstances = cmmnRuntimeService.createUserEventListenerInstanceQuery()
                 .caseInstanceId(caseInstance.getId()).orderByName().asc().list();
         assertThat(userEventListenerInstances)
@@ -528,7 +528,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         // Completing B should activate the stage and remove the orphan event listener C
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstances.get(0).getId());
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
-        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -545,7 +545,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
 
         // Completing C should also remove A and B
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstances.get(2).getId());
-        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult().getName()).isEqualTo("Outside stage");
 
     }
@@ -614,7 +614,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
         Task taskC = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
         assertThat(taskC.getName()).isEqualTo("C");
 
-        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
     }
 
@@ -646,7 +646,7 @@ public class UserEventListenerTest extends FlowableCmmnTestCase {
 
         // Completing task C should remove the user event listener
         cmmnTaskService.complete(tasks.get(2).getId());
-        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createUserEventListenerInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/VariablesTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/VariablesTest.java
@@ -64,17 +64,17 @@ public class VariablesTest extends FlowableCmmnTestCase {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").variables(variables).start();
 
         Map<String, Object> variablesFromGet = cmmnRuntimeService.getVariables(caseInstance.getId());
-        assertThat(variablesFromGet.containsKey("stringVar")).isTrue();
-        assertThat(variablesFromGet.get("stringVar")).isEqualTo("Hello World");
-        assertThat(variablesFromGet.containsKey("intVar")).isTrue();
+        assertThat(variablesFromGet).containsKey("stringVar");
+        assertThat(variablesFromGet).containsEntry("stringVar", "Hello World");
+        assertThat(variablesFromGet).containsKey("intVar");
         assertThat(((Integer) variablesFromGet.get("intVar")).intValue()).isEqualTo(42);
 
         Map<String, VariableInstance> variableInstancesFromGet = cmmnRuntimeService.getVariableInstances(caseInstance.getId());
-        assertThat(variableInstancesFromGet.containsKey("stringVar")).isTrue();
+        assertThat(variableInstancesFromGet).containsKey("stringVar");
         VariableInstance variableInstance = variableInstancesFromGet.get("stringVar");
         assertThat(variableInstance.getValue()).isEqualTo("Hello World");
         assertThat(variableInstance.getTypeName()).isEqualTo("string");
-        assertThat(variableInstancesFromGet.containsKey("intVar")).isTrue();
+        assertThat(variableInstancesFromGet).containsKey("intVar");
         variableInstance = variableInstancesFromGet.get("intVar");
         assertThat(((Integer) variableInstance.getValue()).intValue()).isEqualTo(42);
         assertThat(variableInstance.getTypeName()).isEqualTo("integer");
@@ -107,33 +107,33 @@ public class VariablesTest extends FlowableCmmnTestCase {
         cmmnRuntimeService.setLocalVariable(planItemInstance.getId(), "intVar", 21);
 
         Map<String, Object> variablesFromGet = cmmnRuntimeService.getVariables(caseInstance.getId());
-        assertThat(variablesFromGet.containsKey("stringVar")).isTrue();
-        assertThat(variablesFromGet.get("stringVar")).isEqualTo("Hello World");
-        assertThat(variablesFromGet.containsKey("intVar")).isTrue();
+        assertThat(variablesFromGet).containsKey("stringVar");
+        assertThat(variablesFromGet).containsEntry("stringVar", "Hello World");
+        assertThat(variablesFromGet).containsKey("intVar");
         assertThat(((Integer) variablesFromGet.get("intVar")).intValue()).isEqualTo(42);
 
         Map<String, VariableInstance> variableInstancesFromGet = cmmnRuntimeService.getVariableInstances(caseInstance.getId());
-        assertThat(variableInstancesFromGet.containsKey("stringVar")).isTrue();
+        assertThat(variableInstancesFromGet).containsKey("stringVar");
         VariableInstance variableInstance = variableInstancesFromGet.get("stringVar");
         assertThat(variableInstance.getValue()).isEqualTo("Hello World");
         assertThat(variableInstance.getTypeName()).isEqualTo("string");
-        assertThat(variableInstancesFromGet.containsKey("intVar")).isTrue();
+        assertThat(variableInstancesFromGet).containsKey("intVar");
         variableInstance = variableInstancesFromGet.get("intVar");
         assertThat(((Integer) variableInstance.getValue()).intValue()).isEqualTo(42);
         assertThat(variableInstance.getTypeName()).isEqualTo("integer");
 
         Map<String, Object> localVariablesFromGet = cmmnRuntimeService.getLocalVariables(planItemInstance.getId());
-        assertThat(localVariablesFromGet.containsKey("stringVar")).isTrue();
-        assertThat(localVariablesFromGet.get("stringVar")).isEqualTo("Changed value");
-        assertThat(localVariablesFromGet.containsKey("intVar")).isTrue();
+        assertThat(localVariablesFromGet).containsKey("stringVar");
+        assertThat(localVariablesFromGet).containsEntry("stringVar", "Changed value");
+        assertThat(localVariablesFromGet).containsKey("intVar");
         assertThat(((Integer) localVariablesFromGet.get("intVar")).intValue()).isEqualTo(21);
 
         Map<String, VariableInstance> localVariableInstancesFromGet = cmmnRuntimeService.getLocalVariableInstances(planItemInstance.getId());
-        assertThat(localVariableInstancesFromGet.containsKey("stringVar")).isTrue();
+        assertThat(localVariableInstancesFromGet).containsKey("stringVar");
         variableInstance = localVariableInstancesFromGet.get("stringVar");
         assertThat(variableInstance.getValue()).isEqualTo("Changed value");
         assertThat(variableInstance.getTypeName()).isEqualTo("string");
-        assertThat(variableInstancesFromGet.containsKey("intVar")).isTrue();
+        assertThat(variableInstancesFromGet).containsKey("intVar");
         variableInstance = localVariableInstancesFromGet.get("intVar");
         assertThat(((Integer) variableInstance.getValue()).intValue()).isEqualTo(21);
         assertThat(variableInstance.getTypeName()).isEqualTo("integer");
@@ -268,7 +268,7 @@ public class VariablesTest extends FlowableCmmnTestCase {
 
         // Variables should not be persisted
         assertThat(cmmnRuntimeService.getVariables(caseInstance.getId())).isEmpty();
-        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
     }
 
     @Test
@@ -320,7 +320,7 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 caseInstanceId(caseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate")).isEqualTo("newValue");
+        assertThat(updatedCaseInstance.getCaseVariables()).containsEntry("varToUpdate", "newValue");
     }
 
     @Test
@@ -355,8 +355,9 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 caseInstanceId(caseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate"))
-                .as("resolving variable name expressions does not make sense when it is set locally").isEqualTo("newValue");
+        assertThat(updatedCaseInstance.getCaseVariables())
+                .as("resolving variable name expressions does not make sense when it is set locally")
+                .containsEntry("varToUpdate", "newValue");
     }
 
     @Test
@@ -376,7 +377,7 @@ public class VariablesTest extends FlowableCmmnTestCase {
                 caseInstanceId(subCaseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate")).isEqualTo("newValue");
+        assertThat(updatedCaseInstance.getCaseVariables()).containsEntry("varToUpdate", "newValue");
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/sentry/TriggerModeSentryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/sentry/TriggerModeSentryTest.java
@@ -88,7 +88,7 @@ public class TriggerModeSentryTest extends FlowableCmmnTestCase {
                 .caseDefinitionKey("testIfPartTriggeredOnce")
                 .variable("var", new TestCondition())
                 .start();
-        assertThat(TestCondition.COUNTER.get()).isEqualTo(0);
+        assertThat(TestCondition.COUNTER.get()).isZero();
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(tasks)

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnMailTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnMailTaskTest.java
@@ -166,9 +166,9 @@ public class CmmnMailTaskTest extends FlowableCmmnTestCase {
             MimeMessage mimeMessage = emailMessage.getMimeMessage();
 
             if (htmlMail) {
-                assertThat(mimeMessage.getContentType().contains("multipart/mixed")).isTrue();
+                assertThat(mimeMessage.getContentType()).contains("multipart/mixed");
             } else {
-                assertThat(mimeMessage.getContentType().contains("text/plain")).isTrue();
+                assertThat(mimeMessage.getContentType()).contains("text/plain");
             }
 
             assertThat(mimeMessage.getHeader("Subject", null)).isEqualTo(subject);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnScriptTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnScriptTaskTest.java
@@ -86,7 +86,6 @@ public class CmmnScriptTaskTest extends FlowableCmmnTestCase {
 
         //Check the case variables, one will be created by the script execution
         Map<String, Object> caseVariables = cmmnRuntimeService.getVariables(caseInstance.getId());
-        assertThat(caseVariables).isNotNull();
         assertThat(caseVariables).hasSize(1);
         assertThat(cmmnRuntimeService.hasVariable(caseInstance.getId(), "aInt")).isTrue();
         Object integer = cmmnRuntimeService.getVariable(caseInstance.getId(), "aInt");
@@ -225,7 +224,6 @@ public class CmmnScriptTaskTest extends FlowableCmmnTestCase {
         assertThat(caseInstance).isNotNull();
 
         Map<String, Object> variables = cmmnRuntimeService.getVariables(caseInstance.getId());
-        assertThat(variables).isNotNull();
         assertThat(variables).hasSize(2);
 
         assertThat(cmmnRuntimeService.hasVariable(caseInstance.getId(), "sum")).isTrue();
@@ -248,7 +246,6 @@ public class CmmnScriptTaskTest extends FlowableCmmnTestCase {
         assertThat(caseInstance).isNotNull();
 
         Map<String, Object> variables = cmmnRuntimeService.getVariables(caseInstance.getId());
-        assertThat(variables).isNotNull();
         assertThat(variables).hasSize(1);
 
         assertThat(cmmnRuntimeService.hasVariable(caseInstance.getId(), "sum")).isFalse();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnTaskQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnTaskQueryTest.java
@@ -122,7 +122,7 @@ public class CmmnTaskQueryTest extends FlowableCmmnTestCase {
         assertThat(cmmnTaskService.createTaskQuery().taskAssignee("johnDoe").list()).hasSize(NR_CASE_INSTANCES);
         
         List<CaseInstance> caseInstances = cmmnRuntimeService.createCaseInstanceQuery().caseDefinitionKey("oneTaskCase").list();
-        assertThat(caseInstances.size()).isEqualTo(5);
+        assertThat(caseInstances).hasSize(5);
         
         String caseInstanceId = caseInstances.get(0).getId();
         

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnTaskServiceTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnTaskServiceTest.java
@@ -157,7 +157,7 @@ public class CmmnTaskServiceTest extends FlowableCmmnTestCase {
         );
         HistoricCaseInstance historicCaseInstance = cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).
                 includeCaseVariables().singleResult();
-        assertThat(historicCaseInstance.getCaseVariables().get("variableToUpdate")).isEqualTo("updatedVariableValue");
+        assertThat(historicCaseInstance.getCaseVariables()).containsEntry("variableToUpdate", "updatedVariableValue");
     }
 
     @Test
@@ -175,7 +175,7 @@ public class CmmnTaskServiceTest extends FlowableCmmnTestCase {
         );
         HistoricTaskInstance historicTaskInstance = cmmnHistoryService.createHistoricTaskInstanceQuery().caseInstanceId(caseInstance.getId()).
                 includeTaskLocalVariables().singleResult();
-        assertThat(historicTaskInstance.getTaskLocalVariables().get("variableToUpdate")).isEqualTo("updatedVariableValue");
+        assertThat(historicTaskInstance.getTaskLocalVariables()).containsEntry("variableToUpdate", "updatedVariableValue");
     }
 
     @Test
@@ -192,7 +192,7 @@ public class CmmnTaskServiceTest extends FlowableCmmnTestCase {
                 caseInstanceId(caseInstance.getId()).
                 includeCaseVariables().
                 singleResult();
-        assertThat(updatedCaseInstance.getCaseVariables().get("varToUpdate")).isEqualTo("newValue");
+        assertThat(updatedCaseInstance.getCaseVariables()).containsEntry("varToUpdate", "newValue");
     }
 
     @Test
@@ -213,7 +213,7 @@ public class CmmnTaskServiceTest extends FlowableCmmnTestCase {
                         ScopeTypes.CMMN);
 
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
         assertCaseInstanceEnded(caseInstance);
     }
 


### PR DESCRIPTION
Although it may look like lots of changes this PR is rather simple.  The changes are in the `org.flowable.cmmn.test` package and involve standardizing on similar concepts.  For example, using `hasSize()` instead of `.size().isEqualTo()`.  

There was one file `org.flowable.cmmn.test.prefix.CmmnPrefixTest` that required additional changes to use assertj format.

