### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionAndProcessInstanceQueryVersionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionAndProcessInstanceQueryVersionTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,55 +50,55 @@ public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableFlowab
 
     @Test
     public void testProcessInstanceQueryByProcessDefinitionVersion() {
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(1).count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(2).count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionVersion(3).count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(1).count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(2).list().size());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionVersion(3).list().size());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionVersion(1).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionVersion(2).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionVersion(3).count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionVersion(1).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionVersion(2).list()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionVersion(3).list()).isEmpty();
     }
 
     @Test
     public void testProcessInstanceQueryByProcessDefinitionVersionAndKey() {
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list().size());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list().size());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list().size());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list().size());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list()).isEmpty();
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list()).isEmpty();
     }
 
     @Test
     public void testProcessInstanceOrQueryByProcessDefinitionVersion() {
-        assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().count());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().list().size());
-        assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().list().size());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().list().size());
+        assertThat(runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().list()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().list()).hasSize(1);
+        assertThat(runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().list()).isEmpty();
     }
 
     @Test
     public void testExecutionQueryByProcessDefinitionVersion() {
-        assertEquals(2, runtimeService.createExecutionQuery().processDefinitionVersion(1).count());
-        assertEquals(2, runtimeService.createExecutionQuery().processDefinitionVersion(2).count());
-        assertEquals(0, runtimeService.createExecutionQuery().processDefinitionVersion(3).count());
-        assertEquals(2, runtimeService.createExecutionQuery().processDefinitionVersion(1).list().size());
-        assertEquals(2, runtimeService.createExecutionQuery().processDefinitionVersion(2).list().size());
-        assertEquals(0, runtimeService.createExecutionQuery().processDefinitionVersion(3).list().size());
+        assertThat(runtimeService.createExecutionQuery().processDefinitionVersion(1).count()).isEqualTo(2);
+        assertThat(runtimeService.createExecutionQuery().processDefinitionVersion(2).count()).isEqualTo(2);
+        assertThat(runtimeService.createExecutionQuery().processDefinitionVersion(3).count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processDefinitionVersion(1).list()).hasSize(2);
+        assertThat(runtimeService.createExecutionQuery().processDefinitionVersion(2).list()).hasSize(2);
+        assertThat(runtimeService.createExecutionQuery().processDefinitionVersion(3).list()).isEmpty();
     }
 
     @Test
     public void testExecutionQueryByProcessDefinitionVersionAndKey() {
-        assertEquals(2, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
-        assertEquals(2, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());
-        assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count());
-        assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count());
-        assertEquals(2, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list().size());
-        assertEquals(2, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list().size());
-        assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list().size());
-        assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list().size());
+        assertThat(runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count()).isEqualTo(2);
+        assertThat(runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count()).isEqualTo(2);
+        assertThat(runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list()).hasSize(2);
+        assertThat(runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list()).hasSize(2);
+        assertThat(runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list()).isEmpty();
+        assertThat(runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list()).isEmpty();
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/InstanceInvolvementTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/InstanceInvolvementTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -63,7 +65,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         // there are supposed to be 3 tasks
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(instanceId).list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
         // "user1" should now be involved as the starter of the new process
         // instance. "user2" is still not involved.
@@ -93,11 +95,11 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         // note that since "user1" already is the starter, he is not involved as
         // a participant as well
         List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(instanceId);
-        assertTrue(containsIdentityLink(identityLinks, "user1", "starter"));
-        assertTrue(containsIdentityLink(identityLinks, "user2", "participant"));
-        assertTrue(containsIdentityLink(identityLinks, "user3", "participant"));
-        assertTrue(containsIdentityLink(identityLinks, "user4", "custom"));
-        assertEquals(4, identityLinks.size());
+        assertThat(containsIdentityLink(identityLinks, "user1", "starter")).isTrue();
+        assertThat(containsIdentityLink(identityLinks, "user2", "participant")).isTrue();
+        assertThat(containsIdentityLink(identityLinks, "user3", "participant")).isTrue();
+        assertThat(containsIdentityLink(identityLinks, "user4", "custom")).isTrue();
+        assertThat(identityLinks).hasSize(4);
 
         // "user1" completes the remaining task, ending the process
         completeTaskAsUser(tasks.get(2).getId(), "user1");
