### PR TITLE
Update assertj fluent style in flowable-cmmn-engine-configurator module.

### DIFF
--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/AbstractProcessEngineIntegrationTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/AbstractProcessEngineIntegrationTest.java
@@ -112,8 +112,8 @@ public abstract class AbstractProcessEngineIntegrationTest {
 
     protected void assertCaseInstanceEnded(CaseInstance caseInstance) {
         long count = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).count();
-        assertThat(count).as(createCaseInstanceEndedErrorMessage(caseInstance, count)).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).as("Runtime case instance found").isEqualTo(0);
+        assertThat(count).as(createCaseInstanceEndedErrorMessage(caseInstance, count)).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).as("Runtime case instance found").isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().caseInstanceId(caseInstance.getId()).finished().count()).isEqualTo(1);
     }
 

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/BpmnTimerTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/BpmnTimerTaskTest.java
@@ -69,8 +69,9 @@ public class BpmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
         processEngine.getProcessEngineConfiguration().setClock(clock);
 
         timerJobs = processEngineManagementService.createTimerJobQuery().processInstanceId(processInstance.getId()).executable().list();
-        assertThat(timerJobs).hasSize(1);
-        assertThat(timerJobs.get(0).getId()).isEqualTo(timerJobId);
+        assertThat(timerJobs)
+                .extracting(Job::getId)
+                .containsExactly(timerJobId);
 
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngine.getProcessEngineConfiguration(), processEngineManagementService, 7000, 200, true);
 
