### PR TITLE
Use assert fluent style in secondary modules.

### DIFF
--- a/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
@@ -247,7 +247,7 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(numberOfResultsExpected, dataNode.size());
+        assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         List<String> toBeFound = new ArrayList<>(Arrays.asList(expectedResourceIds));
@@ -256,7 +256,9 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
             String id = it.next().get("id").textValue();
             toBeFound.remove(id);
         }
-        assertTrue("Not all expected ids have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+        assertThat(toBeFound)
+                .as("Not all expected ids have been found in result, missing: " + StringUtils.join(toBeFound, ", "))
+                .isEmpty();
     }
 
     protected void assertResultsPresentInPostDataResponse(String url, ObjectNode body, String... expectedResourceIds) throws JsonProcessingException, IOException {
@@ -278,7 +280,7 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
             // Check status and size
             JsonNode rootNode = objectMapper.readTree(response.getEntity().getContent());
             JsonNode dataNode = rootNode.get("data");
-            assertEquals(numberOfResultsExpected, dataNode.size());
+            assertThat(dataNode).hasSize(numberOfResultsExpected);
 
             // Check presence of ID's
             if (expectedResourceIds != null) {
@@ -288,7 +290,9 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
                     String id = it.next().get("id").textValue();
                     toBeFound.remove(id);
                 }
-                assertTrue("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+                assertThat(toBeFound)
+                        .as("Not all entries have been found in result, missing: " + StringUtils.join(toBeFound, ", "))
+                        .isEmpty();
             }
         }
 
@@ -302,7 +306,7 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        assertEquals(0, dataNode.size());
+        assertThat(dataNode).isEmpty();
     }
 
     /**

--- a/modules/flowable-form-json-converter/pom.xml
+++ b/modules/flowable-form-json-converter/pom.xml
@@ -48,6 +48,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>

--- a/modules/flowable-form-json-converter/src/test/java/org/flowable/editor/form/converter/FormJsonConverterTest.java
+++ b/modules/flowable-form-json-converter/src/test/java/org/flowable/editor/form/converter/FormJsonConverterTest.java
@@ -12,10 +12,8 @@
  */
 package org.flowable.editor.form.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -48,16 +46,16 @@ public class FormJsonConverterTest {
         String testJsonResource = readJsonToString(JSON_RESOURCE_1);
         SimpleFormModel formModel = new FormJsonConverter().convertToFormModel(testJsonResource);
 
-        assertNotNull(formModel);
-        assertNotNull(formModel.getFields());
-        assertEquals(1, formModel.getFields().size());
+        assertThat(formModel).isNotNull();
+        assertThat(formModel.getFields()).isNotNull();
+        assertThat(formModel.getFields().size()).isEqualTo(1);
 
         FormField formField = formModel.getFields().get(0);
-        assertEquals("input1", formField.getId());
-        assertEquals("Input1", formField.getName());
-        assertEquals("text", formField.getType());
-        assertFalse(formField.isRequired());
-        assertEquals("empty", formField.getPlaceholder());
+        assertThat(formField.getId()).isEqualTo("input1");
+        assertThat(formField.getName()).isEqualTo("Input1");
+        assertThat(formField.getType()).isEqualTo("text");
+        assertThat(formField.isRequired()).isFalse();
+        assertThat(formField.getPlaceholder()).isEqualTo("empty");
     }
 
     /* Helper methods */

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -159,6 +159,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>

--- a/modules/flowable-form-rest/src/test/java/org/flowable/form/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-form-rest/src/test/java/org/flowable/form/rest/service/BaseSpringRestTestCase.java
@@ -12,9 +12,18 @@
  */
 package org.flowable.form.rest.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
