### PR TITLE
Use assertj fluent style in flowable-camel-cdi module

### DIFF
--- a/modules/flowable-camel-cdi/pom.xml
+++ b/modules/flowable-camel-cdi/pom.xml
@@ -47,6 +47,11 @@
           <scope>test</scope>
       </dependency>
       <dependency>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
           <groupId>com.h2database</groupId>
           <artifactId>h2</artifactId>
           <scope>test</scope>

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomContextTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomContextTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.camel.cdi.named;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -95,19 +93,19 @@ public class CdiCustomContextTest extends NamedCamelCdiFlowableTestCase {
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
         List<ProcessInstance> processInstances = processEngine.getRuntimeService().createProcessInstanceQuery().list();
         ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         tpl.sendBodyAndProperty("direct:receive", null, FlowableProducer.PROCESS_ID_PROPERTY, instanceId);
 
         // check process ended
         processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         service1.assertIsSatisfied();
 
         @SuppressWarnings("rawtypes")
         Map m = service2.getExchanges().get(0).getIn().getBody(Map.class);
-        assertEquals("ala", m.get("var1"));
-        assertEquals("var2", m.get("var2"));
+        assertThat(m.get("var1")).isEqualTo("ala");
+        assertThat(m.get("var2")).isEqualTo("var2");
     }
 }

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomNonDefaultNamedContextTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/named/CdiCustomNonDefaultNamedContextTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.camel.cdi.named;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -98,19 +96,19 @@ public class CdiCustomNonDefaultNamedContextTest extends NamedCamelCdiFlowableTe
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
 
         ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         tpl.sendBodyAndProperty("direct:receive", null, FlowableProducer.PROCESS_ID_PROPERTY, instanceId);
 
         // check process ended
         processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         service1.assertIsSatisfied();
 
         @SuppressWarnings("rawtypes")
         Map m = service2.getExchanges().get(0).getIn().getBody(Map.class);
-        assertEquals("ala", m.get("var1"));
-        assertEquals("var2", m.get("var2"));
+        assertThat(m.get("var1")).isEqualTo("ala");
+        assertThat(m.get("var2")).isEqualTo("var2");
     }
 }

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiAsyncPingTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiAsyncPingTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.camel.cdi.std;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import javax.inject.Inject;
@@ -23,7 +25,6 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -64,15 +65,15 @@ public class CdiAsyncPingTest extends StdCamelCdiFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncPingProcess");
 
         List<Execution> executionList = runtimeService.createExecutionQuery().list();
-        Assert.assertEquals(2, executionList.size());
+        assertThat(executionList).hasSize(2);
 
         managementService.executeJob(managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult().getId());
         Thread.sleep(1500);
 
         executionList = runtimeService.createExecutionQuery().list();
-        Assert.assertEquals(0, executionList.size());
+        assertThat(executionList).isEmpty();
 
-        Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 
 }

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiCamelVariableBodyMapTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiCamelVariableBodyMapTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.camel.cdi.std;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -78,13 +78,13 @@ public class CdiCamelVariableBodyMapTest extends StdCamelCdiFlowableTestCase {
         service1.expectedBodiesReceived(varMap);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HelloCamel", varMap);
         // Ensure that the variable is equal to the expected value.
-        assertEquals("hello world", runtimeService.getVariable(processInstance.getId(), "camelBody"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "camelBody")).isEqualTo("hello world");
         service1.assertIsSatisfied();
 
         Task task = taskService.createTaskQuery().singleResult();
 
         // Ensure that the name of the task is correct.
-        assertEquals("Hello Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Hello Task");
 
         // Complete the task.
         taskService.complete(task.getId());

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiCamelVariableBodyTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiCamelVariableBodyTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.camel.cdi.std;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -75,13 +75,13 @@ public class CdiCamelVariableBodyTest extends StdCamelCdiFlowableTestCase {
         varMap.put("camelBody", "hello world");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HelloCamel", varMap);
         // Ensure that the variable is equal to the expected value.
-        assertEquals("hello world", runtimeService.getVariable(processInstance.getId(), "camelBody"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "camelBody")).isEqualTo("hello world");
         service1.assertIsSatisfied();
 
         Task task = taskService.createTaskQuery().singleResult();
 
         // Ensure that the name of the task is correct.
-        assertEquals("Hello Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Hello Task");
 
         // Complete the task.
         taskService.complete(task.getId());

--- a/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiSimpleProcessTest.java
+++ b/modules/flowable-camel-cdi/src/test/java/org/flowable/camel/cdi/std/CdiSimpleProcessTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.camel.cdi.std;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -90,18 +88,18 @@ public class CdiSimpleProcessTest extends StdCamelCdiFlowableTestCase {
         String instanceId = (String) exchange.getProperty("PROCESS_ID_PROPERTY");
 
         ProcessInstance processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
 
         tpl.sendBodyAndProperty("direct:receive", null, FlowableProducer.PROCESS_ID_PROPERTY, instanceId);
 
         // check process ended
         processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(instanceId).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         service1.assertIsSatisfied();
         Map<?, ?> m = service2.getExchanges().get(0).getIn().getBody(Map.class);
-        assertEquals("ala", m.get("var1"));
-        assertEquals("var2", m.get("var2"));
+        assertThat(m.get("var1")).isEqualTo("ala");
+        assertThat(m.get("var2")).isEqualTo("var2");
     }
 
 }


### PR DESCRIPTION
Straightforward conversion of the module to assertj style once the jar was added to the POM.