@@ -83,7 +84,7 @@ public class BpmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
 
         processEngineTaskService.complete(task.getId());
 
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         cmmnEngineConfiguration.resetClock();
         ((ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration()).resetClock();

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CaseTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CaseTaskTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.assertj.core.api.Assertions;
 import org.assertj.core.groups.Tuple;
 import org.flowable.cmmn.api.CallbackTypes;
 import org.flowable.cmmn.api.runtime.CaseInstance;
@@ -98,7 +97,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             assertThat(processTasks).hasSize(1);
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
@@ -366,7 +365,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             assertThat(processTasks).hasSize(1);
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
@@ -574,7 +573,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             assertThat(processEngineRuntimeService.getVariable(processInstance.getId(), "processResult")).isEqualTo("someResult");
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
@@ -657,7 +656,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             assertThat(processTasks).hasSize(1);
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
@@ -673,7 +672,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
 
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneProcessTaskCase").start();
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
             HistoricVariableInstance variableInstance = cmmnHistoryService.createHistoricVariableInstanceQuery()
                     .variableName("linkCount")
                     .singleResult();
@@ -696,7 +695,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             Task task = processEngineTaskService.createTaskQuery().taskDefinitionKey("userTask").singleResult();
             processEngineTaskService.complete(task.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
             HistoricVariableInstance variableInstance = cmmnHistoryService.createHistoricVariableInstanceQuery()
                     .variableName("linkCount")
                     .singleResult();
@@ -759,12 +758,12 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             Task task = processEngineTaskService.createTaskQuery()
                     .processInstanceId(processInstance.getProcessInstanceId())
                     .singleResult();
-            Assertions.assertThat(task).isNotNull();
-            Assertions.assertThat(task.getTaskDefinitionKey()).isEqualTo("formTask1");
+            assertThat(task).isNotNull();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("formTask1");
 
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(1);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(1);
 
             Execution caseTask1Execution = processEngineRuntimeService.createExecutionQuery().activityId("caseTask1").singleResult();
             assertThat(caseTask1Execution.getReferenceId()).isNotNull();
@@ -776,7 +775,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(0);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isZero();
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
@@ -795,12 +794,12 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             Task task = processEngineTaskService.createTaskQuery()
                     .processInstanceId(processInstance.getProcessInstanceId())
                     .singleResult();
-            Assertions.assertThat(task).isNotNull();
-            Assertions.assertThat(task.getTaskDefinitionKey()).isEqualTo("formTask1");
+            assertThat(task).isNotNull();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("formTask1");
 
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(2);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(2);
 
             Execution caseTask1Execution = processEngineRuntimeService.createExecutionQuery().activityId("caseTask1").singleResult();
             assertThat(caseTask1Execution.getReferenceId()).isNotNull();
@@ -812,7 +811,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(0);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isZero();
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
@@ -831,14 +830,14 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             Task task = processEngineTaskService.createTaskQuery()
                     .processInstanceId(processInstance.getProcessInstanceId())
                     .singleResult();
-            Assertions.assertThat(task).isNotNull();
-            Assertions.assertThat(task.getTaskDefinitionKey()).isEqualTo("formTask1");
+            assertThat(task).isNotNull();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("formTask1");
 
             processEngineManagementService.executeCommand(new ClearExecutionReferenceCmd());
 
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(2);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(2);
 
             Execution caseTask1Execution = processEngineRuntimeService.createExecutionQuery().activityId("caseTask1").singleResult();
             assertThat(caseTask1Execution.getReferenceId()).isNull();
@@ -849,7 +848,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(0);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isZero();
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
@@ -867,7 +866,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             ProcessInstance processInstance = processEngineRuntimeService.startProcessInstanceByKey("terminateBySignalTestCase");
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(1);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(1);
 
             Execution myExternalSignalExecution = processEngineRuntimeService.createExecutionQuery()
                     .processInstanceId(processInstance.getProcessInstanceId())
@@ -887,7 +886,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(0);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isZero();
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
@@ -906,7 +905,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             ProcessInstance processInstance = processEngineRuntimeService.startProcessInstanceByKey("terminateBySignalTestCase");
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(1);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(1);
 
             processEngineManagementService.executeCommand(new ClearExecutionReferenceCmd());
 
@@ -925,7 +924,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(0);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isZero();
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
@@ -944,7 +943,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             ProcessInstance processInstance = processEngineRuntimeService.startProcessInstanceByKey("terminateTwoCasesWithinSubprocessBySignalEvent");
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(2);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(2);
 
             Execution myExternalSignalExecution = processEngineRuntimeService.createExecutionQuery()
                     .processInstanceId(processInstance.getProcessInstanceId())
@@ -961,7 +960,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(0);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isZero();
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
@@ -980,7 +979,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             ProcessInstance processInstance = processEngineRuntimeService.startProcessInstanceByKey("terminateTwoCasesWithinSubprocessBySignalEvent");
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(2);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(2);
 
             processEngineManagementService.executeCommand(new ClearExecutionReferenceCmd());
 
@@ -999,7 +998,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(0);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isZero();
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
@@ -1018,7 +1017,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             ProcessInstance processInstance = processEngineRuntimeService.startProcessInstanceByKey("terminateOneOfTwoCasesBySignalTestCase");
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(2);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(2);
 
             Execution myExternalSignalExecution = processEngineRuntimeService.createExecutionQuery()
                     .processInstanceId(processInstance.getProcessInstanceId())
@@ -1035,7 +1034,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(1);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(1);
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceQuery()
                     .singleResult();
             cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
@@ -1057,7 +1056,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             ProcessInstance processInstance = processEngineRuntimeService.startProcessInstanceByKey("terminateOneOfTwoCasesBySignalTestCase");
             long numberOfActiveCaseInstances = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstances).isEqualTo(2);
+            assertThat(numberOfActiveCaseInstances).isEqualTo(2);
 
             processEngineManagementService.executeCommand(new ClearExecutionReferenceCmd());
 
@@ -1076,7 +1075,7 @@ public class CaseTaskTest extends AbstractProcessEngineIntegrationTest {
             // Assert
             long numberOfActiveCaseInstancesAfterCompletion = cmmnRuntimeService.createCaseInstanceQuery()
                     .count();
-            Assertions.assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(1);
+            assertThat(numberOfActiveCaseInstancesAfterCompletion).isEqualTo(1);
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceQuery()
                     .singleResult();
             cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ChangeStateProcessTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ChangeStateProcessTaskTest.java
@@ -56,8 +56,8 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
 
         processEngineTaskService.complete(task.getId());
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
 
@@ -73,9 +73,9 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
         assertThat(planItemInstances).hasSize(1);
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -97,9 +97,9 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
 
         processEngineTaskService.complete(task.getId());
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -128,9 +128,9 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
 
         processEngineTaskService.complete(task.getId());
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -138,7 +138,7 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
     public void testActivateProcessTaskInStage() {
         CaseInstance caseInstance = startCaseInstanceWithOneTaskProcess("activateStage", false);
 
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         cmmnRuntimeService.createChangePlanItemStateBuilder()
                 .caseInstanceId(caseInstance.getId())
@@ -173,9 +173,9 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
 
         processEngineTaskService.complete(task.getId());
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -208,9 +208,9 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
 
         processEngineTaskService.complete(task.getId());
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -257,9 +257,9 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
                 .list();
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -350,9 +350,9 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
         assertThat(planItemInstances).hasSize(1);
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -391,9 +391,9 @@ public class ChangeStateProcessTaskTest extends AbstractProcessEngineIntegration
                 .variableName("numVar")
                 .singleResult().getValue()).isEqualTo(10);
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     protected CaseInstance startCaseInstanceWithOneTaskProcess(String variableName, boolean activate) {

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnEngineConfiguratorAsyncHistoryTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnEngineConfiguratorAsyncHistoryTest.java
@@ -87,8 +87,8 @@ public class CmmnEngineConfiguratorAsyncHistoryTest {
                 cmmnEngine.getCmmnRuntimeService().createPlanItemInstanceQuery().planItemInstanceState(PlanItemInstanceState.ACTIVE).singleResult().getId());
 
         // As async history is enabled, there should be  no historical entries yet, but there should be history jobs
-        assertThat(cmmnEngine.getCmmnHistoryService().createHistoricCaseInstanceQuery().count()).isEqualTo(0);
-        assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnEngine.getCmmnHistoryService().createHistoricCaseInstanceQuery().count()).isZero();
+        assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery().count()).isZero();
 
         // 3 history jobs expected:
         // - one for the case instance start
@@ -120,8 +120,8 @@ public class CmmnEngineConfiguratorAsyncHistoryTest {
 
         assertThat(cmmnEngine.getCmmnHistoryService().createHistoricCaseInstanceQuery().count()).isEqualTo(1);
         assertThat(processEngine.getHistoryService().createHistoricProcessInstanceQuery().count()).isEqualTo(1);
-        assertThat(cmmnEngine.getCmmnManagementService().createHistoryJobQuery().count()).isEqualTo(0);
-        assertThat(processEngine.getManagementService().createHistoryJobQuery().count()).isEqualTo(0);
+        assertThat(cmmnEngine.getCmmnManagementService().createHistoryJobQuery().count()).isZero();
+        assertThat(processEngine.getManagementService().createHistoryJobQuery().count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnTimerTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnTimerTaskTest.java
@@ -51,7 +51,7 @@ public class CmmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerInStage").start();
 
         assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).planItemInstanceState(PlanItemInstanceState.ACTIVE)
-                .count()).isEqualTo(1L);
+                .count()).isEqualTo(1);
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
@@ -59,7 +59,7 @@ public class CmmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
                 .singleResult();
         assertThat(planItemInstance).isNotNull();
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1L);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1);
 
         List<Job> timerJobs = processEngineManagementService.createTimerJobQuery().scopeId(caseInstance.getId()).scopeType(ScopeTypes.CMMN).list();
         assertThat(timerJobs).hasSize(1);
