### PR TITLE
Update assertj fluent style in flowable-idm-engine module.

### DIFF
--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/ForceCloseMybatisConnectionPoolTest.java
@@ -46,7 +46,7 @@ public class ForceCloseMybatisConnectionPoolTest {
         idmEngine.close();
 
         // the idle connections are closed
-        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
     @Test
@@ -73,7 +73,7 @@ public class ForceCloseMybatisConnectionPoolTest {
         assertThat(state.getIdleConnectionCount()).isPositive();
 
         pooledDataSource.forceCloseAll();
-        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/IdentityServiceTest.java
@@ -306,7 +306,7 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
     public void testFindUsersByGroupUnexistingGroup() {
         List<User> users = idmIdentityService.createUserQuery().memberOfGroup("unexistinggroup").list();
         assertThat(users).isNotNull();
-        assertThat(users.isEmpty()).isTrue();
+        assertThat(users).isEmpty();
     }
 
     @Test
@@ -327,13 +327,14 @@ public class IdentityServiceTest extends PluggableFlowableIdmTestCase {
         idmIdentityService.createMembership(johndoe.getId(), sales.getId());
 
         List<Group> groups = idmIdentityService.createGroupQuery().groupMember(johndoe.getId()).list();
-        assertThat(groups).hasSize(1);
-        assertThat(groups.get(0).getId()).isEqualTo("sales");
+        assertThat(groups)
+                .extracting(Group::getId)
+                .containsExactly("sales");
 
         // Delete the membership and check members of sales group
         idmIdentityService.deleteMembership(johndoe.getId(), sales.getId());
         groups = idmIdentityService.createGroupQuery().groupMember(johndoe.getId()).list();
-        assertThat(groups.isEmpty()).isTrue();
+        assertThat(groups).isEmpty();
 
         idmIdentityService.deleteGroup("sales");
         idmIdentityService.deleteUser("johndoe");

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PrivilegesTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/PrivilegesTest.java
@@ -15,7 +15,6 @@ package org.flowable.idm.engine.test.api.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -191,21 +190,12 @@ public class PrivilegesTest extends PluggableFlowableIdmTestCase {
         Privilege modelerPrivilege = idmIdentityService.createPrivilegeQuery().privilegeName("access modeler application").singleResult();
         List<PrivilegeMapping> privilegeMappings = idmIdentityService.getPrivilegeMappingsByPrivilegeId(modelerPrivilege.getId());
         assertThat(privilegeMappings).hasSize(3);
-        List<String> users = new ArrayList<>();
-        List<String> groups = new ArrayList<>();
-
-        for (PrivilegeMapping privilegeMapping : privilegeMappings) {
-            if (privilegeMapping.getUserId() != null) {
-                users.add(privilegeMapping.getUserId());
-
-            } else if (privilegeMapping.getGroupId() != null) {
-                groups.add(privilegeMapping.getGroupId());
-            }
-        }
-
-        assertThat(users.contains("kermit")).isTrue();
-        assertThat(groups.contains("admins")).isTrue();
-        assertThat(groups.contains("engineering")).isTrue();
+        assertThat(privilegeMappings)
+                .extracting(PrivilegeMapping::getUserId)
+                .contains("kermit");
+        assertThat(privilegeMappings)
+                .extracting(PrivilegeMapping::getGroupId)
+                .contains("admins", "engineering");
     }
 
     @Test

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/TokenQueryTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/TokenQueryTest.java
@@ -337,8 +337,7 @@ public class TokenQueryTest extends PluggableFlowableIdmTestCase {
         // paging
         assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(0, 2)).hasSize(2);
         assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(1, 3)).hasSize(2);
-        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "1111").listPage(0, 1).size())
-                .isEqualTo(1);
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "1111").listPage(0, 1)).hasSize(1);
     }
 
 }

--- a/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserQueryTest.java
+++ b/modules/flowable-idm-engine/src/test/java/org/flowable/idm/engine/test/api/identity/UserQueryTest.java
@@ -368,8 +368,7 @@ public class UserQueryTest extends PluggableFlowableIdmTestCase {
         // paging
         assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(0, 2)).hasSize(2);
         assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql).listPage(1, 3)).hasSize(2);
-        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").listPage(0, 1).size())
-                .isEqualTo(1);
+        assertThat(idmIdentityService.createNativeUserQuery().sql(baseQuerySql + " where ID_ = #{id}").parameter("id", "kermit").listPage(0, 1)).hasSize(1);
     }
 
 }


### PR DESCRIPTION
A very few updates/consistency changes for the `org.flowable.idm.engine.test.api.identity` package in assertj usage.
