### PR TITLE
Use assertj fluent style in flowable-jmx module.

### DIFF
--- a/modules/flowable-jmx/pom.xml
+++ b/modules/flowable-jmx/pom.xml
@@ -36,6 +36,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 	    <dependency>
 	      <groupId>org.slf4j</groupId>
 	      <artifactId>slf4j-log4j12</artifactId>

--- a/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/DefaultManagementAgentTest.java
+++ b/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/DefaultManagementAgentTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.management.jmx;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -77,11 +76,11 @@ public class DefaultManagementAgentTest {
         verify(mbeanServer).isRegistered(sourceObjectName);
         verify(mbeanServer).registerMBean(any(RequiredModelMBean.class), any(ObjectName.class));
 
-        assertTrue(agent.isRegistered(sourceObjectName));
+        assertThat(agent.isRegistered(sourceObjectName)).isTrue();
 
         agent.unregister(sourceObjectName);
         verify(mbeanServer).unregisterMBean(registeredObjectName);
-        assertFalse(agent.isRegistered(sourceObjectName));
+        assertThat(agent.isRegistered(sourceObjectName)).isFalse();
 
     }
 
@@ -107,7 +106,7 @@ public class DefaultManagementAgentTest {
         verify(mbeanServer).isRegistered(sourceObjectName);
         verify(mbeanServer, never()).unregisterMBean(registeredObjectName);
 
-        assertFalse(agent.isRegistered(sourceObjectName));
+        assertThat(agent.isRegistered(sourceObjectName)).isFalse();
 
     }
 