@@ -83,8 +83,9 @@ public class CmmnTimerTaskTest extends AbstractProcessEngineIntegrationTest {
         cmmnEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + (3 * 60 * 60 * 1000 + 1)));
 
         timerJobs = cmmnManagementService.createTimerJobQuery().caseInstanceId(caseInstance.getId()).executable().list();
-        assertThat(timerJobs).hasSize(1);
-        assertThat(timerJobs.get(0).getId()).isEqualTo(timerJobId);
+        assertThat(timerJobs)
+                .extracting(Job::getId)
+                .containsExactly(timerJobId);
 
         CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 7000L, 200L, true);
 

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/EntityLinkDeletionTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/EntityLinkDeletionTest.java
@@ -71,8 +71,8 @@ public class EntityLinkDeletionTest extends AbstractProcessEngineIntegrationTest
             // Entity links are only cleaned up when the root instance is deleted.
             // At this point, the two child process instances and two child case instance are deleted,
             // yet the entity links still are there
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1L); // the root instance
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1); // the root instance
             assertThat(getRootEntityLinks(processInstance.getId(), ScopeTypes.BPMN)).hasSize(13); // +1 for the task in the root instance
 
             // All case/process instances still need to have entity links
@@ -85,7 +85,7 @@ public class EntityLinkDeletionTest extends AbstractProcessEngineIntegrationTest
 
             // Completing the root instance, deletes all entity links
             processEngineTaskService.complete(task.getId());
-            assertThat(getRootEntityLinks(processInstance.getId(), ScopeTypes.BPMN)).hasSize(0);
+            assertThat(getRootEntityLinks(processInstance.getId(), ScopeTypes.BPMN)).isEmpty();
 
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
@@ -117,8 +117,8 @@ public class EntityLinkDeletionTest extends AbstractProcessEngineIntegrationTest
             // Entity links are only cleaned up when the root instance is deleted.
             // At this point, the two child process instances and two child case instance are deleted,
             // yet the entity links still are there
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1L);
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0L); // the root instance
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(1);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero(); // the root instance
             assertThat(getRootEntityLinks(caseInstance.getId(), ScopeTypes.CMMN)).hasSize(11);
 
             // All case/process instances still need to have entity links
@@ -131,8 +131,8 @@ public class EntityLinkDeletionTest extends AbstractProcessEngineIntegrationTest
 
             // Completing the root instance, deletes all entity links
             cmmnTaskService.complete(cmmnTaskService.createTaskQuery().singleResult().getId());
