### PR TITLE
Update assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
@@ -294,14 +294,14 @@ public class JobEventsTest extends PluggableFlowableTestCase {
 
         // the second timer job will be fired and no jobs should be remaining
         waitForJobExecutorToProcessAllJobs(2000, 200);
-        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         nowCalendar.add(Calendar.HOUR, 1);
         nowCalendar.add(Calendar.MINUTE, 5);
         testClock.setCurrentTime(nowCalendar.getTime());
         waitForJobExecutorToProcessAllJobs(2000, 200);
 
-        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         checkEventCount(1, FlowableEngineEventType.TIMER_FIRED);
         checkEventContext(filterEvents(FlowableEngineEventType.TIMER_FIRED).get(0), secondTimerInstance);
@@ -519,7 +519,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
 
         event = (FlowableEngineEvent) listener.getEventsReceived().get(7);
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.JOB_RETRIES_DECREMENTED);
-        assertThat(((Job) ((FlowableEntityEvent) event).getEntity()).getRetries()).isEqualTo(0);
+        assertThat(((Job) ((FlowableEntityEvent) event).getEntity()).getRetries()).isZero();
         checkEventContext(event, theJob);
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -467,7 +467,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(processCancelledEvent.getCause()).as("The cause has to be the same as in deleteProcessInstance method call").isEqualTo("delete_test");
 
         assertThat(this.taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).as("No task can be active for deleted process.")
-                .isEqualTo(0);
+                .isZero();
 
         List<FlowableEvent> taskCancelledEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
         assertThat(taskCancelledEvents).as("ActivitiEventType.ACTIVITY_CANCELLED was expected 2 times.").hasSize(2);
