### PR TITLE
Update assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataDeleteTest.java
@@ -93,7 +93,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
                     
             query.delete();
 
-            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
             assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
@@ -106,9 +106,9 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
                     
             historyService.deleteTaskAndActivityDataOfRemovedHistoricProcessInstances();
 
-            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
-            assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
-            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
             assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId()).size()).isGreaterThan(0);
             assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTaskTest.java
@@ -12,10 +12,11 @@
  */
 package org.flowable.engine.test.bpmn.exclusive;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
-import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,13 +32,13 @@ public class ExclusiveTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("exclusive");
         // now there should be 1 non-exclusive job in the database:
         Job job = managementService.createJobQuery().singleResult();
-        assertNotNull(job);
-        assertFalse(((JobEntity) job).isExclusive());
+        assertThat(job).isNotNull();
+        assertThat(job.isExclusive()).isFalse();
 
         waitForJobExecutorToProcessAllJobs(6000L, 100L);
 
         // all the jobs are done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     @Test
@@ -47,13 +48,13 @@ public class ExclusiveTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("exclusive");
         // now there should be 1 exclusive job in the database:
         Job job = managementService.createJobQuery().singleResult();
-        assertNotNull(job);
-        assertTrue(((JobEntity) job).isExclusive());
+        assertThat(job).isNotNull();
+        assertThat(job.isExclusive()).isTrue();
 
         waitForJobExecutorToProcessAllJobs(6000L, 100L);
 
         // all the jobs are done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
     @Test
@@ -62,12 +63,12 @@ public class ExclusiveTaskTest extends PluggableFlowableTestCase {
         // start process
         runtimeService.startProcessInstanceByKey("exclusive");
         // now there should be 3 exclusive jobs in the database:
-        assertEquals(3, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isEqualTo(3);
 
         waitForJobExecutorToProcessAllJobs(20000L, 400L);
 
         // all the jobs are done
-        assertEquals(0, managementService.createJobQuery().count());
+        assertThat(managementService.createJobQuery().count()).isZero();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/exclusive/ExclusiveTimerEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.exclusive;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -32,13 +34,13 @@ public class ExclusiveTimerEventTest extends PluggableFlowableTestCase {
         // After process start, there should be 3 timers created
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("exclusiveTimers");
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
-        assertEquals(3, jobQuery.count());
+        assertThat(jobQuery.count()).isEqualTo(3);
 
         // After setting the clock to time '50minutes and 5 seconds', the timers should fire
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
         waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(7000L, 500L);
 
-        assertEquals(0, jobQuery.count());
+        assertThat(jobQuery.count()).isZero();
         assertProcessEnded(pi.getProcessInstanceId());
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/CallServiceInServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/CallServiceInServiceTaskTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.bpmn.servicetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -35,7 +38,7 @@ public class CallServiceInServiceTaskTest extends PluggableFlowableTestCase {
         // Starting the process should lead to two processes being started,
         // The other one started from the java delegate in the service task
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(2, processInstances.size());
+        assertThat(processInstances).hasSize(2);
 
         boolean startProcessFromDelegateFound = false;
         boolean oneTaskProcessFound = false;
@@ -48,24 +51,18 @@ public class CallServiceInServiceTaskTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertTrue(startProcessFromDelegateFound);
-        assertTrue(oneTaskProcessFound);
+        assertThat(startProcessFromDelegateFound).isTrue();
+        assertThat(oneTaskProcessFound).isTrue();
     }
 
     @Test
     @Deployment
     public void testRollBackOnException() {
-        Exception expectedException = null;
-        try {
-            runtimeService.startProcessInstanceByKey("startProcessFromDelegate");
-            fail("expected exception");
-        } catch (Exception e) {
-            expectedException = e;
-        }
-        assertNotNull(expectedException);
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("startProcessFromDelegate"))
+                .isInstanceOf(Exception.class);
 
         // Starting the process should cause a rollback of both processes
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
@@ -75,10 +72,10 @@ public class CallServiceInServiceTaskTest extends PluggableFlowableTestCase {
 
         // The service task should have created a user which is part of the admin group
         User user = identityService.createUserQuery().singleResult();
-        assertEquals("Kermit", user.getId());
+        assertThat(user.getId()).isEqualTo("Kermit");
         Group group = identityService.createGroupQuery().groupMember(user.getId()).singleResult();
-        assertNotNull(group);
-        assertEquals("admin", group.getId());
+        assertThat(group).isNotNull();
+        assertThat(group.getId()).isEqualTo("admin");
 
         // Cleanup
         identityService.deleteUser("Kermit");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/DynamicServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/DynamicServiceTaskTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.servicetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,8 +45,8 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(1, runtimeService.getVariable(processInstance.getId(), "count"));
-        assertEquals(0, runtimeService.getVariable(processInstance.getId(), "count2"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "count")).isEqualTo(1);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "count2")).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
@@ -64,8 +66,8 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.getVariable(processInstance.getId(), "count"));
-        assertEquals(1, runtimeService.getVariable(processInstance.getId(), "count2"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "count")).isEqualTo(0);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "count2")).isEqualTo(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
@@ -90,8 +92,8 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
                     .processInstanceId(processInstance.getId())
                     .variableName("executed")
                     .singleResult();
-            assertNotNull(historicVariableInstance);
-            assertTrue((Boolean) historicVariableInstance.getValue());
+            assertThat(historicVariableInstance).isNotNull();
+            assertThat((Boolean) historicVariableInstance.getValue()).isTrue();
         }
 
         assertProcessEnded(processInstance.getId());
