### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormPropertyDefaultValueTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/form/FormPropertyDefaultValueTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.api.form;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,31 +37,24 @@ public class FormPropertyDefaultValueTest extends PluggableFlowableTestCase {
 
         TaskFormData formData = formService.getTaskFormData(task.getId());
         List<FormProperty> formProperties = formData.getFormProperties();
-        assertEquals(4, formProperties.size());
-
-        for (FormProperty prop : formProperties) {
-            if ("booleanProperty".equals(prop.getId())) {
-                assertEquals("true", prop.getValue());
-            } else if ("stringProperty".equals(prop.getId())) {
-                assertEquals("someString", prop.getValue());
-            } else if ("longProperty".equals(prop.getId())) {
-                assertEquals("42", prop.getValue());
-            } else if ("longExpressionProperty".equals(prop.getId())) {
-                assertEquals("23", prop.getValue());
-            } else {
-                fail("Invalid form property: " + prop.getId());
-            }
-        }
+        assertThat(formProperties)
+                .extracting(FormProperty::getId, FormProperty::getValue)
+                .containsExactlyInAnyOrder(
+                        tuple("booleanProperty", "true"),
+                        tuple("stringProperty", "someString"),
+                        tuple("longProperty", "42"),
+                        tuple("longExpressionProperty", "23")
+                );
 
         Map<String, String> formDataUpdate = new HashMap<>();
         formDataUpdate.put("longExpressionProperty", "1");
         formDataUpdate.put("booleanProperty", "false");
         formService.submitTaskFormData(task.getId(), formDataUpdate);
 
-        assertEquals(false, runtimeService.getVariable(processInstance.getId(), "booleanProperty"));
-        assertEquals("someString", runtimeService.getVariable(processInstance.getId(), "stringProperty"));
-        assertEquals(42L, runtimeService.getVariable(processInstance.getId(), "longProperty"));
-        assertEquals(1L, runtimeService.getVariable(processInstance.getId(), "longExpressionProperty"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "booleanProperty")).isEqualTo(false);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "stringProperty")).isEqualTo("someString");
+        assertThat(runtimeService.getVariable(processInstance.getId(), "longProperty")).isEqualTo(42L);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "longExpressionProperty")).isEqualTo(1L);
     }
 
     @Test
@@ -69,32 +65,24 @@ public class FormPropertyDefaultValueTest extends PluggableFlowableTestCase {
         StartFormData startForm = formService.getStartFormData(processDefinitionId);
 
         List<FormProperty> formProperties = startForm.getFormProperties();
-        assertEquals(4, formProperties.size());
+        assertThat(formProperties)
+                .extracting(FormProperty::getId, FormProperty::getValue)
+                .containsExactlyInAnyOrder(
+                        tuple("booleanProperty", "true"),
+                        tuple("stringProperty", "someString"),
+                        tuple("longProperty", "42"),
+                        tuple("longExpressionProperty", "23")
+                );
 
-        for (FormProperty prop : formProperties) {
-            if ("booleanProperty".equals(prop.getId())) {
-                assertEquals("true", prop.getValue());
-            } else if ("stringProperty".equals(prop.getId())) {
-                assertEquals("someString", prop.getValue());
-            } else if ("longProperty".equals(prop.getId())) {
-                assertEquals("42", prop.getValue());
-            } else if ("longExpressionProperty".equals(prop.getId())) {
-                assertEquals("23", prop.getValue());
-            } else {
-                fail("Invalid form property: " + prop.getId());
-            }
-        }
-
-        // Override 2 properties. The others should pe posted as the
-        // default-value
+        // Override 2 properties. The others should pe posted as the default-value
         Map<String, String> formDataUpdate = new HashMap<>();
         formDataUpdate.put("longExpressionProperty", "1");
         formDataUpdate.put("booleanProperty", "false");
         ProcessInstance processInstance = formService.submitStartFormData(processDefinitionId, formDataUpdate);
 
-        assertEquals(false, runtimeService.getVariable(processInstance.getId(), "booleanProperty"));
-        assertEquals("someString", runtimeService.getVariable(processInstance.getId(), "stringProperty"));
-        assertEquals(42L, runtimeService.getVariable(processInstance.getId(), "longProperty"));
-        assertEquals(1L, runtimeService.getVariable(processInstance.getId(), "longExpressionProperty"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "booleanProperty")).isEqualTo(false);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "stringProperty")).isEqualTo("someString");
+        assertThat(runtimeService.getVariable(processInstance.getId(), "longProperty")).isEqualTo(42L);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "longExpressionProperty")).isEqualTo(1L);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/nonpublic/EventSubscriptionQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/nonpublic/EventSubscriptionQueryTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.api.nonpublic;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.common.engine.impl.interceptor.Command;
@@ -60,10 +62,10 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
         });
 
         List<EventSubscription> list = newEventSubscriptionQuery().eventName("messageName").list();
-        assertEquals(2, list.size());
+        assertThat(list).hasSize(2);
 
         list = newEventSubscriptionQuery().eventName("messageName2").list();
-        assertEquals(1, list.size());
+        assertThat(list).hasSize(1);
 
         cleanDb();
 
@@ -93,10 +95,10 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
         });
 
         List<EventSubscription> list = newEventSubscriptionQuery().eventType("signal").list();
-        assertEquals(1, list.size());
+        assertThat(list).hasSize(1);
 
         list = newEventSubscriptionQuery().eventType("message").list();
-        assertEquals(2, list.size());
+        assertThat(list).hasSize(2);
 
         cleanDb();
 
@@ -129,10 +131,10 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
         });
 
         List<EventSubscription> list = newEventSubscriptionQuery().activityId("someOtherActivity").list();
-        assertEquals(1, list.size());
+        assertThat(list).hasSize(1);
 
         list = newEventSubscriptionQuery().activityId("someActivity").eventType("message").list();
-        assertEquals(2, list.size());
+        assertThat(list).hasSize(2);
 
         cleanDb();
 
@@ -160,13 +162,13 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
         });
 
         List<EventSubscription> list = newEventSubscriptionQuery().activityId("someOtherActivity").list();
-        assertEquals(1, list.size());
+        assertThat(list).hasSize(1);
 
         final EventSubscription entity = list.get(0);
 
         list = newEventSubscriptionQuery().id(entity.getId()).list();
 
-        assertEquals(1, list.size());
+        assertThat(list).hasSize(1);
 
         cleanDb();
 
@@ -182,15 +184,15 @@ public class EventSubscriptionQueryTest extends PluggableFlowableTestCase {
 
         // test query by process instance id
         EventSubscription subscription = newEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNotNull(subscription);
+        assertThat(subscription).isNotNull();
 
         Execution executionWaitingForSignal = runtimeService.createExecutionQuery().activityId("signalEvent").processInstanceId(processInstance.getId()).singleResult();
 
         // test query by execution id
         EventSubscription signalSubscription = newEventSubscriptionQuery().executionId(executionWaitingForSignal.getId()).singleResult();
-        assertNotNull(signalSubscription);
+        assertThat(signalSubscription).isNotNull();
 
-        assertEquals(signalSubscription, subscription);
+        assertThat(subscription).isEqualTo(signalSubscription);
 
         cleanDb();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/DelegateTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/DelegateTaskTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -38,19 +40,17 @@ public class DelegateTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("DelegateTaskTest.testGetCandidates");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
 
         @SuppressWarnings("unchecked")
         Set<String> candidateUsers = (Set<String>) taskService.getVariable(task.getId(), DelegateTaskTestTaskListener.VARNAME_CANDIDATE_USERS);
-        assertEquals(2, candidateUsers.size());
-        assertTrue(candidateUsers.contains("kermit"));
-        assertTrue(candidateUsers.contains("gonzo"));
+        assertThat(candidateUsers)
+                .containsOnly("kermit", "gonzo");
 
         @SuppressWarnings("unchecked")
         Set<String> candidateGroups = (Set<String>) taskService.getVariable(task.getId(), DelegateTaskTestTaskListener.VARNAME_CANDIDATE_GROUPS);
-        assertEquals(2, candidateGroups.size());
-        assertTrue(candidateGroups.contains("management"));
-        assertTrue(candidateGroups.contains("accountancy"));
+        assertThat(candidateGroups)
+                .containsOnly("management", "accountancy");
     }
 
     @Test
