### PR TITLE
Update assertj fluent style in flowable-content-rest module.

### DIFF
--- a/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.content.rest.service.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -56,7 +58,6 @@ import org.flowable.content.rest.util.TestServerUtil.TestServer;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -180,7 +181,7 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
                 request.addHeader(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"));
             }
             response = client.execute(request);
-            Assert.assertNotNull(response.getStatusLine());
+            assertThat(response.getStatusLine()).isNotNull();
 
             int responseStatusCode = response.getStatusLine().getStatusCode();
             if (expectedStatusCode != responseStatusCode) {
@@ -188,14 +189,14 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
                 LOGGER.info("Response body: {}", IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8));
             }
 
-            Assert.assertEquals(expectedStatusCode, responseStatusCode);
+            assertThat(responseStatusCode).isEqualTo(expectedStatusCode);
             httpResponses.add(response);
             return response;
 
         } catch (ClientProtocolException e) {
-            Assert.fail(e.getMessage());
+            fail(e.getMessage());
         } catch (IOException e) {
-            Assert.fail(e.getMessage());
+            fail(e.getMessage());
         }
         return null;
     }


### PR DESCRIPTION
Update a file that was over looked when the module was originally converted to assertj.