@@ -661,7 +661,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
             "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
     public void testDeleteMultiInstanceCallActivityProcessInstance() {
-        assertThat(taskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().count()).isZero();
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelCallActivity");
         assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(7);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(12);
@@ -673,8 +673,8 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
                 .isEqualTo(FlowableEngineEventType.ACTIVITY_CANCELLED);
         assertThat(this.listener.getEventsReceived().get(2).getType()).as("SubProcess cancelled event has to be fired.")
                 .isEqualTo(FlowableEngineEventType.PROCESS_CANCELLED);
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
-        assertThat(taskService.createTaskQuery().count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+        assertThat(taskService.createTaskQuery().count()).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/SignalThrowingEventListenerTest.java
@@ -192,12 +192,12 @@ public class SignalThrowingEventListenerTest extends PluggableFlowableTestCase {
             assertThat(failedJob.getRetries()).isEqualTo(2);
 
             // Three retries should each have triggered dispatching of a retry-decrement event
-            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
             managementService.moveTimerToExecutableJob(failedJob.getId());
             assertThatThrownBy(() -> managementService.executeJob(signalJob.getId()))
                     .isInstanceOf(FlowableException.class);
-            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
         } finally {
             processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
@@ -121,7 +121,7 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
     public void testProcessExecutionWithRollback() {
 
         assertThat(TestTransactionEventListener.eventsReceived).isEmpty();
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // Regular execution, no exception
         runtimeService.startProcessInstanceByKey("testProcessExecutionWithRollback", CollectionUtil.singletonMap("throwException", false));

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdmTransactionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdmTransactionsTest.java
@@ -79,7 +79,7 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
 
         // Should have rolled back to task
         assertThat(taskService.createTaskQuery().singleResult()).isNotNull();
-        assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(0L);
+        assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isZero();
 
         // The logic in the tasklistener (creating a new user) should rolled back too:
         // no new user should have been created

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ExternalWorkerJobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ExternalWorkerJobQueryTest.java
@@ -72,7 +72,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
                 .containsOnly(processInstance2.getId());
 
         query = managementService.createExternalWorkerJobQuery().processInstanceId("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }
@@ -89,7 +89,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
                 .containsOnly(processInstance1.getId(), processInstance2.getId());
 
         query = managementService.createExternalWorkerJobQuery().processDefinitionId("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }
@@ -119,7 +119,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
         assertThat(query.singleResult()).isNotNull();
 
         query = managementService.createExternalWorkerJobQuery().executionId("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }
@@ -137,7 +137,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
                 .containsExactlyInAnyOrder(processInstance1.getId(), processInstance2.getId());
 
         query = managementService.createExternalWorkerJobQuery().elementId("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
 
     }
@@ -155,7 +155,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
                 .containsExactlyInAnyOrder(processInstance1.getId(), processInstance2.getId());
 
         query = managementService.createExternalWorkerJobQuery().elementName("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
     }
 
@@ -169,7 +169,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
         assertThat(query.list()).hasSize(2);
 
         query = managementService.createExternalWorkerJobQuery().handlerType("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
     }
 
@@ -225,7 +225,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
         assertThat(job.getExceptionMessage()).isEqualTo("Error message");
 
         query = managementService.createExternalWorkerJobQuery().exceptionMessage("Error");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }
@@ -302,7 +302,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
         assertThat(job.getLockExpirationTime()).isNotNull();
 
         query = managementService.createExternalWorkerJobQuery().lockOwner("invalid");
-        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/JobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/JobQueryTest.java
@@ -226,7 +226,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
     public void testByInvalidCorrelationId() {
         assertThat(managementService.createJobQuery().correlationId("invalid").singleResult()).isNull();
         assertThat(managementService.createJobQuery().correlationId("invalid").list()).isEmpty();
-        assertThat(managementService.createJobQuery().correlationId("invalid").count()).isEqualTo(0);
+        assertThat(managementService.createJobQuery().correlationId("invalid").count()).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/TimerJobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/TimerJobQueryTest.java
@@ -86,7 +86,7 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testByExecutable() {
-        assertThat(managementService.createTimerJobQuery().executable().count()).isEqualTo(0);
+        assertThat(managementService.createTimerJobQuery().executable().count()).isZero();
         assertThat(managementService.createTimerJobQuery().executable().list()).isEmpty();
         processEngineConfiguration.getClock().setCurrentTime(new Date(testStartTime.getTime() + (5 * 60 * 1000 * 1000)));
         assertThat(managementService.createTimerJobQuery().executable().count()).isEqualTo(3);
@@ -97,14 +97,14 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
     public void testByHandlerType() {
         assertThat(managementService.createTimerJobQuery().handlerType(TriggerTimerEventJobHandler.TYPE).count()).isEqualTo(3);
         assertThat(managementService.createTimerJobQuery().handlerType(TriggerTimerEventJobHandler.TYPE).list()).hasSize(3);
-        assertThat(managementService.createTimerJobQuery().handlerType("invalid").count()).isEqualTo(0);
+        assertThat(managementService.createTimerJobQuery().handlerType("invalid").count()).isZero();
     }
 
     @Test
     public void testByJobType() {
         assertThat(managementService.createTimerJobQuery().timers().count()).isEqualTo(3);
         assertThat(managementService.createTimerJobQuery().timers().list()).hasSize(3);
-        assertThat(managementService.createTimerJobQuery().messages().count()).isEqualTo(0);
+        assertThat(managementService.createTimerJobQuery().messages().count()).isZero();
         assertThat(managementService.createTimerJobQuery().messages().list()).isEmpty();
 
         // Executing the async job throws an exception -> job retry + creation of timer
@@ -112,7 +112,7 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
         assertThat(asyncJob).isNotNull();
         assertThatThrownBy(() -> managementService.executeJob(asyncJob.getId()));
 
-        assertThat(managementService.createJobQuery().count()).isEqualTo(0);
+        assertThat(managementService.createJobQuery().count()).isZero();
         assertThat(managementService.createTimerJobQuery().timers().count()).isEqualTo(3);
         assertThat(managementService.createTimerJobQuery().timers().list()).hasSize(3);
         assertThat(managementService.createTimerJobQuery().messages().count()).isEqualTo(1);
@@ -131,7 +131,7 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testByDuedateHigherThan() {
-        assertThat(managementService.createTimerJobQuery().timers().duedateLowerThan(testStartTime).count()).isEqualTo(0);
+        assertThat(managementService.createTimerJobQuery().timers().duedateLowerThan(testStartTime).count()).isZero();
         assertThat(managementService.createTimerJobQuery().timers().duedateLowerThan(testStartTime).list()).isEmpty();
     }
 
@@ -151,7 +151,7 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
     public void testByInvalidCorrelationId() {
         assertThat(managementService.createTimerJobQuery().correlationId("invalid").singleResult()).isNull();
         assertThat(managementService.createTimerJobQuery().correlationId("invalid").list()).isEmpty();
-        assertThat(managementService.createTimerJobQuery().correlationId("invalid").count()).isEqualTo(0);
+        assertThat(managementService.createTimerJobQuery().correlationId("invalid").count()).isZero();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeploymentQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeploymentQueryTest.java
@@ -193,7 +193,7 @@ public class DeploymentQueryTest extends PluggableFlowableTestCase {
     @Test
     public void testNativeQuery() {
         assertThat(managementService.getTableName(Deployment.class, false)).isEqualTo("ACT_RE_DEPLOYMENT");
-        assertEquals("ACT_RE_DEPLOYMENT", managementService.getTableName(DeploymentEntity.class, false));
+        assertThat(managementService.getTableName(DeploymentEntity.class, false)).isEqualTo("ACT_RE_DEPLOYMENT");
         String tableName = managementService.getTableName(Deployment.class);
         String baseQuerySql = "SELECT * FROM " + tableName;
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
@@ -75,8 +75,8 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
-        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count()).isEqualTo(0);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(1);
@@ -112,8 +112,8 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
-        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count()).isEqualTo(0);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(1);
@@ -138,7 +138,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
         assertThat(subProcessInstance).isNotNull();
 
-        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
@@ -148,7 +148,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
         taskService.complete(task.getId());
 
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -187,7 +187,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
         assertThat(subProcessInstance).isNotNull();
 
-        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
@@ -228,7 +228,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
 
         taskService.complete(firstSecondTask.getId());
 
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         Task secondTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(secondTask.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -268,7 +268,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
         assertThat(subProcessInstance).isNotNull();
 
-        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
@@ -278,7 +278,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
         taskService.complete(task.getId());
 
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
@@ -325,7 +325,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
         assertThat(subProcessInstance).isNotNull();
 
-        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
@@ -335,7 +335,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
         taskService.complete(task.getId());
 
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -1020,8 +1019,8 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(6);
         Map<String, List<Task>> taskGroups = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(taskGroups.keySet()).hasSize(2);
-        assertThat(taskGroups.keySet()).isEqualTo(new HashSet<>(Arrays.asList("forkTask1", "forkTask2")));
+        assertThat(taskGroups)
+                .containsOnlyKeys("forkTask1", "forkTask2");
         assertThat(taskGroups.get("forkTask1")).hasSize(3);
         assertThat(taskGroups.get("forkTask2")).hasSize(3);
 
@@ -1098,8 +1097,8 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(6);
         Map<String, List<Task>> taskGroups = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(taskGroups.keySet()).hasSize(2);
-        assertThat(taskGroups.keySet()).isEqualTo(new HashSet<>(Arrays.asList("forkTask1", "forkTask2")));
+        assertThat(taskGroups)
+                .containsOnlyKeys("forkTask1", "forkTask2");
         assertThat(taskGroups.get("forkTask1")).hasSize(3);
         assertThat(taskGroups.get("forkTask2")).hasSize(3);
 
@@ -1166,8 +1165,8 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
 
         //Move all activities
         runtimeService.createChangeActivityStateBuilder()
@@ -1219,8 +1218,8 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<Task>> classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(3);
-        assertThat(classifiedTasks).containsKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3");
 
         //Finish one activity in two MI subProcesses
         taskService.complete(classifiedTasks.get("taskInclusive1").get(1).getId());
@@ -1278,8 +1277,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(4);
-        assertThat(classifiedTasks).containsKeys("taskInclusive1", "taskInclusive2", "taskInclusive3", "postForkTask");
+        assertThat(classifiedTasks).containsOnlyKeys("taskInclusive1", "taskInclusive2", "taskInclusive3", "postForkTask");
         assertThat(classifiedTasks.get("taskInclusive1")).hasSize(1);
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(1);
         assertThat(classifiedTasks.get("taskInclusive3")).hasSize(2);
@@ -1311,8 +1309,8 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
-        assertThat(classifiedTasks).hasSize(2);
-        assertThat(classifiedTasks).containsKeys("postForkTask", "taskInclusive2");
+        assertThat(classifiedTasks)
+                .containsOnlyKeys("postForkTask", "taskInclusive2");
         assertThat(classifiedTasks.get("postForkTask")).hasSize(2);
         assertThat(classifiedTasks.get("taskInclusive2")).hasSize(1);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
@@ -2335,8 +2335,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(localVariables.get("localVar2")).isEqualTo(20);
 
         // Verify events
-        Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
-
         assertThat(changeStateEventListener.getEvents())
                 .extracting(FlowableEvent::getType)
                 .containsExactly(
@@ -2422,7 +2420,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(localVariables.get("localVar2")).isEqualTo(20);
 
         // Verify events
-        Iterator<FlowableEvent> iterator = changeStateEventListener.iterator();
         assertThat(changeStateEventListener.getEvents())
                 .extracting(FlowableEvent::getType)
                 .containsExactly(
@@ -2604,7 +2601,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions).isEmpty();
-        ;
 
         //Move to catchEvent
         runtimeService.createChangeActivityStateBuilder()
@@ -2617,7 +2613,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2635,7 +2631,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2662,7 +2657,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2684,7 +2679,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the task once more
         taskService.complete(tasks.get(0).getId());
@@ -2696,7 +2690,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2718,7 +2712,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2744,7 +2737,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2765,7 +2758,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the task once more
         taskService.complete(tasks.get(0).getId());
@@ -2777,7 +2769,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2798,7 +2790,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2820,7 +2811,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions).isEmpty();
-        ;
 
         //Move to catchEvent
         runtimeService.createChangeActivityStateBuilder()
@@ -2834,7 +2824,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2853,7 +2843,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2876,7 +2865,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions).isEmpty();
-        ;
 
         //Move to catchEvent
         runtimeService.createChangeActivityStateBuilder()
@@ -2889,7 +2877,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2908,7 +2896,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -2935,7 +2922,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2957,7 +2944,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the task once more
         taskService.complete(tasks.get(0).getId());
@@ -2969,7 +2955,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -2991,7 +2977,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -3017,7 +3002,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -3038,7 +3023,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the task once more
         taskService.complete(tasks.get(0).getId());
@@ -3050,7 +3034,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -3071,7 +3055,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //Complete the process
         taskService.complete(tasks.get(0).getId());
@@ -3089,7 +3072,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
             List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
             Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
             assertThat(classifiedEventSubscriptions).isEmpty();
-            ;
         });
     }
 
@@ -3100,7 +3082,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
             assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
             List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
             assertThat(tasks).isEmpty();
-            ;
+
             List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
             Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
             assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -3117,7 +3099,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
             assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
             List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
             assertThat(eventSubscriptions).isEmpty();
-            ;
         });
     }
 
@@ -3238,7 +3219,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
         assertThat(tasks).isEmpty();
-        ;
+
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -3255,7 +3236,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions).isEmpty();
-        ;
 
         //Trigger signal
         runtimeService.signalEventReceived("someSignal");
@@ -3277,7 +3257,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //ProcessInstance2 is waiting for the event
         processId = processInstance2.getId();
@@ -3287,7 +3266,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processId).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -3342,7 +3321,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
         assertThat(tasks).isEmpty();
-        ;
+
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         Map<String, List<EventSubscription>> classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);
@@ -3359,7 +3338,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions).isEmpty();
-        ;
 
         //Trigger signal
         runtimeService.signalEventReceived("someSignal");