@@ -114,8 +116,8 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
                     .processInstanceId(processInstance.getId())
                     .variableName("executed")
                     .singleResult();
-            assertNotNull(historicVariableInstance);
-            assertTrue((Boolean) historicVariableInstance.getValue());
+            assertThat(historicVariableInstance).isNotNull();
+            assertThat((Boolean) historicVariableInstance.getValue()).isTrue();
         }
 
         assertProcessEnded(processInstance.getId());
@@ -138,8 +140,8 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
                     .processInstanceId(processInstance.getId())
                     .variableName("executed")
                     .singleResult();
-            assertNotNull(historicVariableInstance);
-            assertTrue((Boolean) historicVariableInstance.getValue());
+            assertThat(historicVariableInstance).isNotNull();
+            assertThat((Boolean) historicVariableInstance.getValue()).isTrue();
         }
 
         assertProcessEnded(processInstance.getId());
@@ -162,8 +164,8 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
                     .processInstanceId(processInstance.getId())
                     .variableName("executed")
                     .singleResult();
-            assertNotNull(historicVariableInstance);
-            assertTrue((Boolean) historicVariableInstance.getValue());
+            assertThat(historicVariableInstance).isNotNull();
+            assertThat((Boolean) historicVariableInstance.getValue()).isTrue();
         }
 
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/RepeatingServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/RepeatingServiceTaskTest.java
@@ -27,7 +27,7 @@ public class RepeatingServiceTaskTest extends PluggableFlowableTestCase {
         // ProcessInstance processInstance =
         // runtimeService.startProcessInstanceByKey("repeating",
         // CollectionUtil.singletonMap("count", 0));
-        // assertTrue(processInstance.isEnded());
+        // assertThat(processInstance.isEnded()).isTrue();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskDelegateExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskDelegateExpressionTest.java
@@ -64,17 +64,17 @@ public class ServiceTaskDelegateExpressionTest extends PluggableFlowableTestCase
                 List<ActivityInstanceEntity> activityInstances = activityInstanceEntityManager.findActivityInstancesByProcessInstanceId(processId, true);
                 assertThat(activityInstances).hasSize(5);
                 Map<String, List<ActivityInstanceEntity>> activityInstanceMap = activityInstances.stream().collect(Collectors.groupingBy(ActivityInstanceEntity::getActivityId));
-                assertThat(activityInstanceMap.containsKey("theStart")).isTrue();
+                assertThat(activityInstanceMap).containsKey("theStart");
                 assertThat(activityInstanceMap.get("theStart")).hasSize(1);
                 assertThat(activityInstanceMap.get("theStart").get(0).getEndTime()).isNotNull();
                 assertThat(activityInstanceMap.get("theStart").get(0).getTransactionOrder()).isEqualTo(1);
                 
-                assertThat(activityInstanceMap.containsKey("service1")).isTrue();
+                assertThat(activityInstanceMap).containsKey("service1");
                 assertThat(activityInstanceMap.get("service1")).hasSize(1);
                 assertThat(activityInstanceMap.get("service1").get(0).getEndTime()).isNotNull();
                 assertThat(activityInstanceMap.get("service1").get(0).getTransactionOrder()).isEqualTo(3);
                 
-                assertThat(activityInstanceMap.containsKey("usertask1")).isTrue();
+                assertThat(activityInstanceMap).containsKey("usertask1");
                 assertThat(activityInstanceMap.get("usertask1")).hasSize(1);
                 assertThat(activityInstanceMap.get("usertask1").get(0).getEndTime()).isNull();
                 assertThat(activityInstanceMap.get("usertask1").get(0).getTransactionOrder()).isEqualTo(5);
@@ -101,12 +101,12 @@ public class ServiceTaskDelegateExpressionTest extends PluggableFlowableTestCase
                 List<ActivityInstanceEntity> activityInstances = activityInstanceEntityManager.findActivityInstancesByProcessInstanceId(processId, true);
                 assertThat(activityInstances).hasSize(7);
                 Map<String, List<ActivityInstanceEntity>> activityInstanceMap = activityInstances.stream().collect(Collectors.groupingBy(ActivityInstanceEntity::getActivityId));
-                assertThat(activityInstanceMap.containsKey("usertask1")).isTrue();
+                assertThat(activityInstanceMap).containsKey("usertask1");
                 assertThat(activityInstanceMap.get("usertask1")).hasSize(1);
                 assertThat(activityInstanceMap.get("usertask1").get(0).getEndTime()).isNotNull();
                 assertThat(activityInstanceMap.get("usertask1").get(0).getTransactionOrder()).isEqualTo(5);
                 
-                assertThat(activityInstanceMap.containsKey("theEnd")).isTrue();
+                assertThat(activityInstanceMap).containsKey("theEnd");
                 assertThat(activityInstanceMap.get("theEnd")).hasSize(1);
                 assertThat(activityInstanceMap.get("theEnd").get(0).getEndTime()).isNotNull();
                 assertThat(activityInstanceMap.get("theEnd").get(0).getTransactionOrder()).isEqualTo(2);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskVariablesTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.servicetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.Serializable;
 
 import org.flowable.engine.delegate.DelegateExecution;
@@ -85,15 +87,15 @@ public class ServiceTaskVariablesTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("process");
 
         Job job = managementService.createJobQuery().singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         managementService.executeJob(job.getId());
 
         job = managementService.createJobQuery().singleResult();
-        assertNotNull(job);
+        assertThat(job).isNotNull();
         managementService.executeJob(job.getId());
 
-        assertTrue(isOkInDelegate2);
-        assertTrue(isOkInDelegate3);
+        assertThat(isOkInDelegate2).isTrue();
+        assertThat(isOkInDelegate3).isTrue();
     }
 
     @Test
