### PR TITLE
Update assertj fluent style in flowable-spring-boot-samples module.

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-app/src/test/java/org/flowable/test/spring/boot/app/AppSampleApplicationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-app/src/test/java/org/flowable/test/spring/boot/app/AppSampleApplicationTest.java
@@ -38,6 +38,6 @@ public class AppSampleApplicationTest {
         assertThat(repositoryService).as("App repository service").isNotNull();
         assertThat(repositoryService.createAppDefinitionQuery().count())
             .as("All app definitions")
-            .isEqualTo(0);
+            .isZero();
     }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-form/src/test/java/org/flowable/test/spring/boot/FormSampleApplicationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-form/src/test/java/org/flowable/test/spring/boot/FormSampleApplicationTest.java
@@ -42,7 +42,7 @@ public class FormSampleApplicationTest {
         List<FormDefinition> formDefinitions = repositoryService.createFormDefinitionQuery().list();
         assertThat(formDefinitions)
             .extracting(FormDefinition::getKey, FormDefinition::getName)
-            .containsExactlyInAnyOrder(
+            .containsExactly(
                 tuple("form1", "My first form")
             );
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-jpa-all/src/test/java/org/flowable/test/spring/boot/JpaApplicationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-jpa-all/src/test/java/org/flowable/test/spring/boot/JpaApplicationTest.java
@@ -121,6 +121,6 @@ public class JpaApplicationTest {
         taskService.complete(reviewTask.getId(), Collections.singletonMap("approved", true));
 
         assertThat(runtimeService.createProcessInstanceQuery().count())
-            .isEqualTo(0);
+            .isZero();
     }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-ldap/src/test/java/flowable/SampleLdapApplicationRestTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-ldap/src/test/java/flowable/SampleLdapApplicationRestTest.java
@@ -115,11 +115,11 @@ public class SampleLdapApplicationRestTest extends AbstractSampleLdapTest {
 
     protected static HttpHeaders createHeaders(String username, String password) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.AUTHORIZATION, base64Auhentication(username, password));
+        headers.set(HttpHeaders.AUTHORIZATION, base64Authentication(username, password));
         return headers;
     }
 
-    protected static String base64Auhentication(String username, String password) {
+    protected static String base64Authentication(String username, String password) {
         String auth = username + ":" + password;
         return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes());
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-process/src/test/java/org/flowable/test/spring/boot/BasicApplicationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-process/src/test/java/org/flowable/test/spring/boot/BasicApplicationTest.java
@@ -49,11 +49,8 @@ public class BasicApplicationTest {
             .processDefinitionKey("waiter")
             .list();
         assertThat(processDefinitionList)
-            .hasSize(1)
-            .first()
-            .as("First process definition")
-            .satisfies(processDefinition -> assertThat(processDefinition.getKey())
-                .as("Process definition key")
-                .isEqualTo("waiter"));
+            .extracting(ProcessDefinition::getKey)
+            .as("First process definition with definition key")
+            .containsExactly("waiter");
     }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-1.5.x/src/test/java/org/flowable/test/spring/boot/RestApiApplicationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-1.5.x/src/test/java/org/flowable/test/spring/boot/RestApiApplicationTest.java
@@ -114,7 +114,7 @@ public class RestApiApplicationTest {
         assertThat(contentItems).isNotNull();
         assertThat(contentItems.getData())
             .isEmpty();
-        assertThat(contentItems.getTotal()).isEqualTo(0);
+        assertThat(contentItems.getTotal()).isZero();
     }
 
     @Test
@@ -133,7 +133,7 @@ public class RestApiApplicationTest {
         assertThat(deployments).isNotNull();
         assertThat(deployments.getData())
             .isEmpty();
-        assertThat(deployments.getTotal()).isEqualTo(0);
+        assertThat(deployments.getTotal()).isZero();
     }
 
     @Test
@@ -152,7 +152,7 @@ public class RestApiApplicationTest {
         assertThat(formDefinitions).isNotNull();
         assertThat(formDefinitions.getData())
             .isEmpty();
-        assertThat(formDefinitions.getTotal()).isEqualTo(0);
+        assertThat(formDefinitions.getTotal()).isZero();
     }
 
     @Test
@@ -171,7 +171,7 @@ public class RestApiApplicationTest {
         assertThat(groups).isNotNull();
         assertThat(groups.getData())
             .extracting(GroupResponse::getId, GroupResponse::getType, GroupResponse::getName, GroupResponse::getUrl)
-            .containsExactlyInAnyOrder(
+            .containsExactly(
                 tuple("user", "security-role", "users", null)
             );
         assertThat(groups.getTotal()).isEqualTo(1);

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api-security/src/test/java/org/flowable/test/spring/boot/RestApiSecurityApplicationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api-security/src/test/java/org/flowable/test/spring/boot/RestApiSecurityApplicationTest.java
@@ -74,27 +74,15 @@ public class RestApiSecurityApplicationTest {
 
     @Test
     public void userDetailsService() {
-        assertThat(userDetailsService.loadUserByUsername("jlong"))
-            .as("jlong user")
-            .isNotNull()
-            .satisfies(user -> {
-                assertThat(user.getAuthorities())
-                    .as("jlong authorities")
-                    .hasSize(1)
-                    .extracting(GrantedAuthority::getAuthority)
-                    .containsExactlyInAnyOrder("user-privilege");
-            });
+        assertThat(userDetailsService.loadUserByUsername("jlong").getAuthorities())
+                .as("jlong user's authorities")
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactly("user-privilege");
 
-        assertThat(userDetailsService.loadUserByUsername("jbarrez"))
-            .as("jbarrez user")
-            .isNotNull()
-            .satisfies(user -> {
-                assertThat(user.getAuthorities())
-                    .as("jbarrez authorities")
-                    .hasSize(2)
-                    .extracting(GrantedAuthority::getAuthority)
-                    .containsExactlyInAnyOrder("user-privilege", "admin-privilege");
-            });
+        assertThat(userDetailsService.loadUserByUsername("jbarrez").getAuthorities())
+                .as("jbarrez user's authorities")
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder("user-privilege", "admin-privilege");
     }
 
     @Test
@@ -121,7 +109,7 @@ public class RestApiSecurityApplicationTest {
         latch401.await(500, TimeUnit.MILLISECONDS);
         assertThat(latch401.getCount())
             .as("401 Latch")
-            .isEqualTo(0);
+            .isZero();
     }
 
     @Test
@@ -181,7 +169,7 @@ public class RestApiSecurityApplicationTest {
         assertThat(contentItems).isNotNull();
         assertThat(contentItems.getData())
             .isEmpty();
-        assertThat(contentItems.getTotal()).isEqualTo(0);
+        assertThat(contentItems.getTotal()).isZero();
     }
     @Test
     public void testDmnRestApiIntegrationWithAuthentication() {
@@ -199,7 +187,7 @@ public class RestApiSecurityApplicationTest {
         assertThat(deployments).isNotNull();
         assertThat(deployments.getData())
             .isEmpty();
-        assertThat(deployments.getTotal()).isEqualTo(0);
+        assertThat(deployments.getTotal()).isZero();
     }
     @Test
     public void testFormRestApiIntegrationWithAuthentication() {
@@ -217,7 +205,7 @@ public class RestApiSecurityApplicationTest {
         assertThat(formDefinitions).isNotNull();
         assertThat(formDefinitions.getData())
             .isEmpty();
-        assertThat(formDefinitions.getTotal()).isEqualTo(0);
+        assertThat(formDefinitions.getTotal()).isZero();
     }
     @Test
     public void testIdmRestApiIntegrationWithAuthentication() {
@@ -244,11 +232,11 @@ public class RestApiSecurityApplicationTest {
 
     protected static HttpHeaders createHeaders(String username, String password) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.AUTHORIZATION, base64Auhentication(username, password));
+        headers.set(HttpHeaders.AUTHORIZATION, base64Authentication(username, password));
         return headers;
     }
 
-    protected static String base64Auhentication(String username, String password) {
+    protected static String base64Authentication(String username, String password) {
         String auth = username + ":" + password;
         return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes());
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api-security/src/test/java/org/flowable/test/spring/boot/SecurityAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api-security/src/test/java/org/flowable/test/spring/boot/SecurityAutoConfigurationTest.java
@@ -55,8 +55,8 @@ public class SecurityAutoConfigurationTest {
         this.applicationContext.refresh();
         UserDetailsService userDetailsService = this.applicationContext.getBean(UserDetailsService.class);
         assertThat(userDetailsService).as("the userDetailsService should not be null").isNotNull();
-        assertThat(userDetailsService.loadUserByUsername("jlong2").getAuthorities().size()).as("there should only be 1 authority").isEqualTo(1);
-        assertThat(userDetailsService.loadUserByUsername("jbarrez2").getAuthorities().size()).as("there should be 2 authorities").isEqualTo(2);
+        assertThat(userDetailsService.loadUserByUsername("jlong2").getAuthorities()).as("there should only be 1 authority").hasSize(1);
+        assertThat(userDetailsService.loadUserByUsername("jbarrez2").getAuthorities()).as("there should be 2 authorities").hasSize(2);
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api/src/test/java/org/flowable/test/spring/boot/RestApiApplicationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api/src/test/java/org/flowable/test/spring/boot/RestApiApplicationTest.java
@@ -126,7 +126,7 @@ public class RestApiApplicationTest {
         assertThat(contentItems).isNotNull();
         assertThat(contentItems.getData())
             .isEmpty();
-        assertThat(contentItems.getTotal()).isEqualTo(0);
+        assertThat(contentItems.getTotal()).isZero();
     }
     @Test
     public void testDmnRestApiIntegration() {
@@ -143,7 +143,7 @@ public class RestApiApplicationTest {
         assertThat(deployments).isNotNull();
         assertThat(deployments.getData())
             .isEmpty();
-        assertThat(deployments.getTotal()).isEqualTo(0);
+        assertThat(deployments.getTotal()).isZero();
     }
     @Test
     public void testFormRestApiIntegration() {
@@ -160,7 +160,7 @@ public class RestApiApplicationTest {
         assertThat(formDefinitions).isNotNull();
         assertThat(formDefinitions.getData())
             .isEmpty();
-        assertThat(formDefinitions.getTotal()).isEqualTo(0);
+        assertThat(formDefinitions.getTotal()).isZero();
     }
     @Test
     public void testIdmRestApiIntegration() {
@@ -177,7 +177,7 @@ public class RestApiApplicationTest {
         assertThat(groups).isNotNull();
         assertThat(groups.getData())
             .extracting(GroupResponse::getId, GroupResponse::getType, GroupResponse::getName, GroupResponse::getUrl)
-            .containsExactlyInAnyOrder(
+            .containsExactly(
                 tuple("user", "security-role", "users", null)
             );
         assertThat(groups.getTotal()).isEqualTo(1);
@@ -196,7 +196,7 @@ public class RestApiApplicationTest {
                 .isEqualTo(HttpStatus.OK);
         DataResponse<JsonNode> jobs = response.getBody();
         assertThat(jobs).isNotNull();
-        assertThat(jobs.getTotal()).isEqualTo(0);
+        assertThat(jobs.getTotal()).isZero();
         assertThat(jobs.getData()).isEmpty();
     }
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/test/java/flowable/MixedAsyncExecutorsTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-starter/src/test/java/flowable/MixedAsyncExecutorsTest.java
@@ -77,12 +77,12 @@ public class MixedAsyncExecutorsTest {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testStageAfterTimerEventListener")
             .start();
 
-        assertThat(cmmnTaskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(cmmnTaskService.createTaskQuery().count()).isZero();
 
         // Start the Process instance
         ProcessInstance processInstance = processRule.getRuntimeService().createProcessInstanceBuilder().processDefinitionKey("testTimerEvent").start();
 
-        assertThat(processRule.getTaskService().createTaskQuery().count()).isEqualTo(0);
+        assertThat(processRule.getTaskService().createTaskQuery().count()).isZero();
 
         // Timer fires after 1 day, so setting it to 1 day + 1 second
         setClockTo(new Date(startTime.getTime() + (24 * 60 * 60 * 1000 + 1)));
@@ -97,7 +97,7 @@ public class MixedAsyncExecutorsTest {
     
     @Test
     public void testAppDefinitions() {
-        assertThat(appRepositoryService.createAppDefinitionQuery().count()).isEqualTo(0);
+        assertThat(appRepositoryService.createAppDefinitionQuery().count()).isZero();
     }
 
     protected void setClockTo(Date time) {


### PR DESCRIPTION
Updates to `org.flowable.test.spring.boot` package.

- use `hasSize()`
- correct spelling
- use `isZero()`
- simplify a few code constructs
- correct usage of `containsExactlyInAnyOrder`