@@ -3385,7 +3363,6 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         assertThat(eventSubscriptions).isEmpty();
-        ;
 
         //ProcessInstance2 is waiting for the event
         processId = processInstance2.getId();
@@ -3395,7 +3372,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
         tasks = taskService.createTaskQuery().processInstanceId(processId).list();
         assertThat(tasks).isEmpty();
-        ;
+
         eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processId).list();
         classifiedEventSubscriptions = groupListContentBy(eventSubscriptions, EventSubscription::getActivityId);
         assertThat(classifiedEventSubscriptions.get("intermediateCatchEvent")).hasSize(1);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
@@ -143,7 +143,6 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         migrationResult = processMigrationService.getResultsOfBatchProcessInstanceMigration(migrationBatch.getId());
         assertThat(migrationResult).isNotNull();
 
-        assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
         assertThat(migrationResult.getAllMigrationParts()).hasSize(2);
@@ -245,7 +244,6 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         migrationResult = processMigrationService.getResultsOfBatchProcessInstanceMigration(migrationBatch.getId());
         assertThat(migrationResult).isNotNull();
 
-        assertThat(migrationResult).isNotNull();
         assertThat(migrationResult.getBatchId()).isEqualTo(migrationBatch.getId());
         assertThat(migrationResult.getStatus()).isEqualTo(ProcessInstanceBatchMigrationResult.STATUS_COMPLETED);
         assertThat(migrationResult.getAllMigrationParts()).hasSize(2);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationCallActivityTest.java
