### PR TITLE
Use assertj fluent style in flowable-dmn-rest module.

### DIFF
--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -133,6 +133,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/BaseSpringDmnRestTestCase.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/BaseSpringDmnRestTestCase.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.rest.service.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -41,9 +43,9 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 import org.eclipse.jetty.server.Server;
+import org.flowable.dmn.api.DmnDecisionService;
 import org.flowable.dmn.api.DmnHistoryService;
 import org.flowable.dmn.api.DmnRepositoryService;
-import org.flowable.dmn.api.DmnDecisionService;
 import org.flowable.dmn.engine.DmnEngine;
 import org.flowable.dmn.engine.DmnEngineConfiguration;
 import org.flowable.dmn.engine.DmnEngines;
@@ -52,7 +54,6 @@ import org.flowable.dmn.engine.test.DmnTestHelper;
 import org.flowable.dmn.rest.conf.ApplicationConfiguration;
 import org.flowable.dmn.rest.util.TestServerUtil;
 import org.flowable.dmn.rest.util.TestServerUtil.TestServer;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -180,7 +181,7 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
                 request.addHeader(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"));
             }
             response = client.execute(request);
-            Assert.assertNotNull(response.getStatusLine());
+            assertThat(response.getStatusLine()).isNotNull();
 
             int responseStatusCode = response.getStatusLine().getStatusCode();
             if (expectedStatusCode != responseStatusCode) {
@@ -188,14 +189,14 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
                 LOGGER.info("Response body: {}", IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8));
             }
 
-            Assert.assertEquals(expectedStatusCode, responseStatusCode);
+            assertThat(responseStatusCode).isEqualTo(expectedStatusCode);
             httpResponses.add(response);
             return response;
 
         } catch (ClientProtocolException e) {
-            Assert.fail(e.getMessage());
+            fail(e.getMessage());
         } catch (IOException e) {
-            Assert.fail(e.getMessage());
+            fail(e.getMessage());
         }
         return null;
     }
@@ -246,7 +247,7 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         List<String> toBeFound = new ArrayList<>(Arrays.asList(expectedResourceIds));
@@ -255,7 +256,9 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
             String id = it.next().get("id").textValue();
             toBeFound.remove(id);
         }
-        assertTrue("Not all expected ids have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+        assertThat(toBeFound)
+                .as("Not all expected ids have been found in result, missing: " + StringUtils.join(toBeFound, ", "))
+                .isEmpty();
     }
 
     protected void assertResultsPresentInPostDataResponseWithStatusCheck(String url, ObjectNode body, int expectedStatusCode, String... expectedResourceIds) throws JsonProcessingException, IOException {
@@ -273,7 +276,7 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
             // Check status and size
             JsonNode rootNode = objectMapper.readTree(response.getEntity().getContent());
             JsonNode dataNode = rootNode.get("data");
-            assertEquals(numberOfResultsExpected, dataNode.size());
+            assertThat(dataNode).hasSize(numberOfResultsExpected);
 
             // Check presence of ID's
             if (expectedResourceIds != null) {
@@ -283,7 +286,9 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
                     String id = it.next().get("id").textValue();
                     toBeFound.remove(id);
                 }
-                assertTrue("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+                assertThat(toBeFound)
+                        .as("Not all expected ids have been found in result, missing: " + StringUtils.join(toBeFound, ", "))
+                        .isEmpty();
             }
         }
 

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/decision/DmnRuleServiceResourceTest.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/decision/DmnRuleServiceResourceTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.rest.service.api.decision;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -55,7 +57,7 @@ public class DmnRuleServiceResourceTest extends BaseSpringDmnRestTestCase {
 
         ArrayNode resultVariables = (ArrayNode) responseNode.get("resultVariables");
 
-        assertEquals(3, resultVariables.size());
+        assertThat(resultVariables).hasSize(3);
     }
 
 