-            assertThat(getRootEntityLinks(caseInstance.getId(), ScopeTypes.CMMN)).hasSize(0);
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0L);
+            assertThat(getRootEntityLinks(caseInstance.getId(), ScopeTypes.CMMN)).isEmpty();
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
 
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ExternalWorkerCombinedScopeTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ExternalWorkerCombinedScopeTest.java
@@ -45,7 +45,7 @@ public class ExternalWorkerCombinedScopeTest extends AbstractProcessEngineIntegr
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/ExternalWorkerCombinedScopeTest.simpleCase.cmmn")
     public void testSimpleCombined() {
-        Deployment deployment = processEngineRepositoryService.createDeployment()
+        processEngineRepositoryService.createDeployment()
                 .addClasspathResource("org/flowable/cmmn/test/ExternalWorkerCombinedScopeTest.simpleProcess.bpmn20.xml")
                 .deploy();
 

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/HumanTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/HumanTaskTest.java
@@ -51,9 +51,9 @@ public class HumanTaskTest extends AbstractProcessEngineIntegrationTest {
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/CaseTaskTest.testCaseTask.cmmn")
     public void completeHumanTaskWithoutVariables() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("myCase").
-                start();
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("myCase")
+                .start();
         assertThat(caseInstance).isNotNull();
 
         Task caseTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ProcessTaskTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/ProcessTaskTest.java
@@ -14,6 +14,7 @@ package org.flowable.cmmn.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Collections;
@@ -87,7 +88,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
 
         processEngine.getTaskService().complete(processTasks.get(0).getId());
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -102,7 +103,6 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                     .caseDefinitionKey("myCase")
                     .start();
-            String caseInstanceId = caseInstance.getId();
 
             List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                     .caseInstanceId(caseInstance.getId())
@@ -196,7 +196,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             assertThat(entityLink.getCreateTime()).isNotNull();
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
             List<HistoricEntityLink> historicEntityLinks = cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstance.getId());
             assertThat(historicEntityLinks).hasSize(3);
@@ -368,7 +368,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                     );
 
             processEngineTaskService.complete(processTask.getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
             List<HistoricEntityLink> historicEntityLinks = cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(caseInstanceId);
             assertThat(historicEntityLinks)
@@ -518,7 +518,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         assertThat(planItemInstances.get(0).getName()).isEqualTo("The Process");
         assertThat(planItemInstances.get(0).getReferenceId()).isNotNull();
         assertThat(planItemInstances.get(0).getReferenceType()).isEqualTo(ReferenceTypes.PLAN_ITEM_CHILD_PROCESS);
-        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isZero();
 
         ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().singleResult();
         assertThat(processInstance).isNotNull();
@@ -741,7 +741,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         assertThat(task).isNotNull();
 
         // Completing task will trigger completion of process task plan item
-        assertThat(((Number) processEngine.getRuntimeService().getVariable(task.getProcessInstanceId(), "numberVariable")).longValue()).isEqualTo(2L);
+        assertThat(((Number) processEngine.getRuntimeService().getVariable(task.getProcessInstanceId(), "numberVariable")).longValue()).isEqualTo(2);
         processEngine.getTaskService().complete(task.getId(), Collections.singletonMap("processVariable", "Hello World"));
 
         assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVariable")).isEqualTo("Hello World");
@@ -815,8 +815,8 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
 
         cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("skipExpressionCaseTest").start();
 
-        assertThat(processEngineTaskService.createTaskQuery().list().isEmpty()).isTrue();
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().list().isEmpty()).isTrue();
+        assertThat(processEngineTaskService.createTaskQuery().list()).isEmpty();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().list()).isEmpty();
     }
 
     @Test
@@ -826,8 +826,8 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .addClasspathResource("org/flowable/cmmn/test/processWithInclusiveGateway.bpmn20.xml").deploy();
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-            assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(0);
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isZero();
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
             List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                     .caseInstanceId(caseInstance.getId())
@@ -836,7 +836,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                     .list();
             assertThat(planItemInstances).hasSize(1);
             cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).as("No process instance started").isEqualTo(1L);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).as("No process instance started").isEqualTo(1);
 
             assertThat(processEngineTaskService.createTaskQuery().count()).isEqualTo(2);
 
@@ -844,8 +844,8 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             processEngine.getTaskService().complete(tasks.get(0).getId());
             processEngine.getTaskService().complete(tasks.get(1).getId());
 
-            assertThat(processEngineTaskService.createTaskQuery().count()).isEqualTo(0);
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineTaskService.createTaskQuery().count()).isZero();
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
             planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                     .caseInstanceId(caseInstance.getId())
@@ -879,8 +879,8 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
 
         CaseInstance caseInstance = caseInstanceBuilder.start();
 
-        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -888,7 +888,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .list();
         assertThat(planItemInstances).hasSize(1);
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(0).getId());
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).as("No process instance started").isEqualTo(1L);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).as("No process instance started").isEqualTo(1);
         return caseInstance;
     }
 