@@ -410,9 +410,9 @@ public class ProcessInstanceMigrationCallActivityTest extends PluggableFlowableT
                 .containsOnly(procDefCallActivityV1.getId());
 
         List<Task> subProcessTasks = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).list();
-        assertThat(task)
+        assertThat(subProcessTasks)
                 .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
-                .contains("theTask", procDefSimpleOneTask.getId());
+                .contains(tuple("userTask1Id", procDefCallActivityV1.getId()));
 
         //Complete process
         completeProcessInstanceTasks(subProcessInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationDocumentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationDocumentTest.java
@@ -339,7 +339,7 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
     public void testSerializeDeSerializeProcessInstanceMigrationDocumentForDefinitionKeyVersion() {
 
         String definitionKey = "MyProcessKey";
-        Integer definitionVer = 5;
+        int definitionVer = 5;
         String definitionTenantId = "admin";
         ActivityMigrationMapping.OneToOneMapping oneToOne1 = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1");
         ActivityMigrationMapping.OneToOneMapping oneToOne2 = ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2");
@@ -368,7 +368,7 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
     @Test
     public void testSerializeDeSerializeProcessInstanceMigrationDocumentWithVariables() {
         String definitionKey = "MyProcessKey";
-        Integer definitionVer = 5;
+        int definitionVer = 5;
         String definitionTenantId = "admin";
 
         ActivityMigrationMapping.OneToOneMapping oneToOne1 = ActivityMigrationMapping.createMappingFor("originalActivity1", "newActivity1")
@@ -376,7 +376,7 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         ActivityMigrationMapping.OneToOneMapping oneToOne2 = ActivityMigrationMapping.createMappingFor("originalActivity2", "newActivity2")
                 .withLocalVariable("variableDouble", 12345.6789);
 
-        HashMap processInstanceVars = new HashMap<String, Object>() {
+        HashMap<String, Object> processInstanceVars = new HashMap<String, Object>() {
 
             {
                 put("instanceVar1", "stringValue");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
@@ -422,8 +422,9 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
                 .extracting("processDefinitionId")
                 .containsOnly(procDefOneTask.getId());
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("userTask1Id");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procDefOneTask.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("userTask1Id", procDefOneTask.getId());
         List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(eventSubscriptions).isEmpty();
 
@@ -449,8 +450,9 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
                 .extracting("processDefinitionId")
                 .containsOnly(procWithSignal.getId());
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("eventSubProcessTask");
-        assertThat(task).extracting(Task::getProcessDefinitionId).isEqualTo(procWithSignal.getId());
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactly("eventSubProcessTask", procWithSignal.getId());
 
         //Since the only task in the parent scope was moved, it behaves as a interrupting eventSubProcess
         Job job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
@@ -94,10 +94,9 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .processDefinitionKey("MP")
                 .list();
 
-        assertThat(processDefinitions).hasSize(2);
-        processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        assertThat(version1ProcessDef.getId()).isEqualTo(processDefinitions.get(0).getId());
-        assertThat(version2ProcessDef.getId()).isEqualTo(processDefinitions.get(1).getId());
+        assertThat(processDefinitions)
+                .extracting(ProcessDefinition::getId)
+                .containsExactlyInAnyOrder(version1ProcessDef.getId(), version2ProcessDef.getId());
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(executions).hasSize(2); //includes root execution
@@ -672,10 +671,9 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .processDefinitionKey("MP")
                 .list();
 
-        assertThat(processDefinitions).hasSize(2);
-        processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        assertThat(version1ProcessDef.getId()).isEqualTo(processDefinitions.get(0).getId());
-        assertThat(version2ProcessDef.getId()).isEqualTo(processDefinitions.get(1).getId());
+        assertThat(processDefinitions)
+                .extracting(ProcessDefinition::getId)
+                .containsExactlyInAnyOrder(version1ProcessDef.getId(), version2ProcessDef.getId());
 
         List<Execution> executionsBefore = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(executionsBefore).hasSize(2); //includes root execution
@@ -766,10 +764,9 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .processDefinitionKey("MP")
                 .list();
 
-        assertThat(processDefinitions).hasSize(2);
-        processDefinitions.sort(Comparator.comparingInt(ProcessDefinition::getVersion));
-        assertThat(version1ProcessDef.getId()).isEqualTo(processDefinitions.get(0).getId());
-        assertThat(version2ProcessDef.getId()).isEqualTo(processDefinitions.get(1).getId());
+        assertThat(processDefinitions)
+                .extracting(ProcessDefinition::getId)
+                .containsExactlyInAnyOrder(version1ProcessDef.getId(), version2ProcessDef.getId());
 
         List<Execution> executionsBefore = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(executionsBefore).hasSize(2); //includes root execution
@@ -1761,7 +1758,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Job timerJob1 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob1).isNotNull();
         assertThat(timerJob1).extracting(Job::getProcessDefinitionId).isEqualTo(procDefSubProcWithTimer.getId());
-        assertThat(timerJob1).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
+        assertThat(timerJob1.getJobHandlerConfiguration()).contains("boundaryTimerEvent");
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
@@ -1869,7 +1866,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procDefSubProcWithTimer.getId());
-        assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
+        assertThat(timerJob.getJobHandlerConfiguration()).contains("boundaryTimerEvent");
 
         // Verify events
         assertThat(changeStateEventListener.hasEvents()).isTrue();
@@ -1952,7 +1949,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procDefSubProcWithTimer.getId());
-        assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
+        assertThat(timerJob.getJobHandlerConfiguration()).contains("boundaryTimerEvent");
 
         // Verify events
         assertThat(changeStateEventListener.hasEvents()).isTrue();
@@ -2007,7 +2004,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procVersion1.getId());
-        assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
+        assertThat(timerJob.getJobHandlerConfiguration()).contains("boundaryTimerEvent");
 
         changeStateEventListener.clear();
         //Migrate to the other processDefinition
@@ -2124,7 +2121,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procDefTimerTaskInSubProcess.getId());
-        assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
+        assertThat(timerJob.getJobHandlerConfiguration()).contains("boundaryTimerEvent");
         //Job is attached to the activity
         Execution timerExecution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         Job timerFromTask = managementService.createTimerJobQuery().executionId(timerExecution.getId()).singleResult();
@@ -2213,7 +2210,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
         assertThat(timerJob).extracting(Job::getProcessDefinitionId).isEqualTo(procDefTimerTaskInSubProcess.getId());
-        assertThat(timerJob).extracting(Job::getJobHandlerConfiguration).toString().contains("boundaryTimerEvent");
+        assertThat(timerJob.getJobHandlerConfiguration()).contains("boundaryTimerEvent");
         //Job is attached to the activity
         Execution timerExecution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
         Job timerFromTask = managementService.createTimerJobQuery().executionId(timerExecution.getId()).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
@@ -147,7 +147,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
                 .latestVersion()
                 .singleResult().getId()).isEqualTo(processDefinitionIdWithTenant2);
         assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").processDefinitionTenantId("Not a tenant")