@@ -91,7 +93,7 @@ public class DmnRuleServiceResourceTest extends BaseSpringDmnRestTestCase {
 
         ArrayNode resultVariables = (ArrayNode) responseNode.get("resultVariables");
 
-        assertEquals(1, resultVariables.size());
+        assertThat(resultVariables).hasSize(1);
     }
 
 

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/history/HistoricDecisionExecutionAuditDataResourceTest.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/history/HistoricDecisionExecutionAuditDataResourceTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.dmn.rest.service.api.history;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -27,6 +30,8 @@ import org.flowable.dmn.rest.service.api.DmnRestUrls;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Tijs Rademakers
@@ -49,11 +54,15 @@ public class HistoricDecisionExecutionAuditDataResourceTest extends BaseSpringDm
         // Check "OK" status
         String content = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
         closeResponse(response);
-        assertNotNull(content);
+        assertThat(content).isNotNull();
         
         JsonNode auditNode = new ObjectMapper().readTree(content);
-        assertEquals("decision", auditNode.get("decisionKey").asText());
-        assertEquals("Full Decision", auditNode.get("decisionName").asText());
+        assertThatJson(auditNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "   decisionKey: 'decision',"
+                        + "   decisionName: 'Full Decision'"
+                        + " }");
     }
 
     public void testGetDecisionTableResourceForUnexistingDecisionTable() throws Exception {
@@ -61,7 +70,11 @@ public class HistoricDecisionExecutionAuditDataResourceTest extends BaseSpringDm
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_NOT_FOUND);
         try (InputStream contentStream = response.getEntity().getContent()) {
             JsonNode errorNode = objectMapper.readTree(contentStream);
-            assertEquals("Could not find a decision execution with id 'unexisting'", errorNode.get("exception").textValue());
+            assertThatJson(errorNode)
+                    .when(Option.IGNORING_EXTRA_FIELDS)
+                    .isEqualTo("{"
+                            + "   exception: 'Could not find a decision execution with id \\'unexisting\\''"
+                            + " }");
         }
         closeResponse(response);
     }

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/history/HistoricDecisionExecutionCollectionResourceTest.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/history/HistoricDecisionExecutionCollectionResourceTest.java
@@ -18,8 +18,6 @@ import java.util.Map;
 
 import org.flowable.dmn.api.DmnDecision;
 import org.flowable.dmn.api.DmnDeployment;
-import org.flowable.dmn.api.DmnHistoricDecisionExecution;
-import org.flowable.dmn.api.DmnHistoricDecisionExecutionQuery;
 import org.flowable.dmn.rest.service.api.BaseSpringDmnRestTestCase;
 import org.flowable.dmn.rest.service.api.DmnRestUrls;
 

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DecisionTableCollectionResourceTest.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DecisionTableCollectionResourceTest.java
@@ -83,7 +83,7 @@ public class DecisionTableCollectionResourceTest extends BaseSpringDmnRestTestCa
             url = baseUrl + "?latest=true";
             assertResultsPresentInDataResponse(url, latestDefinition.getId(), decisionTwo.getId());
             url = baseUrl + "?latest=false";
-            assertResultsPresentInDataResponse(baseUrl, firstDefinition.getId(), latestDefinition.getId(), decisionTwo.getId());
+            assertResultsPresentInDataResponse(url, firstDefinition.getId(), latestDefinition.getId(), decisionTwo.getId());
 
             // Test deploymentId
             url = baseUrl + "?deploymentId=" + secondDeployment.getId();

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DecisionTableModelResourceTest.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DecisionTableModelResourceTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.dmn.rest.service.api.repository;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -21,6 +24,8 @@ import org.flowable.dmn.rest.service.api.BaseSpringDmnRestTestCase;
 import org.flowable.dmn.rest.service.api.DmnRestUrls;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Yvo Swillens