--- a/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/DefaultManagementMBeanAssemblerTest.java
+++ b/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/DefaultManagementMBeanAssemblerTest.java
@@ -13,9 +13,7 @@
 
 package org.flowable.management.jmx;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -43,17 +41,17 @@ public class DefaultManagementMBeanAssemblerTest {
     public void testHappyPath() throws MalformedObjectNameException, JMException {
         TestMbean testMbean = new TestMbean();
         ModelMBean mbean = defaultManagementMBeanAssembler.assemble(testMbean, new ObjectName("org.flowable.jmx.Mbeans:type=something"));
-        assertNotNull(mbean);
-        assertNotNull(mbean.getMBeanInfo());
-        assertNotNull(mbean.getMBeanInfo().getAttributes());
+        assertThat(mbean).isNotNull();
+        assertThat(mbean.getMBeanInfo()).isNotNull();
+        assertThat(mbean.getMBeanInfo().getAttributes()).isNotNull();
         MBeanAttributeInfo[] attributes = mbean.getMBeanInfo().getAttributes();
-        assertEquals(2, attributes.length);
-        assertTrue((attributes[0].getName().equals("TestAttributeString") && attributes[1].getName().equals("TestAttributeBoolean") || (attributes[1].getName().equals("TestAttributeString") && attributes[0]
-                .getName().equals("TestAttributeBoolean"))));
-        assertNotNull(mbean.getMBeanInfo().getOperations());
+        assertThat(attributes).hasSize(2);
+        assertThat((attributes[0].getName().equals("TestAttributeString") && attributes[1].getName().equals("TestAttributeBoolean") || (attributes[1].getName().equals("TestAttributeString") && attributes[0]
+                .getName().equals("TestAttributeBoolean")))).isTrue();
+        assertThat(mbean.getMBeanInfo().getOperations()).isNotNull();
         MBeanOperationInfo[] operations = mbean.getMBeanInfo().getOperations();
-        assertNotNull(operations);
-        assertEquals(3, operations.length);
+        assertThat(operations).isNotNull();
+        assertThat(operations).hasSize(3);
 
     }
 
@@ -61,11 +59,11 @@ public class DefaultManagementMBeanAssemblerTest {
     public void testNotificationAware() throws MalformedObjectNameException, JMException {
         NotificationSenderAware mockedNotificationAwareMbean = mock(NotificationSenderAware.class);
         ModelMBean modelBean = defaultManagementMBeanAssembler.assemble(mockedNotificationAwareMbean, new ObjectName("org.flowable.jmx.Mbeans:type=something"));
-        assertNotNull(modelBean);
+        assertThat(modelBean).isNotNull();
         ArgumentCaptor<NotificationSender> argument = ArgumentCaptor.forClass(NotificationSender.class);
         verify(mockedNotificationAwareMbean).setNotificationSender(argument.capture());
-        assertNotNull(argument);
-        assertNotNull(argument.getValue());
+        assertThat(argument).isNotNull();
+        assertThat(argument.getValue()).isNotNull();
 
     }
 

--- a/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/DeploymentsJMXClientTest.java
+++ b/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/DeploymentsJMXClientTest.java
@@ -13,12 +13,8 @@
 
 package org.flowable.management.jmx;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.net.URL;
 import java.util.List;
@@ -61,7 +57,7 @@ public class DeploymentsJMXClientTest {
 
         // no process deployed yet
         List<List<String>> deployments = (List<List<String>>) mbsc.getAttribute(deploymentsBeanName, "Deployments");
-        assertEquals(0, deployments.size());
+        assertThat(deployments).isEmpty();
 
         // deploy process remotely
 
@@ -70,39 +66,39 @@ public class DeploymentsJMXClientTest {
 
         // one process is there now, test remote deployments
         deployments = (List<List<String>>) mbsc.getAttribute(deploymentsBeanName, "Deployments");
-        assertNotNull(deployments);
-        assertEquals(1, deployments.size());
-        assertEquals(3, deployments.get(0).size());
+        assertThat(deployments).isNotNull();
+        assertThat(deployments).hasSize(1);
+        assertThat(deployments.get(0)).hasSize(3);
         String firstDeploymentId = deployments.get(0).get(0);
 
         // test remote process definition
         List<List<String>> pdList = (List<List<String>>) mbsc.getAttribute(deploymentsBeanName, "ProcessDefinitions");
-        assertNotNull(pdList);
-        assertEquals(1, pdList.size());
-        assertEquals(5, pdList.get(0).size());
-        assertNotNull(pdList.get(0).get(0));
-        assertEquals("My process", pdList.get(0).get(1));
-        assertEquals("1", pdList.get(0).get(2)); // version
-        assertEquals("false", pdList.get(0).get(3)); // not suspended
-        assertEquals("This process to test JMX", pdList.get(0).get(4));
+        assertThat(pdList).isNotNull();
+        assertThat(pdList).hasSize(1);
+        assertThat(pdList.get(0)).hasSize(5);
+        assertThat(pdList.get(0).get(0)).isNotNull();
+        assertThat(pdList.get(0).get(1)).isEqualTo("My process");
+        assertThat(pdList.get(0).get(2)).isEqualTo("1"); // version
+        assertThat(pdList.get(0).get(3)).isEqualTo("false"); // not suspended
+        assertThat(pdList.get(0).get(4)).isEqualTo("This process to test JMX");
 
         // redeploy the same process
         mbsc.invoke(deploymentsBeanName, "deployProcessDefinition", new String[] { "trivialProcess.bpmn", fileName.getFile() }, new String[] { String.class.getName(), String.class.getName() });
 
         // now there should be two deployments
         deployments = (List<List<String>>) mbsc.getAttribute(deploymentsBeanName, "Deployments");
-        assertNotNull(deployments);
-        assertEquals(2, deployments.size());
-        assertEquals(3, deployments.get(0).size());
-        assertEquals(3, deployments.get(1).size());
+        assertThat(deployments).isNotNull();
+        assertThat(deployments).hasSize(2);
+        assertThat(deployments.get(0)).hasSize(3);
+        assertThat(deployments.get(1)).hasSize(3);
 
         // there should be two process definitions, one with version equals to
         // two
         pdList = (List<List<String>>) mbsc.getAttribute(deploymentsBeanName, "ProcessDefinitions");
-        assertNotNull(pdList);
-        assertEquals(2, pdList.size());
-        assertEquals(5, pdList.get(0).size());
-        assertEquals(5, pdList.get(1).size());
+        assertThat(pdList).isNotNull();
+        assertThat(pdList).hasSize(2);
+        assertThat(pdList.get(0)).hasSize(5);
+        assertThat(pdList.get(1)).hasSize(5);
 
         // check there is one with version= = 1 and another one with version ==
         // 2, other attributed are the same
@@ -118,69 +114,69 @@ public class DeploymentsJMXClientTest {
         } else
             fail("there should one process definition with version == 1 and another one with version == 2. It is not the case");
 
-        assertNotNull(pdList.get(0).get(0));
-        assertNotNull(pdList.get(1).get(0));
-        assertEquals("My process", pdList.get(0).get(1));
-        assertEquals("My process", pdList.get(1).get(1));
-        assertEquals("false", pdList.get(0).get(3)); // not suspended
-        assertEquals("false", pdList.get(1).get(3)); // not suspended
-        assertEquals("This process to test JMX", pdList.get(0).get(4));
-        assertEquals("This process to test JMX", pdList.get(1).get(4));
+        assertThat(pdList.get(0).get(0)).isNotNull();
+        assertThat(pdList.get(1).get(0)).isNotNull();
+        assertThat(pdList.get(0).get(1)).isEqualTo("My process");
+        assertThat(pdList.get(1).get(1)).isEqualTo("My process");
+        assertThat(pdList.get(0).get(3)).isEqualTo("false"); // not suspended
+        assertThat(pdList.get(1).get(3)).isEqualTo("false"); // not suspended
+        assertThat(pdList.get(0).get(4)).isEqualTo("This process to test JMX");
+        assertThat(pdList.get(1).get(4)).isEqualTo("This process to test JMX");
 
         // suspend the one with version == 2
         mbsc.invoke(deploymentsBeanName, "suspendProcessDefinitionById", new String[] { pidV2 }, new String[] { String.class.getName() });
         RepositoryService repositoryService = processEngine.getRepositoryService();
 
         // test if it is really suspended and not the other one
-        assertTrue(repositoryService.getProcessDefinition(pidV2).isSuspended());
-        assertFalse(repositoryService.getProcessDefinition(pidV1).isSuspended());
+        assertThat(repositoryService.getProcessDefinition(pidV2).isSuspended()).isTrue();
+        assertThat(repositoryService.getProcessDefinition(pidV1).isSuspended()).isFalse();
 
         // test if it is reported as suspended and not the other one
         List<String> pd = (List<String>) mbsc.invoke(deploymentsBeanName, "getProcessDefinitionById", new String[] { pidV2 }, new String[] { String.class.getName() });
-        assertNotNull(pd);
-        assertEquals(5, pd.size());
-        assertEquals("true", pd.get(3));
+        assertThat(pd).isNotNull();
+        assertThat(pd).hasSize(5);
+        assertThat(pd.get(3)).isEqualTo("true");
 
         pd = (List<String>) mbsc.invoke(deploymentsBeanName, "getProcessDefinitionById", new String[] { pidV1 }, new String[] { String.class.getName() });
-        assertNotNull(pd);
-        assertEquals(5, pd.size());
-        assertEquals("false", pd.get(3));
+        assertThat(pd).isNotNull();
+        assertThat(pd).hasSize(5);
+        assertThat(pd.get(3)).isEqualTo("false");
 
         // now reactivate the same suspended process
         mbsc.invoke(deploymentsBeanName, "activatedProcessDefinitionById", new String[] { pidV2 }, new String[] { String.class.getName() });
 
         // test if both processes are active again
-        assertFalse(repositoryService.getProcessDefinition(pidV2).isSuspended());
-        assertFalse(repositoryService.getProcessDefinition(pidV1).isSuspended());
+        assertThat(repositoryService.getProcessDefinition(pidV2).isSuspended()).isFalse();
+        assertThat(repositoryService.getProcessDefinition(pidV1).isSuspended()).isFalse();
 
         // test if they are properly reported as activated
 
         pd = (List<String>) mbsc.invoke(deploymentsBeanName, "getProcessDefinitionById", new String[] { pidV2 }, new String[] { String.class.getName() });
-        assertNotNull(pd);
-        assertEquals(5, pd.size());
-        assertEquals("false", pd.get(3));
+        assertThat(pd).isNotNull();
+        assertThat(pd).hasSize(5);
+        assertThat(pd.get(3)).isEqualTo("false");
 
         pd = (List<String>) mbsc.invoke(deploymentsBeanName, "getProcessDefinitionById", new String[] { pidV1 }, new String[] { String.class.getName() });
-        assertNotNull(pd);
-        assertEquals(5, pd.size());
-        assertEquals("false", pd.get(3));
+        assertThat(pd).isNotNull();
+        assertThat(pd).hasSize(5);
+        assertThat(pd.get(3)).isEqualTo("false");
 
         // now undeploy the one with version == 1
         mbsc.invoke(deploymentsBeanName, "deleteDeployment", new String[] { firstDeploymentId }, new String[] { String.class.getName() });
 
         // now there should be only one deployment and only one process
         // definition with version 2, first check it with API
-        assertEquals(1, repositoryService.createDeploymentQuery().count());
+        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
 
-        assertNotEquals(repositoryService.createDeploymentQuery().singleResult().getId(), firstDeploymentId);
+        assertThat(firstDeploymentId).isNotEqualTo(repositoryService.createDeploymentQuery().singleResult().getId());
 
         // check if it is also affected in returned results.
 
         deployments = (List<List<String>>) mbsc.getAttribute(deploymentsBeanName, "Deployments");
-        assertNotNull(deployments);
-        assertEquals(1, deployments.size());
-        assertEquals(3, deployments.get(0).size());
-        assertNotEquals(deployments.get(0).get(0), firstDeploymentId);
+        assertThat(deployments).isNotNull();
+        assertThat(deployments).hasSize(1);
+        assertThat(deployments.get(0)).hasSize(3);
+        assertThat(firstDeploymentId).isNotEqualTo(deployments.get(0).get(0));
 
     }
 

--- a/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/JobExecutorJMXClientTest.java
+++ b/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/JobExecutorJMXClientTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.management.jmx;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -49,20 +48,20 @@ public class JobExecutorJMXClientTest {
 
         // first check that job executor is not activated and correctly reported
         // as being inactive
-        assertFalse(processEngineConfig.isAsyncExecutorActivate());
-        assertFalse((Boolean) mbsc.getAttribute(jobExecutorBeanName, "JobExecutorActivated"));
+        assertThat(processEngineConfig.isAsyncExecutorActivate()).isFalse();
+        assertThat((Boolean) mbsc.getAttribute(jobExecutorBeanName, "JobExecutorActivated")).isFalse();
         // now activate it remotely
         mbsc.invoke(jobExecutorBeanName, "setJobExecutorActivate", new Boolean[] { true }, new String[] { Boolean.class.getName() });
 
         // check if it has the effect and correctly reported
         // assertTrue(processEngineConfig.getJobExecutor().isActive());
-        assertTrue((Boolean) mbsc.getAttribute(jobExecutorBeanName, "JobExecutorActivated"));
+        assertThat((Boolean) mbsc.getAttribute(jobExecutorBeanName, "JobExecutorActivated")).isTrue();
 
         // again disable and check it
         mbsc.invoke(jobExecutorBeanName, "setJobExecutorActivate", new Boolean[] { false }, new String[] { Boolean.class.getName() });
 
         // check if it has the effect and correctly reported
-        assertFalse(processEngineConfig.isAsyncExecutorActivate());
-        assertFalse((Boolean) mbsc.getAttribute(jobExecutorBeanName, "JobExecutorActivated"));
+        assertThat(processEngineConfig.isAsyncExecutorActivate()).isFalse();
+        assertThat((Boolean) mbsc.getAttribute(jobExecutorBeanName, "JobExecutorActivated")).isFalse();
     }
 }

--- a/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/MBeanInfoAssemblerTest.java
+++ b/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/MBeanInfoAssemblerTest.java
@@ -13,11 +13,7 @@
 
 package org.flowable.management.jmx;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.management.JMException;
 import javax.management.MBeanAttributeInfo;
@@ -47,52 +43,52 @@ public class MBeanInfoAssemblerTest {
     public void testNullInputs() throws JMException {
 
         // at least one of the first parameters should be not null
-        assertNull(mbeanInfoAssembler.getMBeanInfo(null, null, ""));
+        assertThat(mbeanInfoAssembler.getMBeanInfo(null, null, "")).isNull();
 
         // mbean should be not null
-        assertNull(mbeanInfoAssembler.getMBeanInfo(testMbean, testMbean, null));
+        assertThat(mbeanInfoAssembler.getMBeanInfo(testMbean, testMbean, null)).isNull();
 
         // it should return something if at least one of the first parameters
         // are
         // not null
         NotManagedMBean notManagedMbean = new NotManagedMBean();
-        assertNotNull(mbeanInfoAssembler.getMBeanInfo(null, notManagedMbean, "someName"));
-        assertNotNull(mbeanInfoAssembler.getMBeanInfo(notManagedMbean, null, "someName"));
+        assertThat(mbeanInfoAssembler.getMBeanInfo(null, notManagedMbean, "someName")).isNotNull();
+        assertThat(mbeanInfoAssembler.getMBeanInfo(notManagedMbean, null, "someName")).isNotNull();
 
     }
 
     @Test
     public void testReadAttributeInfoHappyPath() throws JMException {
         ModelMBeanInfo beanInfo = mbeanInfoAssembler.getMBeanInfo(testMbean, null, "someName");
-        assertNotNull(beanInfo);
+        assertThat(beanInfo).isNotNull();
 
-        assertEquals("test description", beanInfo.getDescription());
+        assertThat(beanInfo.getDescription()).isEqualTo("test description");
         MBeanAttributeInfo[] testAttributes = beanInfo.getAttributes();
-        assertNotNull(testAttributes);
-        assertEquals(2, testAttributes.length);
+        assertThat(testAttributes).isNotNull();
+        assertThat(testAttributes).hasSize(2);
 
         int counter = 0;
         for (MBeanAttributeInfo info : testAttributes) {
             if (info.getName().equals("TestAttributeBoolean")) {
                 counter++;
-                assertEquals("test attribute Boolean description", info.getDescription());
-                assertEquals("java.lang.Boolean", info.getType());
-                assertTrue(info.isReadable());
-                assertFalse(info.isWritable());
+                assertThat(info.getDescription()).isEqualTo("test attribute Boolean description");
+                assertThat(info.getType()).isEqualTo("java.lang.Boolean");
+                assertThat(info.isReadable()).isTrue();
+                assertThat(info.isWritable()).isFalse();
             } else if (info.getName().equals("TestAttributeString")) {
                 counter++;
-                assertEquals("test attribute String description", info.getDescription());
-                assertEquals("java.lang.String", info.getType());
-                assertTrue(info.isReadable());
-                assertFalse(info.isWritable());
+                assertThat(info.getDescription()).isEqualTo("test attribute String description");
+                assertThat(info.getType()).isEqualTo("java.lang.String");
+                assertThat(info.isReadable()).isTrue();
+                assertThat(info.isWritable()).isFalse();
             }
         }
-        assertEquals(2, counter);
+        assertThat(counter).isEqualTo(2);
 
         // check the single operation
 
-        assertNotNull(beanInfo.getOperations());
-        assertEquals(3, beanInfo.getOperations().length);
+        assertThat(beanInfo.getOperations()).isNotNull();
+        assertThat(beanInfo.getOperations()).hasSize(3);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -129,11 +125,11 @@ public class MBeanInfoAssemblerTest {
     @Test
     public void testInherited() throws JMException {
         ModelMBeanInfo beanInfo = mbeanInfoAssembler.getMBeanInfo(new BadInherited(), null, "someName");
-        assertNotNull(beanInfo);
-        assertNotNull(beanInfo.getAttributes());
-        assertEquals(2, beanInfo.getAttributes().length);
-        assertNotNull(beanInfo.getOperations());
-        assertEquals(3, beanInfo.getOperations().length);
+        assertThat(beanInfo).isNotNull();
+        assertThat(beanInfo.getAttributes()).isNotNull();
+        assertThat(beanInfo.getAttributes()).hasSize(2);
+        assertThat(beanInfo.getOperations()).isNotNull();
+        assertThat(beanInfo.getOperations()).hasSize(3);
 
     }
 

--- a/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/mbeans/JobExecutorMBeanTest.java
+++ b/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/mbeans/JobExecutorMBeanTest.java
@@ -13,10 +13,7 @@
 
 package org.flowable.management.jmx.mbeans;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -64,7 +61,7 @@ public class JobExecutorMBeanTest {
 
         boolean result = jobExecutorMbean.isJobExecutorActivated();
         verify(jobExecutor).isActive();
-        assertFalse(result);
+        assertThat(result).isFalse();
 
     }
 
@@ -73,7 +70,7 @@ public class JobExecutorMBeanTest {
         when(jobExecutor.isActive()).thenReturn(true);
         boolean result = jobExecutorMbean.isJobExecutorActivated();
         verify(jobExecutor).isActive();
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
     @Test
@@ -92,38 +89,38 @@ public class JobExecutorMBeanTest {
     public void testAnnotations() throws MalformedObjectNameException, JMException {
 
         ModelMBean modelBean = assembler.assemble(jobExecutorMbean, new ObjectName("domain", "key", "value"));
-        assertNotNull(modelBean);
+        assertThat(modelBean).isNotNull();
         MBeanInfo beanInfo = modelBean.getMBeanInfo();
-        assertNotNull(beanInfo);
-        assertNotNull(beanInfo.getOperations());
-        assertEquals(2, beanInfo.getOperations().length);
+        assertThat(beanInfo).isNotNull();
+        assertThat(beanInfo.getOperations()).isNotNull();
+        assertThat(beanInfo.getOperations()).hasSize(2);
         int counter = 0;
 
         for (MBeanOperationInfo op : beanInfo.getOperations()) {
             if (op.getName().equals("setJobExecutorActivate")) {
                 counter++;
-                assertEquals("set job executor activate", op.getDescription());
-                assertEquals("void", op.getReturnType());
-                assertEquals(1, op.getSignature().length);
-                assertEquals("java.lang.Boolean", op.getSignature()[0].getType());
+                assertThat(op.getDescription()).isEqualTo("set job executor activate");
+                assertThat(op.getReturnType()).isEqualTo("void");
+                assertThat(op.getSignature()).hasSize(1);
+                assertThat(op.getSignature()[0].getType()).isEqualTo("java.lang.Boolean");
             }
         }
-        assertEquals(1, counter);
+        assertThat(counter).isEqualTo(1);
 
         // check attributes
-        assertNotNull(beanInfo.getAttributes());
-        assertEquals(1, beanInfo.getAttributes().length);
+        assertThat(beanInfo.getAttributes()).isNotNull();
+        assertThat(beanInfo.getAttributes()).hasSize(1);
 
         counter = 0;
 
         for (MBeanAttributeInfo attr : beanInfo.getAttributes()) {
             if (attr.getName().equals("JobExecutorActivated")) {
                 counter++;
-                assertEquals("check if the job executor is activated", attr.getDescription());
-                assertEquals("boolean", attr.getType());
+                assertThat(attr.getDescription()).isEqualTo("check if the job executor is activated");
+                assertThat(attr.getType()).isEqualTo("boolean");
             }
         }
-        assertEquals(1, counter);
+        assertThat(counter).isEqualTo(1);
 
     }
 

--- a/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/mbeans/ProcessDefinitionsTest.java
+++ b/modules/flowable-jmx/src/test/java/org/flowable/management/jmx/mbeans/ProcessDefinitionsTest.java
@@ -13,8 +13,7 @@
 
 package org.flowable.management.jmx.mbeans;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -96,19 +95,19 @@ public class ProcessDefinitionsTest {
         when(processDefinitionQuery.list()).thenReturn(processDefinitionList);
 
         List<List<String>> result = processDefinitionsMBean.getProcessDefinitions();
-        assertNotNull(result);
-        assertEquals(1, result.size());
-        assertEquals(5, result.get(0).size());
-        assertEquals("testId", result.get(0).get(0));
-        assertEquals("testName", result.get(0).get(1));
-        assertEquals("175", result.get(0).get(2));
-        assertEquals("false", result.get(0).get(3));
-        assertEquals("testDescription", result.get(0).get(4));
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).hasSize(5);
+        assertThat(result.get(0).get(0)).isEqualTo("testId");
+        assertThat(result.get(0).get(1)).isEqualTo("testName");
+        assertThat(result.get(0).get(2)).isEqualTo("175");
+        assertThat(result.get(0).get(3)).isEqualTo("false");
+        assertThat(result.get(0).get(4)).isEqualTo("testDescription");
 
         pd.setSuspensionState(2);
 
         result = processDefinitionsMBean.getProcessDefinitions();
-        assertEquals("true", result.get(0).get(3));
+        assertThat(result.get(0).get(3)).isEqualTo("true");
 
     }
 
@@ -124,12 +123,12 @@ public class ProcessDefinitionsTest {
         when(deploymentQuery.list()).thenReturn(deploymentList);
 
         List<List<String>> result = processDefinitionsMBean.getDeployments();
-        assertNotNull(result);
-        assertEquals(1, result.size());
-        assertEquals(3, result.get(0).size());
-        assertEquals("testDeploymentId", result.get(0).get(0));
-        assertEquals("testDeploymentName", result.get(0).get(1));
-        assertEquals("tenantId", result.get(0).get(2));
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).hasSize(3);
+        assertThat(result.get(0).get(0)).isEqualTo("testDeploymentId");
+        assertThat(result.get(0).get(1)).isEqualTo("testDeploymentName");
+        assertThat(result.get(0).get(2)).isEqualTo("tenantId");
 
     }
 
@@ -167,75 +166,75 @@ public class ProcessDefinitionsTest {
     public void testAnnotations() throws MalformedObjectNameException, JMException {
 
         ModelMBean modelBean = assembler.assemble(processDefinitionsMBean, new ObjectName("domain", "key", "value"));
-        assertNotNull(modelBean);
+        assertThat(modelBean).isNotNull();
         MBeanInfo beanInfo = modelBean.getMBeanInfo();
-        assertNotNull(beanInfo);
-        assertNotNull(beanInfo.getOperations());
-        assertEquals(9, beanInfo.getOperations().length);
+        assertThat(beanInfo).isNotNull();
+        assertThat(beanInfo.getOperations()).isNotNull();
+        assertThat(beanInfo.getOperations()).hasSize(9);
         int counter = 0;
 
         for (MBeanOperationInfo op : beanInfo.getOperations()) {
             if (op.getName().equals("deleteDeployment")) {
                 counter++;
-                assertEquals("delete deployment", op.getDescription());
-                assertEquals("void", op.getReturnType());
-                assertEquals(1, op.getSignature().length);
-                assertEquals("java.lang.String", op.getSignature()[0].getType());
+                assertThat(op.getDescription()).isEqualTo("delete deployment");
+                assertThat(op.getReturnType()).isEqualTo("void");
+                assertThat(op.getSignature()).hasSize(1);
+                assertThat(op.getSignature()[0].getType()).isEqualTo("java.lang.String");
             } else if (op.getName().equals("suspendProcessDefinitionById")) {
                 counter++;
-                assertEquals("Suspend given process ID", op.getDescription());
-                assertEquals("void", op.getReturnType());
-                assertEquals(1, op.getSignature().length);
-                assertEquals("java.lang.String", op.getSignature()[0].getType());
+                assertThat(op.getDescription()).isEqualTo("Suspend given process ID");
+                assertThat(op.getReturnType()).isEqualTo("void");
+                assertThat(op.getSignature()).hasSize(1);
+                assertThat(op.getSignature()[0].getType()).isEqualTo("java.lang.String");
             } else if (op.getName().equals("activatedProcessDefinitionById")) {
                 counter++;
-                assertEquals("Activate given process ID", op.getDescription());
-                assertEquals("void", op.getReturnType());
-                assertEquals(1, op.getSignature().length);
-                assertEquals("java.lang.String", op.getSignature()[0].getType());
+                assertThat(op.getDescription()).isEqualTo("Activate given process ID");
+                assertThat(op.getReturnType()).isEqualTo("void");
+                assertThat(op.getSignature()).hasSize(1);
+                assertThat(op.getSignature()[0].getType()).isEqualTo("java.lang.String");
             } else if (op.getName().equals("suspendProcessDefinitionByKey")) {
                 counter++;
-                assertEquals("Suspend given process ID", op.getDescription());
-                assertEquals("void", op.getReturnType());
-                assertEquals(1, op.getSignature().length);
-                assertEquals("java.lang.String", op.getSignature()[0].getType());
+                assertThat(op.getDescription()).isEqualTo("Suspend given process ID");
+                assertThat(op.getReturnType()).isEqualTo("void");
+                assertThat(op.getSignature()).hasSize(1);
+                assertThat(op.getSignature()[0].getType()).isEqualTo("java.lang.String");
             } else if (op.getName().equals("activatedProcessDefinitionByKey")) {
                 counter++;
-                assertEquals("Activate given process ID", op.getDescription());
-                assertEquals("void", op.getReturnType());
-                assertEquals(1, op.getSignature().length);
-                assertEquals("java.lang.String", op.getSignature()[0].getType());
+                assertThat(op.getDescription()).isEqualTo("Activate given process ID");
+                assertThat(op.getReturnType()).isEqualTo("void");
+                assertThat(op.getSignature()).hasSize(1);
+                assertThat(op.getSignature()[0].getType()).isEqualTo("java.lang.String");
             } else if (op.getName().equals("deployProcessDefinition")) {
                 counter++;
-                assertEquals("Deploy Process Definition", op.getDescription());
-                assertEquals("void", op.getReturnType());
-                assertEquals(2, op.getSignature().length);
-                assertEquals("java.lang.String", op.getSignature()[0].getType());
-                assertEquals("java.lang.String", op.getSignature()[1].getType());
+                assertThat(op.getDescription()).isEqualTo("Deploy Process Definition");
+                assertThat(op.getReturnType()).isEqualTo("void");
+                assertThat(op.getSignature()).hasSize(2);
+                assertThat(op.getSignature()[0].getType()).isEqualTo("java.lang.String");
+                assertThat(op.getSignature()[1].getType()).isEqualTo("java.lang.String");
             }
 
         }
-        assertEquals(6, counter);
+        assertThat(counter).isEqualTo(6);
 
         // check attributes
-        assertNotNull(beanInfo.getAttributes());
-        assertEquals(2, beanInfo.getAttributes().length);
+        assertThat(beanInfo.getAttributes()).isNotNull();
+        assertThat(beanInfo.getAttributes()).hasSize(2);
 
         counter = 0;
 
         for (MBeanAttributeInfo attr : beanInfo.getAttributes()) {
             if (attr.getName().equals("ProcessDefinitions")) {
                 counter++;
-                assertEquals("List of Process definitions", attr.getDescription());
-                assertEquals("java.util.List", attr.getType());
+                assertThat(attr.getDescription()).isEqualTo("List of Process definitions");
+                assertThat(attr.getType()).isEqualTo("java.util.List");
             } else if (attr.getName().equals("Deployments")) {
                 counter++;
-                assertEquals("List of deployed Processes", attr.getDescription());
-                assertEquals("java.util.List", attr.getType());
+                assertThat(attr.getDescription()).isEqualTo("List of deployed Processes");
+                assertThat(attr.getType()).isEqualTo("java.util.List");
             }
 
         }
-        assertEquals(2, counter);
+        assertThat(counter).isEqualTo(2);
     }
 
 }


### PR DESCRIPTION
Straight forward conversion to assertj fluent style in `flowable-jmx` module was the necessary dependency was added to `pom.xml'.