-                .latestVersion().count()).isEqualTo(0);
+                .latestVersion().count()).isZero();
         assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").processDefinitionWithoutTenantId().latestVersion()
                 .singleResult().getId()).isEqualTo(processDefinitionIdWithoutTenant);
 
@@ -494,7 +494,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
         assertThat(this.repositoryService.createProcessDefinitionQuery()
                 .processDefinitionTenantId("tenantA")
-                .count()).isEqualTo(0);
+                .count()).isZero();
 
         // Deploying another version should just up the version
         String processDefinitionIdNoTenant2 = deployOneTaskTestProcess();
@@ -730,7 +730,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         // Now, start 1 process instance that fires a signal event (not in
         // tenant context), it should only continue those without tenant
         runtimeService.startProcessInstanceByKey("testMtSignalFiring");
-        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isZero();
         assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isEqualTo(2);
 
         // Start a process instance that is running in tenant context
@@ -773,7 +773,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         // Signal through API (with tenant)
         runtimeService.signalEventReceivedWithTenantId("The Signal", TEST_TENANT_ID);
         assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isEqualTo(4);
-        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isZero();
 
         // Signal through API (without tenant)
         runtimeService.signalEventReceived("The Signal");
@@ -815,7 +815,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
         // Signal through API (without tenant)
         runtimeService.signalEventReceived("The Signal");
