### PR TITLE
Use assertj fluent style in flowable-cxf module.

### DIFF
--- a/modules/flowable-cxf/pom.xml
+++ b/modules/flowable-cxf/pom.xml
@@ -145,6 +145,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WSDLImporterTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WSDLImporterTest.java
@@ -12,8 +12,8 @@
  */
 package org.flowable.engine.impl.webservice;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -48,16 +48,16 @@ public class WSDLImporterTest {
         importer.importFrom(url.toString());
 
         List<WSService> services = new ArrayList<>(importer.getServices().values());
-        assertEquals(1, services.size());
+        assertThat(services).hasSize(1);
         WSService service = services.get(0);
 
-        assertEquals("Counter", service.getName());
-        assertEquals("http://localhost:63081/webservicemock", service.getLocation());
+        assertThat(service.getName()).isEqualTo("Counter");
+        assertThat(service.getLocation()).isEqualTo("http://localhost:63081/webservicemock");
 
         List<StructureDefinition> structures = sortStructures();
         List<WSOperation> operations = sortOperations();
 
-        assertEquals(7, operations.size());
+        assertThat(operations).hasSize(7);
         this.assertOperation(operations.get(0), "getCount", service);
         this.assertOperation(operations.get(1), "inc", service);
         this.assertOperation(operations.get(2), "noNameResult", service);
@@ -66,7 +66,7 @@ public class WSDLImporterTest {
         this.assertOperation(operations.get(5), "reset", service);
         this.assertOperation(operations.get(6), "setTo", service);
 
-        assertEquals(14, structures.size());
+        assertThat(structures).hasSize(14);
         this.assertStructure(structures.get(0), "getCount", new String[] {}, new Class<?>[] {});
         this.assertStructure(structures.get(1), "getCountResponse", new String[] { "count" }, new Class<?>[] { Integer.class });
         this.assertStructure(structures.get(2), "inc", new String[] {}, new Class<?>[] {});
@@ -89,16 +89,15 @@ public class WSDLImporterTest {
         importer.importFrom(url.toString());
 
         List<WSService> services = new ArrayList<>(importer.getServices().values());
-        assertEquals(1, services.size());
-        WSService service = services.get(0);
-
-        assertEquals("Counter", service.getName());
-        assertEquals("http://localhost:63081/webservicemock", service.getLocation());
+        assertThat(services)
+                .extracting(WSService::getName, WSService::getLocation)
+                .containsExactly(tuple("Counter", "http://localhost:63081/webservicemock"));
 
         List<StructureDefinition> structures = sortStructures();
         List<WSOperation> operations = sortOperations();
 
-        assertEquals(7, operations.size());
+        WSService service = services.get(0);
+        assertThat(operations).hasSize(7);
         this.assertOperation(operations.get(0), "getCount", service);
         this.assertOperation(operations.get(1), "inc", service);
         this.assertOperation(operations.get(2), "noNameResult", service);
@@ -107,7 +106,7 @@ public class WSDLImporterTest {
         this.assertOperation(operations.get(5), "reset", service);
         this.assertOperation(operations.get(6), "setTo", service);
 
-        assertEquals(14, structures.size());
+        assertThat(structures).hasSize(14);
         this.assertStructure(structures.get(0), "getCount", new String[] {}, new Class<?>[] {});
         this.assertStructure(structures.get(1), "getCountResponse", new String[] { "count" }, new Class<?>[] { Integer.class });
         this.assertStructure(structures.get(2), "inc", new String[] {}, new Class<?>[] {});
@@ -147,39 +146,39 @@ public class WSDLImporterTest {
     }
 
     private void assertOperation(WSOperation wsOperation, String name, WSService service) {
-        assertEquals(name, wsOperation.getName());
-        assertEquals(service, wsOperation.getService());
+        assertThat(wsOperation.getName()).isEqualTo(name);
+        assertThat(wsOperation.getService()).isEqualTo(service);
     }
 
     private void assertStructure(StructureDefinition structure, String structureId, String[] parameters, Class<?>[] classes) {
         SimpleStructureDefinition simpleStructure = (SimpleStructureDefinition) structure;
 
-        assertEquals(structureId, simpleStructure.getId());
+        assertThat(simpleStructure.getId()).isEqualTo(structureId);
 
         for (int i = 0; i < simpleStructure.getFieldSize(); i++) {
-            assertEquals(parameters[i], simpleStructure.getFieldNameAt(i));
-            assertEquals(classes[i], simpleStructure.getFieldTypeAt(i));
+            assertThat(simpleStructure.getFieldNameAt(i)).isEqualTo(parameters[i]);
+            assertThat(simpleStructure.getFieldTypeAt(i)).isEqualTo(classes[i]);
         }
     }
 
     @Test
     public void testImportInheritedElement() throws Exception {
         URL url = ReflectUtil.getResource("org/flowable/engine/impl/webservice/inherited-elements-in-types.wsdl");
-        assertNotNull(url);
+        assertThat(url).isNotNull();
         importer.importFrom(url.toString());
 
         List<StructureDefinition> structures = sortStructures();
-        assertEquals(1, structures.size());
+        assertThat(structures).hasSize(1);
         final Object structureTypeInst = ReflectUtil.instantiate("org.flowable.webservice.counter.StructureType");
         final Class<? extends Object> structureType = structureTypeInst.getClass();
         this.assertStructure(structures.get(0), "inheritedRequest", new String[] { "rootElt", "inheritedElt", "newSimpleElt",
                 "newStructuredElt" }, new Class<?>[] { Short.class, Integer.class, String.class, structureType });
         List<Field> declaredFields = filterJacoco(structureType.getDeclaredFields());
-        assertEquals(2, declaredFields.size());
-        assertNotNull(structureType.getDeclaredField("booleanElt"));
-        assertNotNull(structureType.getDeclaredField("dateElt"));
-        assertEquals(1, filterJacoco(structureType.getSuperclass().getDeclaredFields()).size());
-        assertNotNull(structureType.getSuperclass().getDeclaredField("rootElt"));
+        assertThat(declaredFields).hasSize(2);
+        assertThat(structureType.getDeclaredField("booleanElt")).isNotNull();
+        assertThat(structureType.getDeclaredField("dateElt")).isNotNull();
+        assertThat(filterJacoco(structureType.getSuperclass().getDeclaredFields())).hasSize(1);
+        assertThat(structureType.getSuperclass().getDeclaredField("rootElt")).isNotNull();
     }
 
     protected List<Field> filterJacoco(Field[] declaredFields) {
@@ -191,7 +190,7 @@ public class WSDLImporterTest {
     @Test
     public void testImportBasicElement() throws Exception {
         URL url = ReflectUtil.getResource("org/flowable/engine/impl/webservice/basic-elements-in-types.wsdl");
-        assertNotNull(url);
+        assertThat(url).isNotNull();
         importer.importFrom(url.toString());
     }
 

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/sendtask/WebServiceSimplisticTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/sendtask/WebServiceSimplisticTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.sendtask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +35,7 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
     @Test
     @Deployment
     public void testAsyncInvocationWithSimplisticDataFlow() throws Exception {
-        assertEquals(-1, webServiceMock.getCount());
+        assertThat(webServiceMock.getCount()).isEqualTo(-1);
 
         Map<String, Object> variables = new HashMap<>();
         variables.put("NewCounterValueVariable", 23);
@@ -41,6 +43,6 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
         processEngine.getRuntimeService().startProcessInstanceByKey("asyncWebServiceInvocationWithSimplisticDataFlow", variables);
         waitForJobExecutorToProcessAllJobs(10000L, 250L);
 
-        assertEquals(23, webServiceMock.getCount());
+        assertThat(webServiceMock.getCount()).isEqualTo(23);
     }
 }

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/sendtask/WebServiceTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/sendtask/WebServiceTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.sendtask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.bpmn.servicetask.AbstractWebServiceTaskTest;
 import org.junit.jupiter.api.Test;
@@ -25,11 +27,11 @@ public class WebServiceTest extends AbstractWebServiceTaskTest {
     @Test
     @Deployment
     public void testAsyncInvocationWithoutDataFlow() throws Exception {
-        assertEquals(-1, webServiceMock.getCount());
+        assertThat(webServiceMock.getCount()).isEqualTo(-1);
 
         processEngine.getRuntimeService().startProcessInstanceByKey("asyncWebServiceInvocationWithoutDataFlow");
         waitForJobExecutorToProcessAllJobs(10000L, 250L);
 
-        assertEquals(0, webServiceMock.getCount());
+        assertThat(webServiceMock.getCount()).isZero();
     }
 }

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/WebServiceSimplisticTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/WebServiceSimplisticTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.servicetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,7 +42,7 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
         waitForJobExecutorToProcessAllJobs(10000L, 250L);
 
         String response = (String) processEngine.getRuntimeService().getVariable(instance.getId(), "OutputVariable");
-        assertEquals("The counter has the value -1. Good news", response);
+        assertThat(response).isEqualTo("The counter has the value -1. Good news");
     }
 
     @Test
@@ -54,7 +56,7 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
         waitForJobExecutorToProcessAllJobs(10000L, 250L);
 
         String response = (String) processEngine.getRuntimeService().getVariable(instance.getId(), "OutputVariable");
-        assertEquals("The counter has the value -1. Good news (NO NAME)", response);
+        assertThat(response).isEqualTo("The counter has the value -1. Good news (NO NAME)");
     }
 
     @Test
@@ -68,6 +70,6 @@ public class WebServiceSimplisticTest extends AbstractWebServiceTaskTest {
         waitForJobExecutorToProcessAllJobs(10000L, 250L);
 
         String response = (String) processEngine.getRuntimeService().getVariable(instance.getId(), "OutputVariable");
-        assertEquals("The counter has the value -1. Good news Keyword", response);
+        assertThat(response).isEqualTo("The counter has the value -1. Good news Keyword");
     }
 }

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/WebServiceTaskTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/test/bpmn/servicetask/WebServiceTaskTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.servicetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.test.Deployment;
 import org.junit.jupiter.api.Test;
 
@@ -23,11 +25,11 @@ public class WebServiceTaskTest extends AbstractWebServiceTaskTest {
     @Test
     @Deployment
     public void testWebServiceInvocationWithoutDataFlow() throws Exception {
-        assertEquals(-1, webServiceMock.getCount());
+        assertThat(webServiceMock.getCount()).isEqualTo(-1);
 
         processEngine.getRuntimeService().startProcessInstanceByKey("webServiceInvocationWithoutDataFlow");
         waitForJobExecutorToProcessAllJobs(10000L, 250L);
 
-        assertEquals(0, webServiceMock.getCount());
+        assertThat(webServiceMock.getCount()).isZero();
     }
 }


### PR DESCRIPTION
For the most part a straightforward conversion of the module to assertj style once the jar was added to the POM.  Especially true after Filip fixed a test that wasn't working at all. 👍 
