### PR TITLE
Remove obvious redundant and unneeded casts

### DIFF
--- a/modules/flowable-cmmn-engine-configurator/src/main/java/org/flowable/cmmn/engine/configurator/CmmnEngineConfigurator.java
+++ b/modules/flowable-cmmn-engine-configurator/src/main/java/org/flowable/cmmn/engine/configurator/CmmnEngineConfigurator.java
@@ -135,7 +135,7 @@ public class CmmnEngineConfigurator extends AbstractEngineConfigurator {
             cmmnEngineConfiguration.setAsyncHistoryJsonGzipCompressionEnabled(processEngineConfiguration.isAsyncHistoryJsonGzipCompressionEnabled());
             
             // See the beforeInit
-            ((CmmnEngineConfiguration) cmmnEngineConfiguration).setHistoryJobExecutionScope(JobServiceConfiguration.JOB_EXECUTION_SCOPE_ALL);
+            cmmnEngineConfiguration.setHistoryJobExecutionScope(JobServiceConfiguration.JOB_EXECUTION_SCOPE_ALL);
         }
     }
     

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/CaseTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/CaseTaskActivityBehavior.java
@@ -151,7 +151,7 @@ public class CaseTaskActivityBehavior extends ChildTaskActivityBehavior implemen
         }
 
         if (!evaluateIsBlocking(planItemInstanceEntity)) {
-            CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation((PlanItemInstanceEntity) planItemInstanceEntity);
+            CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation(planItemInstanceEntity);
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
@@ -158,7 +158,7 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
 
         } else {
             // if not blocking, treat as a manual task. No need to create a task entry.
-            CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation((PlanItemInstanceEntity) planItemInstanceEntity);
+            CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation(planItemInstanceEntity);
 
         }
     }
@@ -403,7 +403,7 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
             }
         }
 
-        CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation((PlanItemInstanceEntity) planItemInstance);
+        CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation(planItemInstance);
     }
 
     @Override

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/TaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/TaskActivityBehavior.java
@@ -38,7 +38,7 @@ public class TaskActivityBehavior extends CoreCmmnTriggerableActivityBehavior {
     @Override
     public void execute(CommandContext commandContext, PlanItemInstanceEntity planItemInstanceEntity) {
         if (!evaluateIsBlocking(planItemInstanceEntity)) {
-            CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation((PlanItemInstanceEntity) planItemInstanceEntity);
+            CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation(planItemInstanceEntity);
         }
     }
 
@@ -56,7 +56,7 @@ public class TaskActivityBehavior extends CoreCmmnTriggerableActivityBehavior {
         if (!PlanItemInstanceState.ACTIVE.equals(planItemInstance.getState())) {
             throw new FlowableIllegalStateException("Can only trigger a plan item that is in the ACTIVE state");
         }
-        CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation((PlanItemInstanceEntity) planItemInstance);
+        CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation(planItemInstance);
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/listener/ExpressionPlanItemLifecycleListener.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/listener/ExpressionPlanItemLifecycleListener.java
@@ -44,7 +44,7 @@ public class ExpressionPlanItemLifecycleListener implements PlanItemInstanceLife
 
     @Override
     public void stateChanged(DelegatePlanItemInstance planItemInstance, String oldState, String newState) {
-        expression.getValue((DelegatePlanItemInstance) planItemInstance);
+        expression.getValue(planItemInstance);
     }
 
     /**

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/MybatisCaseInstanceDataManagerImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/MybatisCaseInstanceDataManagerImpl.java
@@ -170,7 +170,7 @@ public class MybatisCaseInstanceDataManagerImpl extends AbstractCmmnDataManager<
         // paging doesn't work for combining case instances and variables due
         // to an outer join, so doing it in-memory
 
-        CaseInstanceQueryImpl caseInstanceQuery = (CaseInstanceQueryImpl) query;
+        CaseInstanceQueryImpl caseInstanceQuery = query;
         int firstResult = caseInstanceQuery.getFirstResult();
         int maxResults = caseInstanceQuery.getMaxResults();
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/AbstractFlowableVariableExpressionFunction.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/AbstractFlowableVariableExpressionFunction.java
@@ -103,7 +103,7 @@ public abstract class AbstractFlowableVariableExpressionFunction implements Flow
         if (variableName == null) {
             throw new FlowableIllegalArgumentException("Variable name passed is null");
         }
-        return variableContainer.getVariable((String) variableName);
+        return variableContainer.getVariable(variableName);
     }
     
     protected static boolean valuesAreNumbers(Object variableValue, Object actualValue) {

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/interceptor/TransactionContextInterceptor.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/interceptor/TransactionContextInterceptor.java
@@ -44,7 +44,7 @@ public class TransactionContextInterceptor extends AbstractCommandInterceptor {
         try {
 
             if (openTransaction) {
-                TransactionContext transactionContext = (TransactionContext) transactionContextFactory.openTransactionContext(commandContext);
+                TransactionContext transactionContext = transactionContextFactory.openTransactionContext(commandContext);
                 Context.setTransactionContext(transactionContext);
                 isContextSet = true;
                 commandContext.addCloseListener(new TransactionCommandContextCloseListener(transactionContext));

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -307,7 +307,7 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
     @SuppressWarnings("rawtypes")
     protected void executeOriginalBehavior(DelegateExecution execution, ExecutionEntity multiInstanceRootExecution, int loopCounter) {
         if (usesCollection() && collectionElementVariable != null) {
-            Collection collection = (Collection) resolveAndValidateCollection(execution);
+            Collection collection = resolveAndValidateCollection(execution);
 
             Object value = null;
             int index = 0;


### PR DESCRIPTION
Remove unnecessary `casts` where the variable is already defined of the same type or the method returns the required variable type.

There are many other casts that could be removed but these are the simplest ones to see and verify.
