### PR TITLE
Update assertj fluent style in flowable-event-registry module.

### DIFF
--- a/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/DefaultEventRegistryDataChangeDetectorShutdownTest.java
+++ b/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/DefaultEventRegistryDataChangeDetectorShutdownTest.java
@@ -33,7 +33,6 @@ public class DefaultEventRegistryDataChangeDetectorShutdownTest {
         assertThat(eventRegistryEngine.getEventRegistryEngineConfiguration().getEventRegistryChangeDetectionManager()).isNotNull();
         EventRegistryChangeDetectionExecutor eventRegistryChangeDetectionExecutor = eventRegistryEngine.getEventRegistryEngineConfiguration()
                 .getEventRegistryChangeDetectionExecutor();
-        assertThat(eventRegistryChangeDetectionExecutor).isNotNull();
         assertThat(eventRegistryChangeDetectionExecutor).isInstanceOf(DefaultEventRegistryChangeDetectionExecutor.class);
 
         DefaultEventRegistryChangeDetectionExecutor executor = (DefaultEventRegistryChangeDetectionExecutor) eventRegistryChangeDetectionExecutor;

--- a/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/DefaultEventRegistryDataChangeDetectorTest.java
+++ b/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/DefaultEventRegistryDataChangeDetectorTest.java
@@ -29,7 +29,6 @@ public class DefaultEventRegistryDataChangeDetectorTest extends AbstractFlowable
         assertThat(eventRegistryEngine.getEventRegistryEngineConfiguration().getEventRegistryChangeDetectionManager()).isNotNull();
         EventRegistryChangeDetectionExecutor eventRegistryChangeDetectionExecutor = eventRegistryEngine.getEventRegistryEngineConfiguration()
                 .getEventRegistryChangeDetectionExecutor();
-        assertThat(eventRegistryChangeDetectionExecutor).isNotNull();
         assertThat(eventRegistryChangeDetectionExecutor).isInstanceOf(DefaultEventRegistryChangeDetectionExecutor.class);
 
         DefaultEventRegistryChangeDetectionExecutor executor = (DefaultEventRegistryChangeDetectionExecutor) eventRegistryChangeDetectionExecutor;


### PR DESCRIPTION
Remove unneeded `isnotNull()` test as it is covered in the following `isInstanceOf()` test.