### PR TITLE
Use assertj fluent style in flowable-content-spring module.

### DIFF
--- a/modules/flowable-content-spring/pom.xml
+++ b/modules/flowable-content-spring/pom.xml
@@ -139,6 +139,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-content-spring/src/test/java/org/flowable/spring/test/engine/SpringContentEngineTest.java
+++ b/modules/flowable-content-spring/src/test/java/org/flowable/spring/test/engine/SpringContentEngineTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.spring.test.engine;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.content.engine.ContentEngines;
 import org.junit.Test;
@@ -31,8 +31,8 @@ public class SpringContentEngineTest {
 
     @Test
     public void testGetEngineFromCache() {
-        assertNotNull(ContentEngines.getDefaultContentEngine());
-        assertNotNull(ContentEngines.getContentEngine("default"));
+        assertThat(ContentEngines.getDefaultContentEngine()).isNotNull();
+        assertThat(ContentEngines.getContentEngine("default")).isNotNull();
     }
 
 }


### PR DESCRIPTION
Straightforward conversion of the module to assertj style once the jar was added to the POM.