@@ -106,8 +108,8 @@ public class ServiceTaskVariablesTest extends PluggableFlowableTestCase {
         waitForJobExecutorToProcessAllJobs(10000, 500);
 
         synchronized (ServiceTaskVariablesTest.class) {
-            assertTrue(isOkInDelegate2);
-            assertTrue(isOkInDelegate3);
+            assertThat(isOkInDelegate2).isTrue();
+            assertThat(isOkInDelegate3).isTrue();
         }
 
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/TriggerableServiceTaskTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.servicetask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,17 +35,17 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         String processId = runtimeService.startProcessInstanceByKey("process").getProcessInstanceId();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("service1").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         int count = (int) runtimeService.getVariable(processId, "count");
-        assertEquals(1, count);
+        assertThat(count).isEqualTo(1);
 
         Map<String,Object> processVariables = new HashMap<>();
         processVariables.put("count", ++count);
         runtimeService.trigger(execution.getId(), processVariables, null);
 
         execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("usertask1").singleResult();
-        assertNotNull(execution);
-        assertEquals(3, runtimeService.getVariable(processId, "count"));
+        assertThat(execution).isNotNull();
+        assertThat(runtimeService.getVariable(processId, "count")).isEqualTo(3);
     }
 
     @Test
@@ -55,17 +57,17 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         String processId = runtimeService.startProcessInstanceByKey("process", varMap).getProcessInstanceId();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("service1").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         int count = (int) runtimeService.getVariable(processId, "count");
-        assertEquals(1, count);
+        assertThat(count).isEqualTo(1);
 
         Map<String,Object> processVariables = new HashMap<>();
         processVariables.put("count", ++count);
         runtimeService.trigger(execution.getId(), processVariables, null);
 
         execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("usertask1").singleResult();
-        assertNotNull(execution);
-        assertEquals(3, runtimeService.getVariable(processId, "count"));
+        assertThat(execution).isNotNull();
+        assertThat(runtimeService.getVariable(processId, "count")).isEqualTo(3);
     }
 
     @Test
@@ -78,16 +80,16 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         String processId = runtimeService.startProcessInstanceByKey("process", varMap).getProcessInstanceId();
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("service1").singleResult();
-        assertNotNull(execution);
-        assertTrue((boolean) runtimeService.getVariable(processId, "executed"));
+        assertThat(execution).isNotNull();
+        assertThat((boolean) runtimeService.getVariable(processId, "executed")).isTrue();
 
         Map<String, Object> processVariables = new HashMap<>();
         processVariables.put("count", 1);
         runtimeService.trigger(execution.getId(), processVariables, null);
 
         execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("usertask1").singleResult();
-        assertNotNull(execution);
-        assertEquals(1, runtimeService.getVariable(processId, "count"));
+        assertThat(execution).isNotNull();
+        assertThat(runtimeService.getVariable(processId, "count")).isEqualTo(1);
     }
 
     @Test
