### PR TITLE
Use java.nio.charset.StandardCharsets.UTF_8 as appropriate

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/AbstractEncryptingService.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/AbstractEncryptingService.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.ui.admin.service.engine;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
 
@@ -29,7 +29,6 @@ import org.flowable.ui.admin.properties.FlowableAdminAppProperties;
  */
 public abstract class AbstractEncryptingService {
 
-    public static final String UTF8_ENCODING = "UTF-8";
     public static final String AES_KEY = "AES";
     public static final String AES_CYPHER = "AES/CBC/PKCS5PADDING";
 
@@ -42,13 +41,8 @@ public abstract class AbstractEncryptingService {
         String ivString = encryption.getCredentialsIVSpec();
         String secretString = encryption.getCredentialsSecretSpec();
 
-        try {
-            initializationVectorSpec = new IvParameterSpec(ivString.getBytes(UTF8_ENCODING));
-            secretKeySpec = new SecretKeySpec(secretString.getBytes(UTF8_ENCODING), AES_KEY);
-        } catch (UnsupportedEncodingException e) {
-            // Should never happen, UTF-8 is supported on all java platforms
-            throw new RuntimeException(e);
-        }
+        initializationVectorSpec = new IvParameterSpec(ivString.getBytes(StandardCharsets.UTF_8));
+        secretKeySpec = new SecretKeySpec(secretString.getBytes(StandardCharsets.UTF_8), AES_KEY);
     }
 
     protected String encrypt(String value) {
@@ -56,11 +50,9 @@ public abstract class AbstractEncryptingService {
             Cipher cipher = Cipher.getInstance(AES_CYPHER);
             cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, initializationVectorSpec);
             byte[] encrypted = cipher.doFinal(value.getBytes());
-            return new String(Base64.getEncoder().encode(encrypted), UTF8_ENCODING);
+            return new String(Base64.getEncoder().encode(encrypted), StandardCharsets.UTF_8);
         } catch (GeneralSecurityException nsae) {
             throw new RuntimeException(nsae);
-        } catch (UnsupportedEncodingException uee) {
-            throw new RuntimeException(uee);
         }
     }
 
@@ -69,12 +61,10 @@ public abstract class AbstractEncryptingService {
         try {
             cipher = Cipher.getInstance(AES_CYPHER);
             cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, initializationVectorSpec);
-            byte[] original = cipher.doFinal(Base64.getDecoder().decode(encrypted.getBytes(UTF8_ENCODING)));
-            return new String(original, UTF8_ENCODING);
+            byte[] original = cipher.doFinal(Base64.getDecoder().decode(encrypted.getBytes(StandardCharsets.UTF_8)));
+            return new String(original, StandardCharsets.UTF_8);
         } catch (GeneralSecurityException nsae) {
             throw new RuntimeException(nsae);
-        } catch (UnsupportedEncodingException usee) {
-            throw new RuntimeException(usee);
         }
     }
 