@@ -65,16 +65,16 @@ public class DelegateTaskTest extends PluggableFlowableTestCase {
         // Assert there are three tasks with the default category
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         for (org.flowable.task.api.Task task : tasks) {
-            assertEquals("approval", task.getCategory());
+            assertThat(task.getCategory()).isEqualTo("approval");
             Map<String, Object> taskVariables = new HashMap<>();
             taskVariables.put("outcome", "approve");
             taskService.complete(task.getId(), taskVariables, true);
         }
 
         // After completion, the task category should be changed in the script listener working on the delegate task
-        assertEquals(0, taskService.createTaskQuery().processInstanceId(processInstance.getId()).count());
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
         for (HistoricTaskInstance historicTaskInstance : historyService.createHistoricTaskInstanceQuery().list()) {
-            assertEquals("approved", historicTaskInstance.getCategory());
+            assertThat(historicTaskInstance.getCategory()).isEqualTo("approved");
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskQueryTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,12 +65,12 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryExcludeSubtasks() throws Exception {
         // query all tasks, including subtasks
         TaskQuery query = taskService.createTaskQuery();
-        assertEquals(10, query.count());
-        assertEquals(10, query.list().size());
+        assertThat(query.count()).isEqualTo(10);
+        assertThat(query.list()).hasSize(10);
         // query only parent tasks (exclude subtasks)
         query = taskService.createTaskQuery().excludeSubtasks();
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
     }
 
     /**
@@ -78,12 +80,12 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryWithPagination() throws Exception {
         // query all tasks, including subtasks
         TaskQuery query = taskService.createTaskQuery();
-        assertEquals(10, query.count());
-        assertEquals(2, query.listPage(0, 2).size());
+        assertThat(query.count()).isEqualTo(10);
+        assertThat(query.listPage(0, 2)).hasSize(2);
         // query only parent tasks (exclude subtasks)
         query = taskService.createTaskQuery().excludeSubtasks();
-        assertEquals(3, query.count());
-        assertEquals(1, query.listPage(0, 1).size());
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.listPage(0, 1)).hasSize(1);
     }
 
     /**
@@ -93,12 +95,12 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
     public void testQueryExcludeSubtasksSorted() throws Exception {
         // query all tasks, including subtasks
         TaskQuery query = taskService.createTaskQuery().orderByTaskAssignee().asc();
-        assertEquals(10, query.count());
-        assertEquals(10, query.list().size());
+        assertThat(query.count()).isEqualTo(10);
+        assertThat(query.list()).hasSize(10);
         // query only parent tasks (exclude subtasks)
         query = taskService.createTaskQuery().excludeSubtasks().orderByTaskAssignee().desc();
-        assertEquals(3, query.count());
-        assertEquals(3, query.list().size());
+        assertThat(query.count()).isEqualTo(3);
+        assertThat(query.list()).hasSize(3);
     }
 
     /**
@@ -109,24 +111,24 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
         // gonzo has 2 root tasks and 3+2 subtasks assigned
         // include subtasks
         TaskQuery query = taskService.createTaskQuery().taskAssignee("gonzo");
-        assertEquals(7, query.count());
-        assertEquals(7, query.list().size());
+        assertThat(query.count()).isEqualTo(7);
+        assertThat(query.list()).hasSize(7);
         // exclude subtasks
         query = taskService.createTaskQuery().taskAssignee("gonzo").excludeSubtasks();
-        assertEquals(2, query.count());
-        assertEquals(2, query.list().size());
+        assertThat(query.count()).isEqualTo(2);
+        assertThat(query.list()).hasSize(2);
 
         // kermit has no root tasks and no subtasks assigned
         // include subtasks
         query = taskService.createTaskQuery().taskAssignee("kermit");
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.singleResult()).isNull();
         // exclude subtasks
         query = taskService.createTaskQuery().taskAssignee("kermit").excludeSubtasks();
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.singleResult()).isNull();
     }
 
     /**
@@ -137,24 +139,24 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
         // gonzo has 2 root tasks and 3+2 subtasks assigned
         // include subtasks
         TaskQuery query = taskService.createTaskQuery().taskAssignee("gonzo");
-        assertEquals(7, query.count());
-        assertEquals(2, query.listPage(0, 2).size());
+        assertThat(query.count()).isEqualTo(7);
+        assertThat(query.listPage(0, 2)).hasSize(2);
         // exclude subtasks
         query = taskService.createTaskQuery().taskAssignee("gonzo").excludeSubtasks();
-        assertEquals(2, query.count());
-        assertEquals(1, query.listPage(0, 1).size());
+        assertThat(query.count()).isEqualTo(2);
+        assertThat(query.listPage(0, 1)).hasSize(1);
 
         // kermit has no root tasks and no subtasks assigned
         // include subtasks
         query = taskService.createTaskQuery().taskAssignee("kermit");
-        assertEquals(0, query.count());
-        assertEquals(0, query.listPage(0, 2).size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.listPage(0, 2)).isEmpty();
+        assertThat(query.singleResult()).isNull();
         // exclude subtasks
         query = taskService.createTaskQuery().taskAssignee("kermit").excludeSubtasks();
-        assertEquals(0, query.count());
-        assertEquals(0, query.listPage(0, 2).size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.listPage(0, 2)).isEmpty();
+        assertThat(query.singleResult()).isNull();
     }
 
     /**
@@ -167,28 +169,28 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
         // gonzo has 2 root tasks and 3+2 subtasks assigned
         // include subtasks
         TaskQuery query = taskService.createTaskQuery().taskAssignee("gonzo").orderByTaskCreateTime().desc();
-        assertEquals(7, query.count());
-        assertEquals(7, query.list().size());
-        assertEquals(sdf.parse("02/01/2009 01:01:01.000"), query.list().get(0).getCreateTime());
+        assertThat(query.count()).isEqualTo(7);
+        assertThat(query.list()).hasSize(7);
+        assertThat(query.list().get(0).getCreateTime()).isEqualTo(sdf.parse("02/01/2009 01:01:01.000"));
 
         // exclude subtasks
         query = taskService.createTaskQuery().taskAssignee("gonzo").excludeSubtasks().orderByTaskCreateTime().asc();
-        assertEquals(2, query.count());
-        assertEquals(2, query.list().size());
-        assertEquals(sdf.parse("01/02/2008 02:02:02.000"), query.list().get(0).getCreateTime());
-        assertEquals(sdf.parse("05/02/2008 02:02:02.000"), query.list().get(1).getCreateTime());
+        assertThat(query.count()).isEqualTo(2);
+        assertThat(query.list()).hasSize(2);
+        assertThat(query.list().get(0).getCreateTime()).isEqualTo(sdf.parse("01/02/2008 02:02:02.000"));
+        assertThat(query.list().get(1).getCreateTime()).isEqualTo(sdf.parse("05/02/2008 02:02:02.000"));
 
         // kermit has no root tasks and no subtasks assigned
         // include subtasks
         query = taskService.createTaskQuery().taskAssignee("kermit").orderByTaskCreateTime().asc();
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.singleResult()).isNull();
         // exclude subtasks
         query = taskService.createTaskQuery().taskAssignee("kermit").excludeSubtasks().orderByTaskCreateTime().desc();
-        assertEquals(0, query.count());
-        assertEquals(0, query.list().size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.list()).isEmpty();
+        assertThat(query.singleResult()).isNull();
     }
 
     /**
@@ -201,34 +203,34 @@ public class SubTaskQueryTest extends PluggableFlowableTestCase {
         // gonzo has 2 root tasks and 3+2 subtasks assigned
         // include subtasks
         TaskQuery query = taskService.createTaskQuery().taskAssignee("gonzo").orderByTaskCreateTime().asc();
-        assertEquals(7, query.count());
-        assertEquals(1, query.listPage(0, 1).size());
-        assertEquals(sdf.parse("01/02/2008 02:02:02.000"), query.listPage(0, 1).get(0).getCreateTime());
-        assertEquals(1, query.listPage(1, 1).size());
-        assertEquals(sdf.parse("05/02/2008 02:02:02.000"), query.listPage(1, 1).get(0).getCreateTime());
-        assertEquals(2, query.listPage(0, 2).size());
-        assertEquals(sdf.parse("01/02/2008 02:02:02.000"), query.listPage(0, 2).get(0).getCreateTime());
-        assertEquals(sdf.parse("05/02/2008 02:02:02.000"), query.listPage(0, 2).get(1).getCreateTime());
+        assertThat(query.count()).isEqualTo(7);
+        assertThat(query.listPage(0, 1)).hasSize(1);
+        assertThat(query.listPage(0, 1).get(0).getCreateTime()).isEqualTo(sdf.parse("01/02/2008 02:02:02.000"));
+        assertThat(query.listPage(1, 1)).hasSize(1);
+        assertThat(query.listPage(1, 1).get(0).getCreateTime()).isEqualTo(sdf.parse("05/02/2008 02:02:02.000"));
+        assertThat(query.listPage(0, 2)).hasSize(2);
+        assertThat(query.listPage(0, 2).get(0).getCreateTime()).isEqualTo(sdf.parse("01/02/2008 02:02:02.000"));
+        assertThat(query.listPage(0, 2).get(1).getCreateTime()).isEqualTo(sdf.parse("05/02/2008 02:02:02.000"));
 
         // exclude subtasks
         query = taskService.createTaskQuery().taskAssignee("gonzo").excludeSubtasks().orderByTaskCreateTime().desc();
-        assertEquals(2, query.count());
-        assertEquals(1, query.listPage(1, 1).size());
-        assertEquals(sdf.parse("01/02/2008 02:02:02.000"), query.listPage(1, 1).get(0).getCreateTime());
-        assertEquals(1, query.listPage(0, 1).size());
-        assertEquals(sdf.parse("05/02/2008 02:02:02.000"), query.listPage(0, 1).get(0).getCreateTime());
+        assertThat(query.count()).isEqualTo(2);
+        assertThat(query.listPage(1, 1)).hasSize(1);
+        assertThat(query.listPage(1, 1).get(0).getCreateTime()).isEqualTo(sdf.parse("01/02/2008 02:02:02.000"));
+        assertThat(query.listPage(0, 1)).hasSize(1);
+        assertThat(query.listPage(0, 1).get(0).getCreateTime()).isEqualTo(sdf.parse("05/02/2008 02:02:02.000"));
 
         // kermit has no root tasks and no subtasks assigned
         // include subtasks
         query = taskService.createTaskQuery().taskAssignee("kermit").orderByTaskCreateTime().asc();
-        assertEquals(0, query.count());
-        assertEquals(0, query.listPage(0, 2).size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.listPage(0, 2)).isEmpty();
+        assertThat(query.singleResult()).isNull();
         // exclude subtasks
         query = taskService.createTaskQuery().taskAssignee("kermit").excludeSubtasks().orderByTaskCreateTime().desc();
-        assertEquals(0, query.count());
-        assertEquals(0, query.listPage(0, 2).size());
-        assertNull(query.singleResult());
+        assertThat(query.count()).isZero();
+        assertThat(query.listPage(0, 2)).isEmpty();
+        assertThat(query.singleResult()).isNull();
     }
 
     /**

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/SubTaskTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -52,8 +54,8 @@ public class SubTaskTest extends PluggableFlowableTestCase {
         taskService.saveTask(subTaskTwo);
         
         String subTaskId = subTaskOne.getId();
-        assertTrue(taskService.getSubTasks(subTaskId).isEmpty());
-        assertTrue(historyService.createHistoricTaskInstanceQuery().taskParentTaskId(subTaskId).list().isEmpty());
+        assertThat(taskService.getSubTasks(subTaskId)).isEmpty();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskParentTaskId(subTaskId).list()).isEmpty();
 
         List<Task> subTasks = taskService.getSubTasks(gonzoTaskId);
         Set<String> subTaskNames = new HashSet<>();
@@ -66,7 +68,7 @@ public class SubTaskTest extends PluggableFlowableTestCase {
             expectedSubTaskNames.add("subtask one");
             expectedSubTaskNames.add("subtask two");
 
-            assertEquals(expectedSubTaskNames, subTaskNames);
+            assertThat(subTaskNames).isEqualTo(expectedSubTaskNames);
 
             List<HistoricTaskInstance> historicSubTasks = historyService.createHistoricTaskInstanceQuery().taskParentTaskId(gonzoTaskId).list();
 
@@ -75,7 +77,7 @@ public class SubTaskTest extends PluggableFlowableTestCase {
                 subTaskNames.add(historicSubTask.getName());
             }
 
-            assertEquals(expectedSubTaskNames, subTaskNames);
+            assertThat(subTaskNames).isEqualTo(expectedSubTaskNames);
         }
 
         taskService.deleteTask(gonzoTaskId, true);
@@ -97,11 +99,11 @@ public class SubTaskTest extends PluggableFlowableTestCase {
         subTaskTwo.setParentTaskId(parentTask.getId());
         taskService.saveTask(subTaskTwo);
 
-        assertEquals(2, taskService.getSubTasks(parentTask.getId()).size());
+        assertThat(taskService.getSubTasks(parentTask.getId())).hasSize(2);
         
         if (processEngineConfiguration.getPerformanceSettings().isEnableTaskRelationshipCounts()) {
             CountingTaskEntity countingTaskEntity = (CountingTaskEntity) taskService.createTaskQuery().taskId(parentTask.getId()).singleResult();
-            assertEquals(2, countingTaskEntity.getSubTaskCount());
+            assertThat(countingTaskEntity.getSubTaskCount()).isEqualTo(2);
         }
         
         subTaskTwo = taskService.createTaskQuery().taskId(subTaskTwo.getId()).singleResult();
@@ -110,10 +112,10 @@ public class SubTaskTest extends PluggableFlowableTestCase {
         
         if (processEngineConfiguration.getPerformanceSettings().isEnableTaskRelationshipCounts()) {
             CountingTaskEntity countingTaskEntity = (CountingTaskEntity) taskService.createTaskQuery().taskId(parentTask.getId()).singleResult();
-            assertEquals(1, countingTaskEntity.getSubTaskCount());
+            assertThat(countingTaskEntity.getSubTaskCount()).isEqualTo(1);
         }
         
-        assertEquals(1, taskService.getSubTasks(parentTask.getId()).size());
+        assertThat(taskService.getSubTasks(parentTask.getId())).hasSize(1);
         taskService.deleteTask(parentTask.getId(), true);
         taskService.deleteTask(subTaskTwo.getId(), true);
     }
@@ -141,23 +143,23 @@ public class SubTaskTest extends PluggableFlowableTestCase {
         taskService.saveTask(subTask2);
 
         List<Task> tasks = taskService.createTaskQuery().taskAssignee("test").list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
 
         runtimeService.deleteProcessInstance(processInstance.getId(), "none");
 
         tasks = taskService.createTaskQuery().taskAssignee("test").list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("test").list();
-            assertEquals(3, historicTasks.size());
+            assertThat(historicTasks).hasSize(3);
 
             historyService.deleteHistoricProcessInstance(processInstance.getId());
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
             historicTasks = historyService.createHistoricTaskInstanceQuery().taskAssignee("test").list();
-            assertEquals(0, historicTasks.size());
+            assertThat(historicTasks).isEmpty();
         }
 
         repositoryService.deleteDeployment(deployment.getId(), true);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
@@ -75,14 +75,14 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
     @Deployment
     public void testQuery() {
         org.flowable.task.api.Task task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("gonzo").singleResult();
+        assertThat(task.getProcessVariables()).isEmpty();
         Map<String, Object> variableMap = task.getTaskLocalVariables();
         assertThat(variableMap).hasSize(3);
-        assertThat(task.getProcessVariables()).isEmpty();
-        assertThat(variableMap.get("testVar")).isNotNull();
-        assertThat(variableMap.get("testVar")).isEqualTo("someVariable");
-        assertThat(variableMap.get("testVar2")).isNotNull();
-        assertThat(variableMap.get("testVar2")).isEqualTo(123);
-        assertThat(variableMap.get("testVarBinary")).isNotNull();
+        assertThat(variableMap)
+                .contains(
+                        entry("testVar", "someVariable"),
+                        entry("testVar2", 123)
+                );
         assertThat(new String((byte[]) variableMap.get("testVarBinary"))).isEqualTo("This is a binary variable");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
@@ -108,14 +108,19 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("kermit").singleResult();
         assertThat(task.getProcessVariables()).isEmpty();
-        assertThat(task.getTaskLocalVariables()).hasSize(1);
-        assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
+        assertThat(task.getTaskLocalVariables())
+                .containsOnly(
+                        entry("localVar", "test")
+                );
 
         task = taskService.createTaskQuery().includeProcessVariables().taskAssignee("kermit").singleResult();
-        assertThat(task.getProcessVariables()).hasSize(3);
         assertThat(task.getTaskLocalVariables()).isEmpty();
-        assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(task.getProcessVariables()).hasSize(3);
+        assertThat(task.getProcessVariables())
+                .contains(
+                        entry("processVar", true),
+                        entry("anotherProcessVar", 123)
+                );
         assertThat(new String((byte[]) task.getProcessVariables().get("binaryVariable"))).isEqualTo("This is a binary process variable");
 
         tasks = taskService.createTaskQuery().includeTaskLocalVariables().taskCandidateUser("kermit").list();
@@ -131,21 +136,31 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("kermit").taskVariableValueEquals("localVar", "test").singleResult();
         assertThat(task.getProcessVariables()).isEmpty();
-        assertThat(task.getTaskLocalVariables()).hasSize(1);
-        assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
+        assertThat(task.getTaskLocalVariables())
+                .containsOnly(
+                        entry("localVar", "test")
+                );
 
         task = taskService.createTaskQuery().includeProcessVariables().taskAssignee("kermit").taskVariableValueEquals("localVar", "test").singleResult();
         assertThat(task.getProcessVariables()).hasSize(3);
         assertThat(task.getTaskLocalVariables()).isEmpty();
-        assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(task.getProcessVariables())
+                .contains(
+                        entry("processVar", true),
+                        entry("anotherProcessVar", 123)
+                );
 
         task = taskService.createTaskQuery().includeTaskLocalVariables().includeProcessVariables().taskAssignee("kermit").singleResult();
         assertThat(task.getProcessVariables()).hasSize(3);
-        assertThat(task.getTaskLocalVariables()).hasSize(1);
-        assertThat(task.getTaskLocalVariables().get("localVar")).isEqualTo("test");
-        assertThat(task.getProcessVariables().get("processVar")).isEqualTo(true);
-        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(task.getTaskLocalVariables())
+                .containsOnly(
+                        entry("localVar", "test")
+                );
+        assertThat(task.getProcessVariables())
+                .contains(
+                        entry("processVar", true),
+                        entry("anotherProcessVar", 123)
+                );
         assertThat(new String((byte[]) task.getProcessVariables().get("binaryVariable"))).isEqualTo("This is a binary process variable");
     }
     
@@ -304,28 +319,36 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("undefined", 999)
                 .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertThat(task.getProcessVariables()).hasSize(1);
-        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(task.getProcessVariables())
+                .containsOnly(
+                        entry("anotherProcessVar", 123)
+                );
 
         task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("undefined", 999).endOr().singleResult();
         assertThat(task).isNull();
 
         task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 123)
                 .processVariableValueEquals("undefined", 999).endOr().singleResult();
-        assertThat(task.getProcessVariables()).hasSize(1);
-        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(task.getProcessVariables())
+                .containsOnly(
+                        entry("anotherProcessVar", 123)
+                );
 
         task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertThat(task.getProcessVariables()).hasSize(1);
-        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(task.getProcessVariables())
+                .containsOnly(
+                        entry("anotherProcessVar", 123)
+                );
 
         task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 999).endOr().singleResult();
         assertThat(task).isNull();
 
         task = taskService.createTaskQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 999)
                 .processVariableValueEquals("anotherProcessVar", 123).endOr().singleResult();
-        assertThat(task.getProcessVariables()).hasSize(1);
-        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(task.getProcessVariables())
+                .containsOnly(
+                        entry("anotherProcessVar", 123)
+                );
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskBatchDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskBatchDeleteTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
@@ -27,8 +29,8 @@ public class TaskBatchDeleteTest extends PluggableFlowableTestCase {
     public void testDeleteTaskWithChildren() throws Exception {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testBatchDeleteOfTask");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         // Get first task and finish. This should destroy the scope and trigger
         // some deletes, including:
@@ -36,13 +38,13 @@ public class TaskBatchDeleteTest extends PluggableFlowableTestCase {
         // The task deletes shouldn't be batched in this case, keeping the
         // related entity delete order
         org.flowable.task.api.Task firstTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskOne").singleResult();
-        assertNotNull(firstTask);
+        assertThat(firstTask).isNotNull();
 
         taskService.complete(firstTask.getId());
 
         // Process should have ended fine
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
     }
 
@@ -51,21 +53,21 @@ public class TaskBatchDeleteTest extends PluggableFlowableTestCase {
     public void testDeleteCancelledMultiInstanceTasks() throws Exception {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testBatchDeleteOfTask");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         org.flowable.task.api.Task lastTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("multiInstance").listPage(4, 1).get(0);
 
         taskService.addCandidateGroup(lastTask.getId(), "sales");
 
         org.flowable.task.api.Task firstTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("multiInstance").listPage(0, 1).get(0);
-        assertNotNull(firstTask);
+        assertThat(firstTask).isNotNull();
 
         taskService.complete(firstTask.getId());
 
         // Process should have ended fine
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskDueDateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskDueDateTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Date;
 import java.util.List;
 
@@ -55,104 +57,104 @@ public class TaskDueDateTest extends PluggableFlowableTestCase {
         createTask("task4", null);
         createTask("task5", null);
 
-        assertEquals(6, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(6);
 
         // Sorting on due date asc should put the nulls at the end
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByDueDateNullsLast().asc().list();
 
         for (int i = 0; i < 4; i++) {
-            assertNotNull(tasks.get(i).getDueDate());
+            assertThat(tasks.get(i).getDueDate()).isNotNull();
         }
 
-        assertEquals("task3", tasks.get(0).getName());
-        assertEquals("task1", tasks.get(1).getName());
-        assertEquals("task2", tasks.get(2).getName());
-        assertEquals("task0", tasks.get(3).getName());
-        assertNull(tasks.get(4).getDueDate());
-        assertNull(tasks.get(5).getDueDate());
+        assertThat(tasks.get(0).getName()).isEqualTo("task3");
+        assertThat(tasks.get(1).getName()).isEqualTo("task1");
+        assertThat(tasks.get(2).getName()).isEqualTo("task2");
+        assertThat(tasks.get(3).getName()).isEqualTo("task0");
+        assertThat(tasks.get(4).getDueDate()).isNull();
+        assertThat(tasks.get(5).getDueDate()).isNull();
 
         // The same, but now desc
         tasks = taskService.createTaskQuery().orderByDueDateNullsLast().desc().list();
 
         for (int i = 0; i < 4; i++) {
-            assertNotNull(tasks.get(i).getDueDate());
+            assertThat(tasks.get(i).getDueDate()).isNotNull();
         }
 
-        assertEquals("task0", tasks.get(0).getName());
-        assertEquals("task2", tasks.get(1).getName());
-        assertEquals("task1", tasks.get(2).getName());
-        assertEquals("task3", tasks.get(3).getName());
-        assertNull(tasks.get(4).getDueDate());
-        assertNull(tasks.get(5).getDueDate());
+        assertThat(tasks.get(0).getName()).isEqualTo("task0");
+        assertThat(tasks.get(1).getName()).isEqualTo("task2");
+        assertThat(tasks.get(2).getName()).isEqualTo("task1");
+        assertThat(tasks.get(3).getName()).isEqualTo("task3");
+        assertThat(tasks.get(4).getDueDate()).isNull();
+        assertThat(tasks.get(5).getDueDate()).isNull();
 
         // The same but now nulls first
         tasks = taskService.createTaskQuery().orderByDueDateNullsFirst().asc().list();
 
-        assertNull(tasks.get(0).getDueDate());
-        assertNull(tasks.get(1).getDueDate());
-        assertEquals("task3", tasks.get(2).getName());
-        assertEquals("task1", tasks.get(3).getName());
-        assertEquals("task2", tasks.get(4).getName());
-        assertEquals("task0", tasks.get(5).getName());
+        assertThat(tasks.get(0).getDueDate()).isNull();
+        assertThat(tasks.get(1).getDueDate()).isNull();
+        assertThat(tasks.get(2).getName()).isEqualTo("task3");
+        assertThat(tasks.get(3).getName()).isEqualTo("task1");
+        assertThat(tasks.get(4).getName()).isEqualTo("task2");
+        assertThat(tasks.get(5).getName()).isEqualTo("task0");
 
         // And now desc
         tasks = taskService.createTaskQuery().orderByDueDateNullsFirst().desc().list();
 
-        assertNull(tasks.get(0).getDueDate());
-        assertNull(tasks.get(1).getDueDate());
-        assertEquals("task0", tasks.get(2).getName());
-        assertEquals("task2", tasks.get(3).getName());
-        assertEquals("task1", tasks.get(4).getName());
-        assertEquals("task3", tasks.get(5).getName());
+        assertThat(tasks.get(0).getDueDate()).isNull();
+        assertThat(tasks.get(1).getDueDate()).isNull();
+        assertThat(tasks.get(2).getName()).isEqualTo("task0");
+        assertThat(tasks.get(3).getName()).isEqualTo("task2");
+        assertThat(tasks.get(4).getName()).isEqualTo("task1");
+        assertThat(tasks.get(5).getName()).isEqualTo("task3");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             // And now the same, but for history!
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery().orderByDueDateNullsLast().asc().list();
 
             for (int i = 0; i < 4; i++) {
-                assertNotNull(historicTasks.get(i).getDueDate());
+                assertThat(historicTasks.get(i).getDueDate()).isNotNull();
             }
 
-            assertEquals("task3", historicTasks.get(0).getName());
-            assertEquals("task1", historicTasks.get(1).getName());
-            assertEquals("task2", historicTasks.get(2).getName());
-            assertEquals("task0", historicTasks.get(3).getName());
-            assertNull(historicTasks.get(4).getDueDate());
-            assertNull(historicTasks.get(5).getDueDate());
+            assertThat(historicTasks.get(0).getName()).isEqualTo("task3");
+            assertThat(historicTasks.get(1).getName()).isEqualTo("task1");
+            assertThat(historicTasks.get(2).getName()).isEqualTo("task2");
+            assertThat(historicTasks.get(3).getName()).isEqualTo("task0");
+            assertThat(historicTasks.get(4).getDueDate()).isNull();
+            assertThat(historicTasks.get(5).getDueDate()).isNull();
 
             // The same, but now desc
             historicTasks = historyService.createHistoricTaskInstanceQuery().orderByDueDateNullsLast().desc().list();
 
             for (int i = 0; i < 4; i++) {
-                assertNotNull(historicTasks.get(i).getDueDate());
+                assertThat(historicTasks.get(i).getDueDate()).isNotNull();
             }
 
-            assertEquals("task0", historicTasks.get(0).getName());
-            assertEquals("task2", historicTasks.get(1).getName());
-            assertEquals("task1", historicTasks.get(2).getName());
-            assertEquals("task3", historicTasks.get(3).getName());
-            assertNull(historicTasks.get(4).getDueDate());
-            assertNull(historicTasks.get(5).getDueDate());
+            assertThat(historicTasks.get(0).getName()).isEqualTo("task0");
+            assertThat(historicTasks.get(1).getName()).isEqualTo("task2");
+            assertThat(historicTasks.get(2).getName()).isEqualTo("task1");
+            assertThat(historicTasks.get(3).getName()).isEqualTo("task3");
+            assertThat(historicTasks.get(4).getDueDate()).isNull();
+            assertThat(historicTasks.get(5).getDueDate()).isNull();
 
             // The same but now nulls first
             historicTasks = historyService.createHistoricTaskInstanceQuery().orderByDueDateNullsFirst().asc().list();
 
-            assertNull(historicTasks.get(0).getDueDate());
-            assertNull(historicTasks.get(1).getDueDate());
-            assertEquals("task3", historicTasks.get(2).getName());
-            assertEquals("task1", historicTasks.get(3).getName());
-            assertEquals("task2", historicTasks.get(4).getName());
-            assertEquals("task0", historicTasks.get(5).getName());
+            assertThat(historicTasks.get(0).getDueDate()).isNull();
+            assertThat(historicTasks.get(1).getDueDate()).isNull();
+            assertThat(historicTasks.get(2).getName()).isEqualTo("task3");
+            assertThat(historicTasks.get(3).getName()).isEqualTo("task1");
+            assertThat(historicTasks.get(4).getName()).isEqualTo("task2");
+            assertThat(historicTasks.get(5).getName()).isEqualTo("task0");
 
             // And now desc
             historicTasks = historyService.createHistoricTaskInstanceQuery().orderByDueDateNullsFirst().desc().list();
 
-            assertNull(historicTasks.get(0).getDueDate());
-            assertNull(historicTasks.get(1).getDueDate());
-            assertEquals("task0", historicTasks.get(2).getName());
-            assertEquals("task2", historicTasks.get(3).getName());
-            assertEquals("task1", historicTasks.get(4).getName());
-            assertEquals("task3", historicTasks.get(5).getName());
+            assertThat(historicTasks.get(0).getDueDate()).isNull();
+            assertThat(historicTasks.get(1).getDueDate()).isNull();
+            assertThat(historicTasks.get(2).getName()).isEqualTo("task0");
+            assertThat(historicTasks.get(3).getName()).isEqualTo("task2");
+            assertThat(historicTasks.get(4).getName()).isEqualTo("task1");
+            assertThat(historicTasks.get(5).getName()).isEqualTo("task3");
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
@@ -17,8 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import org.flowable.common.engine.impl.history.HistoryLevel;
@@ -53,18 +51,13 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.addCandidateUser(taskId, "kermit");
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        IdentityLink identityLink = identityLinks.get(0);
-
-        assertNull(identityLink.getGroupId());
-        assertEquals("kermit", identityLink.getUserId());
-        assertEquals(IdentityLinkType.CANDIDATE, identityLink.getType());
-        assertEquals(taskId, identityLink.getTaskId());
-
-        assertEquals(1, identityLinks.size());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getGroupId, IdentityLink::getUserId, IdentityLink::getType, IdentityLink::getTaskId)
+                .containsExactly(tuple(null, "kermit", IdentityLinkType.CANDIDATE, taskId));
 
         taskService.deleteCandidateUser(taskId, "kermit");
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
     }
 
     @Test
@@ -77,40 +70,33 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.addCandidateGroup(taskId, "muppets");
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        IdentityLink identityLink = identityLinks.get(0);
-
-        assertEquals("muppets", identityLink.getGroupId());
-        assertNull("kermit", identityLink.getUserId());
-        assertEquals(IdentityLinkType.CANDIDATE, identityLink.getType());
-        assertEquals(taskId, identityLink.getTaskId());
-
-        assertEquals(1, identityLinks.size());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getGroupId, IdentityLink::getUserId, IdentityLink::getType, IdentityLink::getTaskId)
+                .containsExactly(tuple("muppets", null, IdentityLinkType.CANDIDATE, taskId));
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<Event> taskEvents = taskService.getTaskEvents(taskId);
-            assertEquals(1, taskEvents.size());
+            assertThat(taskEvents).hasSize(1);
             Event taskEvent = taskEvents.get(0);
-            assertEquals(Event.ACTION_ADD_GROUP_LINK, taskEvent.getAction());
+            assertThat(taskEvent.getAction()).isEqualTo(Event.ACTION_ADD_GROUP_LINK);
             List<String> taskEventMessageParts = taskEvent.getMessageParts();
-            assertEquals("muppets", taskEventMessageParts.get(0));
-            assertEquals(IdentityLinkType.CANDIDATE, taskEventMessageParts.get(1));
-            assertEquals(2, taskEventMessageParts.size());
+            assertThat(taskEventMessageParts)
+                    .containsExactlyInAnyOrder("muppets", IdentityLinkType.CANDIDATE);
         }
 
         taskService.deleteCandidateGroup(taskId, "muppets");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             List<Event> taskEvents = taskService.getTaskEvents(taskId);
+            assertThat(taskEvents).hasSize(2);
             Event taskEvent = findTaskEvent(taskEvents, Event.ACTION_DELETE_GROUP_LINK);
-            assertEquals(Event.ACTION_DELETE_GROUP_LINK, taskEvent.getAction());
+            assertThat(taskEvent.getAction()).isEqualTo(Event.ACTION_DELETE_GROUP_LINK);
             List<String> taskEventMessageParts = taskEvent.getMessageParts();
-            assertEquals("muppets", taskEventMessageParts.get(0));
-            assertEquals(IdentityLinkType.CANDIDATE, taskEventMessageParts.get(1));
-            assertEquals(2, taskEventMessageParts.size());
-            assertEquals(2, taskEvents.size());
+            assertThat(taskEventMessageParts)
+                    .containsExactlyInAnyOrder("muppets", IdentityLinkType.CANDIDATE);
         }
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
     }
     
     @Test
@@ -126,36 +112,24 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
 
         taskService.setAssignee(taskId, "kermit");
 
-        assertEquals(1, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).hasSize(1);
 
         assertTaskEvent(taskId, 1, Event.ACTION_ADD_USER_LINK, "kermit", IdentityLinkType.ASSIGNEE);
 
         taskService.setAssignee(taskId, null);
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
 
         assertTaskEvent(taskId, 2, Event.ACTION_DELETE_USER_LINK, "kermit", IdentityLinkType.ASSIGNEE);
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
-        assertEquals(2, history.size());
-        
-        Collections.sort(history, new Comparator<HistoricIdentityLink>() {
-
-            @Override
-            public int compare(HistoricIdentityLink hi1, HistoricIdentityLink hi2) {
-               return hi1.getCreateTime().compareTo(hi2.getCreateTime());
-            }
-            
-        });
-        
-        HistoricIdentityLink assigned = history.get(0);
-        assertEquals(IdentityLinkType.ASSIGNEE, assigned.getType());
-        assertEquals("kermit", assigned.getUserId());
-        HistoricIdentityLink unassigned = history.get(1);
-        assertNull(unassigned.getUserId());
-        assertEquals(IdentityLinkType.ASSIGNEE, unassigned.getType());
-        assertNull(unassigned.getUserId());
+        assertThat(history)
+                .extracting(HistoricIdentityLink::getUserId, HistoricIdentityLink::getType)
+                .containsExactlyInAnyOrder(
+                        tuple("kermit", IdentityLinkType.ASSIGNEE),
+                        tuple(null, IdentityLinkType.ASSIGNEE)
+                );
     }
 
     @Test
@@ -171,36 +145,24 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
 
         taskService.claim(taskId, "kermit");
 
-        assertEquals(1, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).hasSize(1);
 
         assertTaskEvent(taskId, 1, Event.ACTION_ADD_USER_LINK, "kermit", IdentityLinkType.ASSIGNEE);
 
         taskService.unclaim(taskId);
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
 
         assertTaskEvent(taskId, 2, Event.ACTION_DELETE_USER_LINK, "kermit", IdentityLinkType.ASSIGNEE);
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
-        assertEquals(2, history.size());
-        
-        Collections.sort(history, new Comparator<HistoricIdentityLink>() {
-
-            @Override
-            public int compare(HistoricIdentityLink hi1, HistoricIdentityLink hi2) {
-               return hi1.getCreateTime().compareTo(hi2.getCreateTime());
-            }
-            
-        });
-        
-        HistoricIdentityLink assigned = history.get(0);
-        assertEquals(IdentityLinkType.ASSIGNEE, assigned.getType());
-        assertEquals("kermit", assigned.getUserId());
-        HistoricIdentityLink unassigned = history.get(1);
-        assertNull(unassigned.getUserId());
-        assertEquals(IdentityLinkType.ASSIGNEE, unassigned.getType());
-        assertNull(unassigned.getUserId());
+        assertThat(history)
+                .extracting(HistoricIdentityLink::getUserId, HistoricIdentityLink::getType)
+                .containsExactlyInAnyOrder(
+                        tuple("kermit", IdentityLinkType.ASSIGNEE),
+                        tuple(null, IdentityLinkType.ASSIGNEE)
+                );
     }
 
     @Test
@@ -216,35 +178,24 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
 
         taskService.setOwner(taskId, "kermit");
 
-        assertEquals(1, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).hasSize(1);
 
         assertTaskEvent(taskId, 1, Event.ACTION_ADD_USER_LINK, "kermit", IdentityLinkType.OWNER);
 
         taskService.setOwner(taskId, null);
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
 
         assertTaskEvent(taskId, 2, Event.ACTION_DELETE_USER_LINK, "kermit", IdentityLinkType.OWNER);
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
-        assertEquals(2, history.size());
-        Collections.sort(history, new Comparator<HistoricIdentityLink>() {
-
-            @Override
-            public int compare(HistoricIdentityLink hi1, HistoricIdentityLink hi2) {
-               return hi1.getCreateTime().compareTo(hi2.getCreateTime());
-            }
-            
-        });
-        
-        HistoricIdentityLink assigned = history.get(0);
-        assertEquals(IdentityLinkType.OWNER, assigned.getType());
-        assertEquals("kermit", assigned.getUserId());
-        HistoricIdentityLink unassigned = history.get(1);
-        assertNull(unassigned.getUserId());
-        assertEquals(IdentityLinkType.OWNER, unassigned.getType());
-        assertNull(unassigned.getUserId());
+        assertThat(history)
+                .extracting(HistoricIdentityLink::getUserId, HistoricIdentityLink::getType)
+                .containsExactlyInAnyOrder(
+                        tuple("kermit", IdentityLinkType.OWNER),
+                        tuple(null, IdentityLinkType.OWNER)
+                );
     }
     
     @Test
@@ -262,16 +213,15 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.claim(taskId, "kermit");
         taskService.setAssignee(taskId, "kermit");
 
-        assertEquals(1, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).hasSize(1);
 
         assertTaskEvent(taskId, 1, Event.ACTION_ADD_USER_LINK, "kermit", IdentityLinkType.ASSIGNEE);
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
-        assertEquals(1, history.size());
-        HistoricIdentityLink assigned = history.get(0);
-        assertEquals(IdentityLinkType.ASSIGNEE, assigned.getType());
-        assertEquals("kermit", assigned.getUserId());
+        assertThat(history)
+                .extracting(HistoricIdentityLink::getType, HistoricIdentityLink::getUserId)
+                .containsExactly(tuple(IdentityLinkType.ASSIGNEE, "kermit"));
     }
 
     @Test
@@ -288,13 +238,13 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.claim(taskId, null);
         taskService.setAssignee(taskId, null);
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
 
         assertTaskEvent(taskId, 0, null, null, null);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         List<HistoricIdentityLink> history = historyService.getHistoricIdentityLinksForTask(taskId);
-        assertEquals(0, history.size());
+        assertThat(history).isEmpty();
     }
 
     @Test
@@ -307,18 +257,13 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.addUserIdentityLink(taskId, "kermit", "interestee");
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        IdentityLink identityLink = identityLinks.get(0);
-
-        assertNull(identityLink.getGroupId());
-        assertEquals("kermit", identityLink.getUserId());
-        assertEquals("interestee", identityLink.getType());
-        assertEquals(taskId, identityLink.getTaskId());
-
-        assertEquals(1, identityLinks.size());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getGroupId, IdentityLink::getUserId, IdentityLink::getType, IdentityLink::getTaskId)
+                .containsExactly(tuple(null, "kermit", "interestee", taskId));
 
         taskService.deleteUserIdentityLink(taskId, "kermit", "interestee");
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
     }
 
     @Test
@@ -331,18 +276,13 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.addGroupIdentityLink(taskId, "muppets", "playing");
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        IdentityLink identityLink = identityLinks.get(0);
-
-        assertEquals("muppets", identityLink.getGroupId());
-        assertNull("kermit", identityLink.getUserId());
-        assertEquals("playing", identityLink.getType());
-        assertEquals(taskId, identityLink.getTaskId());
-
-        assertEquals(1, identityLinks.size());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getGroupId, IdentityLink::getUserId, IdentityLink::getType, IdentityLink::getTaskId)
+                .containsExactly(tuple("muppets", null, "playing", taskId));
 
         taskService.deleteGroupIdentityLink(taskId, "muppets", "playing");
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
     }
 
     @Test
@@ -354,8 +294,8 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.deleteUserIdentityLink(task.getId(), "nonExistingUser", IdentityLinkType.ASSIGNEE);
 
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertNull(task.getAssignee());
-        assertEquals(0, taskService.getIdentityLinksForTask(task.getId()).size());
+        assertThat(task.getAssignee()).isNull();
+        assertThat(taskService.getIdentityLinksForTask(task.getId())).isEmpty();
 
         // cleanup
         taskService.deleteTask(task.getId(), true);
@@ -370,8 +310,8 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.deleteUserIdentityLink(task.getId(), "nonExistingUser", IdentityLinkType.OWNER);
 
         task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-        assertNull(task.getOwner());
-        assertEquals(0, taskService.getIdentityLinksForTask(task.getId()).size());
+        assertThat(task.getOwner()).isNull();
+        assertThat(taskService.getIdentityLinksForTask(task.getId())).isEmpty();
 
         // cleanup
         taskService.deleteTask(task.getId(), true);
@@ -385,11 +325,9 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         String taskId = taskService.createTaskQuery().singleResult().getId();
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-
-        assertEquals(1, identityLinks.size());
-        IdentityLink identityLink = identityLinks.get(0);
-
-        assertEquals("user", identityLink.getUserId());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getUserId)
+                .containsExactly("user");
     }
 
     @Test
@@ -403,18 +341,13 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         taskService.deleteCandidateUser(taskId, "kermit");
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        assertNotNull(identityLinks);
-        assertEquals(1, identityLinks.size());
-
-        IdentityLink identityLink = identityLinks.get(0);
-        assertEquals("muppets", identityLink.getGroupId());
-        assertNull(identityLink.getUserId());
-        assertEquals(IdentityLinkType.CANDIDATE, identityLink.getType());
-        assertEquals(taskId, identityLink.getTaskId());
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getGroupId, IdentityLink::getUserId, IdentityLink::getType, IdentityLink::getTaskId)
+                .containsExactly(tuple("muppets", null, IdentityLinkType.CANDIDATE, taskId));
 
         taskService.deleteCandidateGroup(taskId, "muppets");
 
-        assertEquals(0, taskService.getIdentityLinksForTask(taskId).size());
+        assertThat(taskService.getIdentityLinksForTask(taskId)).isEmpty();
     }
 
     // Test custom identity links
@@ -424,20 +357,15 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("customIdentityLink");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskInvolvedUser("kermit").list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(tasks.get(0).getId());
-        assertEquals(2, identityLinks.size());
-
-        for (IdentityLink idLink : identityLinks) {
-            assertEquals("businessAdministrator", idLink.getType());
-            String userId = idLink.getUserId();
-            if (userId == null) {
-                assertEquals("management", idLink.getGroupId());
-            } else {
-                assertEquals("kermit", userId);
-            }
-        }
+        assertThat(identityLinks)
+                .extracting(IdentityLink::getGroupId, IdentityLink::getUserId, IdentityLink::getType)
+                .containsExactlyInAnyOrder(
+                        tuple("management", null, "businessAdministrator"),
+                        tuple(null, "kermit", "businessAdministrator")
+                );
     }
 
     @Test
@@ -492,18 +420,17 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
                     String expectedIdentityId, String expectedIdentityType) {
         
         List<Event> taskEvents = taskService.getTaskEvents(taskId);
-        assertEquals(expectedCount, taskEvents.size());
+        assertThat(taskEvents).hasSize(expectedCount);
 
         if (expectedCount == 0) {
             return;
         }
 
         Event lastEvent = taskEvents.get(0);
-        assertEquals(expectedAction, lastEvent.getAction());
+        assertThat(lastEvent.getAction()).isEqualTo(expectedAction);
         List<String> taskEventMessageParts = lastEvent.getMessageParts();
-        assertEquals(expectedIdentityId, taskEventMessageParts.get(0));
-        assertEquals(expectedIdentityType, taskEventMessageParts.get(1));
-        assertEquals(2, taskEventMessageParts.size());
+        assertThat(taskEventMessageParts)
+                .containsOnly(expectedIdentityId, expectedIdentityType);
     }
     
     private Event findTaskEvent(List<Event> taskEvents, String action) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -892,8 +892,8 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Verify task parameters set on execution
         Map<String, Object> variables = runtimeService.getVariables(processInstance.getId());
-        assertThat(variables).hasSize(1);
-        assertThat(variables.get("myParam")).isEqualTo("myValue");
+        assertThat(variables)
+                .containsOnly(entry("myParam", "myValue"));
     }
 
     @Test
@@ -908,10 +908,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         // Complete first task
         Map<String, Object> taskParams = new HashMap<>();
         taskParams.put("myParam", "myValue");
-        taskService.complete(task.getId(), taskParams, false); // Only
-        // difference
-        // with previous
-        // test
+        taskService.complete(task.getId(), taskParams, false); // Only difference with previous test
 
         // Fetch second task
         task = taskService.createTaskQuery().singleResult();
@@ -919,8 +916,8 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         // Verify task parameters set on execution
         Map<String, Object> variables = runtimeService.getVariables(processInstance.getId());
-        assertThat(variables).hasSize(1);
-        assertThat(variables.get("myParam")).isEqualTo("myValue");
+        assertThat(variables)
+                .containsOnly(entry("myParam", "myValue"));
     }
 
     @Test
@@ -1424,10 +1421,9 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         taskService.delegateTask(taskId, "fozzie");
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
-        assertThat(identityLinks).hasSize(2);
         assertThat(identityLinks)
                 .extracting(IdentityLink::getUserId, IdentityLink::getGroupId, IdentityLink::getType)
-                .containsExactly(
+                .containsExactlyInAnyOrder(
                         tuple("fozzie", null, IdentityLinkType.ASSIGNEE),
                         tuple("kermit", null, IdentityLinkType.OWNER)
                 );

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskVariablesTest.java
@@ -13,6 +13,9 @@
 
 package org.flowable.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,7 +43,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
 
         String taskId = task.getId();
         taskService.setVariable(taskId, "instrument", "trumpet");
-        assertEquals("trumpet", taskService.getVariable(taskId, "instrument"));
+        assertThat(taskService.getVariable(taskId, "instrument")).isEqualTo("trumpet");
 
         taskService.deleteTask(taskId, true);
     }
@@ -51,49 +54,72 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         String processInstanceId = runtimeService.startProcessInstanceByKey("oneTaskProcess").getId();
         String taskId = taskService.createTaskQuery().singleResult().getId();
 
-        Map<String, Object> expectedVariables = new HashMap<>();
-        assertEquals(expectedVariables, runtimeService.getVariables(processInstanceId));
-        assertEquals(expectedVariables, taskService.getVariables(taskId));
-        assertEquals(expectedVariables, runtimeService.getVariablesLocal(processInstanceId));
-        assertEquals(expectedVariables, taskService.getVariablesLocal(taskId));
+        assertThat(runtimeService.getVariables(processInstanceId)).isEmpty();
+        assertThat(taskService.getVariables(taskId)).isEmpty();
+        assertThat(runtimeService.getVariablesLocal(processInstanceId)).isEmpty();
+        assertThat(taskService.getVariablesLocal(taskId)).isEmpty();
 
         runtimeService.setVariable(processInstanceId, "instrument", "trumpet");
 
-        expectedVariables = new HashMap<>();
-        assertEquals(expectedVariables, taskService.getVariablesLocal(taskId));
-        expectedVariables.put("instrument", "trumpet");
-        assertEquals(expectedVariables, runtimeService.getVariables(processInstanceId));
-        assertEquals(expectedVariables, taskService.getVariables(taskId));
-        assertEquals(expectedVariables, runtimeService.getVariablesLocal(processInstanceId));
+        assertThat(taskService.getVariablesLocal(taskId)).isEmpty();
+        assertThat(runtimeService.getVariables(processInstanceId))
+                .containsOnly(
+                        entry("instrument", "trumpet")
+                );
+        assertThat(taskService.getVariables(taskId))
+                .containsOnly(
+                        entry("instrument", "trumpet")
+                );
+        assertThat(runtimeService.getVariablesLocal(processInstanceId))
+                .containsOnly(
+                        entry("instrument", "trumpet")
+                );
 
         taskService.setVariable(taskId, "player", "gonzo");
-        assertTrue(taskService.hasVariable(taskId, "player"));
-        assertFalse(taskService.hasVariableLocal(taskId, "budget"));
+        assertThat(taskService.hasVariable(taskId, "player")).isTrue();
+        assertThat(taskService.hasVariableLocal(taskId, "budget")).isFalse();
 
-        expectedVariables = new HashMap<>();
-        assertEquals(expectedVariables, taskService.getVariablesLocal(taskId));
-        expectedVariables.put("player", "gonzo");
-        expectedVariables.put("instrument", "trumpet");
-        assertEquals(expectedVariables, runtimeService.getVariables(processInstanceId));
-        assertEquals(expectedVariables, taskService.getVariables(taskId));
-        assertEquals(expectedVariables, runtimeService.getVariablesLocal(processInstanceId));
+        assertThat(runtimeService.getVariables(processInstanceId))
+                .containsOnly(
+                        entry("player", "gonzo"),
+                        entry("instrument", "trumpet")
+                );
+        assertThat(taskService.getVariables(taskId))
+                .containsOnly(
+                        entry("player", "gonzo"),
+                        entry("instrument", "trumpet")
+                );
+        assertThat(runtimeService.getVariablesLocal(processInstanceId))
+                .containsOnly(
+                        entry("player", "gonzo"),
+                        entry("instrument", "trumpet")
+                );
 
         taskService.setVariableLocal(taskId, "budget", "unlimited");
-        assertTrue(taskService.hasVariableLocal(taskId, "budget"));
-        assertTrue(taskService.hasVariable(taskId, "budget"));
+        assertThat(taskService.hasVariableLocal(taskId, "budget")).isTrue();
+        assertThat(taskService.hasVariable(taskId, "budget")).isTrue();
 
-        expectedVariables = new HashMap<>();
-        expectedVariables.put("budget", "unlimited");
-        assertEquals(expectedVariables, taskService.getVariablesLocal(taskId));
-        expectedVariables.put("player", "gonzo");
-        expectedVariables.put("instrument", "trumpet");
-        assertEquals(expectedVariables, taskService.getVariables(taskId));
+        assertThat(taskService.getVariablesLocal(taskId))
+                .containsOnly(
+                        entry("budget", "unlimited")
+                );
+        assertThat(taskService.getVariables(taskId))
+                .containsOnly(
+                        entry("budget", "unlimited"),
+                        entry("player", "gonzo"),
+                        entry("instrument", "trumpet")
+                );
 
-        expectedVariables = new HashMap<>();
-        expectedVariables.put("player", "gonzo");
-        expectedVariables.put("instrument", "trumpet");
-        assertEquals(expectedVariables, runtimeService.getVariables(processInstanceId));
-        assertEquals(expectedVariables, runtimeService.getVariablesLocal(processInstanceId));
+        assertThat(runtimeService.getVariables(processInstanceId))
+                .containsOnly(
+                        entry("player", "gonzo"),
+                        entry("instrument", "trumpet")
+                );
+        assertThat(runtimeService.getVariablesLocal(processInstanceId))
+                .containsOnly(
+                        entry("player", "gonzo"),
+                        entry("instrument", "trumpet")
+                );
     }
 
     @Test
@@ -110,7 +136,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
 
         // Fetch variable
         MyVariable variable = (MyVariable) taskService.getVariable(task.getId(), "theVar");
-        assertEquals("Hello world", variable.getValue());
+        assertThat(variable.getValue()).isEqualTo("Hello world");
 
         // Cleanup
         taskService.deleteTask(task.getId(), true);
@@ -150,7 +176,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         taskIds.add(taskList1.get(0).getId());
         taskIds.add(taskList1.get(1).getId());
         List<VariableInstance> variables = taskService.getVariableInstancesLocalByTaskIds(taskIds);
-        assertEquals(2, variables.size());
+        assertThat(variables).hasSize(2);
         checkVariable(taskList1.get(0).getId(), "taskVar1", "sayHello1", variables);
         checkVariable(taskList1.get(1).getId(), "taskVar2", "sayHello2", variables);
 
@@ -161,7 +187,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         taskIds.add(taskList2.get(0).getId());
         taskIds.add(taskList2.get(1).getId());
         variables = taskService.getVariableInstancesLocalByTaskIds(taskIds);
-        assertEquals(4, variables.size());
+        assertThat(variables).hasSize(4);
         checkVariable(taskList1.get(0).getId(), "taskVar1", "sayHello1", variables);
         checkVariable(taskList1.get(1).getId(), "taskVar2", "sayHello2", variables);
         checkVariable(taskList2.get(0).getId(), "taskVar3", "sayHello3", variables);
@@ -172,7 +198,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         taskIds.add(taskList1.get(0).getId());
         taskIds.add(taskList2.get(1).getId());
         variables = taskService.getVariableInstancesLocalByTaskIds(taskIds);
-        assertEquals(2, variables.size());
+        assertThat(variables).hasSize(2);
         checkVariable(taskList1.get(0).getId(), "taskVar1", "sayHello1", variables);
         checkVariable(taskList2.get(1).getId(), "taskVar4", "sayHello4", variables);
     }
@@ -180,8 +206,8 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
     private void checkVariable(String taskId, String name, String value, List<VariableInstance> variables) {
         for (VariableInstance variable : variables) {
             if (taskId.equals(variable.getTaskId())) {
-                assertEquals(name, variable.getName());
-                assertEquals(value, variable.getValue());
+                assertThat(variable.getName()).isEqualTo(name);
+                assertThat(variable.getValue()).isEqualTo(value);
                 return;
             }
         }
@@ -208,7 +234,7 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         Set<String> taskIds = new HashSet<>();
         taskIds.add(taskId);
         List<VariableInstance> variables = taskService.getVariableInstancesLocalByTaskIds(taskIds);
-        assertEquals(serializableTypeVar, variables.get(0).getValue());
+        assertThat(variables.get(0).getValue()).isEqualTo(serializableTypeVar);
     }
 
     @Test
@@ -235,11 +261,11 @@ public class TaskVariablesTest extends PluggableFlowableTestCase {
         }
 
         List<VariableInstance> variableInstances = taskService.getVariableInstancesLocalByTaskIds(taskIds);
-        assertEquals(2, variableInstances.size());
-        assertEquals("taskVar", variableInstances.get(0).getName());
-        assertEquals("taskVar", variableInstances.get(0).getValue());
-        assertEquals("taskVar", variableInstances.get(1).getName());
-        assertEquals("taskVar", variableInstances.get(1).getValue());
+        assertThat(variableInstances).hasSize(2);
+        assertThat(variableInstances.get(0).getName()).isEqualTo("taskVar");
+        assertThat(variableInstances.get(0).getValue()).isEqualTo("taskVar");
+        assertThat(variableInstances.get(1).getName()).isEqualTo("taskVar");
+        assertThat(variableInstances.get(1).getValue()).isEqualTo("taskVar");
     }
 
     public static class MyVariable implements Serializable {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6Test.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6Test.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.api.v6;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -26,6 +29,7 @@ import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.job.api.Job;
+import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,8 +44,8 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/api/v6/Flowable6Test.simplestProcessPossible.bpmn20.xml").deploy();
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
-        assertNotNull(processInstance);
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isTrue();
 
         // Cleanup
         for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
@@ -53,12 +57,12 @@ public class Flowable6Test extends PluggableFlowableTestCase {
     @org.flowable.engine.test.Deployment
     public void testOneTaskProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("The famous task", task.getName());
-        assertEquals("kermit", task.getAssignee());
+        assertThat(task.getName()).isEqualTo("The famous task");
+        assertThat(task.getAssignee()).isEqualTo("kermit");
 
         taskService.complete(task.getId());
     }
@@ -67,52 +71,52 @@ public class Flowable6Test extends PluggableFlowableTestCase {
     @org.flowable.engine.test.Deployment(resources = "org/flowable/engine/test/api/v6/Flowable6Test.testOneTaskProcess.bpmn20.xml")
     public void testOneTaskProcessCleanupInMiddleOfProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("The famous task", task.getName());
-        assertEquals("kermit", task.getAssignee());
+        assertThat(task.getName()).isEqualTo("The famous task");
+        assertThat(task.getAssignee()).isEqualTo("kermit");
     }
 
     @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleParallelGateway");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processDefinitionKey("simpleParallelGateway").orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("Task a", tasks.get(0).getName());
-        assertEquals("Task b", tasks.get(1).getName());
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get(0).getName()).isEqualTo("Task a");
+        assertThat(tasks.get(1).getName()).isEqualTo("Task b");
 
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
         }
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleNestedParallelGateway() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleParallelGateway");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processDefinitionKey("simpleParallelGateway").orderByTaskName().asc().list();
-        assertEquals(4, tasks.size());
-        assertEquals("Task a", tasks.get(0).getName());
-        assertEquals("Task b1", tasks.get(1).getName());
-        assertEquals("Task b2", tasks.get(2).getName());
-        assertEquals("Task c", tasks.get(3).getName());
+        assertThat(tasks).hasSize(4);
+        assertThat(tasks.get(0).getName()).isEqualTo("Task a");
+        assertThat(tasks.get(1).getName()).isEqualTo("Task b1");
+        assertThat(tasks.get(2).getName()).isEqualTo("Task b2");
+        assertThat(tasks.get(3).getName()).isEqualTo("Task c");
 
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
         }
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
     /*
@@ -129,14 +133,14 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         vars.put("counter", 0);
         vars.put("maxCount", maxCount);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testLongServiceTaskLoop", vars);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
-        assertEquals(maxCount, CountingServiceTaskTestDelegate.CALL_COUNT.get());
-        assertEquals(maxCount,
-            runtimeService.createActivityInstanceQuery()
+        assertThat(CountingServiceTaskTestDelegate.CALL_COUNT.get()).isEqualTo(maxCount);
+        assertThat(runtimeService.createActivityInstanceQuery()
                 .processInstanceId(processInstance.getId())
                 .activityId("serviceTask")
-                .count());
+                .count())
+                .isEqualTo(maxCount);
     }
 
     @Test
@@ -146,53 +150,53 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         variableMap.put("a", 1);
         variableMap.put("b", 2);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variableMap);
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         Number sumVariable = (Number) runtimeService.getVariable(processInstance.getId(), "sum");
-        assertEquals(3, sumVariable.intValue());
+        assertThat(sumVariable.intValue()).isEqualTo(3);
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         runtimeService.trigger(execution.getId());
 
-        assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult()).isNull();
     }
 
     @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleTimerBoundaryEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleBoundaryTimer");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         Job job = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Task after timer", task.getName());
+        assertThat(task.getName()).isEqualTo("Task after timer");
 
         taskService.complete(task.getId());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
     @org.flowable.engine.test.Deployment
     public void testSimpleTimerBoundaryEventTimerDoesNotFire() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleBoundaryTimer");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("The famous task", task.getName());
+        assertThat(task.getName()).isEqualTo("The famous task");
         taskService.complete(task.getId());
 
-        assertEquals(0, managementService.createTimerJobQuery().count());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -204,26 +208,26 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         // (see the task name ordering in the query to get that specific order)
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleBoundaryTimer");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         Job job = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(job.getId());
         managementService.executeJob(job.getId());
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         // Completing them both should complete the process instance
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
         }
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         // Second test: complete tasks: first task associated with child
         // execution, then parent execution (easier case)
-        processInstance = runtimeService.startProcessInstanceByKey("simpleBoundaryTimer");
+        runtimeService.startProcessInstanceByKey("simpleBoundaryTimer");
 
         job = managementService.createTimerJobQuery().singleResult();
         managementService.moveTimerToExecutableJob(job.getId());
@@ -233,7 +237,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
         }
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -242,44 +246,44 @@ public class Flowable6Test extends PluggableFlowableTestCase {
 
         // 3 conditions are true for input = 2
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testConditions", CollectionUtil.singletonMap("input", 2));
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals("C", tasks.get(2).getName());
+        assertThat(tasks).hasSize(3);
+        assertThat(tasks.get(0).getName()).isEqualTo("A");
+        assertThat(tasks.get(1).getName()).isEqualTo("B");
+        assertThat(tasks.get(2).getName()).isEqualTo("C");
 
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId());
         }
 
         // 2 conditions are true for input = 20
-        processInstance = runtimeService.startProcessInstanceByKey("testConditions", CollectionUtil.singletonMap("input", 20));
+        runtimeService.startProcessInstanceByKey("testConditions", CollectionUtil.singletonMap("input", 20));
         task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
 
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("B", tasks.get(0).getName());
-        assertEquals("C", tasks.get(1).getName());
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get(0).getName()).isEqualTo("B");
+        assertThat(tasks.get(1).getName()).isEqualTo("C");
 
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId());
         }
 
         // 1 condition is true for input = 200
-        processInstance = runtimeService.startProcessInstanceByKey("testConditions", CollectionUtil.singletonMap("input", 200));
+        runtimeService.startProcessInstanceByKey("testConditions", CollectionUtil.singletonMap("input", 200));
         task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
 
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(1, tasks.size());
-        assertEquals("C", tasks.get(0).getName());
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getName()).isEqualTo("C");
 
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId());
@@ -290,55 +294,48 @@ public class Flowable6Test extends PluggableFlowableTestCase {
     @org.flowable.engine.test.Deployment
     public void testNonInterruptingWithVariables() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nonInterrupting", Collections.singletonMap("testVar", "test"));
-        assertNotNull(processInstance);
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isTrue();
         Map<String, Object> varMap = ((ExecutionEntity) processInstance).getVariables();
-        assertEquals(1, varMap.size());
-        assertEquals("test", varMap.get("testVar"));
+        assertThat(varMap)
+                .containsExactly(entry("testVar", "test"));
     }
 
     @Test
     @org.flowable.engine.test.Deployment
     public void testNonInterruptingMoreComplex() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nonInterruptingTimer");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B");
 
         // Triggering the timers cancels B, but A is not interrupted
         List<Job> jobs = managementService.createTimerJobQuery().list();
-        assertEquals(2, jobs.size());
+        assertThat(jobs).hasSize(2);
         for (Job job : jobs) {
             managementService.moveTimerToExecutableJob(job.getId());
             managementService.executeJob(job.getId());
         }
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(5, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("C", tasks.get(1).getName());
-        assertEquals("D", tasks.get(2).getName());
-        assertEquals("E", tasks.get(3).getName());
-        assertEquals("F", tasks.get(4).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "C", "D", "E", "F");
 
         // Firing timer shouldn't cancel anything, but create new task
         jobs = managementService.createTimerJobQuery().list();
-        assertEquals(1, jobs.size());
+        assertThat(jobs).hasSize(1);
         managementService.moveTimerToExecutableJob(jobs.get(0).getId());
         managementService.executeJob(jobs.get(0).getId());
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(6, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("C", tasks.get(1).getName());
-        assertEquals("D", tasks.get(2).getName());
-        assertEquals("E", tasks.get(3).getName());
-        assertEquals("F", tasks.get(4).getName());
-        assertEquals("G", tasks.get(5).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "C", "D", "E", "F", "G");
 
         // Completing all tasks in this order should give the engine a bit
         // exercise (parent executions first)
@@ -346,7 +343,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
         }
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -355,85 +352,84 @@ public class Flowable6Test extends PluggableFlowableTestCase {
 
         // Use case 1: no timers fire
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nonInterruptingWithInclusiveMerge");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals(2, managementService.createTimerJobQuery().count());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B");
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(2);
 
         // Completing A
         taskService.complete(tasks.get(0).getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(1, tasks.size());
-        assertEquals("B", tasks.get(0).getName());
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("B");
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         // Completing B should end the process
         taskService.complete(tasks.get(0).getId());
-        assertEquals(0, managementService.createTimerJobQuery().count());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         // Use case 2: The non interrupting timer on B fires
         processInstance = runtimeService.startProcessInstanceByKey("nonInterruptingWithInclusiveMerge");
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals(2, managementService.createTimerJobQuery().count());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B");
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(2);
 
         // Completing B
         taskService.complete(tasks.get(1).getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(1, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A");
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         // Firing the timer should activate E and F too
         String jobId = managementService.createTimerJobQuery().singleResult().getId();
         managementService.moveTimerToExecutableJob(jobId);
         managementService.executeJob(jobId);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("C", tasks.get(1).getName());
-        assertEquals("D", tasks.get(2).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "C", "D");
 
         // Firing the timer on D
-        assertEquals(1, managementService.createTimerJobQuery().count());
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
         jobId = managementService.createTimerJobQuery().singleResult().getId();
         managementService.moveTimerToExecutableJob(jobId);
         managementService.executeJob(jobId);
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(4, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("C", tasks.get(1).getName());
-        assertEquals("D", tasks.get(2).getName());
-        assertEquals("G", tasks.get(3).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "C", "D", "G");
 
         // Completing C, D, A and G in that order to give the engine a bit of exercise
         taskService.complete(taskService.createTaskQuery().taskName("C").singleResult().getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("D", tasks.get(1).getName());
-        assertEquals("G", tasks.get(2).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "D", "G");
 
         taskService.complete(taskService.createTaskQuery().taskName("D").singleResult().getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("G", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "G");
 
         taskService.complete(taskService.createTaskQuery().taskName("A").singleResult().getId());
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
-        assertEquals(1, tasks.size());
-        assertEquals("G", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("G");
 
         taskService.complete(taskService.createTaskQuery().taskName("G").singleResult().getId());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
     }
 
@@ -447,28 +443,27 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         // Use case 1 (easy):
         // "When C completes, depending on the data, we can immediately issue E no matter what the status is of A or B."
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("trickyInclusiveMerge");
-        assertNotNull(processInstance);
-        assertFalse(processInstance.isEnded());
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.isEnded()).isFalse();
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
 
         org.flowable.task.api.Task taskC = taskService.createTaskQuery().taskName("C").singleResult();
         taskService.complete(taskC.getId());
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals("E", tasks.get(2).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B", "E");
 
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("D", tasks.get(0).getName());
-        assertEquals("E", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("D", "E");
 
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         // Use case 2 (tricky):
         // "If A and B are complete and C routes to E, D will be issued in Parallel to E"
@@ -476,33 +471,33 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         // Instead, it's done by the InactivatedActivityBehavior
 
         processInstance = runtimeService.startProcessInstanceByKey("trickyInclusiveMerge");
-        assertEquals(3, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
 
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
-        assertEquals("A", tasks.get(0).getName());
-        assertEquals("B", tasks.get(1).getName());
-        assertEquals("C", tasks.get(2).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("A", "B", "C");
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
 
         // C should still be open
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(1, tasks.size());
-        assertEquals("C", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("C");
 
         // If C is now completed, the inclusive gateway should also be completed
         // and D and E should be open tasks
         taskService.complete(tasks.get(0).getId());
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("D", tasks.get(0).getName());
-        assertEquals("E", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("D", "E");
 
         // Completing them should just end the process instance
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     /**
@@ -512,7 +507,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
     @org.flowable.engine.test.Deployment(resources = "org/flowable/engine/test/api/v6/Flowable6Test.testOneTaskProcess.bpmn20.xml")
     public void testProcessDefinitionTagCreated() {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-        assertNull(((ProcessDefinitionEntity) processDefinition).getEngineVersion());
+        assertThat(((ProcessDefinitionEntity) processDefinition).getEngineVersion()).isNull();
     }
 
 }


### PR DESCRIPTION
This PR is a mixture of changes; it some files it is just an update, in others it was already partially converted and this finishes it, and in others it was all conversion to fluent style.

FWIW, there are about 475 `assertEquals()` statements remaining in this module to be converted.