@@ -38,11 +43,15 @@ public class DecisionTableModelResourceTest extends BaseSpringDmnRestTestCase {
         // Check "OK" status
         JsonNode resultNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertNotNull(resultNode);
+        assertThat(resultNode).isNotNull();
         JsonNode firstDecision = resultNode.get("decisions").get(0);
-        assertNotNull(firstDecision);
+        assertThat(firstDecision).isNotNull();
 
         JsonNode decisionTableNode = firstDecision.get("expression");
-        assertEquals("decisionTable", decisionTableNode.get("id").textValue());
+        assertThatJson(decisionTableNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "   id: 'decisionTable'"
+                        + " }");
     }
 }

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DecisionTableResourceDataResourceTest.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DecisionTableResourceDataResourceTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.rest.service.api.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
@@ -39,8 +41,8 @@ public class DecisionTableResourceDataResourceTest extends BaseSpringDmnRestTest
         // Check "OK" status
         String content = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
         closeResponse(response);
-        assertNotNull(content);
-        assertTrue(content.contains("Full Decision"));
+        assertThat(content).isNotNull();
+        assertThat(content.contains("Full Decision")).isTrue();
     }
 
     public void testGetDecisionTableResourceForUnexistingDecisionTable() throws Exception {

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DecisionTableResourceTest.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DecisionTableResourceTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.rest.service.api.repository;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -21,6 +23,8 @@ import org.flowable.dmn.rest.service.api.BaseSpringDmnRestTestCase;
 import org.flowable.dmn.rest.service.api.DmnRestUrls;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import net.javacrumbs.jsonunit.core.Option;
 
 /**
  * @author Yvo Swillens
@@ -36,16 +40,19 @@ public class DecisionTableResourceTest extends BaseSpringDmnRestTestCase {
         CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
         JsonNode responseNode = objectMapper.readTree(response.getEntity().getContent());
         closeResponse(response);
-        assertEquals(definition.getId(), responseNode.get("id").textValue());
-        assertEquals(definition.getKey(), responseNode.get("key").textValue());
-        assertEquals(definition.getCategory(), responseNode.get("category").textValue());
-        assertEquals(definition.getVersion(), responseNode.get("version").intValue());
-        assertEquals(definition.getDescription(), responseNode.get("description").textValue());
-        assertEquals(definition.getName(), responseNode.get("name").textValue());
-
-        // Check URL's
-        assertEquals(httpGet.getURI().toString(), responseNode.get("url").asText());
-        assertEquals(definition.getDeploymentId(), responseNode.get("deploymentId").textValue());
+        assertThatJson(responseNode)
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  id: '" + definition.getId() + "',"
+                        + "  url: '" + httpGet.getURI().toString() + "',"
+                        + "  category: " + definition.getCategory() + ","
+                        + "  name: '" + definition.getName() + "',"
+                        + "  key: '" + definition.getKey() + "',"
+                        + "  description: " + definition.getDescription() + ","
+                        + "  version: " + definition.getVersion() + ","
+                        + "  deploymentId: '" + definition.getDeploymentId() + "'"
+                        + "  }"
+                );
     }
 
     @DmnDeployment(resources = { "org/flowable/dmn/rest/service/api/repository/simple.dmn" })

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DmnDeploymentResourceDataResourceTest.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/repository/DmnDeploymentResourceDataResourceTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.rest.service.api.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -41,8 +43,8 @@ public class DmnDeploymentResourceDataResourceTest extends BaseSpringDmnRestTest
             CloseableHttpResponse response = executeRequest(httpGet, HttpStatus.SC_OK);
             String responseAsString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             closeResponse(response);
-            assertNotNull(responseAsString);
-            assertEquals("Test content", responseAsString);
+            assertThat(responseAsString).isNotNull();
+            assertThat(responseAsString).isEqualTo("Test content");
         } finally {
             // Always cleanup any created deployments, even if the test failed
             List<DmnDeployment> deployments = dmnRepositoryService.createDeploymentQuery().list();


### PR DESCRIPTION
Fairly straight forward conversion once assertj and json-unit jars were added to the pom.

Also removed unused imports and fixed a test that was using the wrong variable (probably a cut-n-paste issue).