@@ -134,7 +136,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addUserIdentityLink(processInstance.getId(), "kermit", "type1");
         runtimeService.addUserIdentityLink(processInstance.getId(), "kermit", "type2");
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().involvedUser("kermit").count());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedUser("kermit").count()).isEqualTo(1);
     }
 
     @Test
@@ -144,8 +146,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
-        assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -156,8 +158,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup2", IdentityLinkType.CANDIDATE);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
-        assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -168,8 +170,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup2", IdentityLinkType.CANDIDATE);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).count());
-        assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -179,8 +181,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).count());
-        assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -191,7 +193,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup2", IdentityLinkType.CANDIDATE);
 
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("nonInvolvedGroup")).count());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("nonInvolvedGroup")).count()).isZero();
     }
 
     @Test
@@ -203,9 +205,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.CANDIDATE);
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup2", IdentityLinkType.CANDIDATE);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
-        assertEquals(processInstance.getId(),
-            runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -216,7 +217,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.deleteGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isZero();
     }
 
     @Test
@@ -226,9 +227,9 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().
-            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
-        assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -239,9 +240,9 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup2", IdentityLinkType.CANDIDATE);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().
-            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
-        assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -252,9 +253,9 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup2", IdentityLinkType.CANDIDATE);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().
-            or().processInstanceId("undefinedId").involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).endOr().count());
-        assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().processInstanceId("undefinedId").involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).endOr().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -264,10 +265,10 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().
-            or().processInstanceId("undefinedId").involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).endOr().count());
-        assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().
-            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().processInstanceId("undefinedId").involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).endOr().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -278,8 +279,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup2", IdentityLinkType.CANDIDATE);
 
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().
-            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("nonInvolvedGroup")).endOr().count());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("nonInvolvedGroup")).endOr().count()).isZero();
     }
 
     @Test
@@ -291,11 +292,10 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.CANDIDATE);
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup2", IdentityLinkType.CANDIDATE);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().
-            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
-        assertEquals(processInstance.getId(),
-            runtimeService.createProcessInstanceQuery().
-                or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
+        assertThat(runtimeService.createProcessInstanceQuery().
+                or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId()).isEqualTo(processInstance.getId());
     }
 
     @Test
@@ -306,8 +306,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.deleteGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().
-            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isZero();
     }
 
     @Test
@@ -318,8 +318,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.addUserIdentityLink(processInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().
-            or().involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).endOr().count());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            or().involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
     }
 
     @Test
@@ -330,8 +330,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.addUserIdentityLink(processInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().
-            involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
     }
 
     @Test
@@ -341,8 +341,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().
-            involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count()).isZero();
     }
 
     @Test
@@ -352,8 +352,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         runtimeService.addUserIdentityLink(processInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().
-            involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
+        assertThat(runtimeService.createProcessInstanceQuery().
+            involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count()).isZero();
     }
 
     @Test
@@ -363,11 +363,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         runtimeService.addUserIdentityLink(processInstance.getId(), "kermit", IdentityLinkType.PARTICIPANT);
 
-        assertEquals(1L, runtimeService.createProcessInstanceQuery().
-            or().
-            involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).
-            endOr().
-            count());
+        assertThat(runtimeService.createProcessInstanceQuery().or().
+            involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
     }
 
     @Test
@@ -378,8 +375,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -392,9 +389,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
         
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
-            assertEquals(processInstance.getId(),
-                    historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -407,9 +403,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).count());
-            assertEquals(processInstance.getId(),
-                    historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -421,8 +416,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         runtimeService.addGroupIdentityLink(processInstance.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -435,7 +430,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(0L, historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("nonInvolvedGroup")).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("nonInvolvedGroup")).count()).isZero();
         }
     }
 