@@ -45,20 +54,14 @@ import org.flowable.form.rest.util.TestServerUtil.TestServer;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.IdmIdentityService;
 import org.flowable.idm.api.User;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import junit.framework.TestCase;
 
 
 public abstract class BaseSpringRestTestCase extends TestCase {
@@ -214,7 +217,7 @@ public abstract class BaseSpringRestTestCase extends TestCase {
                 request.addHeader(new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json"));
             }
             CloseableHttpResponse response = client.execute(request);
-            Assert.assertNotNull(response.getStatusLine());
+            assertThat(response.getStatusLine()).isNotNull();
 
             int responseStatusCode = response.getStatusLine().getStatusCode();
             if (expectedStatusCode != responseStatusCode) {
@@ -224,7 +227,7 @@ public abstract class BaseSpringRestTestCase extends TestCase {
                 }
             }
 
-            Assert.assertEquals(expectedStatusCode, responseStatusCode);
+            assertThat(responseStatusCode).isEqualTo(expectedStatusCode);
             httpResponses.add(response);
             return response;
 
@@ -288,7 +291,7 @@ public abstract class BaseSpringRestTestCase extends TestCase {
         // Check status and size
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
-        // assertEquals(numberOfResultsExpected, dataNode.size());
+        // assertThat(dataNode).hasSize(numberOfResultsExpected);
 
         // Check presence of ID's
         List<String> toBeFound = new ArrayList<>(Arrays.asList(expectedResourceIds));
@@ -296,9 +299,11 @@ public abstract class BaseSpringRestTestCase extends TestCase {
             String id = aDataNode.get("id").textValue();
             String sb = aDataNode.get("submittedBy").textValue();
             toBeFound.remove(id);
-            assertEquals(sb, submittedBy);
+            assertThat(submittedBy).isEqualTo(sb);
         }
-        assertTrue("Not all expected ids have been found in result, missing: " + StringUtils.join(toBeFound, ", "), toBeFound.isEmpty());
+        assertThat(toBeFound)
+                .as("Not all expected ids have been found in result, missing: " + StringUtils.join(toBeFound, ", "))
+                .isEmpty();
     }
 
     public CloseableHttpResponse executeRequest(HttpUriRequest request, int expectedStatusCode) {

--- a/modules/flowable-form-rest/src/test/java/org/flowable/form/rest/service/api/runtime/FormInstanceCollectionResourceTest.java
+++ b/modules/flowable-form-rest/src/test/java/org/flowable/form/rest/service/api/runtime/FormInstanceCollectionResourceTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.form.rest.service.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -40,8 +43,11 @@ public class FormInstanceCollectionResourceTest extends BaseSpringRestTestCase {
         valuesMap.put("number", "1234");
 
         Map<String, Object> formValues = formService.getVariablesFromFormSubmission(formInfo, valuesMap, "default");
-        assertEquals("test", formValues.get("user"));
-        assertEquals("default", formValues.get("form_form1_outcome"));
+        assertThat(formValues)
+                .contains(
+                        entry("user", "test"),
+                        entry("form_form1_outcome", "default")
+                );
 
         FormRequest formRequest = new FormRequest();
         formRequest.setFormDefinitionKey(formInfo.getKey());
@@ -88,7 +94,7 @@ public class FormInstanceCollectionResourceTest extends BaseSpringRestTestCase {
         JsonNode dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
         
-        assertEquals(2, dataNode.size());
+        assertThat(dataNode).hasSize(2);
         
         String formInstanceId = dataNode.get(0).get("id").asText();
         response = executeRequest(new HttpGet(SERVER_URL_PREFIX + url + "?id=" + formInstanceId), HttpStatus.SC_OK);
@@ -97,8 +103,8 @@ public class FormInstanceCollectionResourceTest extends BaseSpringRestTestCase {
         dataNode = objectMapper.readTree(response.getEntity().getContent()).get("data");
         closeResponse(response);
         
-        assertEquals(1, dataNode.size());
-        assertEquals(formInstanceId, dataNode.get(0).get("id").asText());
+        assertThat(dataNode).hasSize(1);
+        assertThat(dataNode.get(0).get("id").asText()).isEqualTo(formInstanceId);
         
         List<FormInstance> formInstances = formService.createFormInstanceQuery().list();
         for (FormInstance formInstance : formInstances) {

--- a/modules/flowable-groovy-script-static-engine/pom.xml
+++ b/modules/flowable-groovy-script-static-engine/pom.xml
@@ -126,21 +126,26 @@
       <artifactId>junit</artifactId>
       <scope>provided</scope>
     </dependency>
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-api</artifactId>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-engine</artifactId>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-          <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/modules/flowable-groovy-script-static-engine/src/test/java/org/flowable/examples/groovy/GroovyStaticScriptTest.java
+++ b/modules/flowable-groovy-script-static-engine/src/test/java/org/flowable/examples/groovy/GroovyStaticScriptTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.examples.groovy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -32,8 +34,8 @@ public class GroovyStaticScriptTest extends PluggableFlowableTestCase {
 
         String result = (String) runtimeService.getVariable(pi.getId(), "a");
         Integer sum = (Integer) runtimeService.getVariable(pi.getId(), "sum");
-        assertEquals("ABC", result);
-        assertEquals(15, sum.intValue());
+        assertThat(result).isEqualTo("ABC");
+        assertThat(sum).isEqualTo(15);
     }
     
     @Test
@@ -44,7 +46,7 @@ public class GroovyStaticScriptTest extends PluggableFlowableTestCase {
 
         String result = (String) runtimeService.getVariable(pi.getId(), "a");
         Integer sum = (Integer) runtimeService.getVariable(pi.getId(), "sum");
-        assertEquals("ABC", result);
-        assertEquals(15, sum.intValue());
+        assertThat(result).isEqualTo("ABC");
+        assertThat(sum).isEqualTo(15);
     }
 }

--- a/modules/flowable-jms-spring-executor/pom.xml
+++ b/modules/flowable-jms-spring-executor/pom.xml
@@ -131,6 +131,11 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
         </dependency>

--- a/modules/flowable-jms-spring-executor/src/test/java/org/flowable/test/spring/executor/jms/SpringJmsTest.java
+++ b/modules/flowable-jms-spring-executor/src/test/java/org/flowable/test/spring/executor/jms/SpringJmsTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.test.spring.executor.jms;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -22,7 +24,6 @@ import org.flowable.engine.ProcessEngine;
 import org.flowable.job.service.impl.asyncexecutor.DefaultAsyncJobExecutor;
 import org.flowable.spring.impl.test.CleanTestExecutionListener;
 import org.flowable.test.spring.executor.jms.config.SpringJmsConfig;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,13 +53,13 @@ public class SpringJmsTest {
 
         // Wait until the process is completely finished
         Awaitility.await().atMost(Duration.ofMinutes(1)).pollInterval(Duration.ofMillis(500)).untilAsserted(
-            () -> Assert.assertEquals(0L, processEngine.getRuntimeService().createProcessInstanceQuery().count()));
+            () -> assertThat(processEngine.getRuntimeService().createProcessInstanceQuery().count()).isZero());
 
         for (String activityName : Arrays.asList("A", "B", "C", "D", "E", "F", "After boundary", "The user task", "G", "G1", "G2", "G3", "H", "I", "J", "K", "L")) {
-            Assert.assertNotNull(processEngine.getHistoryService().createHistoricActivityInstanceQuery().activityName(activityName).singleResult());
+            assertThat(processEngine.getHistoryService().createHistoricActivityInstanceQuery().activityName(activityName).singleResult()).isNotNull();
         }
 
-        Assert.assertNull(((DefaultAsyncJobExecutor) processEngine.getProcessEngineConfiguration().getAsyncExecutor()).getExecutorService());
+        assertThat(((DefaultAsyncJobExecutor) processEngine.getProcessEngineConfiguration().getAsyncExecutor()).getExecutorService()).isNull();
     }
 
 }

--- a/modules/flowable-mule/pom.xml
+++ b/modules/flowable-mule/pom.xml
@@ -122,6 +122,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>

--- a/modules/flowable-mule/src/test/java/org/flowable/mule/MuleHttpBasicAuthTest.java
+++ b/modules/flowable-mule/src/test/java/org/flowable/mule/MuleHttpBasicAuthTest.java
@@ -12,12 +12,13 @@
  */
 package org.flowable.mule;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngines;
 import org.flowable.engine.RuntimeService;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.ProcessInstance;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -28,15 +29,15 @@ public class MuleHttpBasicAuthTest extends AbstractMuleTest {
 
     @Test
     public void httpWithBasicAuth() throws Exception {
-        Assert.assertTrue(muleContext.isStarted());
+        assertThat(muleContext.isStarted()).isTrue();
 
         ProcessEngine processEngine = ProcessEngines.getDefaultProcessEngine();
         Deployment deployment = processEngine.getRepositoryService().createDeployment().addClasspathResource("org/flowable/mule/testHttpBasicAuth.bpmn20.xml").deploy();
         RuntimeService runtimeService = processEngine.getRuntimeService();
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("muleProcess");
-        Assert.assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
         Object result = runtimeService.getVariable(processInstance.getProcessInstanceId(), "theVariable");
-        Assert.assertEquals(10, result);
+        assertThat(result).isEqualTo(10);
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
         processEngine.getHistoryService().deleteHistoricProcessInstance(processInstance.getId());
         processEngine.getRepositoryService().deleteDeployment(deployment.getId());

--- a/modules/flowable-mule/src/test/java/org/flowable/mule/MuleHttpTest.java
+++ b/modules/flowable-mule/src/test/java/org/flowable/mule/MuleHttpTest.java
@@ -12,12 +12,13 @@
  */
 package org.flowable.mule;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngines;
 import org.flowable.engine.RuntimeService;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.ProcessInstance;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -28,15 +29,15 @@ public class MuleHttpTest extends AbstractMuleTest {
 
     @Test
     public void http() throws Exception {
-        Assert.assertTrue(muleContext.isStarted());
+        assertThat(muleContext.isStarted()).isTrue();
 
         ProcessEngine processEngine = ProcessEngines.getDefaultProcessEngine();
         Deployment deployment = processEngine.getRepositoryService().createDeployment().addClasspathResource("org/flowable/mule/testHttp.bpmn20.xml").deploy();
         RuntimeService runtimeService = processEngine.getRuntimeService();
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("muleProcess");
-        Assert.assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
         Object result = runtimeService.getVariable(processInstance.getProcessInstanceId(), "theVariable");
-        Assert.assertEquals(20, result);
+        assertThat(result).isEqualTo(20);
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
         processEngine.getHistoryService().deleteHistoricProcessInstance(processInstance.getId());
         processEngine.getRepositoryService().deleteDeployment(deployment.getId());

--- a/modules/flowable-mule/src/test/java/org/flowable/mule/MuleVMTest.java
+++ b/modules/flowable-mule/src/test/java/org/flowable/mule/MuleVMTest.java
@@ -12,13 +12,14 @@
  */
 package org.flowable.mule;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngines;
 import org.flowable.engine.RepositoryService;
 import org.flowable.engine.RuntimeService;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.ProcessInstance;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -29,7 +30,7 @@ public class MuleVMTest extends AbstractMuleTest {
 
     @Test
     public void send() throws Exception {
-        Assert.assertTrue(muleContext.isStarted());
+        assertThat(muleContext.isStarted()).isTrue();
 
         ProcessEngine processEngine = ProcessEngines.getDefaultProcessEngine();
         RepositoryService repositoryService = processEngine.getRepositoryService();
@@ -37,9 +38,9 @@ public class MuleVMTest extends AbstractMuleTest {
 
         RuntimeService runtimeService = processEngine.getRuntimeService();
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("muleProcess");
-        Assert.assertFalse(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isFalse();
         Object result = runtimeService.getVariable(processInstance.getProcessInstanceId(), "theVariable");
-        Assert.assertEquals(30, result);
+        assertThat(result).isEqualTo(30);
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
 
         processEngine.getHistoryService().deleteHistoricProcessInstance(processInstance.getId());


### PR DESCRIPTION
Straight forward conversion of some smaller modules after updating the `pom.xml`.

Modules touched are:

- flowable-content-rest
- flowable-form-json-converter
- flowable-form-rest
- flowable-groovy-script-static-engine
- flowable-jms-spring-exectuor
- flowable-mule