@@ -96,28 +98,28 @@ public class TriggerableServiceTaskTest extends PluggableFlowableTestCase {
         String processId = runtimeService.startProcessInstanceByKey("process").getProcessInstanceId();
         
         List<Job> jobs = managementService.createJobQuery().processInstanceId(processId).list();
-        assertEquals(1, jobs.size());
-        assertEquals(AsyncContinuationJobHandler.TYPE, jobs.get(0).getJobHandlerType());
+        assertThat(jobs).hasSize(1);
+        assertThat(jobs.get(0).getJobHandlerType()).isEqualTo(AsyncContinuationJobHandler.TYPE);
         
         waitForJobExecutorToProcessAllJobs(7000L, 250L);
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("service1").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
         int count = (int) runtimeService.getVariable(processId, "count");
-        assertEquals(1, count);
+        assertThat(count).isEqualTo(1);
 
         Map<String,Object> processVariables = new HashMap<>();
         processVariables.put("count", ++count);
         runtimeService.triggerAsync(execution.getId(), processVariables);
         
         jobs = managementService.createJobQuery().processInstanceId(processId).list();
-        assertEquals(1, jobs.size());
-        assertEquals(AsyncTriggerJobHandler.TYPE, jobs.get(0).getJobHandlerType());
+        assertThat(jobs).hasSize(1);
+        assertThat(jobs.get(0).getJobHandlerType()).isEqualTo(AsyncTriggerJobHandler.TYPE);
         
         waitForJobExecutorToProcessAllJobs(7000L, 250L);
 
         execution = runtimeService.createExecutionQuery().processInstanceId(processId).activityId("usertask1").singleResult();
-        assertNotNull(execution);
-        assertEquals(3, runtimeService.getVariable(processId, "count"));
+        assertThat(execution).isNotNull();
+        assertThat(runtimeService.getVariable(processId, "count")).isEqualTo(3);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DisabledDefinitionInfoCacheTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DisabledDefinitionInfoCacheTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,7 +42,7 @@ public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
         String processDefinitionId = processInstance.getProcessDefinitionId();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("test", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("test");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -52,7 +54,7 @@ public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("dynamicUserTask");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("test", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("test");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -70,8 +72,8 @@ public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(1, runtimeService.getVariable(processInstance.getId(), "count"));
-        assertEquals(0, runtimeService.getVariable(processInstance.getId(), "count2"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "count")).isEqualTo(1);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "count2")).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
@@ -91,8 +93,8 @@ public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());
 
-        assertEquals(1, runtimeService.getVariable(processInstance.getId(), "count"));
-        assertEquals(0, runtimeService.getVariable(processInstance.getId(), "count2"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "count")).isEqualTo(1);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "count2")).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +41,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         String processDefinitionId = processInstance.getProcessDefinitionId();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("test", task.getAssignee());
+        assertThat(task.getAssignee()).isEqualTo("test");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -51,7 +53,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("dynamicUserTask");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("test2", task.getAssignee());
+        assertThat(task.getAssignee()).isEqualTo("test2");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -65,7 +67,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         String processDefinitionId = processInstance.getProcessDefinitionId();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("ownerTest", task.getOwner());
+        assertThat(task.getOwner()).isEqualTo("ownerTest");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -77,7 +79,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("dynamicUserTask");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("ownerTest2", task.getOwner());
+        assertThat(task.getOwner()).isEqualTo("ownerTest2");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -100,7 +102,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertFalse(candidateUserTestFound);
+        assertThat(candidateUserTestFound).isFalse();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -121,7 +123,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertTrue(candidateUserTestFound);
+        assertThat(candidateUserTestFound).isTrue();
         taskService.complete(task.getId());
 
         infoNode = dynamicBpmnService.getProcessDefinitionInfo(processDefinitionId);
@@ -143,8 +145,8 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertTrue(candidateUserTestFound);
-        assertTrue(candidateUserTest2Found);
+        assertThat(candidateUserTestFound).isTrue();
+        assertThat(candidateUserTest2Found).isTrue();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -167,7 +169,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertFalse(candidateGroupTestFound);
+        assertThat(candidateGroupTestFound).isFalse();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -188,7 +190,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertTrue(candidateGroupTestFound);
+        assertThat(candidateGroupTestFound).isTrue();
         taskService.complete(task.getId());
 
         infoNode = dynamicBpmnService.getProcessDefinitionInfo(processDefinitionId);
@@ -210,8 +212,8 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertTrue(candidateGroupTestFound);
-        assertTrue(candidateGroupTest2Found);
+        assertThat(candidateGroupTestFound).isTrue();
+        assertThat(candidateGroupTest2Found).isTrue();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -239,8 +241,8 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertFalse(candidateUserTestFound);
-        assertFalse(candidateGroupTestFound);
+        assertThat(candidateUserTestFound).isFalse();
+        assertThat(candidateGroupTestFound).isFalse();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -267,8 +269,8 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertTrue(candidateUserTestFound);
-        assertTrue(candidateGroupTestFound);
+        assertThat(candidateUserTestFound).isTrue();
+        assertThat(candidateGroupTestFound).isTrue();
         taskService.complete(task.getId());
 
         infoNode = dynamicBpmnService.getProcessDefinitionInfo(processDefinitionId);
@@ -299,10 +301,10 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
                 }
             }
         }
