### PR TITLE
Correct variable name

### DIFF
--- a/modules/flowable-dmn-json-converter/src/main/java/org/flowable/dmn/editor/converter/DmnJsonConverterUtil.java
+++ b/modules/flowable-dmn-json-converter/src/main/java/org/flowable/dmn/editor/converter/DmnJsonConverterUtil.java
@@ -280,7 +280,7 @@ public class DmnJsonConverterUtil implements EditorJsonConstants, DmnStencilCons
                     new SimpleDateFormat("yyyy-MM-dd").parse(expressionValue);
                     expressionType = "date";
                 } catch (ParseException pe) {
-                    if ("true".equalsIgnoreCase(expressionValue) || "false".equalsIgnoreCase(expressionType)) {
+                    if ("true".equalsIgnoreCase(expressionValue) || "false".equalsIgnoreCase(expressionValue)) {
                         expressionType = "boolean";
                     }
                 }


### PR DESCRIPTION
In the `if` test for `boolean` the first clause tests the ***value*** for `true`; the second clause tests the ***type*** for `false`.  As `expressionType` is the returned value and not the input this is obviously wrong.  The PR corrects the variable name in the second clause.