-        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isZero();
         assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isEqualTo(5);
 
         // Signal through API (with tenant)
@@ -856,21 +856,21 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
         // Signal through API (with tenant)
         runtimeService.signalEventReceivedAsyncWithTenantId("The Signal", TEST_TENANT_ID);
-        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isEqualTo(0);
-        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isZero();
 
         for (Job job : managementService.createJobQuery().list()) {
             managementService.executeJob(job.getId());
         }
 
         assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isEqualTo(4);
-        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isZero();
 
         // Signal through API (without tenant)
         runtimeService.signalEventReceivedAsync("The Signal");
 
         assertThat(taskService.createTaskQuery().taskName("Task after signal").taskTenantId(TEST_TENANT_ID).count()).isEqualTo(4);
-        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().taskName("Task after signal").taskWithoutTenantId().count()).isZero();
 
         for (Job job : managementService.createJobQuery().list()) {
             managementService.executeJob(job.getId());
@@ -899,7 +899,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         runtimeService.signalEventReceived("The Signal");
         assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(3);
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceWithoutTenantId().count()).isEqualTo(3);
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TEST_TENANT_ID).count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceTenantId(TEST_TENANT_ID).count()).isZero();
 
         // Signalling with tenant
         runtimeService.signalEventReceivedWithTenantId("The Signal", TEST_TENANT_ID);