-        assertTrue(candidateUserTestFound);
-        assertTrue(candidateUserTestFound2);
-        assertTrue(candidateGroupTestFound);
-        assertTrue(candidateGroupTest2Found);
+        assertThat(candidateUserTestFound).isTrue();
+        assertThat(candidateUserTestFound2).isTrue();
+        assertThat(candidateGroupTestFound).isTrue();
+        assertThat(candidateGroupTest2Found).isTrue();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -316,8 +318,8 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         String processDefinitionId = processInstance.getProcessDefinitionId();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(task.getName());
-        assertNull(task.getDescription());
+        assertThat(task.getName()).isNull();
+        assertThat(task.getDescription()).isNull();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -330,8 +332,8 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("dynamicUserTask");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Task name test", task.getName());
-        assertEquals("Task description test", task.getDescription());
+        assertThat(task.getName()).isEqualTo("Task name test");
+        assertThat(task.getDescription()).isEqualTo("Task description test");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -345,8 +347,8 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         String processDefinitionId = processInstance.getProcessDefinitionId();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals(50, task.getPriority());
-        assertNull(task.getCategory());
+        assertThat(task.getPriority()).isEqualTo(50);
+        assertThat(task.getCategory()).isNull();
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -359,8 +361,8 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("dynamicUserTask");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals(99, task.getPriority());
-        assertEquals("categoryTest", task.getCategory());
+        assertThat(task.getPriority()).isEqualTo(99);
+        assertThat(task.getCategory()).isEqualTo("categoryTest");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -374,7 +376,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         String processDefinitionId = processInstance.getProcessDefinitionId();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("test", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("test");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -386,7 +388,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("dynamicUserTask");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("test2", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("test2");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -402,7 +404,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         String processDefinitionId = processInstance.getProcessDefinitionId();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("test", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("test");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -416,7 +418,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("dynamicUserTask", varMap);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("test2", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("test2");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/ImportExportTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/ImportExportTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
@@ -45,7 +47,7 @@ public class ImportExportTest extends ResourceFlowableTestCase {
         String processInstanceKey = runtimeService.startProcessInstanceByKey("process").getId();
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstanceKey).messageEventSubscriptionName("InterruptMessage").singleResult();
 
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
     }
 
     @AfterEach

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/InitiatorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/InitiatorTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,7 @@ public class InitiatorTest extends PluggableFlowableTestCase {
             identityService.setAuthenticatedUserId(null);
         }
 
-        assertEquals(1, taskService.createTaskQuery().taskAssignee("bono").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("bono").count()).isEqualTo(1);
     }
 
     // See ACT-1372
@@ -46,7 +48,7 @@ public class InitiatorTest extends PluggableFlowableTestCase {
             identityService.setAuthenticatedUserId(null);
         }
 
-        assertEquals(1, taskService.createTaskQuery().taskAssignee("bono").count());
+        assertThat(taskService.createTaskQuery().taskAssignee("bono").count()).isEqualTo(1);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentCandidateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentCandidateTest.java
@@ -12,10 +12,13 @@
  */
 package org.flowable.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,13 +50,15 @@ public class TaskAssignmentCandidateTest extends PluggableFlowableTestCase {
                 .createTaskQuery()
                 .taskCandidateGroup("management")
                 .list();
-        assertEquals(1, tasks.size());
-        assertEquals("theTask", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("theTask");
         taskService.complete(tasks.get(0).getId());
 
         tasks = taskService.createTaskQuery().taskCandidateGroup("accounting").list();
-        assertEquals(1, tasks.size());
-        assertEquals("theOtherTask", tasks.get(0).getTaskDefinitionKey());
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("theOtherTask");
         taskService.complete(tasks.get(0).getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.bpmn.usertask;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -64,19 +65,19 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
     public void testAssigneeExtension() {
         runtimeService.startProcessInstanceByKey("assigneeExtension");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
-        assertEquals(1, tasks.size());
-        assertEquals("my task", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("my task");
     }
 
     @Test
     public void testDuplicateAssigneeDeclaration() {
-        try {
+        assertThatThrownBy(() -> {
             String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testDuplicateAssigneeDeclaration");
             repositoryService.createDeployment().addClasspathResource(resource).deploy();
-            fail("Invalid BPMN 2.0 process should not parse, but it gets parsed successfully");
-        } catch (XMLException e) {
-            // Exception is to be expected
-        }
+        })
+                .as("Invalid BPMN 2.0 process should not parse, but it gets parsed successfully")
+                .isInstanceOf(XMLException.class);
     }
 
     @Test
@@ -84,8 +85,9 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
     public void testOwnerExtension() {
         runtimeService.startProcessInstanceByKey("ownerExtension");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskOwner("gonzo").list();
-        assertEquals(1, tasks.size());
-        assertEquals("my task", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("my task");
     }
 
     @Test
@@ -93,9 +95,9 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
     public void testCandidateUsersExtension() {
         runtimeService.startProcessInstanceByKey("candidateUsersExtension");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskCandidateUser("kermit").list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
         tasks = taskService.createTaskQuery().taskCandidateUser("gonzo").list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
     }
 
     @Test
@@ -139,17 +141,23 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         // Bugfix check: potentially the query could return 2 tasks since
         // kermit is a member of the two candidate groups
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskCandidateUser("kermit").list();
-        assertEquals(1, tasks.size());
-        assertEquals("make profit", tasks.get(0).getName());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("make profit");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("make profit");
 
         tasks = taskService.createTaskQuery().taskCandidateUser("fozzie").list();
-        assertEquals(1, tasks.size());
-        assertEquals("make profit", tasks.get(0).getName());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("make profit");
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("make profit");
 
         // Test the task query find-by-candidate-group operation
         TaskQuery query = taskService.createTaskQuery();
-        assertEquals(1, query.taskCandidateGroup("management").count());
-        assertEquals(1, query.taskCandidateGroup("accountancy").count());
+        assertThat(query.taskCandidateGroup("management").count()).isEqualTo(1);
+        assertThat(query.taskCandidateGroup("accountancy").count()).isEqualTo(1);
     }
 
     @Test
@@ -162,12 +170,12 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskCandidateUser("kermit").list();
         assertThat(tasks)
                 .extracting(Task::getName)
-                .containsExactlyInAnyOrder("make profit");
+                .containsExactly("make profit");
 
         tasks = taskService.createTaskQuery().taskCandidateUser("fozzie").list();
         assertThat(tasks)
                 .extracting(Task::getName)
-                .containsExactlyInAnyOrder("make profit");
+                .containsExactly("make profit");
 
         // Test the task query find-by-candidate-group operation
         TaskQuery query = taskService.createTaskQuery();
@@ -189,12 +197,12 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskCandidateUser("kermit").list();
         assertThat(tasks)
                 .extracting(Task::getName)
-                .containsExactlyInAnyOrder("make profit");
+                .containsExactly("make profit");
 
         tasks = taskService.createTaskQuery().taskCandidateUser("fozzie").list();
         assertThat(tasks)
                 .extracting(Task::getName)
-                .containsExactlyInAnyOrder("make profit");
+                .containsExactly("make profit");
 
         // Test the task query find-by-candidate-group operation
         TaskQuery query = taskService.createTaskQuery();
@@ -211,16 +219,16 @@ public class TaskAssignmentExtensionsTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("mixedCandidateUser");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskCandidateUser("kermit").list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         tasks = taskService.createTaskQuery().taskCandidateUser("fozzie").list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         tasks = taskService.createTaskQuery().taskCandidateUser("gonzo").list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         tasks = taskService.createTaskQuery().taskCandidateUser("mispiggy").list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -49,8 +51,8 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertNotNull(task.getDueDate());
-        assertEquals(date, task.getDueDate());
+        assertThat(task.getDueDate()).isNotNull();
+        assertThat(task.getDueDate()).isEqualTo(date);
     }
 
     @Test
@@ -65,9 +67,9 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertNotNull(task.getDueDate());
+        assertThat(task.getDueDate()).isNotNull();
         Date date = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss").parse("06-07-1986 12:10:00");
-        assertEquals(date, task.getDueDate());
+        assertThat(task.getDueDate()).isEqualTo(date);
     }
 
     @Test
@@ -84,11 +86,11 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertNotNull(task.getDueDate());
+        assertThat(task.getDueDate()).isNotNull();
         Period period = new Period(task.getCreateTime().getTime(), task.getDueDate().getTime());
-        assertEquals(2, period.getDays());
-        assertEquals(5, period.getHours());
-        assertEquals(40, period.getMinutes());
+        assertThat(period.getDays()).isEqualTo(2);
+        assertThat(period.getHours()).isEqualTo(5);
+        assertThat(period.getMinutes()).isEqualTo(40);
         clock.reset();
     }
 
@@ -104,8 +106,8 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertNotNull(task.getDueDate());
-        assertEquals(new Date(0), task.getDueDate());
+        assertThat(task.getDueDate()).isNotNull();
+        assertThat(task.getDueDate()).isEqualTo(new Date(0));
     }
 
     public static class CustomBusinessCalendar implements BusinessCalendar {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskPriorityExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskPriorityExtensionsTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,7 +45,7 @@ public class TaskPriorityExtensionsTest extends PluggableFlowableTestCase {
 
         final org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertEquals(priority, task.getPriority());
+        assertThat(task.getPriority()).isEqualTo(priority);
     }
 
     @Test
@@ -51,6 +53,6 @@ public class TaskPriorityExtensionsTest extends PluggableFlowableTestCase {
     public void testPriorityExtensionString() throws Exception {
         final ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskPriorityExtensionString");
         final org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals(42, task.getPriority());
+        assertThat(task.getPriority()).isEqualTo(42);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,19 +51,19 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task.getId());
-        assertEquals("my task", task.getName());
-        assertEquals("Very important", task.getDescription());
-        assertTrue(task.getPriority() > 0);
-        assertEquals("kermit", task.getAssignee());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
-        assertNotNull(task.getProcessDefinitionId());
-        assertNotNull(task.getTaskDefinitionKey());
-        assertNotNull(task.getCreateTime());
+        assertThat(task.getId()).isNotNull();
+        assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task.getDescription()).isEqualTo("Very important");
+        assertThat(task.getPriority()).isGreaterThan(0);
+        assertThat(task.getAssignee()).isEqualTo("kermit");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(task.getProcessDefinitionId()).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isNotNull();
+        assertThat(task.getCreateTime()).isNotNull();
         
         // the next test verifies that if an execution creates a task, that no events are created during creation of the task.
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(0, taskService.getTaskEvents(task.getId()).size());
+            assertThat(taskService.getTaskEvents(task.getId())).isEmpty();
         }
     }
 
@@ -71,15 +73,15 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task.getId());
-        assertEquals("my task", task.getName());
-        assertEquals("Very important", task.getDescription());
-        assertTrue(task.getPriority() > 0);
-        assertEquals("kermit", task.getAssignee());
-        assertEquals(processInstance.getId(), task.getProcessInstanceId());
-        assertNotNull(task.getProcessDefinitionId());
-        assertNotNull(task.getTaskDefinitionKey());
-        assertNotNull(task.getCreateTime());
+        assertThat(task.getId()).isNotNull();
+        assertThat(task.getName()).isEqualTo("my task");
+        assertThat(task.getDescription()).isEqualTo("Very important");
+        assertThat(task.getPriority()).isGreaterThan(0);
+        assertThat(task.getAssignee()).isEqualTo("kermit");
+        assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
+        assertThat(task.getProcessDefinitionId()).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isNotNull();
+        assertThat(task.getCreateTime()).isNotNull();
 
         CommandExecutor commandExecutor = processEngine.getProcessEngineConfiguration().getCommandExecutor();
 