@@ -903,7 +903,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)
                 .singleResult();
         assertThat(planItemInstance.getName()).isEqualTo("Task One");
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         /*
          * Triggering the plan item will lead to the plan item that starts the one task process in a non-blocking way.
@@ -914,7 +914,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .isInstanceOf(RuntimeException.class);
 
         // Without shared transaction, following would be 1
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         PlanItemInstance planItemInstance2 = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -938,10 +938,10 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
 
         // Triggering the process plan item should cancel the process instance
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngine.getTaskService().createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
         HistoricMilestoneInstance historicMilestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery().singleResult();
         assertThat(historicMilestoneInstance.getName()).isEqualTo("Process planitem done");
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
@@ -955,7 +955,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(1);
         assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
         HistoricMilestoneInstance historicMilestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery().singleResult();
         assertThat(historicMilestoneInstance.getName()).isEqualTo("Process planitem done");
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
@@ -981,7 +981,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             processEngineTaskService.complete(task.getId());
         }
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
         HistoricMilestoneInstance historicMilestoneInstance = cmmnHistoryService.createHistoricMilestoneInstanceQuery().singleResult();
         assertThat(historicMilestoneInstance.getName()).isEqualTo("Processes done");
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
@@ -1007,12 +1007,12 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(4);
         assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(4);
 
-        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(0);
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isZero();
         cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
 
-        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isEqualTo(0);
-        assertThat(processEngine.getTaskService().createTaskQuery().count()).isEqualTo(0);
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+        assertThat(processEngine.getTaskService().createTaskQuery().count()).isZero();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
         assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().finished().count()).isEqualTo(1);
     }
 
@@ -1032,7 +1032,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         assertThat(userEventListenerInstance.getName()).isEqualTo("Complete stage");
         cmmnRuntimeService.completeUserEventListenerInstance(userEventListenerInstance.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -1066,7 +1066,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
         } finally {
             processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
         }
@@ -1110,7 +1110,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(1);
 
             processEngine.getTaskService().complete(processTasks.get(0).getId());
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         } finally {
             this.processEngineConfiguration.setFallbackToDefaultTenant(false);
@@ -1287,7 +1287,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                         tuple("oneprocesstask4", "enabled")
                 );
 
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().processDefinitionKey("oneTask").count()).isZero();
     }
 
     @Test
@@ -1302,7 +1302,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("activatePlanItemTest").start();
 
             assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").count()).isEqualTo(1);
-            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count()).isEqualTo(0);
+            assertThat(processEngineHistoryService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTask").finished().count()).isZero();
 
             assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId()).list())
                     .extracting(PlanItemInstance::getPlanItemDefinitionId, PlanItemInstance::getState)
@@ -1375,7 +1375,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
     @Test
     @CmmnDeployment
     public void testPassChildTaskVariables() {
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("startChildProcess").start();
         PlanItemInstance processPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
@@ -1392,16 +1392,18 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
         Map<String, Object> variables = cmmnRuntimeService.getVariables(caseInstance.getId());
         // also includes initiator variable
         assertThat(variables).hasSize(2);
-        assertThat(variables.get("caseVar")).isEqualTo("caseValue");
+        assertThat(variables).containsEntry("caseVar", "caseValue");
 
         ProcessInstance processInstance = processEngineRuntimeService.createProcessInstanceQuery()
                 .processInstanceCallbackId(processPlanItemInstance.getId())
                 .singleResult();
         Map<String, Object> processInstanceVariables = processEngineRuntimeService.getVariables(processInstance.getId());
-        assertThat(processInstanceVariables).hasSize(3);
-        assertThat(processInstanceVariables.get("processVar1")).isEqualTo("processValue");
-        assertThat(processInstanceVariables.get("processVar2")).isEqualTo(123);
-        assertThat(processInstanceVariables.get("processVar3")).isEqualTo(456);
+        assertThat(processInstanceVariables)
+                .containsOnly(
+                        entry("processVar1", "processValue"),
+                        entry("processVar2", 123),
+                        entry("processVar3", 456)
+                );
     }
 
     @Test
@@ -1462,11 +1464,11 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
     @Test
     @CmmnDeployment
     public void testExitCaseInstanceOnProcessInstanceComplete() {
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+        cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testExitCaseInstanceOnProcessInstanceComplete")
                 .start();
 
-        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().count()).isZero();
         assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(1);
 
         // Process task is manually activated
@@ -1480,7 +1482,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .singleResult();
         processEngineTaskService.complete(userTaskFromProcess.getId());
 
-        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -1517,7 +1519,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml")
                 .deploy();
 
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+        cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("oneProcessTaskCase")
                 .start();
 
@@ -1535,7 +1537,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .addClasspathResource("org/flowable/cmmn/test/oneTaskProcessV2.bpmn20.xml")
                 .deploy();
 
-        caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+        cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("oneProcessTaskCase")
                 .start();
 
@@ -1556,7 +1558,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .tenantId("flowable")
                 .deploy();
 
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+        cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("oneProcessTaskCase")
                 .tenantId("flowable")
                 .start();
@@ -1577,7 +1579,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .tenantId("flowable")
                 .deploy();
 
-        caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+        cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("oneProcessTaskCase")
                 .tenantId("flowable")
                 .start();
@@ -1599,7 +1601,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml")
                 .deploy();
 
-        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+        cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("oneProcessTaskCase")
                 .start();
 
@@ -1617,7 +1619,7 @@ public class ProcessTaskTest extends AbstractProcessEngineIntegrationTest {
                 .addClasspathResource("org/flowable/cmmn/test/oneTaskProcessV2.bpmn20.xml")
                 .deploy();
 
-        caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+        cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("oneProcessTaskCase")
                 .start();
 

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/SignalEventTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/SignalEventTest.java
@@ -33,7 +33,7 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
 
-            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
             assertThat(task).isNotNull();
@@ -60,11 +60,11 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
 
             processEngineTaskService.complete(task2.getId());
 
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isZero();
 
             cmmnTaskService.complete(cmmnTask.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
@@ -83,7 +83,7 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
 
             CaseInstance anotherCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
 
-            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
             assertThat(task).isNotNull();
@@ -120,11 +120,11 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
 
             processEngineTaskService.complete(task2.getId());
 
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isZero();
 
             cmmnTaskService.complete(cmmnTask.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
@@ -141,7 +141,7 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
         try {
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
 
-            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
             assertThat(task).isNotNull();
@@ -168,11 +168,11 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
 
             processEngineTaskService.complete(task2.getId());
 
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isZero();
 
             cmmnTaskService.complete(cmmnTask.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
@@ -191,7 +191,7 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
 
             CaseInstance anotherCaseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("signalCase").start();
 
-            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
             EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
             assertThat(eventSubscription.getEventName()).isEqualTo("testSignal");
@@ -220,11 +220,11 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
 
             processEngineTaskService.complete(task2.getId());
 
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isZero();
 
             cmmnTaskService.complete(cmmnTask.getId());
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
             anotherEventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(anotherCaseInstance.getId()).singleResult();
             assertThat(anotherEventSubscription.getEventName()).isEqualTo("testSignal");
@@ -249,16 +249,16 @@ public class SignalEventTest extends AbstractProcessEngineIntegrationTest {
             Task task = processEngineTaskService.createTaskQuery().caseInstanceIdWithChildren(caseInstance.getId()).singleResult();
             assertThat(task).isNotNull();
 
-            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
             EventSubscription eventSubscription = cmmnRuntimeService.createEventSubscriptionQuery().scopeId(caseInstance.getId()).singleResult();
             assertThat(eventSubscription.getEventName()).isEqualTo("testSignal");
 
             cmmnRuntimeService.terminateCaseInstance(caseInstance.getId());
 
-            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isEqualTo(0);
+            assertThat(processEngineRuntimeService.createProcessInstanceQuery().processInstanceId(task.getProcessInstanceId()).count()).isZero();
 
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).count()).isZero();
 
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/StagePropagationTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/StagePropagationTest.java
@@ -54,11 +54,9 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
                 .planItemInstanceStateActive()
                 .list();
 
-        assertThat(stages).isNotNull();
         assertThat(stages).hasSize(2);
 
         List<Task> tasks = cmmnTaskService.createTaskQuery().active().list();
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(5);
 
         assertStageInstanceId(tasks, "Task A", stages.get(0).getId());
@@ -73,7 +71,6 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
                 .propagatedStageInstanceId(stages.get(0).getId())
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(3);
 
         assertStageInstanceId(tasks, "Task A", stages.get(0).getId());
@@ -85,14 +82,12 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
                 .propagatedStageInstanceId(stages.get(1).getId())
                 .list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(1);
 
         assertStageInstanceId(tasks, "Task D", stages.get(1).getId());
 
         // now complete the tasks to move the to the history
         tasks = cmmnTaskService.createTaskQuery().active().caseInstanceId(caseInstance.getId()).list();
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(3);
 
         for (Task task : tasks) {
@@ -100,7 +95,6 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
         }
 
         tasks = processEngineTaskService.createTaskQuery().active().list();
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(2);
 
         for (Task task : tasks) {
@@ -114,7 +108,6 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
         List<HistoricTaskInstance> historicTasks = cmmnHistoryService.createHistoricTaskInstanceQuery()
                 .list();
 
-        assertThat(historicTasks).isNotNull();
         assertThat(historicTasks).hasSize(5);
 
         assertStageInstanceId(historicTasks, "Task A", stages.get(0).getId());
@@ -127,7 +120,6 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
                 .propagatedStageInstanceId(stages.get(0).getId())
                 .list();
 
-        assertThat(historicTasks).isNotNull();
         assertThat(historicTasks).hasSize(3);
 
         assertStageInstanceId(historicTasks, "Task A", stages.get(0).getId());
@@ -138,7 +130,6 @@ public class StagePropagationTest extends AbstractProcessEngineIntegrationTest {
                 .propagatedStageInstanceId(stages.get(1).getId())
                 .list();
 
-        assertThat(historicTasks).isNotNull();
         assertThat(historicTasks).hasSize(1);
 
         assertStageInstanceId(historicTasks, "Task D", stages.get(1).getId());

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/form/PlanItemInstanceTransitionBuilderFormTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/form/PlanItemInstanceTransitionBuilderFormTest.java
@@ -361,9 +361,4 @@ public class PlanItemInstanceTransitionBuilderFormTest extends AbstractProcessEn
                 );
     }
 
-    protected FormRepositoryService getFormRepositoryService() {
-        return ((FormEngineConfigurationApi) cmmnEngineConfiguration.getEngineConfigurations()
-                .get(EngineConfigurationConstants.KEY_FORM_ENGINE_CONFIG))
-                .getFormRepositoryService();
-    }
 }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/validate/CaseWithFormTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/validate/CaseWithFormTest.java
@@ -68,17 +68,17 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         cmmnRuntimeService = cmmnEngineConfiguration.getCmmnRuntimeService();
 
         formRepositoryService = FormEngines.getDefaultFormEngine().getFormRepositoryService();
-        formRepositoryService.createDeployment().
-                addClasspathResource("org/flowable/cmmn/test/simple.form").
-                deploy();
+        formRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/simple.form")
+                .deploy();
         cmmnHistoryService = cmmnEngineConfiguration.getCmmnHistoryService();
 
-        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                        replace("CASE_VALIDATE_VALUE", "true").
-                        replace("TASK_VALIDATE_VALUE", "true")
-                ).
-                deploy();
+        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment()
+                .addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE
+                        .replace("CASE_VALIDATE_VALUE", "true")
+                        .replace("TASK_VALIDATE_VALUE", "true")
+                )
+                .deploy();
         SideEffectTaskListener.reset();
         TestValidationFormEngineConfigurator.ThrowExceptionOnValidationFormService.activate();
     }
@@ -107,7 +107,7 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
                 .startWithForm())
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
     @Test
@@ -131,28 +131,28 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         cmmnTaskService.deleteGroupIdentityLink(task.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", Collections.singletonMap("doNotThrowException", ""));
 
-        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(11l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(11);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_CREATED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_NAME_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_PRIORITY_CHANGED.name())
-                .count()).isEqualTo(1l);
+                .count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_ASSIGNEE_CHANGED.name())
-                .count()).isEqualTo(1l);
+                .count()).isEqualTo(1);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_OWNER_CHANGED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_DUEDATE_CHANGED.name())
-                .count()).isEqualTo(1l);
+                .count()).isEqualTo(1);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_ADDED.name())
-                .count()).isEqualTo(2l);
+                .count()).isEqualTo(2);
         assertThat(
                 cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_IDENTITY_LINK_REMOVED.name())
-                        .count()).isEqualTo(2l);
+                        .count()).isEqualTo(2);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_COMPLETED.name()).count())
-                .isEqualTo(1l);
+                .isEqualTo(1);
     }
 
     @Test
@@ -163,17 +163,17 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
                 .startWithForm())
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
     @Test
     public void startCaseWithFormWithDisabledValidationOnEngineLevel() {
         cmmnEngineConfiguration.setFormFieldValidationEnabled(false);
         try {
-            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().
-                    caseDefinitionKey("oneTaskCaseWithForm").
-                    startFormVariables(Collections.singletonMap("variable", "VariableValue")).
-                    startWithForm();
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCaseWithForm")
+                    .startFormVariables(Collections.singletonMap("variable", "VariableValue"))
+                    .startWithForm();
 
             assertThat(caseInstance).isNotNull();
             assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
@@ -189,16 +189,16 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
                 .startWithForm())
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
     @Test
     public void completeCaseTaskWithFormWithValidationDisabledOnConfigLevel() {
         cmmnEngineConfiguration.setFormFieldValidationEnabled(false);
         try {
-            CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                    caseDefinitionKey("oneTaskCaseWithForm").
-                    start();
+            CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCaseWithForm")
+                    .start();
             Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
             FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
             assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
@@ -213,9 +213,9 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
 
     @Test
     public void completeCaseTaskWithForm() {
-        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                start();
+        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
         assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
@@ -224,14 +224,14 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
                 () -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", Collections.singletonMap("var", "value")))
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
     @Test
     public void completeCaseTaskWithFormWithoutVariables() {
-        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                start();
+        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
         assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
@@ -239,20 +239,20 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
     @Test
     public void completeTaskWithoutValidationOnModelLevel() {
-        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                        replace("CASE_VALIDATE_VALUE", "false").
-                        replace("TASK_VALIDATE_VALUE", "false")
-                ).
-                deploy();
-        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                start();
+        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment()
+                .addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE
+                        .replace("CASE_VALIDATE_VALUE", "false")
+                        .replace("TASK_VALIDATE_VALUE", "false")
+                )
+                .deploy();
+        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
         assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
@@ -264,12 +264,12 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
 
     @Test
     public void completeTaskWithoutValidationOnModelLevelExpression() {
-        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                        replace("CASE_VALIDATE_VALUE", "${true}").
-                        replace("TASK_VALIDATE_VALUE", "${allowValidation}")
-                ).
-                deploy();
+        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment()
+                .addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE
+                        .replace("CASE_VALIDATE_VALUE", "${true}")
+                        .replace("TASK_VALIDATE_VALUE", "${allowValidation}")
+                )
+                .deploy();
 
         assertThatThrownBy(() -> cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("oneTaskCaseWithForm")
@@ -277,12 +277,12 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
                 .startWithForm())
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
 
-        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                variables(Collections.singletonMap("allowValidation", true)).
-                start();
+        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .variables(Collections.singletonMap("allowValidation", true))
+                .start();
         assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
         SideEffectTaskListener.reset();
 
@@ -292,21 +292,21 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
     @Test
     public void completeTaskWithoutValidationOnModelLevelBadExpression() {
-        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                        replace("CASE_VALIDATE_VALUE", "true").
-                        replace("TASK_VALIDATE_VALUE", "${BAD_EXPRESSION}")
-                ).
-                deploy();
+        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment()
+                .addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE
+                        .replace("CASE_VALIDATE_VALUE", "true")
+                        .replace("TASK_VALIDATE_VALUE", "${BAD_EXPRESSION}")
+                )
+                .deploy();
 
-        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                start();
+        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
         assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
@@ -315,21 +315,21 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageStartingWith("Unknown property used in expression: ${BAD_EXPRESSION}");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
     @Test
     public void completeTaskWithValidationOnModelLevelStringExpression() {
-        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                        replace("CASE_VALIDATE_VALUE", "true").
-                        replace("TASK_VALIDATE_VALUE", "${true}")
-                ).
-                deploy();
+        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment()
+                .addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE
+                        .replace("CASE_VALIDATE_VALUE", "true")
+                        .replace("TASK_VALIDATE_VALUE", "${true}")
+                )
+                .deploy();
 
-        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                start();
+        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
         assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
@@ -338,21 +338,21 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
     @Test
     public void completeTaskWithoutValidationOnMissingModelLevel() {
-        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment().
-                addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE.
-                        replace("flowable:formFieldValidation=\"CASE_VALIDATE_VALUE\"", "").
-                        replace("flowable:formFieldValidation=\"TASK_VALIDATE_VALUE\"", "")
-                ).
-                deploy();
+        cmmnEngineConfiguration.getCmmnRepositoryService().createDeployment()
+                .addString("org/flowable/cmmn/test/oneTasksCaseWithForm.cmmn", ONE_TASK_CASE
+                        .replace("flowable:formFieldValidation=\"CASE_VALIDATE_VALUE\"", "")
+                        .replace("flowable:formFieldValidation=\"TASK_VALIDATE_VALUE\"", "")
+                )
+                .deploy();
 
-        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder().
-                caseDefinitionKey("oneTaskCaseWithForm").
-                start();
+        CaseInstance caze = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCaseWithForm")
+                .start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caze.getId()).singleResult();
         FormDefinition formDefinition = formRepositoryService.createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
         assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(1);
@@ -361,7 +361,7 @@ public class CaseWithFormTest extends AbstractProcessEngineIntegrationTest {
         assertThatThrownBy(() -> cmmnTaskService.completeTaskWithForm(task.getId(), formDefinition.getId(), "__COMPLETE", null))
                 .isInstanceOf(FlowableFormValidationException.class)
                 .hasMessageStartingWith("Validation failed by default");
-        assertThat(SideEffectTaskListener.getSideEffect()).isEqualTo(0);
+        assertThat(SideEffectTaskListener.getSideEffect()).isZero();
     }
 
 }


### PR DESCRIPTION
Assertj updates to the `org.flowable.cmmn.test` package.   The changes are minor; things like

- using `isZero()`
- removing null checks before `hasSize()` tests
- a few formatting changes so the code agreed with the majority format (that is `.` starting a line and not ending it)
- removing unnecessary `L` (long) on `hasSize()` and `isEqualTo()` statements
- etc.

No real substantial logic changes.