@@ -950,7 +950,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
         assertThat(taskService.createTaskQuery().taskName("My task").count()).isEqualTo(2);
         assertThat(taskService.createTaskQuery().taskName("My task").taskWithoutTenantId().count()).isEqualTo(2);
-        assertThat(taskService.createTaskQuery().taskName("My task").taskTenantId(TEST_TENANT_ID).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().taskName("My task").taskTenantId(TEST_TENANT_ID).count()).isZero();
 
         // Start a process instance by message with tenant
         runtimeService.startProcessInstanceByMessageAndTenantId("My message", TEST_TENANT_ID);
@@ -982,7 +982,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByMessageAndTenantId("My message", TEST_TENANT_ID);
         runtimeService.startProcessInstanceByMessageAndTenantId("My message", TEST_TENANT_ID);
         assertThat(taskService.createTaskQuery().taskName("My task").count()).isEqualTo(3);
-        assertThat(taskService.createTaskQuery().taskName("My task").taskWithoutTenantId().count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().taskName("My task").taskWithoutTenantId().count()).isZero();
         assertThat(taskService.createTaskQuery().taskName("My task").taskTenantId(TEST_TENANT_ID).count()).isEqualTo(3);
 
         // Start a process instance by message without tenant

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/BpmnEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/BpmnEventRegistryConsumerTest.java
@@ -204,7 +204,7 @@ public class BpmnEventRegistryConsumerTest extends FlowableEventRegistryBpmnTest
 
         inboundEventChannelAdapter.triggerTestEvent("kermit");
         assertThat(taskService.createTaskQuery().processInstanceId(kermitProcessInstance.getId()).count()).isEqualTo(1);
