### PR TITLE
Use assertj fluent style in flowable-engine-configurator module.

### DIFF
--- a/modules/flowable-engine-configurator/pom.xml
+++ b/modules/flowable-engine-configurator/pom.xml
@@ -34,6 +34,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/modules/flowable-engine-configurator/src/test/java/org/flowable/engine/configurator/test/DeploymentTest.java
+++ b/modules/flowable-engine-configurator/src/test/java/org/flowable/engine/configurator/test/DeploymentTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.engine.configurator.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.app.api.repository.AppDefinition;
 import org.flowable.app.api.repository.AppDeployment;
@@ -49,35 +48,35 @@ public class DeploymentTest extends FlowableAppTestCase {
         
         try {
             AppDeployment queryAppDeployment = appRepositoryService.createDeploymentQuery().singleResult();
-            assertNotNull(queryAppDeployment);
-            assertEquals(appDeployment.getId(), queryAppDeployment.getId());
+            assertThat(queryAppDeployment).isNotNull();
+            assertThat(queryAppDeployment.getId()).isEqualTo(appDeployment.getId());
             
             AppDefinition appDefinition = appRepositoryService.createAppDefinitionQuery().deploymentId(appDeployment.getId()).singleResult();
-            assertNotNull(appDefinition.getId());
-            assertNotNull(appDeployment.getId(), appDefinition.getDeploymentId());
-            assertEquals("testApp", appDefinition.getKey());
-            assertEquals("Test app", appDefinition.getName());
-            assertEquals(1, appDefinition.getVersion());
+            assertThat(appDefinition.getId()).isNotNull();
+            assertThat(appDefinition.getDeploymentId()).isNotNull();
+            assertThat(appDefinition.getKey()).isEqualTo("testApp");
+            assertThat(appDefinition.getName()).isEqualTo("Test app");
+            assertThat(appDefinition.getVersion()).isEqualTo(1);
             
             processEngineConfiguration = (ProcessEngineConfiguration) appEngineConfiguration.getEngineConfigurations()
                             .get(EngineConfigurationConstants.KEY_PROCESS_ENGINE_CONFIG);
             RepositoryService repositoryService = processEngineConfiguration.getRepositoryService();
             deployment = repositoryService.createDeploymentQuery().parentDeploymentId(appDeployment.getId()).singleResult();
-            assertNotNull(deployment);
-            assertEquals(appDeployment.getId(), deployment.getParentDeploymentId());
+            assertThat(deployment).isNotNull();
+            assertThat(deployment.getParentDeploymentId()).isEqualTo(appDeployment.getId());
             ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deployment.getId()).singleResult();
-            assertNotNull(processDefinition);
-            assertEquals("oneTask", processDefinition.getKey());
+            assertThat(processDefinition).isNotNull();
+            assertThat(processDefinition.getKey()).isEqualTo("oneTask");
             
             cmmnEngineConfiguration = (CmmnEngineConfiguration) appEngineConfiguration.getEngineConfigurations()
                             .get(EngineConfigurationConstants.KEY_CMMN_ENGINE_CONFIG);
             CmmnRepositoryService cmmnRepositoryService = cmmnEngineConfiguration.getCmmnRepositoryService();
             cmmnDeployment = cmmnRepositoryService.createDeploymentQuery().parentDeploymentId(appDeployment.getId()).singleResult();
-            assertNotNull(cmmnDeployment);
-            assertEquals(appDeployment.getId(), cmmnDeployment.getParentDeploymentId());
+            assertThat(cmmnDeployment).isNotNull();
+            assertThat(cmmnDeployment.getParentDeploymentId()).isEqualTo(appDeployment.getId());
             CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(cmmnDeployment.getId()).singleResult();
-            assertNotNull(caseDefinition);
-            assertEquals("oneTaskCase", caseDefinition.getKey());
+            assertThat(caseDefinition).isNotNull();
+            assertThat(caseDefinition.getKey()).isEqualTo("oneTaskCase");
             
             
         } finally {

--- a/modules/flowable-engine-configurator/src/test/java/org/flowable/engine/configurator/test/ProcessTest.java
+++ b/modules/flowable-engine-configurator/src/test/java/org/flowable/engine/configurator/test/ProcessTest.java
@@ -12,9 +12,8 @@
  */
 package org.flowable.engine.configurator.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,33 +50,24 @@ public class ProcessTest extends FlowableAppTestCase {
         try {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTask");
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
             
             runtimeService.addUserIdentityLink(processInstance.getId(), "anotherUser", IdentityLinkType.STARTER);
             taskService.addUserIdentityLink(task.getId(), "testUser", IdentityLinkType.PARTICIPANT);
             
-            assertEquals(2, runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()).size());
-            assertEquals(1, taskService.getIdentityLinksForTask(task.getId()).size());
+            assertThat(runtimeService.getIdentityLinksForProcessInstance(processInstance.getId())).hasSize(2);
+            assertThat(taskService.getIdentityLinksForTask(task.getId())).hasSize(1);
             
             taskService.complete(task.getId());
-            
-            try {
-                assertEquals(0, runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()).size());
-                fail("object not found expected");
-            } catch (FlowableObjectNotFoundException e) {
-                // expected
-            }
-            
-            try {
-                assertEquals(0, taskService.getIdentityLinksForTask(task.getId()).size());
-                fail("object not found expected");
-            } catch (FlowableObjectNotFoundException e) {
-                // expected
-            }
-            
-            assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
-            
-            
+
+            assertThatThrownBy(() -> runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()))
+                    .isInstanceOf(FlowableObjectNotFoundException.class);
+
+            assertThatThrownBy(() -> taskService.getIdentityLinksForTask(task.getId()))
+                    .isInstanceOf(FlowableObjectNotFoundException.class);
+
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+
         } finally {
             appRepositoryService.deleteDeployment(deployment.getId(), true);
             processEngineConfiguration.getRepositoryService()
@@ -104,38 +94,29 @@ public class ProcessTest extends FlowableAppTestCase {
         try {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTask");
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
             
             runtimeService.addUserIdentityLink(processInstance.getId(), "anotherUser", IdentityLinkType.STARTER);
             taskService.addUserIdentityLink(task.getId(), "testUser", IdentityLinkType.PARTICIPANT);
             
-            assertEquals(2, runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()).size());
-            assertEquals(1, taskService.getIdentityLinksForTask(task.getId()).size());
+            assertThat(runtimeService.getIdentityLinksForProcessInstance(processInstance.getId())).hasSize(2);
+            assertThat(taskService.getIdentityLinksForTask(task.getId())).hasSize(1);
             
             FormDefinition formDefinition = formEngineConfiguration.getFormRepositoryService().createFormDefinitionQuery().formDefinitionKey("form1").singleResult();
-            assertNotNull(formDefinition);
+            assertThat(formDefinition).isNotNull();
             
             Map<String, Object> variables = new HashMap<>();
             variables.put("input1", "test");
             taskService.completeTaskWithForm(task.getId(), formDefinition.getId(), null, variables);
-            
-            try {
-                assertEquals(0, runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()).size());
-                fail("object not found expected");
-            } catch (FlowableObjectNotFoundException e) {
-                // expected
-            }
-            
-            try {
-                assertEquals(0, taskService.getIdentityLinksForTask(task.getId()).size());
-                fail("object not found expected");
-            } catch (FlowableObjectNotFoundException e) {
-                // expected
-            }
-            
-            assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
-            
-            
+
+            assertThatThrownBy(() -> runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()))
+                    .isInstanceOf(FlowableObjectNotFoundException.class);
+
+            assertThatThrownBy(() -> taskService.getIdentityLinksForTask(task.getId()))
+                    .isInstanceOf(FlowableObjectNotFoundException.class);
+
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+
         } finally {
             appRepositoryService.deleteDeployment(deployment.getId(), true);
             processEngineConfiguration.getRepositoryService()
@@ -168,22 +149,22 @@ public class ProcessTest extends FlowableAppTestCase {
         try {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTask");
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            assertNotNull(task);
+            assertThat(task).isNotNull();
 
             runtimeService.addUserIdentityLink(processInstance.getId(), "anotherUser", IdentityLinkType.STARTER);
             taskService.addUserIdentityLink(task.getId(), "testUser", IdentityLinkType.PARTICIPANT);
 
-            assertEquals(2, runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()).size());
-            assertEquals(1, taskService.getIdentityLinksForTask(task.getId()).size());
+            assertThat(runtimeService.getIdentityLinksForProcessInstance(processInstance.getId())).hasSize(2);
+            assertThat(taskService.getIdentityLinksForTask(task.getId())).hasSize(1);
 
             FormDefinition formDefinition = formEngineConfiguration.getFormRepositoryService().createFormDefinitionQuery().formDefinitionKey("anotherForm").singleResult();
-            assertNotNull(formDefinition);
+            assertThat(formDefinition).isNotNull();
 
             Map<String, Object> variables = new HashMap<>();
             variables.put("anotherInput", "test");
             taskService.completeTaskWithForm(task.getId(), formDefinition.getId(), null, variables);
 
-            assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
 
         } finally {


### PR DESCRIPTION
Once `assertj` was added to the pom the conversion to `assertj` format was straight forward.
