### PR TITLE
Update assert fluent style in flowable-cmmn-json-converter module.

### DIFF
--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/CaseTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/CaseTaskJsonConverterTest.java
@@ -48,7 +48,6 @@ public class CaseTaskJsonConverterTest extends AbstractConverterTest {
         assertThat(planItem.getId()).isEqualTo("planItem1");
         assertThat(planItem.getName()).isEqualTo("caseTaskName");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(CaseTask.class);
         CaseTask caseTask = (CaseTask) planItemDefinition;
         assertThat(caseTask.getId()).isEqualTo("sid-E06221FA-0225-4EF8-A1E8-8DC177326B77");

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/CriterionConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/CriterionConverterTest.java
@@ -39,7 +39,7 @@ public class CriterionConverterTest extends AbstractConverterTest {
         
         PlanItem userEventListenerPlanItem = planModelStage.findPlanItemForPlanItemDefinitionInPlanFragmentOrDownwards("userEventListener1");
         assertThat(userEventListenerPlanItem).isNotNull();
-        assertThat(userEventListenerPlanItem.getOutgoingAssociations().size()).isEqualTo(1);
+        assertThat(userEventListenerPlanItem.getOutgoingAssociations()).hasSize(1);
         Association association = userEventListenerPlanItem.getOutgoingAssociations().get(0);
         assertThat(association.getSourceRef()).isNotNull();
         assertThat(planModelStage.findPlanItemInPlanFragmentOrDownwards(association.getSourceRef()).getPlanItemDefinition().getId()).isEqualTo("userEventListener1");
@@ -48,13 +48,13 @@ public class CriterionConverterTest extends AbstractConverterTest {
         Criterion exitCriterion = (Criterion) association.getTargetElement();
         assertThat(exitCriterion.getAttachedToRefId()).isNull();
         
-        assertThat(planModelStage.getExitCriteria().size()).isEqualTo(2);
+        assertThat(planModelStage.getExitCriteria()).hasSize(2);
         assertThat(planModelStage.getExitCriteria()).extracting(Criterion::getId)
                 .containsExactlyInAnyOrder("exitCriterion1", "exitCriterion2");
         
         Stage claimDecisionStage = (Stage) planModelStage.findPlanItemDefinitionInStageOrDownwards("claimDecisionStage");
         assertThat(claimDecisionStage).isNotNull();
-        assertThat(claimDecisionStage.getExitCriteria().size()).isEqualTo(2);
+        assertThat(claimDecisionStage.getExitCriteria()).hasSize(2);
         assertThat(claimDecisionStage.getExitCriteria()).extracting(Criterion::getId)
                 .containsExactlyInAnyOrder("acceptedExitCriterion", "rejectedExitCriterion");
     }

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/DecisionTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/DecisionTaskJsonConverterTest.java
@@ -48,7 +48,6 @@ public class DecisionTaskJsonConverterTest extends AbstractConverterTest {
         assertThat(planItem.getId()).isEqualTo("planItem1");
         assertThat(planItem.getName()).isEqualTo("dmnTask");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(DecisionTask.class);
         DecisionTask decisionTask = (DecisionTask) planItemDefinition;
         assertThat(decisionTask.getId()).isEqualTo("sid-F4BCA0C7-8737-4279-B50F-59272C7C65A2");

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/HttpTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/HttpTaskJsonConverterTest.java
@@ -50,7 +50,6 @@ public class HttpTaskJsonConverterTest extends AbstractConverterTest {
         assertThat(planItem.getId()).isEqualTo("planItem1");
         assertThat(planItem.getName()).isEqualTo("HttpTaskName");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(ServiceTask.class);
         ServiceTask serviceTask = (ServiceTask) planItemDefinition;
         assertThat(serviceTask.getType()).isEqualTo("http");

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/MailTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/MailTaskJsonConverterTest.java
@@ -41,7 +41,6 @@ public class MailTaskJsonConverterTest extends AbstractConverterTest {
         assertThat(planModelStage).isNotNull();
 
         PlanItemDefinition mailTaskDefinition = planModelStage.findPlanItemDefinitionInStageOrDownwards("mailTask");
-        assertThat(mailTaskDefinition).isNotNull();
         assertThat(mailTaskDefinition).isInstanceOf(ServiceTask.class);
         ServiceTask mailServiceTask = (ServiceTask) mailTaskDefinition;
         assertThat(mailServiceTask.getType()).isEqualTo(ServiceTask.MAIL_TASK);

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/ProcessTaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/ProcessTaskJsonConverterTest.java
@@ -46,7 +46,6 @@ public class ProcessTaskJsonConverterTest extends AbstractConverterTest {
         assertThat(planItem.getId()).isEqualTo("planItem1");
         assertThat(planItem.getName()).isEqualTo("processTaskName");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(ProcessTask.class);
         ProcessTask processTask = (ProcessTask) planItemDefinition;
         assertThat(processTask.getId()).isEqualTo("sid-5E1BEB30-72F7-463C-A1CB-77F000CA7E0F");

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SentryOnPartAssociationsConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SentryOnPartAssociationsConverterTest.java
@@ -62,13 +62,10 @@ public class SentryOnPartAssociationsConverterTest extends AbstractConverterTest
         Map<String, List<Association>> byRelationShip = associations.stream()
                 .collect(Collectors.groupingBy(a -> buildAssociationString(model, a)));
 
-        assertThat(byRelationShip).hasSize(5);
-        assertThat(byRelationShip.containsKey("taskA|taskC|complete")).isTrue();
-        assertThat(byRelationShip.containsKey("taskB|taskC|complete")).isTrue();
-        assertThat(byRelationShip.containsKey("stage1|stage2|terminate")).isTrue();
-        //EXIT CRITERIA ARE "READ" BACKWARDS
-        assertThat(byRelationShip.containsKey("timedTask|expireTimer|occur")).isTrue();
-        assertThat(byRelationShip.containsKey("stage2|abortStageTask|complete")).isTrue();
+        assertThat(byRelationShip)
+                .containsOnlyKeys("taskA|taskC|complete", "taskB|taskC|complete", "stage1|stage2|terminate",
+                        //EXIT CRITERIA ARE "READ" BACKWARDS
+                        "timedTask|expireTimer|occur", "stage2|abortStageTask|complete");
 
         //Coordinates of associations are recalculated based on other elements?
         //This is only a stub that checks the "approximate" coordinates of 1 association

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SimpleConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/SimpleConverterTest.java
@@ -57,7 +57,6 @@ public class SimpleConverterTest extends AbstractConverterTest {
         assertThat(planItem.getId()).isEqualTo("planItem1");
         assertThat(planItem.getName()).isEqualTo("Task B");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         HumanTask humanTask = (HumanTask) planItemDefinition;
         assertThat(humanTask.getId()).isEqualTo("task1");

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/StageConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/StageConverterTest.java
@@ -63,7 +63,6 @@ public class StageConverterTest extends AbstractConverterTest {
         assertThat(planItem.getId()).isEqualTo("planItem1");
         assertThat(planItem.getName()).isEqualTo("Task");
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         HumanTask humanTask = (HumanTask) planItemDefinition;
         assertThat(humanTask.getId()).isEqualTo("task1");
@@ -83,7 +82,6 @@ public class StageConverterTest extends AbstractConverterTest {
         assertThat(taskPlanItem.getId()).isEqualTo("planItem2");
         assertThat(taskPlanItem.getName()).isEqualTo("Task2");
         planItemDefinition = taskPlanItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         humanTask = (HumanTask) planItemDefinition;
         assertThat(humanTask.getId()).isEqualTo("task2");
@@ -103,7 +101,6 @@ public class StageConverterTest extends AbstractConverterTest {
         assertThat(milestonePlanItem.getId()).isEqualTo("planItem6");
         assertThat(milestonePlanItem.getName()).isEqualTo("Milestone 1");
         planItemDefinition = milestonePlanItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(Milestone.class);
         Milestone milestone = (Milestone) planItemDefinition;
         assertThat(milestone.getId()).isEqualTo("milestone1");
@@ -144,7 +141,6 @@ public class StageConverterTest extends AbstractConverterTest {
         assertThat(stagePlanItem.getId()).isEqualTo("planItem5");
         assertThat(stagePlanItem.getName()).isEqualTo("Child stage");
         planItemDefinition = stagePlanItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(Stage.class);
         Stage stage = (Stage) planItemDefinition;
         assertThat(stage.getId()).isEqualTo("childStage");
@@ -166,7 +162,6 @@ public class StageConverterTest extends AbstractConverterTest {
         assertThat(subPlanItem1.getId()).isEqualTo("planItem3");
         assertThat(subPlanItem1.getName()).isEqualTo("Sub task 1");
         planItemDefinition = subPlanItem1.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         humanTask = (HumanTask) planItemDefinition;
         assertThat(humanTask.getId()).isEqualTo("subTask1");
@@ -187,7 +182,6 @@ public class StageConverterTest extends AbstractConverterTest {
         assertThat(subPlanItem2.getId()).isEqualTo("planItem4");
         assertThat(subPlanItem2.getName()).isEqualTo("Sub task 2");
         planItemDefinition = subPlanItem2.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(HumanTask.class);
         humanTask = (HumanTask) planItemDefinition;
         assertThat(humanTask.getId()).isEqualTo("subTask2");

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/TaskJsonConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/TaskJsonConverterTest.java
@@ -56,7 +56,6 @@ public class TaskJsonConverterTest extends AbstractConverterTest {
         assertThat(planItem.getName()).isEqualTo("shareniu_task");
 
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
-        assertThat(planItemDefinition).isNotNull();
         assertThat(planItemDefinition).isInstanceOf(Task.class);
 
         Task task = (Task) planItemDefinition;
@@ -70,7 +69,6 @@ public class TaskJsonConverterTest extends AbstractConverterTest {
         assertThat(planItem2.getName()).isEqualTo("shareniu_human_task");
 
         PlanItemDefinition planItemDefinition2 = planItem2.getPlanItemDefinition();
-        assertThat(planItemDefinition2).isNotNull();
         assertThat(planItemDefinition2).isInstanceOf(HumanTask.class);
 
         HumanTask humanTask = (HumanTask) planItemDefinition2;

--- a/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/UserEventListenerConverterTest.java
+++ b/modules/flowable-cmmn-json-converter/src/test/java/org/flowable/cmmn/editor/UserEventListenerConverterTest.java
@@ -43,12 +43,8 @@ public class UserEventListenerConverterTest extends AbstractConverterTest {
     @Override
     protected void validateModel(CmmnModel cmmnModel) {
         Stage model = cmmnModel.getPrimaryCase().getPlanModel();
-        assertThat(model.getPlanItemDefinitionMap()).hasSize(4);
-
-        assertThat(model.getPlanItemDefinitionMap().get("taskA")).isNotNull();
-        assertThat(model.getPlanItemDefinitionMap().get("taskB")).isNotNull();
-        assertThat(model.getPlanItemDefinitionMap().get("startTaskAUserEvent")).isNotNull();
-        assertThat(model.getPlanItemDefinitionMap().get("stopTaskBUserEvent")).isNotNull();
+        assertThat(model.getPlanItemDefinitionMap())
+                .containsOnlyKeys("taskA", "taskB", "startTaskAUserEvent", "stopTaskBUserEvent");
 
         Map<String, Sentry> sentries = model.getSentries().stream()
                 .collect(Collectors.toMap(Sentry::getName, Function.identity(), (s1, s2) -> s1));


### PR DESCRIPTION
Minor updates to `org.flowable.cmmn.editor` package.  Two biggest changes is removing `isNotNull` test before `isInstanceOf` as it is covered in the later test and combing "only have specific keys" tests.