@@ -449,9 +444,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
-            assertEquals(processInstance.getId(),
-                    historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -464,7 +458,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(0L, historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).count()).isZero();
         }
     }
 
@@ -476,9 +470,9 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
         
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().
-                or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -491,9 +485,9 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().
-                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -506,9 +500,9 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().
-                    or().processInstanceId("undefinedId").involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).endOr().count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().processInstanceId("undefinedId").involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().involvedGroups(Collections.singleton("testGroup")).list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -520,10 +514,10 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().
-                    or().processInstanceId("undefinedId").involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).endOr().count());
-            assertEquals(processInstance.getId(), historyService.createHistoricProcessInstanceQuery().
-                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().processInstanceId("undefinedId").involvedGroups(Stream.of("testGroup", "testGroup2").collect(Collectors.toSet())).endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -536,8 +530,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(0L, historyService.createHistoricProcessInstanceQuery().
-                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("nonInvolvedGroup")).endOr().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("nonInvolvedGroup")).endOr().count()).isZero();
         }
     }
 
@@ -551,11 +545,10 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().
-                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
-            assertEquals(processInstance.getId(),
-                    historyService.createHistoricProcessInstanceQuery().
-                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().list().get(0).getId()).isEqualTo(processInstance.getId());
         }
     }
 
@@ -568,8 +561,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(0L, historyService.createHistoricProcessInstanceQuery().
-                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().processInstanceId("undefinedId").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isZero();
         }
     }
 
@@ -582,8 +575,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().
-                    or().involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).endOr().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    or().involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(1);
         }
     }
 
@@ -596,8 +589,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().
-                    involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
         }
     }
 
@@ -609,8 +602,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(0L, historyService.createHistoricProcessInstanceQuery().
-                    involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count()).isZero();
         }
     }
 
@@ -622,8 +615,8 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(0L, historyService.createHistoricProcessInstanceQuery().
-                    involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().
+                    involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).count()).isZero();
         }
     }
 
@@ -635,21 +628,21 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
         taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().
-                    or().
+            assertThat(historyService.createHistoricProcessInstanceQuery()
+                    .or().
                     involvedUser("kermit").involvedGroups(Collections.singleton("testGroup")).
-                    endOr().
-                    count());
+                    endOr()
+                    .count()).isEqualTo(1);
         }
     }
 
     private void assertNoInvolvement(String userId) {
-        assertEquals(0L, runtimeService.createProcessInstanceQuery().involvedUser(userId).count());
+        assertThat(runtimeService.createProcessInstanceQuery().involvedUser(userId).count()).isZero();
     }
 
     private void assertInvolvement(String userId, String instanceId) {
         ProcessInstance involvedInstance = runtimeService.createProcessInstanceQuery().involvedUser(userId).singleResult();
-        assertEquals(instanceId, involvedInstance.getId());
+        assertThat(involvedInstance.getId()).isEqualTo(instanceId);
     }
 
     private String startProcessAsUser(String processId, String userId) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,72 +80,80 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
     public void testQuery() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables().variableValueEquals("anothertest", 123).singleResult();
         Map<String, Object> variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals(123, variableMap.get("anothertest"));
+        assertThat(variableMap)
+                .containsOnly(entry("anothertest", 123));
 
         List<ProcessInstance> instanceList = runtimeService.createProcessInstanceQuery().includeProcessVariables().list();
-        assertEquals(7, instanceList.size());
+        assertThat(instanceList).hasSize(7);
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .variableValueLike("casetest", "MyCase%").singleResult();
         variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals("MyCaseTest", variableMap.get("casetest"));
+        assertThat(variableMap)
+                .containsOnly(entry("casetest", "MyCaseTest"));
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .variableValueLikeIgnoreCase("casetest", "mycase%").singleResult();
         variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals("MyCaseTest", variableMap.get("casetest"));
+        assertThat(variableMap)
+                .containsOnly(entry("casetest", "MyCaseTest"));
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .variableValueLikeIgnoreCase("casetest", "mycase2%").singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         instanceList = runtimeService.createProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).list();
-        assertEquals(4, instanceList.size());
+        assertThat(instanceList).hasSize(4);
         processInstance = instanceList.get(0);
         variableMap = processInstance.getProcessVariables();
