### PR TITLE
Remove test @Ignore because Spring Boot is updated

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableJpaAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableJpaAutoConfigurationTest.java
@@ -19,7 +19,6 @@ import javax.persistence.EntityManagerFactory;
 import org.flowable.spring.SpringProcessEngineConfiguration;
 import org.flowable.spring.boot.EngineConfigurationConfigurer;
 import org.flowable.spring.boot.FlowableJpaAutoConfiguration;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -45,7 +44,6 @@ public class FlowableJpaAutoConfigurationTest {
             });
     }
 
-    @Ignore("A bug in the Boot 2.0.2 release that has been fixed in 2.0.3. Remove ignore once we go to 2.0.3")
     @Test
     public void withEntityManagerFactoryBeanAndMissingSpringProcessEngineConfigurationClass() {
         contextRunner


### PR DESCRIPTION
Remove the `@Ignore` annotation from a test because Spring Boot is sufficiently past the release that contained the bug that required ignoring the test.
