### PR TITLE
Fix unused variable reference copied in multiple modules

### DIFF
--- a/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/service/api/repository/AppDefinitionCollectionResourceTest.java
+++ b/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/service/api/repository/AppDefinitionCollectionResourceTest.java
@@ -95,7 +95,7 @@ public class AppDefinitionCollectionResourceTest extends BaseSpringRestTestCase 
             url = baseUrl + "?latest=true";
             assertResultsPresentInDataResponse(url, oneApp.getId(), secondApp.getId());
             url = baseUrl + "?latest=false";
-            assertResultsPresentInDataResponse(baseUrl, firstOneApp.getId(), oneApp.getId(), secondApp.getId());
+            assertResultsPresentInDataResponse(url, firstOneApp.getId(), oneApp.getId(), secondApp.getId());
 
             // Test deploymentId
             url = baseUrl + "?deploymentId=" + secondDeployment.getId();

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/repository/CaseDefinitionCollectionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/repository/CaseDefinitionCollectionResourceTest.java
@@ -130,7 +130,7 @@ public class CaseDefinitionCollectionResourceTest extends BaseSpringRestTestCase
             url = baseUrl + "?latest=true";
             assertResultsPresentInDataResponse(url, oneTaskCase.getId(), simpleCaseDef.getId(), repeatingStageCase.getId());
             url = baseUrl + "?latest=false";
-            assertResultsPresentInDataResponse(baseUrl, firstOneTaskCase.getId(), oneTaskCase.getId(), simpleCaseDef.getId(), repeatingStageCase.getId());
+            assertResultsPresentInDataResponse(url, firstOneTaskCase.getId(), oneTaskCase.getId(), simpleCaseDef.getId(), repeatingStageCase.getId());
 
             // Test startableByUser
             url = baseUrl + "?startableByUser=kermit";

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/ChannelDefinitionCollectionResourceTest.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/ChannelDefinitionCollectionResourceTest.java
@@ -88,7 +88,7 @@ public class ChannelDefinitionCollectionResourceTest extends BaseSpringRestTestC
             url = baseUrl + "?latest=true";
             assertResultsPresentInDataResponse(url, myChannelDef2.getId(), orderChannelDef2.getId());
             url = baseUrl + "?latest=false";
-            assertResultsPresentInDataResponse(baseUrl, firstChannelDef.getId(), myChannelDef.getId(), orderChannelDef.getId(), myChannelDef2.getId(), orderChannelDef2.getId());
+            assertResultsPresentInDataResponse(url, firstChannelDef.getId(), myChannelDef.getId(), orderChannelDef.getId(), myChannelDef2.getId(), orderChannelDef2.getId());
 
             // Test deploymentId
             url = baseUrl + "?deploymentId=" + secondDeployment.getId();

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/EventDefinitionCollectionResourceTest.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/api/repository/EventDefinitionCollectionResourceTest.java
@@ -88,7 +88,7 @@ public class EventDefinitionCollectionResourceTest extends BaseSpringRestTestCas
             url = baseUrl + "?latest=true";
             assertResultsPresentInDataResponse(url, myEventDef2.getId(), orderEventDef2.getId());
             url = baseUrl + "?latest=false";
-            assertResultsPresentInDataResponse(baseUrl, firstEventDef.getId(), myEventDef.getId(), orderEventDef.getId(), myEventDef2.getId(), orderEventDef2.getId());
+            assertResultsPresentInDataResponse(url, firstEventDef.getId(), myEventDef.getId(), orderEventDef.getId(), myEventDef2.getId(), orderEventDef2.getId());
 
             // Test deploymentId
             url = baseUrl + "?deploymentId=" + secondDeployment.getId();

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionCollectionResourceTest.java
@@ -128,7 +128,7 @@ public class ProcessDefinitionCollectionResourceTest extends BaseSpringRestTestC
             url = baseUrl + "?latest=true";
             assertResultsPresentInDataResponse(url, latestOneTaskProcess.getId(), twoTaskprocess.getId(), oneTaskWithDiProcess.getId());
             url = baseUrl + "?latest=false";
-            assertResultsPresentInDataResponse(baseUrl, oneTaskProcess.getId(), twoTaskprocess.getId(), latestOneTaskProcess.getId(), oneTaskWithDiProcess.getId());
+            assertResultsPresentInDataResponse(url, oneTaskProcess.getId(), twoTaskprocess.getId(), latestOneTaskProcess.getId(), oneTaskWithDiProcess.getId());
 
             // Test deploymentId
             url = baseUrl + "?deploymentId=" + secondDeployment.getId();


### PR DESCRIPTION
The variable `baseUrl` should be `url` and the code was replicated in multiple modules.