-        assertEquals(2, variableMap.size());
-        assertEquals("test", variableMap.get("test"));
-        assertEquals("test2", variableMap.get("test2"));
+        assertThat(variableMap)
+                .containsOnly(
+                        entry("test", "test"),
+                        entry("test2", "test2")
+                );
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY_2).singleResult();
         variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals(123, variableMap.get("anothertest"));
+        assertThat(variableMap)
+                .containsOnly(entry("anothertest", 123));
 
         instanceList = runtimeService.createProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).listPage(0, 5);
-        assertEquals(4, instanceList.size());
+        assertThat(instanceList).hasSize(4);
         processInstance = instanceList.get(0);
         variableMap = processInstance.getProcessVariables();
-        assertEquals(2, variableMap.size());
-        assertEquals("test", variableMap.get("test"));
-        assertEquals("test2", variableMap.get("test2"));
+        assertThat(variableMap)
+                .containsOnly(
+                        entry("test", "test"),
+                        entry("test2", "test2")
+                );
 
         instanceList = runtimeService.createProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).listPage(0, 1);
-        assertEquals(1, instanceList.size());
+        assertThat(instanceList).hasSize(1);
         processInstance = instanceList.get(0);
         variableMap = processInstance.getProcessVariables();
-        assertEquals(2, variableMap.size());
-        assertEquals("test", variableMap.get("test"));
-        assertEquals("test2", variableMap.get("test2"));
+        assertThat(variableMap)
+                .containsOnly(
+                        entry("test", "test"),
+                        entry("test2", "test2")
+                );
 
         instanceList = runtimeService.createProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).orderByProcessDefinitionKey().asc().listPage(2, 4);
-        assertEquals(2, instanceList.size());
+        assertThat(instanceList).hasSize(2);
         processInstance = instanceList.get(0);
         variableMap = processInstance.getProcessVariables();
-        assertEquals(2, variableMap.size());
-        assertEquals("test", variableMap.get("test"));
-        assertEquals("test2", variableMap.get("test2"));
+        assertThat(variableMap)
+                .containsOnly(
+                        entry("test", "test"),
+                        entry("test2", "test2")
+                );
 
         instanceList = runtimeService.createProcessInstanceQuery().includeProcessVariables().processDefinitionKey(PROCESS_DEFINITION_KEY).orderByProcessDefinitionKey().asc().listPage(4, 5);
-        assertEquals(0, instanceList.size());
+        assertThat(instanceList).isEmpty();
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables().variableValueEquals("test4", "test4").singleResult();
         variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals("test4", variableMap.get("test4"));
+        assertThat(variableMap)
+                .containsOnly(entry("test4", "test4"));
     }
 
     @Test
@@ -150,28 +161,28 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .or().variableValueEquals("undefined", 999).variableValueEquals("anothertest", 123).endOr().singleResult();
         Map<String, Object> variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals(123, variableMap.get("anothertest"));
+        assertThat(variableMap)
+                .containsOnly(entry("anothertest", 123));
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .or().variableValueEquals("undefined", 999).endOr().singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .or().variableValueEquals("anothertest", 123).variableValueEquals("undefined", 999).endOr().singleResult();
         variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals(123, variableMap.get("anothertest"));
+        assertThat(variableMap)
+                .containsOnly(entry("anothertest", 123));
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .or().variableValueEquals("anothertest", 999).endOr().singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         processInstance = runtimeService.createProcessInstanceQuery().includeProcessVariables()
                 .or().variableValueEquals("anothertest", 999).variableValueEquals("anothertest", 123).endOr().singleResult();
         variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals(123, variableMap.get("anothertest"));
+        assertThat(variableMap)
+                .containsOnly(entry("anothertest", 123));
     }
 
     @Test
@@ -181,19 +192,19 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
             query0 = query0.variableValueEquals("anothertest", i);
         }
         query0 = query0.endOr();