@@ -89,15 +91,15 @@ public class UserTaskTest extends PluggableFlowableTestCase {
             return entityLinkService.findEntityLinksByScopeIdAndType(processInstance.getId(), ScopeTypes.BPMN, EntityLinkType.CHILD);
         });
 
-        assertEquals(1, entityLinksByScopeIdAndType.size());
-        assertEquals(HierarchyType.ROOT, entityLinksByScopeIdAndType.get(0).getHierarchyType());
+        assertThat(entityLinksByScopeIdAndType).hasSize(1);
+        assertThat(entityLinksByScopeIdAndType.get(0).getHierarchyType()).isEqualTo(HierarchyType.ROOT);
     }
 
     @Test
     @Deployment
     public void testQuerySortingWithParameter() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).list().size());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).list()).hasSize(1);
     }
 
     @Test
@@ -108,12 +110,12 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         // start the process
         runtimeService.startProcessInstanceByKey("ForkProcess");
         List<org.flowable.task.api.Task> taskList = taskService.createTaskQuery().list();
-        assertNotNull(taskList);
-        assertEquals(2, taskList.size());
+        assertThat(taskList).isNotNull();
+        assertThat(taskList).hasSize(2);
 
         // make sure user task exists
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("SimpleUser").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         // attempt to complete the task and get PersistenceException pointing to
         // "referential integrity constraint violation"
