### PR TITLE
Array index out of bounds

### DIFF
--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/impl/AppTestHelper.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/impl/AppTestHelper.java
@@ -113,7 +113,7 @@ public abstract class AppTestHelper {
                 return resource;
             }
         }
-        return type.getName().replace('.', '/') + "." + name + "." + APP_RESOURCE_SUFFIXES[1];
+        return type.getName().replace('.', '/') + "." + name + "." + APP_RESOURCE_SUFFIXES[0];
     }
 
 }


### PR DESCRIPTION
This file is obviously a clone of similar files in other modules.  The variable:
 `public static final String[] APP_RESOURCE_SUFFIXES = new String[] { "app" };` 
has only one entry so the array index reference should be `0` and not `1`.

FWIW, additional refactoring could be done as the `for each` loop a few lines above only ever has one iteration.