-        assertNull(query0.singleResult());
+        assertThat(query0.singleResult()).isNull();
 
         ProcessInstanceQuery query1 = runtimeService.createProcessInstanceQuery().includeProcessVariables().or().variableValueEquals("anothertest", 123);
         for (int i = 0; i < 20; i++) {
             query1 = query1.variableValueEquals("anothertest", i);
         }
         query1 = query1.endOr();
-        assertNull(query0.singleResult());
+        assertThat(query0.singleResult()).isNull();
 
         ProcessInstance processInstance = query1.singleResult();
         Map<String, Object> variableMap = processInstance.getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals(123, variableMap.get("anothertest"));
+        assertThat(variableMap)
+                .containsOnly(entry("anothertest", 123));
 
         ProcessInstanceQuery query2 = runtimeService.createProcessInstanceQuery().includeProcessVariables().or();
         for (int i = 0; i < 20; i++) {
@@ -204,7 +215,7 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
                 .processDefinitionKey(PROCESS_DEFINITION_KEY_2)
                 .processDefinitionId("undefined")
                 .endOr();
-        assertNull(query2.singleResult());
+        assertThat(query2.singleResult()).isNull();
 
         ProcessInstanceQuery query3 = runtimeService.createProcessInstanceQuery().includeProcessVariables().or().variableValueEquals("anothertest", 123);
         for (int i = 0; i < 20; i++) {
@@ -216,8 +227,8 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
                 .processDefinitionId("undefined")
                 .endOr();
         variableMap = query3.singleResult().getProcessVariables();
-        assertEquals(1, variableMap.size());
-        assertEquals(123, variableMap.get("anothertest"));
+        assertThat(variableMap)
+                .containsOnly(entry("anothertest", 123));
     }
 
     @Test
@@ -227,7 +238,7 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableFlowableTestC
                 .variableValueLikeIgnoreCase("test", "TES%")
                 .variableValueLikeIgnoreCase("test", "%XYZ").endOr()
                 .list();
-        assertEquals(4, instanceList.size());
+        assertThat(instanceList).hasSize(4);
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceCommentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceCommentTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.common.engine.api.FlowableException;
@@ -37,13 +39,13 @@ public class ProcessInstanceCommentTest extends PluggableFlowableTestCase {
             taskService.addComment(null, processInstance.getId(), "Hello World");
 
             List<Comment> comments = taskService.getProcessInstanceComments(processInstance.getId());
-            assertEquals(1, comments.size());
+            assertThat(comments).hasSize(1);
 
             List<Comment> commentsByType = taskService.getProcessInstanceComments(processInstance.getId(), "comment");
-            assertEquals(1, commentsByType.size());
+            assertThat(commentsByType).hasSize(1);
 
             commentsByType = taskService.getProcessInstanceComments(processInstance.getId(), "noThisType");
-            assertEquals(0, commentsByType.size());
+            assertThat(commentsByType).isEmpty();
 
             // Suspend process instance
             runtimeService.suspendProcessInstanceById(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryAndWithExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryAndWithExceptionTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.engine.delegate.DelegateExecution;
@@ -52,31 +54,31 @@ public class ProcessInstanceQueryAndWithExceptionTest extends PluggableFlowableT
         ProcessInstance processNoException = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY_NO_EXCEPTION);
 
         ProcessInstanceQuery queryNoException = runtimeService.createProcessInstanceQuery();
-        assertEquals(1, queryNoException.count());
-        assertEquals(1, queryNoException.list().size());
-        assertEquals(processNoException.getId(), queryNoException.list().get(0).getId());
+        assertThat(queryNoException.count()).isEqualTo(1);
+        assertThat(queryNoException.list()).hasSize(1);
+        assertThat(queryNoException.list().get(0).getId()).isEqualTo(processNoException.getId());
 
         ProcessInstanceQuery queryWithException = runtimeService.createProcessInstanceQuery();
-        assertEquals(0, queryWithException.withJobException().count());
-        assertEquals(0, queryWithException.withJobException().list().size());
+        assertThat(queryWithException.withJobException().count()).isZero();
+        assertThat(queryWithException.withJobException().list()).isEmpty();
 
         ProcessInstance processWithException1 = startProcessInstanceWithFailingJob(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1);
         TimerJobQuery jobQuery1 = managementService.createTimerJobQuery().processInstanceId(processWithException1.getId());
-        assertEquals(1, jobQuery1.withException().count());
-        assertEquals(1, jobQuery1.withException().list().size());
-        assertEquals(1, queryWithException.withJobException().count());
-        assertEquals(1, queryWithException.withJobException().list().size());
-        assertEquals(processWithException1.getId(), queryWithException.withJobException().list().get(0).getId());
+        assertThat(jobQuery1.withException().count()).isEqualTo(1);
+        assertThat(jobQuery1.withException().list()).hasSize(1);
+        assertThat(queryWithException.withJobException().count()).isEqualTo(1);
+        assertThat(queryWithException.withJobException().list()).hasSize(1);
+        assertThat(queryWithException.withJobException().list().get(0).getId()).isEqualTo(processWithException1.getId());
 
         ProcessInstance processWithException2 = startProcessInstanceWithFailingJob(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_2);
         TimerJobQuery jobQuery2 = managementService.createTimerJobQuery().processInstanceId(processWithException2.getId());
-        assertEquals(2, jobQuery2.withException().count());
-        assertEquals(2, jobQuery2.withException().list().size());
+        assertThat(jobQuery2.withException().count()).isEqualTo(2);
+        assertThat(jobQuery2.withException().list()).hasSize(2);
 
-        assertEquals(2, queryWithException.withJobException().count());
-        assertEquals(2, queryWithException.withJobException().list().size());
-        assertEquals(processWithException1.getId(), queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1).list().get(0).getId());
-        assertEquals(processWithException2.getId(), queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_2).list().get(0).getId());
+        assertThat(queryWithException.withJobException().count()).isEqualTo(2);
+        assertThat(queryWithException.withJobException().list()).hasSize(2);
+        assertThat(queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_1).list().get(0).getId()).isEqualTo(processWithException1.getId());
+        assertThat(queryWithException.withJobException().processDefinitionKey(PROCESS_DEFINITION_KEY_WITH_EXCEPTION_2).list().get(0).getId()).isEqualTo(processWithException2.getId());
     }
 
     private ProcessInstance startProcessInstanceWithFailingJob(String processInstanceByKey) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceUpdateBusinessKeyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceUpdateBusinessKeyTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.ExecutionListener;
