### PR TITLE
Update assertj fluent style in flowable-cdi module.

### DIFF
--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/BusinessKeyTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/BusinessKeyTest.java
@@ -12,11 +12,12 @@
  */
 package org.flowable.cdi.test.api.annotation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.cdi.BusinessProcess;
 import org.flowable.cdi.impl.util.ProgrammaticBeanLookup;
 import org.flowable.cdi.test.CdiFlowableTestCase;
 import org.flowable.engine.test.Deployment;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -33,7 +34,7 @@ public class BusinessKeyTest extends CdiFlowableTestCase {
         getBeanInstance(BusinessProcess.class).associateExecutionById(pid);
 
         // assert that now the businessKey-Bean can be looked up:
-        Assert.assertEquals(businessKey, ProgrammaticBeanLookup.lookup("businessKey"));
+        assertThat(ProgrammaticBeanLookup.lookup("businessKey")).isEqualTo(businessKey);
 
     }
 }

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/CompleteTaskTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/CompleteTaskTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.cdi.test.api.annotation;
 
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cdi.BusinessProcess;
 import org.flowable.cdi.impl.annotation.CompleteTaskInterceptor;
@@ -45,7 +45,7 @@ public class CompleteTaskTest extends CdiFlowableTestCase {
         getBeanInstance(DeclarativeProcessController.class).completeTask();
 
         // assert that now the task is completed
-        assertNull(taskService.createTaskQuery().singleResult());
+        assertThat(taskService.createTaskQuery().singleResult()).isNull();
     }
 
 }

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/ProcessIdTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/ProcessIdTest.java
@@ -12,11 +12,12 @@
  */
 package org.flowable.cdi.test.api.annotation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.cdi.BusinessProcess;
 import org.flowable.cdi.test.CdiFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,7 +32,7 @@ public class ProcessIdTest extends CdiFlowableTestCase {
     @Deployment
     public void testProcessIdInjectable() {
         getBeanInstance(BusinessProcess.class).startProcessByKey("keyOfTheProcess");
-        Assert.assertNotNull(getBeanInstance("processInstanceId"));
+        assertThat(getBeanInstance("processInstanceId")).isNotNull();
     }
 
 }

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/StartProcessTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/StartProcessTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cdi.test.api.annotation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cdi.BusinessProcess;
 import org.flowable.cdi.impl.annotation.StartProcessInterceptor;
@@ -34,14 +32,14 @@ public class StartProcessTest extends CdiFlowableTestCase {
     @Deployment(resources = "org/flowable/cdi/test/api/annotation/StartProcessTest.bpmn20.xml")
     public void testStartProcessByKey() {
 
-        assertNull(runtimeService.createProcessInstanceQuery().singleResult());
+        assertThat(runtimeService.createProcessInstanceQuery().singleResult()).isNull();
 
         getBeanInstance(DeclarativeProcessController.class).startProcessByKey();
         BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
-        assertNotNull(runtimeService.createProcessInstanceQuery().singleResult());
+        assertThat(runtimeService.createProcessInstanceQuery().singleResult()).isNotNull();
 
-        assertEquals("Flowable", businessProcess.getVariable("name"));
+        assertThat((String)businessProcess.getVariable("name")).isEqualTo("Flowable");
 
         businessProcess.startTask(taskService.createTaskQuery().singleResult().getId());
         businessProcess.completeTask();
@@ -51,15 +49,15 @@ public class StartProcessTest extends CdiFlowableTestCase {
     @Deployment(resources = "org/flowable/cdi/test/api/annotation/StartProcessTest.bpmn20.xml")
     public void testStartProcessByName() {
 
-        assertNull(runtimeService.createProcessInstanceQuery().singleResult());
+        assertThat(runtimeService.createProcessInstanceQuery().singleResult()).isNull();
 
         getBeanInstance(DeclarativeProcessController.class).startProcessByName();
 
         BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
-        assertNotNull(runtimeService.createProcessInstanceQuery().singleResult());
+        assertThat(runtimeService.createProcessInstanceQuery().singleResult()).isNotNull();
 
-        assertEquals("Flowable", businessProcess.getVariable("name"));
+        assertThat((String)businessProcess.getVariable("name")).isEqualTo("Flowable");
 
         businessProcess.startTask(taskService.createTaskQuery().singleResult().getId());
         businessProcess.completeTask();

--- a/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/TaskIdTest.java
+++ b/modules/flowable-cdi/src/test/java/org/flowable/cdi/test/api/annotation/TaskIdTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.cdi.test.api.annotation;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.cdi.BusinessProcess;
 import org.flowable.cdi.test.CdiFlowableTestCase;
@@ -34,7 +34,7 @@ public class TaskIdTest extends CdiFlowableTestCase {
         businessProcess.startTask(taskService.createTaskQuery().singleResult().getId());
 
         // assert that now the 'taskId'-bean can be looked up
-        assertNotNull(getBeanInstance("taskId"));
+        assertThat(getBeanInstance("taskId")).isNotNull();
 
         businessProcess.completeTask();
     }


### PR DESCRIPTION
I missed a subdirectory in the recent update to the `flowable-cdi` module.  This fixes the oversight.