-        assertThat(taskService.createTaskQuery().processInstanceId(gonzoProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(gonzoProcessInstance.getId()).count()).isZero();
 
         inboundEventChannelAdapter.triggerTestEvent("kermit");
         Task afterTask = taskService.createTaskQuery().processInstanceId(kermitProcessInstance.getId()).singleResult();
@@ -218,7 +218,7 @@ public class BpmnEventRegistryConsumerTest extends FlowableEventRegistryBpmnTest
 
         inboundEventChannelAdapter.triggerTestEvent("fozzie");
         assertThat(taskService.createTaskQuery().processInstanceId(kermitProcessInstance.getId()).count()).isEqualTo(1);
-        assertThat(taskService.createTaskQuery().processInstanceId(gonzoProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(gonzoProcessInstance.getId()).count()).isZero();
 
         inboundEventChannelAdapter.triggerTestEvent("gonzo");
         assertThat(taskService.createTaskQuery().processInstanceId(kermitProcessInstance.getId()).count()).isEqualTo(1);
@@ -260,7 +260,7 @@ public class BpmnEventRegistryConsumerTest extends FlowableEventRegistryBpmnTest
 
         inboundEventChannelAdapter.triggerTestEvent("kermit");
         assertThat(taskService.createTaskQuery().processInstanceId(kermitProcessInstance.getId()).count()).isEqualTo(1);
-        assertThat(taskService.createTaskQuery().processInstanceId(gonzoProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(gonzoProcessInstance.getId()).count()).isZero();
 
         inboundEventChannelAdapter.triggerTestEvent("kermit");
         Task afterTask = taskService.createTaskQuery().processInstanceId(kermitProcessInstance.getId()).singleResult();
@@ -274,7 +274,7 @@ public class BpmnEventRegistryConsumerTest extends FlowableEventRegistryBpmnTest
 
         inboundEventChannelAdapter.triggerTestEvent("fozzie");
         assertThat(taskService.createTaskQuery().processInstanceId(kermitProcessInstance.getId()).count()).isEqualTo(1);
-        assertThat(taskService.createTaskQuery().processInstanceId(gonzoProcessInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(gonzoProcessInstance.getId()).count()).isZero();
 
         inboundEventChannelAdapter.triggerTestEvent("gonzo");
         assertThat(taskService.createTaskQuery().processInstanceId(kermitProcessInstance.getId()).count()).isEqualTo(1);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
@@ -378,7 +378,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
@@ -392,7 +392,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         Execution signalExecution = runtimeService.createExecutionQuery().signalEventSubscriptionName("alert").singleResult();
         runtimeService.signalEventReceived("alert", signalExecution.getId());
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
@@ -414,7 +414,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertThat(waitingExecution).isNotNull();
         runtimeService.signalEventReceived("alert", waitingExecution.getId());
 
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
@@ -483,14 +483,14 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             // The parent and child process should be present in history
-            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(2L);
+            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(2);
 
             // Deleting the parent process should cascade the child-process
             historyService.deleteHistoricProcessInstance(pi.getId());
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
-            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
@@ -333,10 +333,10 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
                 tuple("taskKey123", "Task B")
             );
         assertThat(historyService.createHistoricTaskInstanceQuery().taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid")).count())
-            .isEqualTo(2L);
+            .isEqualTo(2);
 
         assertThat(historyService.createHistoricTaskInstanceQuery().taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).list()).isEmpty();
-        assertThat(historyService.createHistoricTaskInstanceQuery().taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).count()).isEqualTo(0L);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).count()).isZero();
 
         assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid"))
             .endOr().list())
@@ -346,7 +346,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
                 tuple("taskKey123", "Task B")
             );
         assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid"))
-            .endOr().count()).isEqualTo(2L);
+            .endOr().count()).isEqualTo(2);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.java
@@ -37,9 +37,9 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testJavaServiceDelegation() {
-        ProcessInstance pi = runtimeService.startProcessInstanceByKey("javaServiceDelegation", CollectionUtil.singletonMap("input", "Activiti BPM Engine"));
+        ProcessInstance pi = runtimeService.startProcessInstanceByKey("javaServiceDelegation", CollectionUtil.singletonMap("input", "Flowable BPM Engine"));
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).activityId("waitState").singleResult();
-        assertThat(runtimeService.getVariable(execution.getId(), "input")).isEqualTo("ACTIVITI BPM ENGINE");
+        assertThat(runtimeService.getVariable(execution.getId(), "input")).isEqualTo("FLOWABLE BPM ENGINE");
     }
 
     @Test
@@ -169,7 +169,7 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
         Map<String, Object> vars = new HashMap<>();
         vars.put("var", "no-exception");
         runtimeService.startProcessInstanceByKey("exceptionHandling", vars);
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // If variable value == 'throw-exception', process executes
         // service task, which generates and catches exception,


### PR DESCRIPTION
A series of small updates that include:

- removing stray semicolons
- removing dead code
- using primitives instead of types
- using `isZero()`
- combining multiple `assertThat()` into single statements
- replacing `assertEquals()`
- etc.

It may appear that the changes are large but they are not; more like the same change is repeated over and over.