@@ -32,11 +34,11 @@ public class ProcessInstanceUpdateBusinessKeyTest extends PluggableFlowableTestC
         runtimeService.startProcessInstanceByKey("businessKeyProcess");
 
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-        assertEquals("bzKey", processInstance.getBusinessKey());
+        assertThat(processInstance.getBusinessKey()).isEqualTo("bzKey");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
-            assertEquals("bzKey", historicProcessInstance.getBusinessKey());
+            assertThat(historicProcessInstance.getBusinessKey()).isEqualTo("bzKey");
         }
     }
 
@@ -46,21 +48,21 @@ public class ProcessInstanceUpdateBusinessKeyTest extends PluggableFlowableTestC
         runtimeService.startProcessInstanceByKey("businessKeyProcess", "testKey");
 
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-        assertEquals("testKey", processInstance.getBusinessKey());
+        assertThat(processInstance.getBusinessKey()).isEqualTo("testKey");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
-            assertEquals("testKey", historicProcessInstance.getBusinessKey());
+            assertThat(historicProcessInstance.getBusinessKey()).isEqualTo("testKey");
         }
 
         runtimeService.updateBusinessKey(processInstance.getId(), "newKey");
 
         processInstance = runtimeService.createProcessInstanceQuery().singleResult();
-        assertEquals("newKey", processInstance.getBusinessKey());
+        assertThat(processInstance.getBusinessKey()).isEqualTo("newKey");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
-            assertEquals("newKey", historicProcessInstance.getBusinessKey());
+            assertThat(historicProcessInstance.getBusinessKey()).isEqualTo("newKey");
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RecordRuntimeActivitiesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RecordRuntimeActivitiesTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
@@ -34,7 +36,7 @@ public class RecordRuntimeActivitiesTest extends AbstractTestCase {
         try {
             processEngine.getRuntimeService().startProcessInstanceByKey("oneTaskProcess");
 
-            assertTrue(processEngine.getRuntimeService().createActivityInstanceQuery().count() > 0L);
+            assertThat(processEngine.getRuntimeService().createActivityInstanceQuery().count() > 0L).isTrue();
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
             processEngine.close();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,7 +54,7 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
         Set<String> executionIds = new HashSet<>();
         executionIds.add(processInstance1.getId());
         List<VariableInstance> variables = runtimeService.getVariableInstancesByExecutionIds(executionIds);
-        assertEquals(1, variables.size());
+        assertThat(variables).hasSize(1);
         checkVariable(processInstance1.getId(), "executionVar1", "helloWorld1", variables);
 
         // 2 process
@@ -60,7 +62,7 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
         executionIds.add(processInstance1.getId());
         executionIds.add(processInstance2.getId());
         variables = runtimeService.getVariableInstancesByExecutionIds(executionIds);
-        assertEquals(2, variables.size());
+        assertThat(variables).hasSize(2);
         checkVariable(processInstance1.getId(), "executionVar1", "helloWorld1", variables);
         checkVariable(processInstance2.getId(), "executionVar2", "helloWorld2", variables);
     }
@@ -86,14 +88,14 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
         Set<String> executionIds = new HashSet<>();
         executionIds.add(processInstance1.getId());
         List<VariableInstance> variables = runtimeService.getVariableInstancesByExecutionIds(executionIds);
-        assertEquals(serializableTypeVar, variables.get(0).getValue());
+        assertThat(variables.get(0).getValue()).isEqualTo(serializableTypeVar);
     }
 
     private void checkVariable(String executionId, String name, String value, List<VariableInstance> variables) {
         for (VariableInstance variable : variables) {
             if (executionId.equals(variable.getExecutionId())) {
-                assertEquals(name, variable.getName());
-                assertEquals(value, variable.getValue());
+                assertThat(variable.getName()).isEqualTo(name);
+                assertThat(variable.getValue()).isEqualTo(value);
                 return;
             }
         }
@@ -124,17 +126,17 @@ public class RuntimeVariablesTest extends PluggableFlowableTestCase {
         }
 
         List<VariableInstance> executionVariableInstances = runtimeService.getVariableInstancesByExecutionIds(executionIds);
-        assertEquals(2, executionVariableInstances.size());
-        assertEquals("executionVar", executionVariableInstances.get(0).getName());
-        assertEquals("executionVar", executionVariableInstances.get(0).getValue());
-        assertEquals("executionVar", executionVariableInstances.get(1).getName());
-        assertEquals("executionVar", executionVariableInstances.get(1).getValue());
+        assertThat(executionVariableInstances).hasSize(2);
+        assertThat(executionVariableInstances.get(0).getName()).isEqualTo("executionVar");
+        assertThat(executionVariableInstances.get(0).getValue()).isEqualTo("executionVar");
+        assertThat(executionVariableInstances.get(1).getName()).isEqualTo("executionVar");
+        assertThat(executionVariableInstances.get(1).getValue()).isEqualTo("executionVar");
 
         executionIds = new HashSet<>();
         executionIds.add(processInstance.getId());
         executionVariableInstances = runtimeService.getVariableInstancesByExecutionIds(executionIds);
-        assertEquals(1, executionVariableInstances.size());
-        assertEquals("processVar", executionVariableInstances.get(0).getName());
-        assertEquals("processVar", executionVariableInstances.get(0).getValue());
+        assertThat(executionVariableInstances).hasSize(1);
+        assertThat(executionVariableInstances.get(0).getName()).isEqualTo("processVar");
+        assertThat(executionVariableInstances.get(0).getValue()).isEqualTo("processVar");
     }
 }


### PR DESCRIPTION
Found additional files to convert to assertj in the `org.flowable.engine.test.api.runtime` package.  Obviously my other matching tool missed some file :(
