### PR TITLE
Use assertj fluent style in flowable-camel module.

### DIFF
--- a/modules/flowable-camel/pom.xml
+++ b/modules/flowable-camel/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncPingTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncPingTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.apache.camel.CamelContext;
@@ -22,7 +24,6 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.spring.impl.test.SpringFlowableTestCase;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -70,15 +71,15 @@ public class AsyncPingTest extends SpringFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncPingProcess");
 
         List<Execution> executionList = runtimeService.createExecutionQuery().list();
-        Assert.assertEquals(2, executionList.size());
+        assertThat(executionList).hasSize(2);
 
         managementService.executeJob(managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult().getId());
         Thread.sleep(1500);
 
         executionList = runtimeService.createExecutionQuery().list();
-        Assert.assertEquals(0, executionList.size());
+        assertThat(executionList).isEmpty();
 
-        Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/AsyncProcessTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.apache.camel.CamelContext;
@@ -70,8 +72,8 @@ public class AsyncProcessTest extends SpringFlowableTestCase {
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncCamelProcess");
         List<Execution> executionList = runtimeService.createExecutionQuery().list();
-        assertEquals(3, executionList.size());
+        assertThat(executionList).hasSize(3);
         Thread.sleep(4000);
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyMapTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyMapTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,13 +74,13 @@ public class CamelVariableBodyMapTest extends SpringFlowableTestCase {
         service1.expectedBodiesReceived(varMap);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HelloCamel", varMap);
         // Ensure that the variable is equal to the expected value.
-        assertEquals("hello world", runtimeService.getVariable(processInstance.getId(), "camelBody"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "camelBody")).isEqualTo("hello world");
         service1.assertIsSatisfied();
 
         Task task = taskService.createTaskQuery().singleResult();
 
         // Ensure that the name of the task is correct.
-        assertEquals("Hello Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Hello Task");
 
         // Complete the task.
         taskService.complete(task.getId());

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CamelVariableBodyTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,13 +73,13 @@ public class CamelVariableBodyTest extends SpringFlowableTestCase {
         varMap.put("camelBody", "hello world");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HelloCamel", varMap);
         // Ensure that the variable is equal to the expected value.
-        assertEquals("hello world", runtimeService.getVariable(processInstance.getId(), "camelBody"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "camelBody")).isEqualTo("hello world");
         service1.assertIsSatisfied();
 
         Task task = taskService.createTaskQuery().singleResult();
 
         // Ensure that the name of the task is correct.
-        assertEquals("Hello Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Hello Task");
 
         // Complete the task.
         taskService.complete(task.getId());

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/CustomContextTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/CustomContextTest.java
@@ -13,6 +13,9 @@
 
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -96,7 +99,10 @@ public class CustomContextTest extends SpringFlowableTestCase {
 
         @SuppressWarnings("rawtypes")
         Map m = service2.getExchanges().get(0).getIn().getBody(Map.class);
-        assertEquals("ala", m.get("var1"));
-        assertEquals("var2", m.get("var2"));
+        assertThat(m)
+                .contains(
+                        entry("var1", "ala"),
+                        entry("var2", "var2")
+                );
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/EmptyProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/EmptyProcessTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.apache.camel.CamelContext;
@@ -72,11 +74,11 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
         assertProcessEnded(instanceId);
         HistoricVariableInstance var = processEngine.getHistoryService().createHistoricVariableInstanceQuery().variableName("camelBody").singleResult();
-        assertNotNull(var);
-        assertEquals(body, var.getValue());
+        assertThat(var).isNotNull();
+        assertThat(var.getValue()).isEqualTo(body);
         var = processEngine.getHistoryService().createHistoricVariableInstanceQuery().variableName("MyVar").singleResult();
-        assertNotNull(var);
-        assertEquals("Foo", var.getValue());
+        assertThat(var).isNotNull();
+        assertThat(var.getValue()).isEqualTo("Foo");
     }
 
     @Test
@@ -91,8 +93,8 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
         assertProcessEnded(instanceId);
         HistoricVariableInstance var = processEngine.getHistoryService().createHistoricVariableInstanceQuery().variableName("camelBody").singleResult();
-        assertNotNull(var);
-        assertEquals(expectedObj, var.getValue());
+        assertThat(var).isNotNull();
+        assertThat(var.getValue()).isEqualTo(expectedObj);
     }
 
     @Test
@@ -110,7 +112,7 @@ public class EmptyProcessTest extends SpringFlowableTestCase {
 
         assertProcessEnded(instanceId);
         HistoricVariableInstance var = processEngine.getHistoryService().createHistoricVariableInstanceQuery().variableName("camelBody").singleResult();
-        assertNotNull(var);
-        assertEquals(expectedObj.toString(), var.getValue().toString());
+        assertThat(var).isNotNull();
+        assertThat(var.getValue()).hasToString(expectedObj.toString());
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorHandlingTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorHandlingTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,12 +54,12 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("ErrorHandling", variables);
 
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         managementService.executeJob(job.getId());
 
         Thread.sleep(WAIT);
 
-        assertEquals("Process instance not completed", 0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).as("Process instance not completed").isZero();
     }
 
     /**
@@ -73,9 +75,9 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("ErrorHandling", variables);
 
-        assertEquals("No roll-back to previous wait state", 1, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId(PREVIOUS_WAIT_STATE).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId(PREVIOUS_WAIT_STATE).count()).as("No roll-back to previous wait state").isEqualTo(1);
 
-        assertEquals("Process instance advanced to next wait state", 0, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId(NEXT_WAIT_STATE).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId(NEXT_WAIT_STATE).count()).as("Process instance advanced to next wait state").isZero();
     }
 
     /**
@@ -92,11 +94,11 @@ public class ErrorHandlingTest extends SpringFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("ErrorHandling", variables);
 
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         managementService.executeJob(job.getId());
 
         Thread.sleep(WAIT);
 
-        assertEquals("Process instance did not reach next wait state", 1, runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId(NEXT_WAIT_STATE).count());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId(NEXT_WAIT_STATE).count()).as("Process instance did not reach next wait state").isEqualTo(1);
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorMapExceptionTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/ErrorMapExceptionTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.flowable.camel.util.FlagJavaDelegate;
@@ -46,7 +48,7 @@ public class ErrorMapExceptionTest extends SpringFlowableTestCase {
 
         FlagJavaDelegate.reset();
         runtimeService.startProcessInstanceByKey("mapExceptionProcess");
-        assertTrue(FlagJavaDelegate.isFlagSet());
+        assertThat(FlagJavaDelegate.isFlagSet()).isTrue();
     }
 
     @Test
@@ -61,7 +63,7 @@ public class ErrorMapExceptionTest extends SpringFlowableTestCase {
         });
         FlagJavaDelegate.reset();
         runtimeService.startProcessInstanceByKey("mapExceptionDefaultProcess");
-        assertTrue(FlagJavaDelegate.isFlagSet());
+        assertThat(FlagJavaDelegate.isFlagSet()).isTrue();
     }
 
     @Test
@@ -76,7 +78,7 @@ public class ErrorMapExceptionTest extends SpringFlowableTestCase {
         });
         FlagJavaDelegate.reset();
         runtimeService.startProcessInstanceByKey("mapExceptionParentProcess");
-        assertTrue(FlagJavaDelegate.isFlagSet());
+        assertThat(FlagJavaDelegate.isFlagSet()).isTrue();
     }
 
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/ParallelProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/ParallelProcessTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.apache.camel.CamelContext;
@@ -64,6 +66,6 @@ public class ParallelProcessTest extends SpringFlowableTestCase {
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelCamelProcess");
         Thread.sleep(4000);
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleProcessTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -88,8 +90,8 @@ public class SimpleProcessTest extends SpringFlowableTestCase {
 
         service1.assertIsSatisfied();
         Map<?, ?> m = service2.getExchanges().get(0).getIn().getBody(Map.class);
-        assertEquals("ala", m.get("var1"));
-        assertEquals("var2", m.get("var2"));
+        assertThat(m.get("var1")).isEqualTo("ala");
+        assertThat(m.get("var2")).isEqualTo("var2");
     }
 
     @Test

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleSpringProcessTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/SimpleSpringProcessTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -92,8 +94,8 @@ public class SimpleSpringProcessTest extends SpringFlowableTestCase {
 
         service1.assertIsSatisfied();
         Map<?, ?> m = service2.getExchanges().get(0).getIn().getBody(Map.class);
-        assertEquals("ala", m.get("var1"));
-        assertEquals("var2", m.get("var2"));
+        assertThat(m.get("var1")).isEqualTo("ala");
+        assertThat(m.get("var2")).isEqualTo("var2");
 
     }
 

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/initiator/InitiatorCamelCallTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/initiator/InitiatorCamelCallTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel.examples.initiator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
@@ -58,10 +60,10 @@ public class InitiatorCamelCallTest extends SpringFlowableTestCase {
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
 
         String initiator = (String) runtimeService.getVariable(instanceId, "initiator");
-        assertEquals("kermit", initiator);
+        assertThat(initiator).isEqualTo("kermit");
 
         Object camelInitiatorHeader = runtimeService.getVariable(instanceId, "CamelProcessInitiatorHeader");
-        assertNull(camelInitiatorHeader);
+        assertThat(camelInitiatorHeader).isNull();
     }
 
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/multiinstance/MultiInstanceTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/multiinstance/MultiInstanceTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel.examples.multiinstance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.apache.camel.CamelContext;
@@ -54,11 +56,12 @@ public class MultiInstanceTest extends SpringFlowableTestCase {
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miProcessExample");
         List<Job> jobList = managementService.createJobQuery().list();
-        assertEquals(5, jobList.size());
+        assertThat(jobList).hasSize(5);
 
-        assertEquals(5, runtimeService.createExecutionQuery()
+        assertThat(runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
-                .activityId("serviceTask1").count());
+                .activityId("serviceTask1")
+                .count()).isEqualTo(5);
 
         waitForJobExecutorToProcessAllJobs(3000, 500);
         int counter = 0;
@@ -68,6 +71,6 @@ public class MultiInstanceTest extends SpringFlowableTestCase {
             processInstanceCount = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count();
             counter++;
         }
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/examples/ping/PingPongTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/examples/ping/PingPongTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.camel.examples.ping;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,9 +59,8 @@ public class PingPongTest extends SpringFlowableTestCase {
         variables.put("outputMap", outputMap);
 
         runtimeService.startProcessInstanceByKey("PingPongProcess", variables);
-        assertEquals(1, outputMap.size());
-        assertNotNull(outputMap.get("outputValue"));
-        assertEquals("Hello World", outputMap.get("outputValue"));
+        assertThat(outputMap)
+                .containsExactly(entry("outputValue", "Hello World"));
     }
 
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
@@ -95,19 +95,12 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
     public void testNonBpmnExceptionInCamel() {
         // Signal ThrowBpmnExceptionBean to throw a non BPMN Exception
         ThrowBpmnExceptionBean.setExceptionType(ThrowBpmnExceptionBean.ExceptionType.NON_BPMN_EXCEPTION);
-
-        try {
-            runtimeService.startProcessInstanceByKey("exceptionInRouteSynchron");
-        } catch (FlowableException e) {
-            assertThat(e.getCause().getClass()).isEqualTo(Exception.class);
-            assertThat(e.getCause().getMessage()).isEqualTo("arbitrary non bpmn exception");
-
-            assertThat(ExceptionServiceMock.isCalled()).isFalse();
-            assertThat(NoExceptionServiceMock.isCalled()).isFalse();
-
-            return;
-        }
-        fail("Activiti exception expected");
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("exceptionInRouteSynchron"))
+                .isInstanceOf(FlowableException.class)
+                .hasCauseInstanceOf(Exception.class)
+                .hasRootCauseMessage("arbitrary non bpmn exception");
+        assertThat(ExceptionServiceMock.isCalled()).isFalse();
+        assertThat(NoExceptionServiceMock.isCalled()).isFalse();
     }
 
     // check Bpmn Exception in synchronous camel call

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
@@ -13,6 +13,10 @@
 
 package org.flowable.camel.exception;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 
 import org.apache.camel.CamelContext;
@@ -81,8 +85,8 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
         ThrowBpmnExceptionBean.setExceptionType(ThrowBpmnExceptionBean.ExceptionType.NO_EXCEPTION);
         runtimeService.startProcessInstanceByKey("exceptionInRouteSynchron");
 
-        assertFalse(ExceptionServiceMock.isCalled());
-        assertTrue(NoExceptionServiceMock.isCalled());
+        assertThat(ExceptionServiceMock.isCalled()).isFalse();
+        assertThat(NoExceptionServiceMock.isCalled()).isTrue();
     }
 
     // Check Non BPMN error in synchronouse camel call
@@ -95,11 +99,11 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
         try {
             runtimeService.startProcessInstanceByKey("exceptionInRouteSynchron");
         } catch (FlowableException e) {
-            assertEquals(Exception.class, e.getCause().getClass());
-            assertEquals("arbitrary non bpmn exception", e.getCause().getMessage());
+            assertThat(e.getCause().getClass()).isEqualTo(Exception.class);
+            assertThat(e.getCause().getMessage()).isEqualTo("arbitrary non bpmn exception");
 
-            assertFalse(ExceptionServiceMock.isCalled());
-            assertFalse(NoExceptionServiceMock.isCalled());
+            assertThat(ExceptionServiceMock.isCalled()).isFalse();
+            assertThat(NoExceptionServiceMock.isCalled()).isFalse();
 
             return;
         }
@@ -113,14 +117,14 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
         // Signal ThrowBpmnExceptionBean to throw a BPMN Exception
         ThrowBpmnExceptionBean.setExceptionType(ThrowBpmnExceptionBean.ExceptionType.BPMN_EXCEPTION);
 
-        try {
+        // The exception should be handled by camel. No exception expected.
+        assertThatCode(() -> {
             runtimeService.startProcessInstanceByKey("exceptionInRouteSynchron");
-        } catch (FlowableException e) {
-            fail("The exception should be handled by camel. No exception expected.");
-        }
+        })
+                .doesNotThrowAnyException();
 
-        assertTrue(ExceptionServiceMock.isCalled());
-        assertFalse(NoExceptionServiceMock.isCalled());
+        assertThat(ExceptionServiceMock.isCalled()).isTrue();
+        assertThat(NoExceptionServiceMock.isCalled()).isFalse();
     }
 
     // check happy path in asynchronous camel call
@@ -136,9 +140,9 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
 
         managementService.executeJob(job.getId());
 
-        assertFalse(JobTestHelper.areJobsAvailable(managementService));
-        assertFalse(ExceptionServiceMock.isCalled());
-        assertTrue(NoExceptionServiceMock.isCalled());
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isFalse();
+        assertThat(ExceptionServiceMock.isCalled()).isFalse();
+        assertThat(NoExceptionServiceMock.isCalled()).isTrue();
     }
 
     // check non bpmn exception in asynchronouse camel call
@@ -149,22 +153,18 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
         // Signal ThrowBpmnExceptionBean to throw non bpmn exception
         ThrowBpmnExceptionBean.setExceptionType(ThrowBpmnExceptionBean.ExceptionType.NON_BPMN_EXCEPTION);
         runtimeService.startProcessInstanceByKey("exceptionInRouteSynchron");
-        assertTrue(JobTestHelper.areJobsAvailable(managementService));
+        assertThat(JobTestHelper.areJobsAvailable(managementService)).isTrue();
 
         Job job = managementService.createJobQuery().singleResult();
-
-        try {
-            managementService.executeJob(job.getId());
-            fail();
-        } catch (Exception e) {
-            // expected
-        }
+        String jobId = job.getId();
+        assertThatThrownBy(() -> managementService.executeJob(jobId))
+                .isInstanceOf(Exception.class);
 
         // The job is now a timer job, to be retried later
         job = managementService.createTimerJobQuery().singleResult();
-        assertEquals("Unhandled exception on camel route", job.getExceptionMessage());
+        assertThat(job.getExceptionMessage()).isEqualTo("Unhandled exception on camel route");
 
-        assertFalse(ExceptionServiceMock.isCalled());
-        assertFalse(NoExceptionServiceMock.isCalled());
+        assertThat(ExceptionServiceMock.isCalled()).isFalse();
+        assertThat(NoExceptionServiceMock.isCalled()).isFalse();
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/AsyncProcessRevisitedTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel.revisited;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.apache.camel.CamelContext;
@@ -62,11 +64,11 @@ public class AsyncProcessRevisitedTest extends SpringFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncCamelProcessRevisited");
 
         List<Execution> executionList = runtimeService.createExecutionQuery().list();
-        assertEquals(3, executionList.size());
+        assertThat(executionList).hasSize(3);
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000, 200);
 
-        assertTrue(oneExchangeSendToFlowableReceive1.matchesMockWaitTime());
-        assertTrue(oneExchangeSendToFlowableReceive2.matchesMockWaitTime());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(oneExchangeSendToFlowableReceive1.matchesMockWaitTime()).isTrue();
+        assertThat(oneExchangeSendToFlowableReceive2.matchesMockWaitTime()).isTrue();
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/ParallelProcessRevisitedTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/revisited/ParallelProcessRevisitedTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.camel.revisited;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -48,6 +50,6 @@ public class ParallelProcessRevisitedTest extends SpringFlowableTestCase {
     public void testRunProcess() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelCamelProcessRevisited");
         Thread.sleep(4000);
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/variables/CamelVariableTransferTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/variables/CamelVariableTransferTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.camel.variables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 import java.util.List;
 import java.util.Map;
 
@@ -117,15 +120,18 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         Exchange exchange = camelContext.getEndpoint("direct:startAllProperties").createExchange();
         tpl.send("direct:startAllProperties", exchange);
 
-        assertNotNull(taskService);
-        assertNotNull(runtimeService);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService).isNotNull();
+        assertThat(runtimeService).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
-        assertEquals("sampleValueForProperty1", variables.get("property1"));
-        assertEquals("sampleValueForProperty2", variables.get("property2"));
-        assertEquals("sampleValueForProperty3", variables.get("property3"));
+        assertThat(variables)
+                .contains(
+                        entry("property1", "sampleValueForProperty1"),
+                        entry("property2", "sampleValueForProperty2"),
+                        entry("property3", "sampleValueForProperty3")
+                );
     }
 
     // check that body will be copied into variables even if copyVariablesFromProperties=true
@@ -137,16 +143,19 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
 
         tpl.send("direct:startAllProperties", exchange);
 
-        assertNotNull(taskService);
-        assertNotNull(runtimeService);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService).isNotNull();
+        assertThat(runtimeService).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
-        assertEquals("sampleValueForProperty1", variables.get("property1"));
-        assertEquals("sampleValueForProperty2", variables.get("property2"));
-        assertEquals("sampleValueForProperty3", variables.get("property3"));
-        assertEquals("sampleBody", variables.get("camelBody"));
+        assertThat(variables)
+                .contains(
+                        entry("property1", "sampleValueForProperty1"),
+                        entry("property2", "sampleValueForProperty2"),
+                        entry("property3", "sampleValueForProperty3"),
+                        entry("camelBody", "sampleBody")
+                );
     }
 
     @Test
@@ -156,15 +165,18 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         Exchange exchange = camelContext.getEndpoint("direct:startFilteredProperties").createExchange();
         tpl.send("direct:startFilteredProperties", exchange);
 
-        assertNotNull(taskService);
-        assertNotNull(runtimeService);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService).isNotNull();
+        assertThat(runtimeService).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
-        assertEquals("sampleValueForProperty1", variables.get("property1"));
-        assertEquals("sampleValueForProperty2", variables.get("property2"));
-        assertNull(variables.get("property3"));
+        assertThat(variables)
+                .contains(
+                        entry("property1", "sampleValueForProperty1"),
+                        entry("property2", "sampleValueForProperty2")
+                )
+                .doesNotContain(entry("property3", null));
     }
 
     @Test
@@ -174,15 +186,17 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         Exchange exchange = camelContext.getEndpoint("direct:startNoProperties").createExchange();
         tpl.send("direct:startNoProperties", exchange);
 
-        assertNotNull(taskService);
-        assertNotNull(runtimeService);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService).isNotNull();
+        assertThat(runtimeService).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
-        assertNull(variables.get("property1"));
-        assertNull(variables.get("property2"));
-        assertNull(variables.get("property3"));
+        assertThat(variables)
+                .doesNotContain(
+                        entry("property1", null),
+                        entry("property2", null),
+                        entry("property3", null));
     }
 
     @Test
@@ -192,15 +206,18 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         Exchange exchange = camelContext.getEndpoint("direct:startAllProperties").createExchange();
         tpl.send("direct:startAllProperties", exchange);
 
-        assertNotNull(taskService);
-        assertNotNull(runtimeService);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService).isNotNull();
+        assertThat(runtimeService).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
-        assertEquals("sampleValueForProperty1", variables.get("property1"));
-        assertEquals("sampleValueForProperty2", variables.get("property2"));
-        assertEquals("sampleValueForProperty3", variables.get("property3"));
+        assertThat(variables)
+                .contains(
+                        entry("property1", "sampleValueForProperty1"),
+                        entry("property2", "sampleValueForProperty2"),
+                        entry("property3", "sampleValueForProperty3")
+                );
     }
 
     @Test
@@ -210,15 +227,18 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         Exchange exchange = camelContext.getEndpoint("direct:startFilteredHeaders").createExchange();
         tpl.send("direct:startFilteredHeaders", exchange);
 
-        assertNotNull(taskService);
-        assertNotNull(runtimeService);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService).isNotNull();
+        assertThat(runtimeService).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
-        assertEquals("sampleValueForProperty1", variables.get("property1"));
-        assertEquals("sampleValueForProperty2", variables.get("property2"));
-        assertNull(variables.get("property3"));
+        assertThat(variables)
+                .contains(
+                        entry("property1", "sampleValueForProperty1"),
+                        entry("property2", "sampleValueForProperty2")
+                )
+                .doesNotContain(entry("property3", null));
     }
 
     @Test
@@ -228,15 +248,17 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         Exchange exchange = camelContext.getEndpoint("direct:startNoHeaders").createExchange();
         tpl.send("direct:startNoHeaders", exchange);
 
-        assertNotNull(taskService);
-        assertNotNull(runtimeService);
-        assertEquals(1, taskService.createTaskQuery().count());
+        assertThat(taskService).isNotNull();
+        assertThat(runtimeService).isNotNull();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
-        assertNull(variables.get("property1"));
-        assertNull(variables.get("property2"));
-        assertNull(variables.get("property3"));
+        assertThat(variables)
+                .doesNotContain(
+                        entry("property1", null),
+                        entry("property2", null),
+                        entry("property3", null));
     }
 
 }

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/variables/CamelVariableTransferTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/variables/CamelVariableTransferTest.java
@@ -176,7 +176,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
                         entry("property1", "sampleValueForProperty1"),
                         entry("property2", "sampleValueForProperty2")
                 )
-                .doesNotContain(entry("property3", null));
+                .doesNotContainKey("property3");
     }
 
     @Test
@@ -193,10 +193,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
         assertThat(variables)
-                .doesNotContain(
-                        entry("property1", null),
-                        entry("property2", null),
-                        entry("property3", null));
+                .doesNotContainKeys("property1", "property2", "property3");
     }
 
     @Test
@@ -238,7 +235,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
                         entry("property1", "sampleValueForProperty1"),
                         entry("property2", "sampleValueForProperty2")
                 )
-                .doesNotContain(entry("property3", null));
+                .doesNotContainKey("property3");
     }
 
     @Test
@@ -255,10 +252,7 @@ public class CamelVariableTransferTest extends SpringFlowableTestCase {
         assertThat(task).isNotNull();
         Map<String, Object> variables = runtimeService.getVariables(task.getExecutionId());
         assertThat(variables)
-                .doesNotContain(
-                        entry("property1", null),
-                        entry("property2", null),
-                        entry("property3", null));
+                .doesNotContainKeys("property1", "property2", "property3");
     }
 
 }


### PR DESCRIPTION
Straightforward conversion of the module to assertj style once the jar was added to the POM.
