### PR TITLE
Remove redundant modifiers on interfaces or interface components

### DIFF
--- a/modules/flowable-app-engine-api/src/main/java/org/flowable/app/api/AppEngineConfigurationApi.java
+++ b/modules/flowable-app-engine-api/src/main/java/org/flowable/app/api/AppEngineConfigurationApi.java
@@ -14,6 +14,6 @@ package org.flowable.app.api;
 
 public interface AppEngineConfigurationApi {
 
-    public AppManagementService getAppManagementService();
-    public AppRepositoryService getAppRepositoryService();
+    AppManagementService getAppManagementService();
+    AppRepositoryService getAppRepositoryService();
 }

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/AppDeployment.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/AppDeployment.java
@@ -22,8 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AppDeployment {
 
-    public String[] resources() default {};
+    String[] resources() default {};
 
-    public String tenantId() default "";
+    String tenantId() default "";
     
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcessEvent.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcessEvent.java
@@ -29,41 +29,41 @@ public interface BusinessProcessEvent {
     /**
      * @return the process definition in which the event is happening / has happened
      */
-    public ProcessDefinition getProcessDefinition();
+    ProcessDefinition getProcessDefinition();
 
     /**
      * @return the id of the activity the process is currently in / was in at the moment the event was fired.
      */
-    public String getActivityId();
+    String getActivityId();
 
     /**
      * @return the name of the transition being taken / that was taken. (null, if this event is not of type {@link BusinessProcessEventType#TAKE}
      */
-    public String getTransitionName();
+    String getTransitionName();
 
     /**
      * @return the id of the {@link ProcessInstance} this event corresponds to
      */
-    public String getProcessInstanceId();
+    String getProcessInstanceId();
 
     /**
      * @return the id of the {@link Execution} this event corresponds to
      */
-    public String getExecutionId();
+    String getExecutionId();
 
     /**
      * @return the type of the event
      */
-    public BusinessProcessEventType getType();
+    BusinessProcessEventType getType();
 
     /**
      * @return the timestamp indicating the local time at which the event was fired.
      */
-    public Date getTimeStamp();
+    Date getTimeStamp();
 
     /**
      * @return the variable scope associated with the event
      */
-    public VariableScope getVariableScope();
+    VariableScope getVariableScope();
 
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcessEventType.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcessEventType.java
@@ -23,27 +23,27 @@ import org.flowable.engine.delegate.TaskListener;
 public interface BusinessProcessEventType {
 
     /** Signifies that a transition is being taken / was taken **/
-    public static final BusinessProcessEventType TAKE = new DefaultBusinessProcessEventType(ExecutionListener.EVENTNAME_TAKE);
+    BusinessProcessEventType TAKE = new DefaultBusinessProcessEventType(ExecutionListener.EVENTNAME_TAKE);
 
     /** Signifies that an activity is being entered / war entered **/
-    public static final BusinessProcessEventType START_ACTIVITY = new DefaultBusinessProcessEventType(ExecutionListener.EVENTNAME_START);
+    BusinessProcessEventType START_ACTIVITY = new DefaultBusinessProcessEventType(ExecutionListener.EVENTNAME_START);
 
     /** Signifies that an activity is being left / was left **/
-    public static final BusinessProcessEventType END_ACTIVITY = new DefaultBusinessProcessEventType(ExecutionListener.EVENTNAME_END);
+    BusinessProcessEventType END_ACTIVITY = new DefaultBusinessProcessEventType(ExecutionListener.EVENTNAME_END);
 
     /** Signifies that a task has been created **/
-    public static final BusinessProcessEventType CREATE_TASK = new DefaultBusinessProcessEventType(TaskListener.EVENTNAME_CREATE);
+    BusinessProcessEventType CREATE_TASK = new DefaultBusinessProcessEventType(TaskListener.EVENTNAME_CREATE);
 
     /** Signifies that a task has been created **/
-    public static final BusinessProcessEventType ASSIGN_TASK = new DefaultBusinessProcessEventType(TaskListener.EVENTNAME_ASSIGNMENT);
+    BusinessProcessEventType ASSIGN_TASK = new DefaultBusinessProcessEventType(TaskListener.EVENTNAME_ASSIGNMENT);
 
     /** Signifies that a task has been created **/
-    public static final BusinessProcessEventType COMPLETE_TASK = new DefaultBusinessProcessEventType(TaskListener.EVENTNAME_COMPLETE);
+    BusinessProcessEventType COMPLETE_TASK = new DefaultBusinessProcessEventType(TaskListener.EVENTNAME_COMPLETE);
 
     /** Signifies that a task has been deleted **/
-    public static final BusinessProcessEventType DELETE_TASK = new DefaultBusinessProcessEventType(TaskListener.EVENTNAME_DELETE);
+    BusinessProcessEventType DELETE_TASK = new DefaultBusinessProcessEventType(TaskListener.EVENTNAME_DELETE);
 
-    static class DefaultBusinessProcessEventType implements BusinessProcessEventType {
+    class DefaultBusinessProcessEventType implements BusinessProcessEventType {
 
         protected final String typeName;
 

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/ProcessVariable.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/ProcessVariable.java
@@ -51,7 +51,6 @@ public @interface ProcessVariable {
     /**
      * The name of the process variable to look up. Defaults to the name of the annotated field or parameter
      */
-    @Nonbinding
-    public String value() default "";
+    @Nonbinding String value() default "";
 
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/AssignTask.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/AssignTask.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface AssignTask {
     /** the id of the task that has been assigned */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/CompleteTask.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/CompleteTask.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface CompleteTask {
     /** the id of the task that has been completed */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/CreateTask.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/CreateTask.java
@@ -32,6 +32,6 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface CreateTask {
     /** the id of the task that has been created */
-    public String value();
+    String value();
 
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/DeleteTask.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/DeleteTask.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface DeleteTask {
     /** the id of the task that has been deleted */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/EndActivity.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/EndActivity.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface EndActivity {
     /** the id of the activity that is being left / was left */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/StartActivity.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/StartActivity.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface StartActivity {
     /** the id of the activity that is being entered / was entered */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/TakeTransition.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/TakeTransition.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface TakeTransition {
     /** the id of the transition that is being taken */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/ContextAssociationManager.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/ContextAssociationManager.java
@@ -33,17 +33,17 @@ public interface ContextAssociationManager {
      * @throws FlowableException
      *             if no process instance is currently associated
      */
-    public void disAssociate();
+    void disAssociate();
 
     /**
      * @return the id of the execution currently associated or null
      */
-    public String getExecutionId();
+    String getExecutionId();
 
     /**
      * get the current execution
      */
-    public Execution getExecution();
+    Execution getExecution();
 
     /**
      * associate with the provided execution
@@ -53,26 +53,26 @@ public interface ContextAssociationManager {
     /**
      * set a current task
      */
-    public void setTask(Task task);
+    void setTask(Task task);
 
     /**
      * get the current task
      */
-    public Task getTask();
+    Task getTask();
 
     /**
      * set a process variable
      */
-    public void setVariable(String variableName, Object value);
+    void setVariable(String variableName, Object value);
 
     /**
      * get a process variable
      */
-    public Object getVariable(String variableName);
+    Object getVariable(String variableName);
 
     /**
      * @return a map of process variables cached between flushes
      */
-    public Map<String, Object> getCachedVariables();
+    Map<String, Object> getCachedVariables();
 
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/CmmnDeployment.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/CmmnDeployment.java
@@ -22,8 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CmmnDeployment {
 
-    public String[] resources() default {};
+    String[] resources() default {};
 
-    public String tenantId() default "";
+    String tenantId() default "";
     
 }

--- a/modules/flowable-cmmn-image-generator/src/main/java/org/flowable/cmmn/image/CaseDiagramGenerator.java
+++ b/modules/flowable-cmmn-image-generator/src/main/java/org/flowable/cmmn/image/CaseDiagramGenerator.java
@@ -38,8 +38,8 @@ public interface CaseDiagramGenerator {
      * @param customClassLoader
      *            provide a custom classloader for retrieving icon images
      */
-    public InputStream generateDiagram(CmmnModel cmmnModel, String imageType, String activityFontName, String labelFontName, 
-                    String annotationFontName, ClassLoader customClassLoader, double scaleFactor);
+    InputStream generateDiagram(CmmnModel cmmnModel, String imageType, String activityFontName, String labelFontName,
+                                String annotationFontName, ClassLoader customClassLoader, double scaleFactor);
 
     /**
      * Generates a diagram of the given process definition, using the diagram interchange information of the process.
@@ -49,21 +49,21 @@ public interface CaseDiagramGenerator {
      * @param imageType
      *            type of the image to generate.
      */
-    public InputStream generateDiagram(CmmnModel cmmnModel, String imageType);
+    InputStream generateDiagram(CmmnModel cmmnModel, String imageType);
 
-    public InputStream generateDiagram(CmmnModel cmmnModel, String imageType, double scaleFactor);
+    InputStream generateDiagram(CmmnModel cmmnModel, String imageType, double scaleFactor);
 
-    public InputStream generateDiagram(CmmnModel cmmnModel, String imageType, String activityFontName, String labelFontName,
-            String annotationFontName, ClassLoader customClassLoader);
+    InputStream generateDiagram(CmmnModel cmmnModel, String imageType, String activityFontName, String labelFontName,
+                                String annotationFontName, ClassLoader customClassLoader);
 
-    public InputStream generatePngDiagram(CmmnModel cmmnModel);
+    InputStream generatePngDiagram(CmmnModel cmmnModel);
 
-    public InputStream generatePngDiagram(CmmnModel cmmnModel, double scaleFactor);
+    InputStream generatePngDiagram(CmmnModel cmmnModel, double scaleFactor);
 
-    public InputStream generateJpgDiagram(CmmnModel cmmnModel);
+    InputStream generateJpgDiagram(CmmnModel cmmnModel);
 
-    public InputStream generateJpgDiagram(CmmnModel cmmnModel, double scaleFactor);
+    InputStream generateJpgDiagram(CmmnModel cmmnModel, double scaleFactor);
 
-    public BufferedImage generatePngImage(CmmnModel cmmnModel, double scaleFactor);
+    BufferedImage generatePngImage(CmmnModel cmmnModel, double scaleFactor);
 
 }

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/HasAssociations.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/HasAssociations.java
@@ -19,16 +19,16 @@ import java.util.List;
  */
 public interface HasAssociations {
     
-    public void addIncomingAssociation(Association association);
+    void addIncomingAssociation(Association association);
     
-    public List<Association> getIncomingAssociations();
+    List<Association> getIncomingAssociations();
     
-    public void setIncomingAssociations(List<Association> incomingAssociations);
+    void setIncomingAssociations(List<Association> incomingAssociations);
     
-    public void addOutgoingAssociation(Association association);
+    void addOutgoingAssociation(Association association);
     
-    public List<Association> getOutgoingAssociations();
+    List<Association> getOutgoingAssociations();
     
-    public void setOutgoingAssociations(List<Association> outgoingAssociations);
+    void setOutgoingAssociations(List<Association> outgoingAssociations);
 
 }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnDeployment.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnDeployment.java
@@ -49,6 +49,6 @@ import java.lang.annotation.RetentionPolicy;
 public @interface DmnDeployment {
 
     /** Specify resources that make up the process definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
 
 }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnDeploymentAnnotation.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnDeploymentAnnotation.java
@@ -49,6 +49,6 @@ import java.lang.annotation.RetentionPolicy;
 public @interface DmnDeploymentAnnotation {
 
     /** Specify resources that make up the process definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
 
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/ScriptingEngineAwareEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/ScriptingEngineAwareEngineConfiguration.java
@@ -23,7 +23,7 @@ import org.flowable.common.engine.impl.scripting.ScriptingEngines;
  */
 public interface ScriptingEngineAwareEngineConfiguration {
 
-    public ScriptingEngines getScriptingEngines();
+    ScriptingEngines getScriptingEngines();
 
-    public AbstractEngineConfiguration setScriptingEngines(ScriptingEngines scriptingEngines);
+    AbstractEngineConfiguration setScriptingEngines(ScriptingEngines scriptingEngines);
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/SuspensionState.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/SuspensionState.java
@@ -26,7 +26,7 @@ public interface SuspensionState {
 
     // default implementation ///////////////////////////////////////////////////
 
-    static class SuspensionStateImpl implements SuspensionState {
+    class SuspensionStateImpl implements SuspensionState {
 
         public final int stateCode;
         protected final String name;

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/javax/el/ELContextListener.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/javax/el/ELContextListener.java
@@ -25,5 +25,5 @@ public interface ELContextListener extends java.util.EventListener {
 	 * @param ece
 	 *            the notification event.
 	 */
-	public void contextCreated(ELContextEvent ece);
+	void contextCreated(ELContextEvent ece);
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/RepositoryService.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/RepositoryService.java
@@ -390,7 +390,7 @@ public interface RepositoryService {
     /**
      * Creates a new model. The model is transient and must be saved using {@link #saveModel(Model)}.
      */
-    public Model newModel();
+    Model newModel();
 
     /**
      * Saves the model. If the model already existed, the model is updated otherwise a new model is created.
@@ -398,13 +398,13 @@ public interface RepositoryService {
      * @param model
      *            model to save, cannot be null.
      */
-    public void saveModel(Model model);
+    void saveModel(Model model);
 
     /**
      * @param modelId
      *            id of model to delete, cannot be null. When an id is passed for a non-existent model, this operation is ignored.
      */
-    public void deleteModel(String modelId);
+    void deleteModel(String modelId);
 
     /**
      * Saves the model editor source for a model
@@ -412,7 +412,7 @@ public interface RepositoryService {
      * @param modelId
      *            id of model to delete, cannot be null. When an id is passed for a non-existent model, this operation is ignored.
      */
-    public void addModelEditorSource(String modelId, byte[] bytes);
+    void addModelEditorSource(String modelId, byte[] bytes);
 
     /**
      * Saves the model editor source extra for a model
@@ -420,10 +420,10 @@ public interface RepositoryService {
      * @param modelId
      *            id of model to delete, cannot be null. When an id is passed for an unexisting model, this operation is ignored.
      */
-    public void addModelEditorSourceExtra(String modelId, byte[] bytes);
+    void addModelEditorSourceExtra(String modelId, byte[] bytes);
 
     /** Query models. */
-    public ModelQuery createModelQuery();
+    ModelQuery createModelQuery();
 
     /**
      * Returns a new {@link org.flowable.common.engine.api.query.NativeQuery} for process definitions.
@@ -436,7 +436,7 @@ public interface RepositoryService {
      * @param modelId
      *            id of model
      */
-    public Model getModel(String modelId);
+    Model getModel(String modelId);
 
     /**
      * Returns the model editor source as a byte array
@@ -444,7 +444,7 @@ public interface RepositoryService {
      * @param modelId
      *            id of model
      */
-    public byte[] getModelEditorSource(String modelId);
+    byte[] getModelEditorSource(String modelId);
 
     /**
      * Returns the model editor source extra as a byte array
@@ -452,7 +452,7 @@ public interface RepositoryService {
      * @param modelId
      *            id of model
      */
-    public byte[] getModelEditorSourceExtra(String modelId);
+    byte[] getModelEditorSourceExtra(String modelId);
 
     /**
      * Authorizes a candidate user for a process definition.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableCancelledEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableCancelledEvent.java
@@ -20,5 +20,5 @@ public interface FlowableCancelledEvent extends FlowableEngineEvent {
     /**
      * @return the cause of the cancel event. Returns null, if no specific cause has been specified.
      */
-    public Object getCause();
+    Object getCause();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableConditionalEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableConditionalEvent.java
@@ -22,6 +22,6 @@ public interface FlowableConditionalEvent extends FlowableActivityEvent {
     /**
      * @return the condition expression of the conditional event.
      */
-    public String getConditionExpression();
+    String getConditionExpression();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableErrorEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableErrorEvent.java
@@ -24,8 +24,8 @@ public interface FlowableErrorEvent extends FlowableActivityEvent {
     /**
      * @return the error-code of the error. Returns null, if no specific error-code has been specified when the error was thrown.
      */
-    public String getErrorCode();
+    String getErrorCode();
 
-    public String getErrorId();
+    String getErrorId();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableEscalationEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableEscalationEvent.java
@@ -22,11 +22,11 @@ public interface FlowableEscalationEvent extends FlowableActivityEvent {
     /**
      * @return the code of the escalation. Returns null, if no specific escalation code has been specified.
      */
-    public String getEscalationCode();
+    String getEscalationCode();
 
     /**
      * @return the name of the escalation. Returns null, if no specific escalation name has been specified.
      */
-    public String getEscalationName();
+    String getEscalationName();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableJobRescheduledEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableJobRescheduledEvent.java
@@ -18,5 +18,5 @@ public interface FlowableJobRescheduledEvent extends FlowableEntityEvent {
     /**
      * @return the job id of the original job that was rescheduled
      */
-    public String getRescheduledJobId();
+    String getRescheduledJobId();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMessageEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMessageEvent.java
@@ -24,11 +24,11 @@ public interface FlowableMessageEvent extends FlowableActivityEvent {
     /**
      * @return the name of the message.
      */
-    public String getMessageName();
+    String getMessageName();
 
     /**
      * @return the payload that was passed when sending the message. Returns null, if no payload was passed.
      */
-    public Object getMessageData();
+    Object getMessageData();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMultiInstanceActivityCompletedEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMultiInstanceActivityCompletedEvent.java
@@ -13,9 +13,9 @@
 package org.flowable.engine.delegate.event;
 
 public interface FlowableMultiInstanceActivityCompletedEvent extends FlowableMultiInstanceActivityEvent {
-    public int getNumberOfInstances();
+    int getNumberOfInstances();
 
-    public int getNumberOfActiveInstances();
+    int getNumberOfActiveInstances();
 
-    public int getNumberOfCompletedInstances();
+    int getNumberOfCompletedInstances();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMultiInstanceActivityEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMultiInstanceActivityEvent.java
@@ -20,5 +20,5 @@ import org.flowable.common.engine.api.delegate.event.FlowableEvent;
  * @author Robert Hafner
  */
 public interface FlowableMultiInstanceActivityEvent extends FlowableActivityEvent {
-    public boolean isSequential();
+    boolean isSequential();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessTerminatedEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessTerminatedEvent.java
@@ -23,5 +23,5 @@ public interface FlowableProcessTerminatedEvent extends FlowableEntityEvent {
     /**
      * @return the cause of the cancel event. Returns null, if no specific cause has been specified.
      */
-    public Object getCause();
+    Object getCause();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableSignalEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableSignalEvent.java
@@ -24,11 +24,11 @@ public interface FlowableSignalEvent extends FlowableActivityEvent {
     /**
      * @return the name of the signal. Returns null, if no specific signal name has been specified when signaling.
      */
-    public String getSignalName();
+    String getSignalName();
 
     /**
      * @return the payload that was passed when signaling. Returns null, if no payload was passed.
      */
-    public Object getSignalData();
+    Object getSignalData();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ClassDelegateFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ClassDelegateFactory.java
@@ -20,8 +20,8 @@ import org.flowable.engine.impl.bpmn.parser.FieldDeclaration;
 
 /** Constructs {@link ClassDelegate}s. */
 public interface ClassDelegateFactory {
-    public ClassDelegate create(String id, String className, List<FieldDeclaration> fieldDeclarations,
-            boolean triggerable, Expression skipExpression, List<MapExceptionEntry> mapExceptions);
+    ClassDelegate create(String id, String className, List<FieldDeclaration> fieldDeclarations,
+                         boolean triggerable, Expression skipExpression, List<MapExceptionEntry> mapExceptions);
 
-    public ClassDelegate create(String className, List<FieldDeclaration> fieldDeclarations);
+    ClassDelegate create(String className, List<FieldDeclaration> fieldDeclarations);
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/XMLImporterFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/XMLImporterFactory.java
@@ -29,5 +29,5 @@ import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
  */
 public interface XMLImporterFactory {
 
-    public XMLImporter createXMLImporter(Import theImport) throws FlowableException;
+    XMLImporter createXMLImporter(Import theImport) throws FlowableException;
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/event/EventHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/event/EventHandler.java
@@ -21,8 +21,8 @@ import org.flowable.eventsubscription.service.impl.persistence.entity.EventSubsc
  */
 public interface EventHandler {
 
-    public String getEventHandlerType();
+    String getEventHandlerType();
 
-    public void handleEvent(EventSubscriptionEntity eventSubscription, Object payload, CommandContext commandContext);
+    void handleEvent(EventSubscriptionEntity eventSubscription, Object payload, CommandContext commandContext);
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/DelegateInterceptor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/DelegateInterceptor.java
@@ -30,6 +30,6 @@ import org.flowable.engine.impl.delegate.invocation.DelegateInvocation;
  */
 public interface DelegateInterceptor {
 
-    public void handleInvocation(DelegateInvocation invocation);
+    void handleInvocation(DelegateInvocation invocation);
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/DataObject.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/DataObject.java
@@ -21,7 +21,7 @@ public interface DataObject {
     /**
      * The unique id of this Data Object.
      */
-    public String getId();
+    String getId();
 
     /**
      /**

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/Deployment.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/Deployment.java
@@ -61,8 +61,8 @@ import java.lang.annotation.RetentionPolicy;
 public @interface Deployment {
 
     /** Specify resources that make up the process definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
 
     /** Specify tenantId to deploy for */
-    public String tenantId() default "";
+    String tenantId() default "";
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTask.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTask.java
@@ -24,11 +24,11 @@ import java.lang.annotation.RetentionPolicy;
 @Repeatable(MockServiceTasks.class)
 public @interface MockServiceTask {
 
-    public String id() default "";
+    String id() default "";
 
-    public String originalClassName() default "";
+    String originalClassName() default "";
 
-    public String mockedClassName() default "";
+    String mockedClassName() default "";
 
     Class<?> mockedClass() default Void.class;
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTasks.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTasks.java
@@ -22,6 +22,6 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MockServiceTasks {
 
-    public MockServiceTask[] value();
+    MockServiceTask[] value();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/NoOpServiceTasks.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/NoOpServiceTasks.java
@@ -22,12 +22,12 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface NoOpServiceTasks {
 
-    public String value() default "";
+    String value() default "";
 
-    public String[] ids() default {};
+    String[] ids() default {};
 
-    public Class<?>[] classes() default {};
+    Class<?>[] classes() default {};
 
-    public String[] classNames() default {};
+    String[] classNames() default {};
 
 }

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/ChannelDeploymentAnnotation.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/ChannelDeploymentAnnotation.java
@@ -50,8 +50,8 @@ import java.lang.annotation.RetentionPolicy;
 public @interface ChannelDeploymentAnnotation {
 
     /** Specify resources that make up the channel definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
     
-    public String tenantId() default "";
+    String tenantId() default "";
 
 }

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/EventDeploymentAnnotation.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/EventDeploymentAnnotation.java
@@ -50,8 +50,8 @@ import java.lang.annotation.RetentionPolicy;
 public @interface EventDeploymentAnnotation {
 
     /** Specify resources that make up the event definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
     
-    public String tenantId() default "";
+    String tenantId() default "";
 
 }

--- a/modules/flowable-form-api/src/main/java/org/flowable/form/api/FormEngineConfigurationApi.java
+++ b/modules/flowable-form-api/src/main/java/org/flowable/form/api/FormEngineConfigurationApi.java
@@ -14,7 +14,7 @@ package org.flowable.form.api;
 
 public interface FormEngineConfigurationApi {
 
-    public FormManagementService getFormManagementService();
-    public FormRepositoryService getFormRepositoryService();
-    public FormService getFormService();
+    FormManagementService getFormManagementService();
+    FormRepositoryService getFormRepositoryService();
+    FormService getFormService();
 }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FormDeploymentAnnotation.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FormDeploymentAnnotation.java
@@ -50,8 +50,8 @@ import java.lang.annotation.RetentionPolicy;
 public @interface FormDeploymentAnnotation {
 
     /** Specify resources that make up the process definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
     
-    public String tenantId() default "";
+    String tenantId() default "";
 
 }

--- a/modules/flowable-image-generator/src/main/java/org/flowable/image/ProcessDiagramGenerator.java
+++ b/modules/flowable-image-generator/src/main/java/org/flowable/image/ProcessDiagramGenerator.java
@@ -46,8 +46,8 @@ public interface ProcessDiagramGenerator {
      * @param drawSequenceFlowNameWithNoLabelDI
      *            provide a option to also include the sequence flow name in case there's no Label DI
      */
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows,
-            String activityFontName, String labelFontName, String annotationFontName, ClassLoader customClassLoader, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows,
+                                String activityFontName, String labelFontName, String annotationFontName, ClassLoader customClassLoader, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
     /**
      * Generates a diagram of the given process definition, using the diagram interchange information of the process.
@@ -63,28 +63,28 @@ public interface ProcessDiagramGenerator {
      * @param drawSequenceFlowNameWithNoLabelDI
      *            provide a option to also include the sequence flow name in case there's no Label DI
      */
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, String activityFontName, String labelFontName,
-            String annotationFontName, ClassLoader customClassLoader,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, String activityFontName, String labelFontName,
+                                String annotationFontName, ClassLoader customClassLoader, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, String activityFontName, String labelFontName,
-            String annotationFontName, ClassLoader customClassLoader, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, String activityFontName, String labelFontName,
+                                String annotationFontName, ClassLoader customClassLoader, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generatePngDiagram(BpmnModel bpmnModel,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generatePngDiagram(BpmnModel bpmnModel, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generatePngDiagram(BpmnModel bpmnModel, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generatePngDiagram(BpmnModel bpmnModel, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateJpgDiagram(BpmnModel bpmnModel);
+    InputStream generateJpgDiagram(BpmnModel bpmnModel);
 
-    public InputStream generateJpgDiagram(BpmnModel bpmnModel, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateJpgDiagram(BpmnModel bpmnModel, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public BufferedImage generatePngImage(BpmnModel bpmnModel, double scaleFactor);
+    BufferedImage generatePngImage(BpmnModel bpmnModel, double scaleFactor);
 
 }

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/ManagementAgent.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/ManagementAgent.java
@@ -85,8 +85,8 @@ public interface ManagementAgent {
      */
     void setMBeanServer(MBeanServer mbeanServer);
 
-    public void findAndRegisterMbeans() throws Exception;
+    void findAndRegisterMbeans() throws Exception;
 
-    public void doStart();
+    void doStart();
 
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AsyncExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AsyncExecutor.java
@@ -69,9 +69,9 @@ public interface AsyncExecutor {
 
     void setDefaultAsyncJobAcquireWaitTimeInMillis(int waitTimeInMillis);
 
-    public int getDefaultQueueSizeFullWaitTimeInMillis();
+    int getDefaultQueueSizeFullWaitTimeInMillis();
 
-    public void setDefaultQueueSizeFullWaitTimeInMillis(int defaultQueueSizeFullWaitTimeInMillis);
+    void setDefaultQueueSizeFullWaitTimeInMillis(int defaultQueueSizeFullWaitTimeInMillis);
 
     int getMaxAsyncJobsDuePerAcquisition();
 

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/FailedJobCommandFactory.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/FailedJobCommandFactory.java
@@ -16,6 +16,6 @@ import org.flowable.common.engine.impl.interceptor.Command;
 
 public interface FailedJobCommandFactory {
 
-    public Command<Object> getCommand(String jobId, Throwable exception);
+    Command<Object> getCommand(String jobId, Throwable exception);
 
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/message/AsyncJobMessageHandler.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/message/AsyncJobMessageHandler.java
@@ -30,6 +30,6 @@ public interface AsyncJobMessageHandler {
      * Returning true will delete the job.
      * Returning false will unacquire the job and decrement the retries.
      */
-    public abstract boolean handleJob(JobEntity job);
+    boolean handleJob(JobEntity job);
     
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/history/async/message/AsyncHistoryJobMessageHandler.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/history/async/message/AsyncHistoryJobMessageHandler.java
@@ -30,6 +30,6 @@ public interface AsyncHistoryJobMessageHandler {
      * Returning true will delete the job.
      * Returning false will unacquire the job and decrement the retries.
      */
-    public abstract boolean handleJob(HistoryJobEntity historyJobEntity, JsonNode historyData);
+    boolean handleJob(HistoryJobEntity historyJobEntity, JsonNode historyData);
     
 }

--- a/modules/flowable-job-spring-service/src/main/java/org/flowable/spring/job/service/SpringRejectedJobsHandler.java
+++ b/modules/flowable-job-spring-service/src/main/java/org/flowable/spring/job/service/SpringRejectedJobsHandler.java
@@ -25,5 +25,5 @@ import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
  */
 public interface SpringRejectedJobsHandler {
 
-    public void jobRejected(AsyncExecutor asyncExecutor, JobInfo job);
+    void jobRejected(AsyncExecutor asyncExecutor, JobInfo job);
 }

--- a/modules/flowable-ui-common/src/main/java/org/flowable/ui/common/tenant/TenantProvider.java
+++ b/modules/flowable-ui-common/src/main/java/org/flowable/ui/common/tenant/TenantProvider.java
@@ -14,5 +14,5 @@ package org.flowable.ui.common.tenant;
 
 
 public interface TenantProvider {
-    public String getTenantId();
+    String getTenantId();
 }

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/cache/UserCache.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/cache/UserCache.java
@@ -32,7 +32,7 @@ public interface UserCache {
 
     void invalidate(String userId);
 
-    public static class CachedUser {
+    class CachedUser {
 
         private Collection<GrantedAuthority> grantedAuthorities;
 

--- a/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/PersistentTokenService.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/service/PersistentTokenService.java
@@ -29,6 +29,6 @@ public interface PersistentTokenService {
 
     void delete(Token persistentToken);
 
-    public Token createToken(User user, String remoteAddress, String userAgent);
+    Token createToken(User user, String remoteAddress, String userAgent);
 
 }

--- a/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/ui/task/service/api/UserCache.java
+++ b/modules/flowable-ui-task/flowable-ui-task-logic/src/main/java/org/flowable/ui/task/service/api/UserCache.java
@@ -32,7 +32,7 @@ public interface UserCache {
 
     void invalidate(String userId);
 
-    public static class CachedUser {
+    class CachedUser {
 
         private Collection<GrantedAuthority> grantedAuthorities;
 

--- a/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/types/VariableType.java
+++ b/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/types/VariableType.java
@@ -20,7 +20,7 @@ public interface VariableType {
     /**
      * name of variable type (limited to 100 characters length)
      */
-    public String getTypeName();
+    String getTypeName();
 
     /**
      * <p>

--- a/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/types/VariableTypes.java
+++ b/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/types/VariableTypes.java
@@ -24,25 +24,25 @@ public interface VariableTypes {
     /**
      * @return the type for the given type name. Returns null if no type was found with the name.
      */
-    public VariableType getVariableType(String typeName);
+    VariableType getVariableType(String typeName);
 
     /**
      * @return the variable type to be used to store the given value as a variable.
      * @throws org.flowable.common.engine.api.FlowableException
      *             When no available type is capable of storing the value.
      */
-    public VariableType findVariableType(Object value);
+    VariableType findVariableType(Object value);
 
-    public VariableTypes addType(VariableType type);
+    VariableTypes addType(VariableType type);
 
     /**
      * Add type at the given index. The index is used when finding a type for an object. When different types can store a specific object value, the one with the smallest index will be used.
      */
-    public VariableTypes addType(VariableType type, int index);
+    VariableTypes addType(VariableType type, int index);
 
-    public int getTypeIndex(VariableType type);
+    int getTypeIndex(VariableType type);
 
-    public int getTypeIndex(String typeName);
+    int getTypeIndex(String typeName);
 
-    public VariableTypes removeType(VariableType type);
+    VariableTypes removeType(VariableType type);
 }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/CacheableVariable.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/CacheableVariable.java
@@ -21,5 +21,5 @@ package org.flowable.variable.service.impl.types;
  */
 public interface CacheableVariable {
 
-    public void setForceCacheable(boolean forceCachedValue);
+    void setForceCacheable(boolean forceCachedValue);
 }


### PR DESCRIPTION
Typically the redundant modifiers are `public` or `static` for interfaces or interface components.   Some of the files modified already had `public` removed for some of the items; this just completes and standardizes them.

This is the first part of a multipart PR if this change is accepted.