@@ -128,18 +130,18 @@ public class UserTaskTest extends PluggableFlowableTestCase {
 
         // Test if the property set in the model is shown in the task
         String testCategory = "My Category";
-        assertEquals(testCategory, task.getCategory());
+        assertThat(task.getCategory()).isEqualTo(testCategory);
 
         // Test if can be queried by query API
-        assertEquals("Task with category", taskService.createTaskQuery().taskCategory(testCategory).singleResult().getName());
-        assertEquals(0, taskService.createTaskQuery().taskCategory("Does not exist").count());
+        assertThat(taskService.createTaskQuery().taskCategory(testCategory).singleResult().getName()).isEqualTo("Task with category");
+        assertThat(taskService.createTaskQuery().taskCategory("Does not exist").count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // Check historic task
             HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
-            assertEquals(testCategory, historicTaskInstance.getCategory());
-            assertEquals("Task with category", historyService.createHistoricTaskInstanceQuery().taskCategory(testCategory).singleResult().getName());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskCategory("Does not exist").count());
+            assertThat(historicTaskInstance.getCategory()).isEqualTo(testCategory);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskCategory(testCategory).singleResult().getName()).isEqualTo("Task with category");
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskCategory("Does not exist").count()).isZero();
         }
 
         // Update category
@@ -148,18 +150,18 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         taskService.saveTask(task);
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals(newCategory, task.getCategory());
-        assertEquals("Task with category", taskService.createTaskQuery().taskCategory(newCategory).singleResult().getName());
-        assertEquals(0, taskService.createTaskQuery().taskCategory(testCategory).count());
+        assertThat(task.getCategory()).isEqualTo(newCategory);
+        assertThat(taskService.createTaskQuery().taskCategory(newCategory).singleResult().getName()).isEqualTo("Task with category");
+        assertThat(taskService.createTaskQuery().taskCategory(testCategory).count()).isZero();
 
         // Complete task and verify history
         taskService.complete(task.getId());
             
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
-            assertEquals(newCategory, historicTaskInstance.getCategory());
-            assertEquals("Task with category", historyService.createHistoricTaskInstanceQuery().taskCategory(newCategory).singleResult().getName());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskCategory(testCategory).count());
+            assertThat(historicTaskInstance.getCategory()).isEqualTo(newCategory);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskCategory(newCategory).singleResult().getName()).isEqualTo("Task with category");
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskCategory(testCategory).count()).isZero();
         }
     }
 