--- a/modules/flowable-ui-admin/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/CaseDefinitionService.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/CaseDefinitionService.java
@@ -14,6 +14,7 @@ package org.flowable.ui.admin.service.engine;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import javax.xml.stream.XMLInputFactory;
@@ -80,7 +81,7 @@ public class CaseDefinitionService {
             try (CloseableHttpResponse response = client.execute(request)) {
                 InputStream responseContent = response.getEntity().getContent();
                 XMLInputFactory xif = XMLInputFactory.newInstance();
-                InputStreamReader in = new InputStreamReader(responseContent, "UTF-8");
+                InputStreamReader in = new InputStreamReader(responseContent, StandardCharsets.UTF_8);
                 XMLStreamReader xtr = xif.createXMLStreamReader(in);
                 CmmnModel cmmmnModel = new CmmnXmlConverter().convertToCmmnModel(xtr);
 

--- a/modules/flowable-ui-admin/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/FlowableClientService.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/FlowableClientService.java
@@ -12,10 +12,6 @@
  */
 package org.flowable.ui.admin.service.engine;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -59,6 +55,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Service for invoking Flowable REST services.
@@ -148,7 +148,7 @@ public class FlowableClientService {
         try {
             try (CloseableHttpResponse response = client.execute(request)) {
                 InputStream responseContent = response.getEntity().getContent();
-                String strResponse = IOUtils.toString(responseContent, "utf-8");
+                String strResponse = IOUtils.toString(responseContent, StandardCharsets.UTF_8);
 
                 boolean success = response.getStatusLine() != null && response.getStatusLine().getStatusCode() == expectedStatusCode;
                 if (success) {
@@ -208,7 +208,7 @@ public class FlowableClientService {
 
                 } else {
                     JsonNode bodyNode = null;
-                    String strResponse = IOUtils.toString(response.getEntity().getContent(), "utf-8");
+                    String strResponse = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
                     try {
                         bodyNode = objectMapper.readTree(strResponse);
                     } catch (Exception e) {
@@ -393,7 +393,7 @@ public class FlowableClientService {
             CloseableHttpResponse response = client.execute(request);
             boolean success = response.getStatusLine() != null && response.getStatusLine().getStatusCode() == expectedStatusCode;
             if (success) {
-                result = IOUtils.toString(response.getEntity().getContent(), "utf-8");
+                result = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             } else {
                 String errorMessage = null;
                 try {
@@ -648,7 +648,7 @@ public class FlowableClientService {
 
     protected JsonNode readJsonContent(InputStream requestContent) {
         try {
-            return objectMapper.readTree(IOUtils.toString(requestContent, "utf-8"));
+            return objectMapper.readTree(IOUtils.toString(requestContent, StandardCharsets.UTF_8));
         } catch (Exception e) {
             LOGGER.debug("Error parsing error message", e);
         }

--- a/modules/flowable-ui-admin/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/ProcessDefinitionService.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/ProcessDefinitionService.java
@@ -14,6 +14,7 @@ package org.flowable.ui.admin.service.engine;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import javax.xml.stream.XMLInputFactory;
@@ -115,7 +116,7 @@ public class ProcessDefinitionService {
             try (CloseableHttpResponse response = client.execute(request)) {
                 InputStream responseContent = response.getEntity().getContent();
                 XMLInputFactory xif = XMLInputFactory.newInstance();
-                InputStreamReader in = new InputStreamReader(responseContent, "UTF-8");
+                InputStreamReader in = new InputStreamReader(responseContent, StandardCharsets.UTF_8);
                 XMLStreamReader xtr = xif.createXMLStreamReader(in);
                 BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(xtr);
 

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionExportService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionExportService.java
@@ -13,7 +13,7 @@
 package org.flowable.ui.modeler.service;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -353,7 +353,7 @@ public class AppDefinitionExportService extends BaseAppDefinitionService {
     }
 
     protected void createZipEntry(ZipOutputStream zipOutputStream, String filename, String content) throws Exception {
-        createZipEntry(zipOutputStream, filename, content.getBytes(Charset.forName("UTF-8")));
+        createZipEntry(zipOutputStream, filename, content.getBytes(StandardCharsets.UTF_8));
     }
 
     protected void createZipEntry(ZipOutputStream zipOutputStream, String filename, byte[] content) throws Exception {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionImportService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionImportService.java
@@ -14,6 +14,7 @@ package org.flowable.ui.modeler.service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
@@ -221,7 +222,7 @@ public class AppDefinitionImportService {
 
                     } else {
                         modelFileName = modelFileName.replace(".json", "");
-                        String json = IOUtils.toString(zipInputStream, "utf-8");
+                        String json = IOUtils.toString(zipInputStream, StandardCharsets.UTF_8);
 
                         if (zipEntryName.startsWith("bpmn-models/")) {
                             converterContext.getProcessKeyToJsonStringMap().put(modelFileName, json);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionPublishService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionPublishService.java
@@ -15,7 +15,7 @@ package org.flowable.ui.modeler.service;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import javax.net.ssl.HostnameVerifier;
@@ -116,7 +116,7 @@ public class AppDefinitionPublishService extends BaseAppDefinitionService {
 
         HttpPost httpPost = new HttpPost(deployApiUrl);
         httpPost.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + new String(
-                Base64.getEncoder().encode((basicAuthUser + ":" + basicAuthPassword).getBytes(Charset.forName("UTF-8")))));
+                Base64.getEncoder().encode((basicAuthUser + ":" + basicAuthPassword).getBytes(StandardCharsets.UTF_8))));
 
         MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
         entityBuilder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableDecisionServiceService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableDecisionServiceService.java
@@ -16,8 +16,8 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +33,6 @@ import org.flowable.common.engine.api.FlowableException;
 import org.flowable.dmn.editor.converter.DmnJsonConverter;
 import org.flowable.dmn.model.DmnDefinition;
 import org.flowable.dmn.xml.converter.DmnXMLConverter;
-import org.flowable.idm.api.User;
 import org.flowable.ui.common.model.ResultListDataRepresentation;
 import org.flowable.ui.common.security.SecurityUtils;
 import org.flowable.ui.common.service.exception.BadRequestException;
@@ -42,12 +41,8 @@ import org.flowable.ui.common.util.XmlUtil;
 import org.flowable.ui.modeler.domain.AbstractModel;
 import org.flowable.ui.modeler.domain.Model;
 import org.flowable.ui.modeler.domain.ModelHistory;
-import org.flowable.ui.modeler.model.DecisionTableSaveRepresentation;
-import org.flowable.ui.modeler.model.ModelKeyRepresentation;
 import org.flowable.ui.modeler.model.ModelRepresentation;
 import org.flowable.ui.modeler.model.decisionservice.DecisionServiceRepresentation;
-import org.flowable.ui.modeler.model.decisiontable.DecisionTableDefinitionRepresentation;
-import org.flowable.ui.modeler.model.decisiontable.DecisionTableRepresentation;
 import org.flowable.ui.modeler.repository.ModelSort;
 import org.flowable.ui.modeler.serviceapi.ModelService;
 import org.slf4j.Logger;
@@ -190,7 +185,7 @@ public class FlowableDecisionServiceService extends BaseFlowableModelService {
             try {
 
                 XMLInputFactory xif = XmlUtil.createSafeXmlInputFactory();
-                InputStreamReader xmlIn = new InputStreamReader(file.getInputStream(), "UTF-8");
+                InputStreamReader xmlIn = new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8);
                 XMLStreamReader xtr = xif.createXMLStreamReader(xmlIn);
 
                 DmnDefinition dmnDefinition = dmnXmlConverter.convertToDmnModel(xtr);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableDecisionTableService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableDecisionTableService.java
@@ -12,14 +12,11 @@
  */
 package org.flowable.ui.modeler.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -35,9 +32,9 @@ import javax.xml.stream.XMLStreamReader;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.api.FlowableException;
+import org.flowable.dmn.editor.converter.DmnJsonConverter;
 import org.flowable.dmn.model.DmnDefinition;
 import org.flowable.dmn.xml.converter.DmnXMLConverter;
-import org.flowable.dmn.editor.converter.DmnJsonConverter;
 import org.flowable.idm.api.User;
 import org.flowable.ui.common.model.ResultListDataRepresentation;
 import org.flowable.ui.common.security.SecurityUtils;
@@ -60,6 +57,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author erikwinlof
@@ -189,7 +190,7 @@ public class FlowableDecisionTableService extends BaseFlowableModelService {
             try {
 
                 XMLInputFactory xif = XmlUtil.createSafeXmlInputFactory();
-                InputStreamReader xmlIn = new InputStreamReader(file.getInputStream(), "UTF-8");
+                InputStreamReader xmlIn = new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8);
                 XMLStreamReader xtr = xif.createXMLStreamReader(xmlIn);
 
                 DmnDefinition dmnDefinition = dmnXmlConverter.convertToDmnModel(xtr);

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableModelQueryService.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableModelQueryService.java
@@ -13,7 +13,7 @@
 package org.flowable.ui.modeler.service;
 
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,7 +90,7 @@ public class FlowableModelQueryService {
 
         // need to parse the filterText parameter ourselves, due to encoding issues with the default parsing.
         String filterText = null;
-        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), Charset.forName("UTF-8"));
+        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
         if (params != null) {
             for (NameValuePair nameValuePair : params) {
                 if ("filterText".equalsIgnoreCase(nameValuePair.getName())) {
@@ -174,7 +174,7 @@ public class FlowableModelQueryService {
         if (fileName != null && (fileName.endsWith(".bpmn") || fileName.endsWith(".bpmn20.xml"))) {
             try {
                 XMLInputFactory xif = XmlUtil.createSafeXmlInputFactory();
-                InputStreamReader xmlIn = new InputStreamReader(file.getInputStream(), "UTF-8");
+                InputStreamReader xmlIn = new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8);
                 XMLStreamReader xtr = xif.createXMLStreamReader(xmlIn);
                 BpmnModel bpmnModel = bpmnXmlConverter.convertToBpmnModel(xtr);
                 if (CollectionUtils.isEmpty(bpmnModel.getProcesses())) {
@@ -221,7 +221,7 @@ public class FlowableModelQueryService {
         if (fileName != null && (fileName.endsWith(".cmmn") || fileName.endsWith(".cmmn.xml"))) {
             try {
                 XMLInputFactory xif = XmlUtil.createSafeXmlInputFactory();
-                InputStreamReader xmlIn = new InputStreamReader(file.getInputStream(), "UTF-8");
+                InputStreamReader xmlIn = new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8);
                 XMLStreamReader xtr = xif.createXMLStreamReader(xmlIn);
                 CmmnModel cmmnModel = cmmnXmlConverter.convertToCmmnModel(xtr);
                 if (CollectionUtils.isEmpty(cmmnModel.getCases())) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/ModelServiceImpl.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/ModelServiceImpl.java
@@ -14,6 +14,7 @@ package org.flowable.ui.modeler.service;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -443,7 +444,7 @@ public class ModelServiceImpl implements ModelService {
         if (fileName != null && (fileName.endsWith(".bpmn") || fileName.endsWith(".bpmn20.xml"))) {
             try {
                 XMLInputFactory xif = XmlUtil.createSafeXmlInputFactory();
-                InputStreamReader xmlIn = new InputStreamReader(modelStream, "UTF-8");
+                InputStreamReader xmlIn = new InputStreamReader(modelStream, StandardCharsets.UTF_8);
                 XMLStreamReader xtr = xif.createXMLStreamReader(xmlIn);
                 BpmnModel bpmnModel = bpmnXMLConverter.convertToBpmnModel(xtr);
                 if (CollectionUtils.isEmpty(bpmnModel.getProcesses())) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/CaseModelsResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/CaseModelsResource.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.ui.modeler.rest.app;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.flowable.ui.common.model.ResultListDataRepresentation;
@@ -20,10 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
-import java.nio.charset.Charset;
-import java.util.List;
 
 /**
  * @author Tijs Rademakers
@@ -40,7 +41,7 @@ public class CaseModelsResource {
         // need to parse the filterText parameter ourselves, due to encoding issues with the default parsing.
         String filter = null;
         String excludeId = null;
-        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), Charset.forName("UTF-8"));
+        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
         if (params != null) {
             for (NameValuePair nameValuePair : params) {
                 if ("filter".equalsIgnoreCase(nameValuePair.getName())) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/DecisionServicesResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/DecisionServicesResource.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.ui.modeler.rest.app;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -21,7 +21,6 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.flowable.ui.common.model.ResultListDataRepresentation;
 import org.flowable.ui.modeler.service.FlowableDecisionServiceService;
-import org.flowable.ui.modeler.service.FlowableDecisionTableService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,7 +41,7 @@ public class DecisionServicesResource {
     public ResultListDataRepresentation getDecisionTables(HttpServletRequest request) {
         // need to parse the filterText parameter ourselves, due to encoding issues with the default parsing.
         String filter = null;
-        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), Charset.forName("UTF-8"));
+        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
         if (params != null) {
             for (NameValuePair nameValuePair : params) {
                 if ("filter".equalsIgnoreCase(nameValuePair.getName())) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/DecisionTablesResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/DecisionTablesResource.java
@@ -12,6 +12,11 @@
  */
 package org.flowable.ui.modeler.rest.app;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.flowable.ui.common.model.ResultListDataRepresentation;
@@ -20,10 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
-import java.nio.charset.Charset;
-import java.util.List;
 
 /**
  * @author Tijs Rademakers
@@ -39,7 +40,7 @@ public class DecisionTablesResource {
     public ResultListDataRepresentation getDecisionTables(HttpServletRequest request) {
         // need to parse the filterText parameter ourselves, due to encoding issues with the default parsing.
         String filter = null;
-        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), Charset.forName("UTF-8"));
+        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
         if (params != null) {
             for (NameValuePair nameValuePair : params) {
                 if ("filter".equalsIgnoreCase(nameValuePair.getName())) {

--- a/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/FormsResource.java
+++ b/modules/flowable-ui-modeler/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/FormsResource.java
@@ -12,7 +12,14 @@
  */
 package org.flowable.ui.modeler.rest.app;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -29,12 +36,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Tijs Rademakers
@@ -58,7 +60,7 @@ public class FormsResource {
 
         // need to parse the filterText parameter ourselves, due to encoding issues with the default parsing.
         String filter = null;
-        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), Charset.forName("UTF-8"));
+        List<NameValuePair> params = URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
         if (params != null) {
             for (NameValuePair nameValuePair : params) {
                 if ("filter".equalsIgnoreCase(nameValuePair.getName())) {


### PR DESCRIPTION
Changes to use `java.nio.charset.StandardCharsets.UTF_8` instead of local strings or constants.

In the process cleaned up imports (unused and ordering) and some small code changes.
