### PR TITLE
Update assertj fluent style in flowable-spring-boot-starters module.

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/AllEnginesAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/AllEnginesAutoConfigurationTest.java
@@ -46,7 +46,6 @@ import org.flowable.engine.TaskService;
 import org.flowable.engine.spring.configurator.SpringProcessEngineConfigurator;
 import org.flowable.eventregistry.impl.EventRegistryEngine;
 import org.flowable.eventregistry.spring.SpringEventRegistryEngineConfiguration;
-import org.flowable.eventregistry.spring.configurator.SpringEventRegistryConfigurator;
 import org.flowable.form.engine.FormEngine;
 import org.flowable.form.spring.SpringFormEngineConfiguration;
 import org.flowable.form.spring.SpringFormExpressionManager;
@@ -171,7 +170,6 @@ public class AllEnginesAutoConfigurationTest {
             SpringDmnEngineConfigurator dmnConfigurator = context.getBean(SpringDmnEngineConfigurator.class);
             SpringFormEngineConfigurator formConfigurator = context.getBean(SpringFormEngineConfigurator.class);
             SpringIdmEngineConfigurator idmConfigurator = context.getBean(SpringIdmEngineConfigurator.class);
-            SpringEventRegistryConfigurator eventConfigurator = context.getBean(SpringEventRegistryConfigurator.class);
             SpringProcessEngineConfigurator processConfigurator = context.getBean(SpringProcessEngineConfigurator.class);
             assertThat(appEngineConfiguration.getConfigurators())
                     .as("AppEngineConfiguration configurators")

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/AllEnginesAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/AllEnginesAutoConfigurationTest.java
@@ -204,6 +204,14 @@ public class AllEnginesAutoConfigurationTest {
             assertThat(formEngineConfiguration.getExpressionManager()).isInstanceOf(SpringFormExpressionManager.class);
             assertThat(formEngineConfiguration.getExpressionManager().getBeans()).isInstanceOf(SpringBeanFactoryProxyMap.class);
 
+            assertThat(cmmnEngineConfiguration.isDisableEventRegistry()).isTrue();
+            assertThat(cmmnEngineConfiguration.getEventRegistryConfigurator()).isNull();
+            assertThat(processEngineConfiguration.isDisableEventRegistry()).isTrue();
+            assertThat(processEngineConfiguration.getEventRegistryConfigurator()).isNull();
+            assertThat(appEngineConfiguration.getEventRegistryConfigurator())
+                    .as("AppEngineConfiguration eventEngineConfiguration")
+                    .isSameAs(eventConfigurator);
+
             deleteDeployments(context.getBean(AppEngine.class));
             deleteDeployments(context.getBean(CmmnEngine.class));
             deleteDeployments(context.getBean(DmnEngine.class));

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/AllEnginesAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/AllEnginesAutoConfigurationTest.java
@@ -46,6 +46,7 @@ import org.flowable.engine.TaskService;
 import org.flowable.engine.spring.configurator.SpringProcessEngineConfigurator;
 import org.flowable.eventregistry.impl.EventRegistryEngine;
 import org.flowable.eventregistry.spring.SpringEventRegistryEngineConfiguration;
+import org.flowable.eventregistry.spring.configurator.SpringEventRegistryConfigurator;
 import org.flowable.form.engine.FormEngine;
 import org.flowable.form.spring.SpringFormEngineConfiguration;
 import org.flowable.form.spring.SpringFormExpressionManager;
@@ -170,6 +171,7 @@ public class AllEnginesAutoConfigurationTest {
             SpringDmnEngineConfigurator dmnConfigurator = context.getBean(SpringDmnEngineConfigurator.class);
             SpringFormEngineConfigurator formConfigurator = context.getBean(SpringFormEngineConfigurator.class);
             SpringIdmEngineConfigurator idmConfigurator = context.getBean(SpringIdmEngineConfigurator.class);
+            SpringEventRegistryConfigurator eventConfigurator = context.getBean(SpringEventRegistryConfigurator.class);
             SpringProcessEngineConfigurator processConfigurator = context.getBean(SpringProcessEngineConfigurator.class);
             assertThat(appEngineConfiguration.getConfigurators())
                     .as("AppEngineConfiguration configurators")
@@ -223,8 +225,8 @@ public class AllEnginesAutoConfigurationTest {
             TaskService taskService = processEngineConfiguration.getTaskService();
 
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("myCase").start();
-            assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isEqualTo(0);
-            assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(cmmnHistoryService.createHistoricMilestoneInstanceQuery().count()).isZero();
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
             List<PlanItemInstance> planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                     .caseInstanceId(caseInstance.getId())
@@ -241,8 +243,8 @@ public class AllEnginesAutoConfigurationTest {
             taskService.complete(tasks.get(0).getId());
             taskService.complete(tasks.get(1).getId());
 
-            assertThat(taskService.createTaskQuery().count()).isEqualTo(0);
-            assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+            assertThat(taskService.createTaskQuery().count()).isZero();
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
             planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery()
                     .caseInstanceId(caseInstance.getId())

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableJpaAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableJpaAutoConfigurationTest.java
@@ -80,7 +80,7 @@ public class FlowableJpaAutoConfigurationTest {
                 assertThat(configuration.getJpaEntityManagerFactory())
                     .as("Process JPA Entity Manager Factory")
                     .isNull();
-                assertThat(configuration.isJpaCloseEntityManager())
+                assertThat(configuration.isJpaHandleTransaction())
                     .as("Process JPA handle transaction")
                     .isFalse();
                 assertThat(configuration.isJpaCloseEntityManager())
@@ -92,7 +92,7 @@ public class FlowableJpaAutoConfigurationTest {
                 assertThat(configuration.getJpaEntityManagerFactory())
                     .as("Process JPA Entity Manager Factory")
                     .isSameAs(entityManagerFactory);
-                assertThat(configuration.isJpaCloseEntityManager())
+                assertThat(configuration.isJpaHandleTransaction())
                     .as("Process JPA handle transaction")
                     .isFalse();
                 assertThat(configuration.isJpaCloseEntityManager())

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/ProcessAndCmmnEngineAsyncExecutorTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/ProcessAndCmmnEngineAsyncExecutorTest.java
@@ -61,11 +61,12 @@ public class ProcessAndCmmnEngineAsyncExecutorTest {
     @Test
     public void cmmnAndProcessEngineShouldUseDistinctAsyncExecutorsWithDefaultConfiguration() {
         contextRunner.run((context -> {
-            assertThat(context).hasSingleBean(ProcessEngine.class);
-            assertThat(context).hasSingleBean(CmmnEngine.class);
-            assertThat(context).hasBean("taskExecutor");
-            assertThat(context).hasBean("cmmnAsyncExecutor");
-            assertThat(context).hasBean("processAsyncExecutor");
+            assertThat(context)
+                    .hasSingleBean(ProcessEngine.class)
+                    .hasSingleBean(CmmnEngine.class)
+                    .hasBean("taskExecutor")
+                    .hasBean("cmmnAsyncExecutor")
+                    .hasBean("processAsyncExecutor");
             AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
             AsyncExecutor cmmnAsyncExecutor = context.getBean(CmmnEngine.class).getCmmnEngineConfiguration().getAsyncExecutor();
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/eventregistry/EventRegistryAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/eventregistry/EventRegistryAutoConfigurationTest.java
@@ -339,8 +339,6 @@ public class EventRegistryAutoConfigurationTest {
                 EventRegistryEngine eventRegistryEngine = context.getBean(EventRegistryEngine.class);
                 assertThat(eventRegistryEngine).as("Event registry engine").isNotNull();
 
-                EventRegistryEngineConfiguration eventRegistryEngineConfiguration = eventRegistryEngine.getEventRegistryEngineConfiguration();
-
                 IterableAssert<ChannelModelProcessor> channelModelProcessorAssert = assertThat(
                     eventRegistryEngine.getEventRegistryEngineConfiguration().getChannelModelProcessors());
 
@@ -497,7 +495,6 @@ public class EventRegistryAutoConfigurationTest {
 
                 DefaultSpringEventRegistryChangeDetectionExecutor executor = (DefaultSpringEventRegistryChangeDetectionExecutor)
                     eventRegistryEngine.getEventRegistryEngineConfiguration().getEventRegistryChangeDetectionExecutor();
-                assertThat(executor.getTaskScheduler()).isNotNull();
                 assertThat(executor.getTaskScheduler()).isInstanceOf(ThreadPoolTaskScheduler.class);
             });
     }
@@ -520,7 +517,6 @@ public class EventRegistryAutoConfigurationTest {
 
             DefaultSpringEventRegistryChangeDetectionExecutor executor = (DefaultSpringEventRegistryChangeDetectionExecutor)
                 eventRegistryEngine.getEventRegistryEngineConfiguration().getEventRegistryChangeDetectionExecutor();
-            assertThat(executor.getTaskScheduler()).isNotNull();
             assertThat(executor.getTaskScheduler()).isEqualTo(context.getBean(TaskScheduler.class));
         });
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/process/ProcessAsyncHistoryExecutorTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/process/ProcessAsyncHistoryExecutorTest.java
@@ -49,11 +49,12 @@ public class ProcessAsyncHistoryExecutorTest {
     @Test
     public void asyncHistoryExecutorBeanAvailable() {
         contextRunner.withPropertyValues("flowable.process.async-history.enable=true").run((context -> {
-            assertThat(context).hasSingleBean(ProcessEngine.class);
-            assertThat(context).hasBean("taskExecutor");
-            assertThat(context).hasBean("processAsyncExecutor");
-            assertThat(context).hasBean("asyncHistoryExecutor");
-            
+            assertThat(context)
+                    .hasSingleBean(ProcessEngine.class)
+                    .hasBean("taskExecutor")
+                    .hasBean("processAsyncExecutor")
+                    .hasBean("asyncHistoryExecutor");
+
             AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
             assertThat(processAsyncExecutor).isNotNull();
             AsyncExecutor processAsyncHistoryExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncHistoryExecutor();
@@ -65,12 +66,12 @@ public class ProcessAsyncHistoryExecutorTest {
 
             assertThat(((SpringAsyncExecutor) processAsyncExecutor).getTaskExecutor()).isSameAs(taskExecutorBean);
             assertThat(((SpringAsyncExecutor) processAsyncHistoryExecutor).getTaskExecutor()).isSameAs(taskExecutorBean);
-            
+
             assertThat(context.getBean(ProcessEngine.class).getProcessEngineConfiguration().isAsyncExecutorActivate()).isTrue();
             assertThat(context.getBean(ProcessEngine.class).getProcessEngineConfiguration().isAsyncHistoryExecutorActivate()).isTrue();
-            
+
             assertThat(((ProcessEngineConfigurationImpl) context.getBean(ProcessEngine.class).getProcessEngineConfiguration()).isAsyncHistoryEnabled()).isTrue();
-            
+
         }));
     }
 
@@ -79,10 +80,11 @@ public class ProcessAsyncHistoryExecutorTest {
         contextRunner
             .withPropertyValues("flowable.process.async-history.enable=false")
             .run((context -> {
-                assertThat(context).hasSingleBean(ProcessEngine.class);
-                assertThat(context).hasBean("taskExecutor");
-                assertThat(context).hasBean("processAsyncExecutor");
-                assertThat(context).doesNotHaveBean("asyncHistoryExecutor");
+                assertThat(context)
+                        .hasSingleBean(ProcessEngine.class)
+                        .hasBean("taskExecutor")
+                        .hasBean("processAsyncExecutor")
+                        .doesNotHaveBean("asyncHistoryExecutor");
 
                 AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
                 assertThat(processAsyncExecutor).isNotNull();

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/process/ProcessEngineAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/process/ProcessEngineAutoConfigurationTest.java
@@ -114,11 +114,11 @@ public class ProcessEngineAutoConfigurationTest {
     @Test
     public void standaloneProcessEngineWithBasicDatasource() {
         contextRunner.run(context -> {
-            assertThat(context).as("Process engine").hasSingleBean(ProcessEngine.class);
-            assertThat(context)
-                .doesNotHaveBean(AppEngine.class)
-                .doesNotHaveBean(IdGenerator.class)
-                .doesNotHaveBean("processAppEngineConfigurationConfigurer");
+            assertThat(context).as("Process engine")
+                    .hasSingleBean(ProcessEngine.class)
+                    .doesNotHaveBean(AppEngine.class)
+                    .doesNotHaveBean(IdGenerator.class)
+                    .doesNotHaveBean("processAppEngineConfigurationConfigurer");
 
             ProcessEngine processEngine = context.getBean(ProcessEngine.class);
 
@@ -179,11 +179,11 @@ public class ProcessEngineAutoConfigurationTest {
                 "flowable.auto-deployment.engine.bpmn.lock-name=testLock"
             )
             .run(context -> {
-                assertThat(context).as("Process engine").hasSingleBean(ProcessEngine.class);
-                assertThat(context)
-                    .doesNotHaveBean(AppEngine.class)
-                    .doesNotHaveBean(IdGenerator.class)
-                    .doesNotHaveBean("processAppEngineConfigurationConfigurer");
+                assertThat(context).as("Process engine")
+                        .hasSingleBean(ProcessEngine.class)
+                        .doesNotHaveBean(AppEngine.class)
+                        .doesNotHaveBean(IdGenerator.class)
+                        .doesNotHaveBean("processAppEngineConfigurationConfigurer");
 
                 ProcessEngine processEngine = context.getBean(ProcessEngine.class);
 


### PR DESCRIPTION
Minor changes to the `org.flowable.test.spring.boot` package.  

The most noticeable change other than removing unused variables is the correcting of two method names to not duplicate existing code in `FlowableJpaAutoConfigurationTest`.