@@ -171,7 +173,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
 
         // Set variables
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         Map<String, Object> vars = new HashMap<>();
         for (int i = 0; i < 20; i++) {
             vars.put("var" + i, i * 2);
@@ -185,9 +187,9 @@ public class UserTaskTest extends PluggableFlowableTestCase {
 
         // Verify query and check form key
         task = taskService.createTaskQuery().includeProcessVariables().singleResult();
-        assertEquals(vars.size(), task.getProcessVariables().size());
+        assertThat(task.getProcessVariables().size()).isEqualTo(vars.size());
 
-        assertEquals("test123", task.getFormKey());
+        assertThat(task.getFormKey()).isEqualTo("test123");
     }
     
     @Test
@@ -198,26 +200,26 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         variableMap.put("candidateUsers", null);
         variableMap.put("candidateGroups", null);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variableMap);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertNull(task.getAssignee());
+        assertThat(task).isNotNull();
+        assertThat(task.getAssignee()).isNull();
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(task.getId());
-        assertEquals(0, identityLinks.size());
+        assertThat(identityLinks).isEmpty();
         
         variableMap = new HashMap<>();
         variableMap.put("assignee", "");
         variableMap.put("candidateUsers", "");
         variableMap.put("candidateGroups", "");
         processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variableMap);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(task);
-        assertNull(task.getAssignee());
+        assertThat(task).isNotNull();
+        assertThat(task.getAssignee()).isNull();
         identityLinks = taskService.getIdentityLinksForTask(task.getId());
-        assertEquals(0, identityLinks.size());
+        assertThat(identityLinks).isEmpty();
     }
     
     @Test
@@ -235,27 +237,27 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nonStringProperties", vars);
         
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("1", task.getName());
-        assertEquals("2", task.getDescription());
-        assertEquals("3", task.getCategory());
-        assertEquals("4", task.getFormKey());
-        assertEquals("5", task.getAssignee());
-        assertEquals("6", task.getOwner());
+        assertThat(task.getName()).isEqualTo("1");
+        assertThat(task.getDescription()).isEqualTo("2");
+        assertThat(task.getCategory()).isEqualTo("3");
+        assertThat(task.getFormKey()).isEqualTo("4");
+        assertThat(task.getAssignee()).isEqualTo("5");
+        assertThat(task.getOwner()).isEqualTo("6");
         
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(task.getId());
-        assertEquals(4, identityLinks.size());
+        assertThat(identityLinks).hasSize(4);
         int candidateIdentityLinkCount = 0;
         for (IdentityLink identityLink : identityLinks) {
             if (identityLink.getType().equals(IdentityLinkType.CANDIDATE)) {
                 candidateIdentityLinkCount++;
                 if (identityLink.getGroupId() != null) {
-                    assertEquals("7", identityLink.getGroupId());
+                    assertThat(identityLink.getGroupId()).isEqualTo("7");
                 } else {
-                    assertEquals("8", identityLink.getUserId());
+                    assertThat(identityLink.getUserId()).isEqualTo("8");
                 }
             }
         }
-        assertEquals(2, candidateIdentityLinkCount);
+        assertThat(candidateIdentityLinkCount).isEqualTo(2);
     }
     
     @Test
@@ -268,13 +270,13 @@ public class UserTaskTest extends PluggableFlowableTestCase {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task.getId());
-            assertEquals("my task", task.getName());
-            assertEquals("Very important", task.getDescription());
-            assertEquals("testCategory", task.getCategory());
+            assertThat(task.getId()).isNotNull();
+            assertThat(task.getName()).isEqualTo("my task");
+            assertThat(task.getDescription()).isEqualTo("Very important");
+            assertThat(task.getCategory()).isEqualTo("testCategory");
             
-            assertEquals(1, testCreateUserTaskInterceptor.getBeforeCreateUserTaskCounter());
-            assertEquals(1, testCreateUserTaskInterceptor.getAfterCreateUserTaskCounter());
+            assertThat(testCreateUserTaskInterceptor.getBeforeCreateUserTaskCounter()).isEqualTo(1);
+            assertThat(testCreateUserTaskInterceptor.getAfterCreateUserTaskCounter()).isEqualTo(1);
             
         } finally {
             processEngineConfiguration.setCreateUserTaskInterceptor(null);


### PR DESCRIPTION
In the process of making consistency changes in the flowable-engine module I found files that needed conversion to assertj in the `org.flowable.engine.test.bpmn` package.  

There are additional files for this module pending but in an attempt to keep the review manageable only this package is in this PR. 
