### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataDeleteTest.java
@@ -40,7 +40,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
             
             HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
             Calendar cal = new GregorianCalendar();
@@ -52,8 +52,8 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             activityQuery.finishedBefore(cal.getTime());
             activityQuery.delete();
             
-            assertEquals(0, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
         }
     }
     
@@ -65,11 +65,11 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
         runtimeService.setVariable(processInstance.getId(), "numVar", 43);
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
 
             assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
-            assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId()).size()).isGreaterThan(0);
+            assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId())).isNotEmpty();
             assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -82,7 +82,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             query.finishedBefore(cal.getTime());
             query.delete();
 
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
             
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             taskService.setVariableLocal(task.getId(), "taskVar", "taskValue");
@@ -97,7 +97,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
 
             assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
-            assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId()).size()).isGreaterThan(0);
+            assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId())).isNotEmpty();
             assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -110,7 +110,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
             assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
-            assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId()).size()).isGreaterThan(0);
+            assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId())).isNotEmpty();
             assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isGreaterThan(0);
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
@@ -119,14 +119,14 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             
             historyService.deleteRelatedDataOfRemovedHistoricProcessInstances();
             
-            assertEquals(0, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId()).size());
-            assertEquals(0, historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId())).isEmpty();
+            assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
-                assertEquals(0, historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count());
+                assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isZero();
             }
         }
     }
@@ -139,7 +139,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
         runtimeService.setVariable(processInstance.getId(), "numVar", 43);
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             
-            assertEquals(1, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
             
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             taskService.setVariableLocal(task.getId(), "taskVar", "taskValue");
@@ -155,14 +155,14 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             query.finishedBefore(cal.getTime());
             query.deleteWithRelatedData();
             
-            assertEquals(0, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId()).size());
-            assertEquals(0, historyService.getHistoricEntityLinkChildrenForProcessInstance(processInstance.getId()).size());
-            assertEquals(0, historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count());
-            assertEquals(0, historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId())).isEmpty();
+            assertThat(historyService.getHistoricEntityLinkChildrenForProcessInstance(processInstance.getId())).isEmpty();
+            assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstance.getId()).count()).isZero();
         }
     }
     
@@ -179,7 +179,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
         
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             
-            assertEquals(20, historyService.createHistoricProcessInstanceQuery().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(20);
             
             for (int i = 0; i < 10; i++) {
                 Task task = taskService.createTaskQuery().processInstanceId(processInstanceIds.get(i)).singleResult();
@@ -197,25 +197,25 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             query.finishedBefore(cal.getTime());
             query.deleteWithRelatedData();
             
-            assertEquals(10, historyService.createHistoricProcessInstanceQuery().count());
-            assertEquals(30, historyService.createHistoricActivityInstanceQuery().count());
-            assertEquals(10, historyService.createHistoricTaskInstanceQuery().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(10);
+            assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(30);
+            assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(10);
             
             for (int i = 0; i < 20; i++) {
                 if (i < 10) {
-                    assertEquals(0, historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i)).size());
-                    assertEquals(0, historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count());
-                    assertEquals(0, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count());
+                    assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i))).isEmpty();
+                    assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
+                    assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
                     if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
-                        assertEquals(0, historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count());
+                        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
                     }
                     
                 } else {
-                    assertEquals(1, historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i)).size());
-                    assertEquals(1, historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count());
-                    assertEquals(2, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count());
+                    assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i))).hasSize(1);
+                    assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(1);
+                    assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(2);
                     if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
-                        assertEquals(2, historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count());
+                        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(2);
                     }
                 }
             }
@@ -242,7 +242,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
                 
-                assertEquals(20, historyService.createHistoricProcessInstanceQuery().count());
+                assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(20);
                 
                 for (int i = 0; i < 10; i++) {
                     Task task = taskService.createTaskQuery().processInstanceId(processInstanceIds.get(i)).singleResult();
@@ -256,32 +256,32 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
                         
                 managementService.handleHistoryCleanupTimerJob();
                 
-                assertEquals(1, managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count());
+                assertThat(managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count()).isEqualTo(1);
                 
                 Job executableJob = managementService.moveTimerToExecutableJob(managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).singleResult().getId());
                 managementService.executeJob(executableJob.getId());
                 
-                assertEquals(1, managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count());
+                assertThat(managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count()).isEqualTo(1);
                 
-                assertEquals(10, historyService.createHistoricProcessInstanceQuery().count());
-                assertEquals(30, historyService.createHistoricActivityInstanceQuery().count());
-                assertEquals(10, historyService.createHistoricTaskInstanceQuery().count());
+                assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(10);
+                assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(30);
+                assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(10);
                 
                 for (int i = 0; i < 20; i++) {
                     if (i < 10) {
-                        assertEquals(0, historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i)).size());
-                        assertEquals(0, historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count());
-                        assertEquals(0, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count());
+                        assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i))).isEmpty();
+                        assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
+                        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
                         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
-                            assertEquals(0, historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count());
+                            assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
                         }
                         
                     } else {
-                        assertEquals(1, historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i)).size());
-                        assertEquals(1, historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count());
-                        assertEquals(2, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count());
+                        assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i))).hasSize(1);
+                        assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(1);
+                        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(2);
                         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.FULL, processEngineConfiguration)) {
-                            assertEquals(2, historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count());
+                            assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(2);
                         }
                     }
                 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataEngineDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataEngineDeleteTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -52,7 +54,7 @@ public class HistoricDataEngineDeleteTest extends ResourceFlowableTestCase {
             
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
                 
-                assertEquals(20, historyService.createHistoricProcessInstanceQuery().count());
+                assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(20);
                 
                 for (int i = 0; i < 10; i++) {
                     Task task = taskService.createTaskQuery().processInstanceId(processInstanceIds.get(i)).singleResult();
@@ -60,29 +62,29 @@ public class HistoricDataEngineDeleteTest extends ResourceFlowableTestCase {
                     taskService.complete(task.getId());
                 }
                 
-                assertEquals(1, managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count());
+                assertThat(managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count()).isEqualTo(1);
                 
                 Job executableJob = managementService.moveTimerToExecutableJob(managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).singleResult().getId());
                 managementService.executeJob(executableJob.getId());
                 
-                assertEquals(1, managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count());
+                assertThat(managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count()).isEqualTo(1);
                 
-                assertEquals(10, historyService.createHistoricProcessInstanceQuery().count());
-                assertEquals(30, historyService.createHistoricActivityInstanceQuery().count());
-                assertEquals(10, historyService.createHistoricTaskInstanceQuery().count());
+                assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(10);
+                assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(30);
+                assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(10);
                 
                 for (int i = 0; i < 20; i++) {
                     if (i < 10) {
-                        assertEquals(0, historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i)).size());
-                        assertEquals(0, historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count());
-                        assertEquals(0, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count());
-                        assertEquals(0, historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count());
+                        assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i))).isEmpty();
+                        assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
+                        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
+                        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count()).isZero();
                         
                     } else {
-                        assertEquals(1, historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i)).size());
-                        assertEquals(1, historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count());
-                        assertEquals(2, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count());
-                        assertEquals(2, historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count());
+                        assertThat(historyService.getHistoricIdentityLinksForProcessInstance(processInstanceIds.get(i))).hasSize(1);
+                        assertThat(historyService.createHistoricTaskLogEntryQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(1);
+                        assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(2);
+                        assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstanceIds.get(i)).count()).isEqualTo(2);
                     }
                 }
                 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/StartToEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/StartToEndTest.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.test.bpmn;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +37,7 @@ public class StartToEndTest extends PluggableFlowableTestCase {
     public void testStartToEnd() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
         assertProcessEnded(processInstance.getId());
-        assertTrue(processInstance.isEnded());
+        assertThat(processInstance.isEnded()).isTrue();
     }
 
     @Test
@@ -45,7 +48,7 @@ public class StartToEndTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd", varMap);
         assertProcessEnded(processInstance.getId());
         Map<String, Object> returnVarMap = ((ExecutionEntity) processInstance).getVariables();
-        assertEquals("hello", returnVarMap.get("test"));
+        assertThat(returnVarMap).containsEntry("test", "hello");
     }
 
     @Test
@@ -56,11 +59,14 @@ public class StartToEndTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd", varMap);
         assertProcessEnded(processInstance.getId());
         Map<String, Object> returnVarMap = ((ExecutionEntity) processInstance).getVariables();
-        assertEquals("hello", returnVarMap.get("test"));
-        assertEquals("string", returnVarMap.get("string"));
-        assertEquals(true, returnVarMap.get("boolean"));
-        assertEquals(25.5, returnVarMap.get("double"));
-        assertEquals(10L, returnVarMap.get("long"));
+        assertThat(returnVarMap)
+                .contains(
+                        entry("test", "hello"),
+                        entry("string", "string"),
+                        entry("boolean", true),
+                        entry("double", 25.5),
+                        entry("long", 10L)
+                );
     }
 
     @Test
@@ -71,13 +77,13 @@ public class StartToEndTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd", varMap);
         assertProcessEnded(processInstance.getId());
         Map<String, Object> returnVarMap = ((ExecutionEntity) processInstance).getVariables();
-        assertEquals("hello", returnVarMap.get("test"));
+        assertThat(returnVarMap).containsEntry("test", "hello");
         Person person1 = (Person) returnVarMap.get("person1");
-        assertEquals("1", person1.getId());
-        assertEquals("John", person1.getName());
+        assertThat(person1.getId()).isEqualTo("1");
+        assertThat(person1.getName()).isEqualTo("John");
         Person person2 = (Person) returnVarMap.get("person2");
-        assertEquals("2", person2.getId());
-        assertEquals("Paul", person2.getName());
+        assertThat(person2.getId()).isEqualTo("2");
+        assertThat(person2.getName()).isEqualTo("Paul");
     }
 
     public static class PrimitiveServiceTaskDelegate implements JavaDelegate {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/IntermediateNoneEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/IntermediateNoneEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.ExecutionListener;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -33,10 +35,10 @@ public class IntermediateNoneEventTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testIntermediateNoneTimerEvent() throws Exception {
-        assertFalse(listenerExecuted);
+        assertThat(listenerExecuted).isFalse();
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("intermediateNoneEventExample");
         assertProcessEnded(pi.getProcessInstanceId());
-        assertTrue(listenerExecuted);
+        assertThat(listenerExecuted).isTrue();
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/NoneStartEventActivityBehaviorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/NoneStartEventActivityBehaviorTest.java
@@ -28,7 +28,7 @@ class NoneStartEventActivityBehaviorTest extends PluggableFlowableTestCase {
     public void asyncStartEvent() {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("asyncNoneStartEvent");
 
-        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count()).isEqualTo(1l);
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count()).isEqualTo(1);
         Job job = managementService.createJobQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(job).isNotNull();
         assertThat(runtimeService.createExecutionQuery().processInstanceId(pi.getId()).onlyChildExecutions().singleResult().getActivityId()).isEqualTo("theStart");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -13,6 +13,9 @@
 
 package org.flowable.engine.test.bpmn.event.compensate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,7 +47,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
 
-        assertEquals(5, runtimeService.getVariable(processInstance.getId(), "undoBookHotel"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "undoBookHotel")).isEqualTo(5);
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
@@ -56,7 +59,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
     public void testCompensateServiceTask() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
 
-        assertEquals(1, runtimeService.getVariable(processInstance.getId(), "undoBookHotel"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "undoBookHotel")).isEqualTo(1);
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
@@ -68,7 +71,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
     public void testCompensateServiceTaskStartBackwardsCompatible() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
 
-        assertEquals(1, runtimeService.getVariable(processInstance.getId(), "undoBookHotel"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "undoBookHotel")).isEqualTo(1);
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
@@ -95,7 +98,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         Execution execution = runtimeService.createExecutionQuery().activityId("firstWait").singleResult();
         runtimeService.trigger(execution.getId());
 
-        assertEquals(1, runtimeService.getVariable(processInstance.getId(), "undoBookHotel"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "undoBookHotel")).isEqualTo(1);
 
         execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
@@ -107,7 +110,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
 
-        assertEquals(5, runtimeService.getVariable(processInstance.getId(), "undoBookHotel"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "undoBookHotel")).isEqualTo(5);
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
@@ -121,7 +124,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Manually undo book hotel", task.getName());
+        assertThat(task.getName()).isEqualTo("Manually undo book hotel");
         taskService.complete(task.getId());
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
@@ -141,7 +144,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         runtimeService.trigger(execution.getId());
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        assertEquals("Manually undo book hotel", task.getName());
+        assertThat(task.getName()).isEqualTo("Manually undo book hotel");
         taskService.complete(task.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -153,7 +156,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
 
-        assertEquals(5, runtimeService.getVariable(processInstance.getId(), "undoBookHotel"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "undoBookHotel")).isEqualTo(5);
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
@@ -167,8 +170,8 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
 
-        assertEquals(5, runtimeService.getVariable(processInstance.getId(), "undoBookHotel"));
-        assertEquals(5, runtimeService.getVariable(processInstance.getId(), "undoBookFlight"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "undoBookHotel")).isEqualTo(5);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "undoBookFlight")).isEqualTo(5);
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
@@ -186,7 +189,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         initialVariables.put("test", "begin");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess", initialVariables);
 
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // get task from first subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
@@ -204,12 +207,12 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().singleResult();
 
         Object testVariable2 = runtimeService.getVariable(processInstance.getId(), "test2");
-        assertNotNull(testVariable2);
-        assertEquals("compensated2", testVariable2.toString());
+        assertThat(testVariable2).isNotNull();
+        assertThat(testVariable2).hasToString("compensated2");
 
         Object testVariable1 = runtimeService.getVariable(processInstance.getId(), "test1");
-        assertNotNull(testVariable1);
-        assertEquals("compensated1", testVariable1.toString());
+        assertThat(testVariable1).isNotNull();
+        assertThat(testVariable1).hasToString("compensated1");
     }
 
     @Test
@@ -220,40 +223,32 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(5, historyService.createHistoricActivityInstanceQuery().activityId("undoBookHotel").count());
+            assertThat(historyService.createHistoricActivityInstanceQuery().activityId("undoBookHotel").count()).isEqualTo(5);
         }
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
         assertProcessEnded(processInstance.getId());
 
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
-            assertEquals(6, historyService.createHistoricProcessInstanceQuery().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(6);
         }
 
     }
 
     @Test
     public void testMultipleCompensationCatchEventsFails() {
-        try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testMultipleCompensationCatchEventsFails.bpmn20.xml").deploy();
-            fail("exception expected");
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testMultipleCompensationCatchEventsFails.bpmn20.xml").deploy())
+                .isInstanceOf(Exception.class);
     }
 
     @Test
     public void testInvalidActivityRefFails() {
-        try {
-            repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testInvalidActivityRefFails.bpmn20.xml").deploy();
-            fail("exception expected");
-        } catch (Exception e) {
-            if (!e.getMessage().contains("Invalid attribute value for 'activityRef':")) {
-                fail("different exception expected");
-            }
-        }
+        assertThatThrownBy(() -> repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testInvalidActivityRefFails.bpmn20.xml").deploy())
+                .hasMessageContaining("Invalid attribute value for 'activityRef':")
+                .isInstanceOf(Exception.class);
     }
 
     @Test
@@ -261,15 +256,15 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
     public void testCompensationStepEndTimeRecorded() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensationStepEndRecordedProcess");
         assertProcessEnded(processInstance.getId());
-        assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             final HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery().activityId("compensationScriptTask");
-            assertEquals(1, query.count());
+            assertThat(query.count()).isEqualTo(1);
             final HistoricActivityInstance compensationScriptTask = query.singleResult();
-            assertNotNull(compensationScriptTask);
-            assertNotNull(compensationScriptTask.getEndTime());
-            assertNotNull(compensationScriptTask.getDurationInMillis());
+            assertThat(compensationScriptTask).isNotNull();
+            assertThat(compensationScriptTask.getEndTime()).isNotNull();
+            assertThat(compensationScriptTask.getDurationInMillis()).isNotNull();
         }
     }
 
@@ -281,7 +276,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
                     .processInstanceId(processInstance.getId()).activityId("bookHotel").singleResult();
-            assertNotNull(historicActivityInstance.getEndTime());
+            assertThat(historicActivityInstance.getEndTime()).isNotNull();
         }
 
         // Triggering the task will trigger the compensation subprocess
@@ -291,18 +286,18 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task compensationTask1 = taskService.createTaskQuery().processInstanceId(processInstance.getId())
                 .taskDefinitionKey("compensateTask1").singleResult();
-        assertNotNull(compensationTask1);
+        assertThat(compensationTask1).isNotNull();
 
         org.flowable.task.api.Task compensationTask2 = taskService.createTaskQuery().processInstanceId(processInstance.getId())
                 .taskDefinitionKey("compensateTask2").singleResult();
-        assertNotNull(compensationTask2);
+        assertThat(compensationTask2).isNotNull();
 
         taskService.complete(compensationTask1.getId());
         taskService.complete(compensationTask2.getId());
 
         org.flowable.task.api.Task compensationTask3 = taskService.createTaskQuery().processInstanceId(processInstance.getId())
                 .taskDefinitionKey("compensateTask3").singleResult();
-        assertNotNull(compensationTask3);
+        assertThat(compensationTask3).isNotNull();
         taskService.complete(compensationTask3.getId());
 
         assertProcessEnded(processInstance.getId());
@@ -332,11 +327,11 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         // Completing should trigger the compensations
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("afterNestedSubProcess").singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
         org.flowable.task.api.Task compensationTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("undoBookHotel").singleResult();
-        assertNotNull(compensationTask);
+        assertThat(compensationTask).isNotNull();
         taskService.complete(compensationTask.getId());
 
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.escalation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
@@ -29,12 +31,12 @@ public class BoundaryEscalationEventTest extends PluggableFlowableTestCase {
 
         // After process start, usertask in subprocess should exist
         Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("subprocessTask", task.getName());
+        assertThat(task.getName()).isEqualTo("subprocessTask");
 
         // After task completion, escalation end event is reached and caught
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("task after catching the escalation", task.getName());
+        assertThat(task.getName()).isEqualTo("task after catching the escalation");
     }
 
     @Test
@@ -43,13 +45,13 @@ public class BoundaryEscalationEventTest extends PluggableFlowableTestCase {
     public void testCatchEscalationOnCallActivity() {
         String procId = runtimeService.startProcessInstanceByKey("catchEscalationOnCallActivity").getId();
         Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Task in subprocess", task.getName());
+        assertThat(task.getName()).isEqualTo("Task in subprocess");
 
         // Completing the task will reach the end error event,
         // which is caught on the call activity boundary
         taskService.complete(task.getId());
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalated Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
         taskService.complete(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/EscalationEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/EscalationEventSubProcessTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.engine.test.bpmn.event.escalation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
@@ -37,9 +39,9 @@ public class EscalationEventSubProcessTest extends PluggableFlowableTestCase {
         String procId = runtimeService.startProcessInstanceByKey("catchEscalationInEmbeddedSubProcess").getId();
 
         // The process will throw an escalation event, which is caught and escalated by a User org.flowable.task.service.Task
-        assertEquals(1, taskService.createTaskQuery().taskDefinitionKey("taskAfterEscalationCatch2").count());
+        assertThat(taskService.createTaskQuery().taskDefinitionKey("taskAfterEscalationCatch2").count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalated Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
         taskService.complete(task.getId());
@@ -75,17 +77,17 @@ public class EscalationEventSubProcessTest extends PluggableFlowableTestCase {
         
         // task before in sub process
         Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("taskBefore", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
         taskService.complete(task.getId());
         
         task = taskService.createTaskQuery().processInstanceId(task.getProcessInstanceId()).singleResult();
-        assertEquals("taskAfter", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         
         Task escalationTask = taskService.createTaskQuery().processInstanceId(procId).singleResult();
-        assertEquals("Escalated Task", escalationTask.getName());
+        assertThat(escalationTask.getName()).isEqualTo("Escalated Task");
         taskService.complete(escalationTask.getId());
         
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processInstanceId(procId).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(procId).count()).isEqualTo(1);
         taskService.complete(task.getId());
         
         assertProcessEnded(procId);
@@ -94,9 +96,9 @@ public class EscalationEventSubProcessTest extends PluggableFlowableTestCase {
     private void assertThatEscalationHasBeenCaught(String procId) {
         // The process will throw an error event,
         // which is caught and escalated by a User org.flowable.task.service.Task
-        assertEquals("No tasks found in task list.", 1, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).as("No tasks found in task list.").isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Escalated Task", task.getName());
+        assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the org.flowable.task.service.Task will end the process instance
         taskService.complete(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.multiinstance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,6 +29,7 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
+import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.junit.jupiter.api.Test;
 
@@ -44,30 +47,30 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 3)).getId();
     
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_0", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_0");
             
             runtimeService.addMultiInstanceExecution("miTasks", procId, null);
             
             taskService.complete(task.getId());
     
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_1", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_1");
             taskService.complete(task.getId());
     
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_2", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_2");
             taskService.complete(task.getId());
             
             // another mi execution was added
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_3", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_3");
             taskService.complete(task.getId());
     
-            assertNull(taskService.createTaskQuery().singleResult());
+            assertThat(taskService.createTaskQuery().singleResult()).isNull();
             assertProcessEnded(procId);
         }
     }
@@ -83,8 +86,8 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", variableMap).getId();
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("admin", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("admin");
 
             userList.add("hr");
             runtimeService.setVariable(procId, "taskUserList", userList);
@@ -93,11 +96,11 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             taskService.complete(task.getId());
 
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("hr", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("hr");
             taskService.complete(task.getId());
 
-            assertNull(taskService.createTaskQuery().singleResult());
+            assertThat(taskService.createTaskQuery().singleResult()).isNull();
             assertProcessEnded(procId);
         }
     }
@@ -109,22 +112,22 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 3)).getId();
     
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_0", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_0");
             
             runtimeService.deleteMultiInstanceExecution(task.getExecutionId(), false);
     
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_0", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_0");
             taskService.complete(task.getId());
     
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_1", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_1");
             taskService.complete(task.getId());
     
-            assertNull(taskService.createTaskQuery().singleResult());
+            assertThat(taskService.createTaskQuery().singleResult()).isNull();
             assertProcessEnded(procId);
         }
     }
@@ -136,22 +139,22 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miSequentialUserTasks", CollectionUtil.singletonMap("nrOfLoops", 3)).getId();
     
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_0", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_0");
             
             runtimeService.deleteMultiInstanceExecution(task.getExecutionId(), true);
     
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_1", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_1");
             taskService.complete(task.getId());
     
             task = taskService.createTaskQuery().singleResult();
-            assertEquals("My Task", task.getName());
-            assertEquals("kermit_2", task.getAssignee());
+            assertThat(task.getName()).isEqualTo("My Task");
+            assertThat(task.getAssignee()).isEqualTo("kermit_2");
             taskService.complete(task.getId());
     
-            assertNull(taskService.createTaskQuery().singleResult());
+            assertThat(taskService.createTaskQuery().singleResult()).isNull();
             assertProcessEnded(procId);
         }
     }
@@ -163,20 +166,17 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasks").getId();
     
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-            assertEquals(3, tasks.size());
-            assertEquals("My Task 0", tasks.get(0).getName());
-            assertEquals("My Task 1", tasks.get(1).getName());
-            assertEquals("My Task 2", tasks.get(2).getName());
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("My Task 0", "My Task 1", "My Task 2");
             
             runtimeService.addMultiInstanceExecution("miTasks", procId, null);
             
             tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-            assertEquals(4, tasks.size());
-            assertEquals("My Task 0", tasks.get(0).getName());
-            assertEquals("My Task 1", tasks.get(1).getName());
-            assertEquals("My Task 2", tasks.get(2).getName());
-            assertEquals("My Task 3", tasks.get(3).getName());
-    
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("My Task 0", "My Task 1", "My Task 2", "My Task 3");
+
             taskService.complete(tasks.get(0).getId());
             taskService.complete(tasks.get(1).getId());
             taskService.complete(tasks.get(2).getId());
@@ -192,17 +192,16 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasks").getId();
     
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-            assertEquals(3, tasks.size());
-            assertEquals("My Task 0", tasks.get(0).getName());
-            assertEquals("My Task 1", tasks.get(1).getName());
-            assertEquals("My Task 2", tasks.get(2).getName());
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("My Task 0", "My Task 1", "My Task 2");
             
             runtimeService.deleteMultiInstanceExecution(tasks.get(1).getExecutionId(), false);
             
             tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-            assertEquals(2, tasks.size());
-            assertEquals("My Task 0", tasks.get(0).getName());
-            assertEquals("My Task 2", tasks.get(1).getName());
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("My Task 0", "My Task 2");
     
             taskService.complete(tasks.get(0).getId());
             taskService.complete(tasks.get(1).getId());
@@ -218,31 +217,28 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksBasedOnCollection", CollectionUtil.singletonMap("assigneeList", assigneeList)).getId();
         
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskAssignee().asc().list();
-            assertEquals(5, tasks.size());
-            assertEquals("bubba", tasks.get(0).getAssignee());
-            assertEquals("fozzie", tasks.get(1).getAssignee());
-            assertEquals("gonzo", tasks.get(2).getAssignee());
-            assertEquals("kermit", tasks.get(3).getAssignee());
-            assertEquals("mispiggy", tasks.get(4).getAssignee());
+            assertThat(tasks)
+                    .extracting(Task::getAssignee)
+                    .containsExactly("bubba", "fozzie", "gonzo", "kermit", "mispiggy");
             
             runtimeService.addMultiInstanceExecution("miTasks", procId, Collections.singletonMap("assignee", (Object) "johndoe"));
             tasks = taskService.createTaskQuery().orderByTaskAssignee().asc().list();
-            assertEquals(6, tasks.size());
+            assertThat(tasks).hasSize(6);
         
             // Completing 3 tasks will not yet trigger completion condition
             taskService.complete(tasks.get(0).getId());
             taskService.complete(tasks.get(1).getId());
             taskService.complete(tasks.get(2).getId());
             
-            assertEquals(3, taskService.createTaskQuery().count());
+            assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
             
             org.flowable.task.api.Task newTask = taskService.createTaskQuery().processInstanceId(procId).taskAssignee("johndoe").singleResult();
-            assertNotNull(newTask);
+            assertThat(newTask).isNotNull();
             
             // Completing task will trigger completion condition
             taskService.complete(newTask.getId());
             
-            assertEquals(0, taskService.createTaskQuery().count());
+            assertThat(taskService.createTaskQuery().count()).isZero();
             assertProcessEnded(procId);
         }
     }
@@ -255,12 +251,12 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivity").getId();
             
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-            assertEquals(14, tasks.size());
+            assertThat(tasks).hasSize(14);
             
             runtimeService.addMultiInstanceExecution("miCallActivity", procId, null);
             
             tasks = taskService.createTaskQuery().list();
-            assertEquals(16, tasks.size());
+            assertThat(tasks).hasSize(16);
             
             for (int i = 0; i < 16; i++) {
                 taskService.complete(tasks.get(i).getId());
@@ -287,14 +283,13 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             }
             
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-            assertEquals(14, tasks.size());
+            assertThat(tasks).hasSize(14);
             
-            assertNotNull(childExecutions);
-            assertEquals(7, childExecutions.size());
+            assertThat(childExecutions).hasSize(7);
             runtimeService.deleteMultiInstanceExecution(childExecutions.get(2).getId(), false);
             
             tasks = taskService.createTaskQuery().list();
-            assertEquals(12, tasks.size());
+            assertThat(tasks).hasSize(12);
             
             for (int i = 0; i < 12; i++) {
                 taskService.complete(tasks.get(i).getId());
@@ -315,10 +310,9 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
             for (int i = 0; i < 3; i++) {
                 List<org.flowable.task.api.Task> tasks = query.list();
-                assertEquals(2, tasks.size());
-    
-                assertEquals("task one", tasks.get(0).getName());
-                assertEquals("task two", tasks.get(1).getName());
+                assertThat(tasks)
+                        .extracting(Task::getName)
+                        .containsExactly("task one", "task two");
     
                 taskService.complete(tasks.get(0).getId());
                 taskService.complete(tasks.get(1).getId());
@@ -344,7 +338,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
                 }
             }
             
-            assertNotNull(miExecution);
+            assertThat(miExecution).isNotNull();
             
             List<Execution> childExecutions = runtimeService.createExecutionQuery().parentId(miExecution.getId()).list();
             runtimeService.deleteMultiInstanceExecution(childExecutions.get(0).getId(), false);
@@ -352,10 +346,9 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
             for (int i = 0; i < 3; i++) {
                 List<org.flowable.task.api.Task> tasks = query.list();
-                assertEquals(2, tasks.size());
-    
-                assertEquals("task one", tasks.get(0).getName());
-                assertEquals("task two", tasks.get(1).getName());
+                assertThat(tasks)
+                        .extracting(Task::getName)
+                        .containsExactly("task one", "task two");
     
                 taskService.complete(tasks.get(0).getId());
                 taskService.complete(tasks.get(1).getId());
@@ -381,7 +374,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
                 }
             }
             
-            assertNotNull(miExecution);
+            assertThat(miExecution).isNotNull();
             
             List<Execution> childExecutions = runtimeService.createExecutionQuery().parentId(miExecution.getId()).list();
             runtimeService.deleteMultiInstanceExecution(childExecutions.get(0).getId(), true);
@@ -389,10 +382,9 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
             for (int i = 0; i < 2; i++) {
                 List<org.flowable.task.api.Task> tasks = query.list();
-                assertEquals(2, tasks.size());
-    
-                assertEquals("task one", tasks.get(0).getName());
-                assertEquals("task two", tasks.get(1).getName());
+                assertThat(tasks)
+                        .extracting(Task::getName)
+                        .containsExactly("task one", "task two");
     
                 taskService.complete(tasks.get(0).getId());
                 taskService.complete(tasks.get(1).getId());
@@ -417,10 +409,9 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
             for (int i = 0; i < 5; i++) {
                 List<org.flowable.task.api.Task> tasks = query.list();
-                assertEquals(2, tasks.size());
-    
-                assertEquals("task one", tasks.get(0).getName());
-                assertEquals("task two", tasks.get(1).getName());
+                assertThat(tasks)
+                        .extracting(Task::getName)
+                        .containsExactly("task one", "task two");
     
                 taskService.complete(tasks.get(0).getId());
                 taskService.complete(tasks.get(1).getId());
@@ -437,7 +428,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             String procId = runtimeService.startProcessInstanceByKey("miMultipleParallelSubProcess").getId();
             
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(procId).list();
-            assertEquals(8, tasks.size());
+            assertThat(tasks).hasSize(8);
             
             try {
                 runtimeService.addMultiInstanceExecution("miSubProcess", procId, null);
@@ -447,17 +438,17 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             }
             
             List<Execution> miExecutions = runtimeService.createExecutionQuery().activityId("nesting1").list();
-            assertEquals(4, miExecutions.size());
+            assertThat(miExecutions).hasSize(4);
             
             runtimeService.addMultiInstanceExecution("miSubProcess", miExecutions.get(1).getId(), null);
             
             tasks = taskService.createTaskQuery().processInstanceId(procId).list();
-            assertEquals(9, tasks.size());
+            assertThat(tasks).hasSize(9);
             
             runtimeService.addMultiInstanceExecution("nesting1", procId, null);
             
             tasks = taskService.createTaskQuery().processInstanceId(procId).list();
-            assertEquals(11, tasks.size());
+            assertThat(tasks).hasSize(11);
             
             for (org.flowable.task.api.Task task : tasks) {
                 taskService.complete(task.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.multiinstance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -67,21 +69,21 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         String procId = runtimeService.startProcessInstanceByKey(processDefinitionKey, CollectionUtil.singletonMap("nrOfLoops", 3)).getId();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("My Task", task.getName());
-        assertEquals("kermit_0", task.getAssignee());
+        assertThat(task.getName()).isEqualTo("My Task");
+        assertThat(task.getAssignee()).isEqualTo("kermit_0");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("My Task", task.getName());
-        assertEquals("kermit_1", task.getAssignee());
+        assertThat(task.getName()).isEqualTo("My Task");
+        assertThat(task.getAssignee()).isEqualTo("kermit_1");
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().singleResult();
-        assertEquals("My Task", task.getName());
-        assertEquals("kermit_2", task.getAssignee());
+        assertThat(task.getName()).isEqualTo("My Task");
+        assertThat(task.getAssignee()).isEqualTo("kermit_2");
         taskService.complete(task.getId());
 
-        assertNull(taskService.createTaskQuery().singleResult());
+        assertThat(taskService.createTaskQuery().singleResult()).isNull();
         assertProcessEnded(procId);
     }
 
@@ -97,21 +99,21 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
 
             List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
-            assertEquals(4, historicTaskInstances.size());
+            assertThat(historicTaskInstances).hasSize(4);
             for (HistoricTaskInstance ht : historicTaskInstances) {
-                assertNotNull(ht.getAssignee());
-                assertNotNull(ht.getStartTime());
-                assertNotNull(ht.getEndTime());
+                assertThat(ht.getAssignee()).isNotNull();
+                assertThat(ht.getStartTime()).isNotNull();
+                assertThat(ht.getEndTime()).isNotNull();
             }
 
             List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("userTask").list();
-            assertEquals(4, historicActivityInstances.size());
+            assertThat(historicActivityInstances).hasSize(4);
             for (HistoricActivityInstance hai : historicActivityInstances) {
-                assertNotNull(hai.getActivityId());
-                assertNotNull(hai.getActivityName());
-                assertNotNull(hai.getStartTime());
-                assertNotNull(hai.getEndTime());
-                assertNotNull(hai.getAssignee());
+                assertThat(hai.getActivityId()).isNotNull();
+                assertThat(hai.getActivityName()).isNotNull();
+                assertThat(hai.getStartTime()).isNotNull();
+                assertThat(hai.getEndTime()).isNotNull();
+                assertThat(hai.getAssignee()).isNotNull();
             }
 
         }
@@ -131,7 +133,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
         assertProcessEnded(procId);
     }
@@ -146,7 +148,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
             taskService.complete(task.getId());
         }
-        assertNull(taskService.createTaskQuery().singleResult());
+        assertThat(taskService.createTaskQuery().singleResult()).isNull();
         assertProcessEnded(procId);
     }
 
@@ -157,7 +159,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         for (int i = 0; i < 3; i++) {
             org.flowable.task.api.Task task = taskService.createTaskQuery().taskAssignee("kermit").singleResult();
-            assertEquals("My Task", task.getName());
+            assertThat(task.getName()).isEqualTo("My Task");
             taskService.complete(task.getId());
         }
 
@@ -170,10 +172,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasks").getId();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
-        assertEquals("My Task 0", tasks.get(0).getName());
-        assertEquals("My Task 1", tasks.get(1).getName());
-        assertEquals("My Task 2", tasks.get(2).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("My Task 0", "My Task 1", "My Task 2");
 
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
@@ -186,9 +187,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testParallelUserTasksHistory() {
         runtimeService.startProcessInstanceByKey("miParallelUserTasks");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
+        assertThat(tasks).hasSize(3);
         for (int i = 0; i < tasks.size(); i++) {
-            assertEquals("My Task " + i, tasks.get(i).getName());
+            assertThat(tasks.get(i).getName()).isEqualTo("My Task " + i);
             taskService.complete(tasks.get(i).getId());
         }
 
@@ -197,19 +198,19 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().orderByTaskAssignee().asc().list();
             for (int i = 0; i < historicTaskInstances.size(); i++) {
                 HistoricTaskInstance hi = historicTaskInstances.get(i);
-                assertNotNull(hi.getStartTime());
-                assertNotNull(hi.getEndTime());
-                assertEquals("My Task " + i, hi.getName());
-                assertEquals("kermit_" + i, hi.getAssignee());
+                assertThat(hi.getStartTime()).isNotNull();
+                assertThat(hi.getEndTime()).isNotNull();
+                assertThat(hi.getName()).isEqualTo("My Task " + i);
+                assertThat(hi.getAssignee()).isEqualTo("kermit_" + i);
             }
 
             List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("userTask").list();
-            assertEquals(3, historicActivityInstances.size());
+            assertThat(historicActivityInstances).hasSize(3);
             for (HistoricActivityInstance hai : historicActivityInstances) {
-                assertNotNull(hai.getStartTime());
-                assertNotNull(hai.getEndTime());
-                assertNotNull(hai.getAssignee());
-                assertEquals("userTask", hai.getActivityType());
+                assertThat(hai.getStartTime()).isNotNull();
+                assertThat(hai.getEndTime()).isNotNull();
+                assertThat(hai.getAssignee()).isNotNull();
+                assertThat(hai.getActivityType()).isEqualTo("userTask");
             }
         }
     }
@@ -228,7 +229,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
         assertProcessEnded(procId);
     }
@@ -238,12 +239,12 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testParallelUserTasksCompletionCondition() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksCompletionCondition").getId();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(5, tasks.size());
+        assertThat(tasks).hasSize(5);
 
         // Completing 3 tasks gives 50% of tasks completed, which triggers
         // completionCondition
         for (int i = 0; i < 3; i++) {
-            assertEquals(5 - i, taskService.createTaskQuery().count());
+            assertThat(taskService.createTaskQuery().count()).isEqualTo(5 - i);
             taskService.complete(tasks.get(i).getId());
         }
         assertProcessEnded(procId);
@@ -256,18 +257,15 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksBasedOnCollection", CollectionUtil.singletonMap("assigneeList", assigneeList)).getId();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskAssignee().asc().list();
-        assertEquals(5, tasks.size());
-        assertEquals("bubba", tasks.get(0).getAssignee());
-        assertEquals("fozzie", tasks.get(1).getAssignee());
-        assertEquals("gonzo", tasks.get(2).getAssignee());
-        assertEquals("kermit", tasks.get(3).getAssignee());
-        assertEquals("mispiggy", tasks.get(4).getAssignee());
+        assertThat(tasks)
+                .extracting(Task::getAssignee)
+                .containsExactly("bubba", "fozzie", "gonzo", "kermit", "mispiggy");
 
         // Completing 3 tasks will trigger completioncondition
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
         taskService.complete(tasks.get(2).getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isZero();
         assertProcessEnded(procId);
     }
 
@@ -281,23 +279,25 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     	ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(processDefinitionKey);
 
         List<Task> tasks = taskService.createTaskQuery().taskCandidateUser("wfuser1").list();
-        assertEquals(1, tasks.size());
-        assertEquals("My Task 0", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("My Task 0");
 
         tasks = taskService.createTaskQuery().taskCandidateUser("wfuser2").list();
-        assertEquals(1, tasks.size());
-        assertEquals("My Task 1", tasks.get(0).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("My Task 1");
 
         // should be 2 tasks total
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("My Task 0", tasks.get(0).getName());
-        assertEquals("My Task 1", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("My Task 0", "My Task 1");
 
         // Completing 3 tasks will trigger completion condition
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isZero();
         assertProcessEnded(processInstance.getProcessInstanceId());
     }
 
@@ -371,21 +371,20 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(processDefinitionKey, vars);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(3, tasks.size());
-        assertEquals("My Task 0", tasks.get(0).getName());
-        assertEquals("My Task 1", tasks.get(1).getName());
-        assertEquals("My Task 2", tasks.get(2).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("My Task 0", "My Task 1", "My Task 2");
 
         tasks = taskService.createTaskQuery().orderByTaskAssignee().asc().list();
-        assertEquals("fozzie", tasks.get(0).getAssignee());
-        assertEquals("gonzo", tasks.get(1).getAssignee());
-        assertEquals("kermit", tasks.get(2).getAssignee());
+        assertThat(tasks)
+                .extracting(Task::getAssignee)
+                .containsExactly("fozzie", "gonzo", "kermit");
 
         // Completing 3 tasks will trigger completion condition
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
         taskService.complete(tasks.get(2).getId());
-        assertEquals(0, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isZero();
         assertProcessEnded(processInstance.getProcessInstanceId());
     }
 
@@ -399,10 +398,10 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
 
         Execution waitState = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
-        assertNotNull(waitState);
+        assertThat(waitState).isNotNull();
 
-        assertEquals(3, runtimeService.getVariable(processInstance.getId(), "taskListenerCounter"));
-        assertEquals(3, runtimeService.getVariable(processInstance.getId(), "executionListenerCounter"));
+        assertThat(runtimeService.getVariable(processInstance.getId(), "taskListenerCounter")).isEqualTo(3);
+        assertThat(runtimeService.getVariable(processInstance.getId(), "executionListenerCounter")).isEqualTo(3);
 
         runtimeService.trigger(waitState.getId());
         assertProcessEnded(processInstance.getId());
@@ -419,14 +418,14 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         vars.put("countersignAssigneeList", countersigns);
         vars.put("approveResult", "notpass");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("approve-process", vars);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
                         processEngineConfiguration.getManagementService(), 7000, 200);
 
         List<Task> tasks = taskService.createTaskQuery().list();
         for (Task task : tasks){
-            assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
+            assertThat(taskService.getVariable(task.getId(), "csAssignee")).isEqualTo(task.getAssignee());
             taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
             taskService.complete(task.getId());
             
@@ -448,13 +447,13 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         vars.put("countersignAssigneeList", countersigns);
         vars.put("approveResult", "notpass");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("approve-process", vars);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
                         processEngineConfiguration.getManagementService(), 7000, 200);
 
         Task task = taskService.createTaskQuery().singleResult();
-        assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
+        assertThat(taskService.getVariable(task.getId(), "csAssignee")).isEqualTo(task.getAssignee());
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
         taskService.complete(task.getId());
         
@@ -462,7 +461,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                         processEngineConfiguration.getManagementService(), 7000, 200);
         
         task = taskService.createTaskQuery().singleResult();
-        assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
+        assertThat(taskService.getVariable(task.getId(), "csAssignee")).isEqualTo(task.getAssignee());
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
         taskService.complete(task.getId());
         
@@ -470,7 +469,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                         processEngineConfiguration.getManagementService(), 7000, 200);
         
         task = taskService.createTaskQuery().singleResult();
-        assertEquals(task.getAssignee(), taskService.getVariable(task.getId(), "csAssignee"));
+        assertThat(taskService.getVariable(task.getId(), "csAssignee")).isEqualTo(task.getAssignee());
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
         taskService.complete(task.getId());
         
@@ -487,7 +486,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
         for (org.flowable.task.api.Task task : tasks) {
-            assertEquals("My Task", task.getName());
+            assertThat(task.getName()).isEqualTo("My Task");
             taskService.complete(task.getId());
         }
 
@@ -502,7 +501,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         vars.put("nrOfLoops", 5);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miSequentialScriptTask", vars);
         int sum = (Integer) runtimeService.getVariable(processInstance.getId(), "sum");
-        assertEquals(10, sum);
+        assertThat(sum).isEqualTo(10);
     }
 
     @Test
@@ -516,13 +515,13 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         // Validate history
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicInstances = historyService.createHistoricActivityInstanceQuery().activityType("scriptTask").orderByActivityId().asc().list();
-            assertEquals(7, historicInstances.size());
+            assertThat(historicInstances).hasSize(7);
             for (int i = 0; i < 7; i++) {
                 HistoricActivityInstance hai = historicInstances.get(i);
                 assertActivityInstancesAreSame(hai, runtimeService.createActivityInstanceQuery().activityInstanceId(hai.getId()).singleResult());
-                assertEquals("scriptTask", hai.getActivityType());
-                assertNotNull(hai.getStartTime());
-                assertNotNull(hai.getEndTime());
+                assertThat(hai.getActivityType()).isEqualTo("scriptTask");
+                assertThat(hai.getStartTime()).isNotNull();
+                assertThat(hai.getEndTime()).isNotNull();
             }
         }
     }
@@ -532,7 +531,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testSequentialScriptTasksCompletionCondition() {
         runtimeService.startProcessInstanceByKey("miSequentialScriptTaskCompletionCondition").getId();
         List<Execution> executions = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Execution processInstanceExecution = null;
         Execution waitStateExecution = null;
         for (Execution execution : executions) {
@@ -542,10 +541,10 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                 waitStateExecution = execution;
             }
         }
-        assertNotNull(processInstanceExecution);
-        assertNotNull(waitStateExecution);
+        assertThat(processInstanceExecution).isNotNull();
+        assertThat(waitStateExecution).isNotNull();
         int sum = (Integer) runtimeService.getVariable(waitStateExecution.getId(), "sum");
-        assertEquals(5, sum);
+        assertThat(sum).isEqualTo(5);
     }
 
     @Test
@@ -556,7 +555,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         vars.put("nrOfLoops", 10);
         runtimeService.startProcessInstanceByKey("miParallelScriptTask", vars);
         List<Execution> executions = runtimeService.createExecutionQuery().list();
-        assertEquals(2, executions.size());
+        assertThat(executions).hasSize(2);
         Execution processInstanceExecution = null;
         Execution waitStateExecution = null;
         for (Execution execution : executions) {
@@ -566,10 +565,10 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                 waitStateExecution = execution;
             }
         }
-        assertNotNull(processInstanceExecution);
-        assertNotNull(waitStateExecution);
+        assertThat(processInstanceExecution).isNotNull();
+        assertThat(waitStateExecution).isNotNull();
         int sum = (Integer) runtimeService.getVariable(waitStateExecution.getId(), "sum");
-        assertEquals(45, sum);
+        assertThat(sum).isEqualTo(45);
     }
 
     @Test
@@ -582,11 +581,11 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("scriptTask").list();
-            assertEquals(4, historicActivityInstances.size());
+            assertThat(historicActivityInstances).hasSize(4);
             for (HistoricActivityInstance hai : historicActivityInstances) {
                 assertActivityInstancesAreSame(hai, runtimeService.createActivityInstanceQuery().activityInstanceId(hai.getId()).singleResult());
-                assertNotNull(hai.getStartTime());
-                assertNotNull(hai.getEndTime());
+                assertThat(hai.getStartTime()).isNotNull();
+                assertThat(hai.getEndTime()).isNotNull();
             }
         }
     }
@@ -596,9 +595,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testParallelScriptTasksCompletionCondition() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelScriptTaskCompletionCondition");
         Execution waitStateExecution = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
-        assertNotNull(waitStateExecution);
+        assertThat(waitStateExecution).isNotNull();
         int sum = (Integer) runtimeService.getVariable(processInstance.getId(), "sum");
-        assertEquals(2, sum);
+        assertThat(sum).isEqualTo(2);
         runtimeService.trigger(waitStateExecution.getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -609,7 +608,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("miParallelScriptTaskCompletionCondition");
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("scriptTask").list();
-            assertEquals(2, historicActivityInstances.size());
+            assertThat(historicActivityInstances).hasSize(2);
         }
     }
 
@@ -621,18 +620,16 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
         for (int i = 0; i < 4; i++) {
             List<org.flowable.task.api.Task> tasks = query.list();
-            assertEquals(2, tasks.size());
-
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("task one", "task two");
 
             taskService.complete(tasks.get(0).getId());
             taskService.complete(tasks.get(1).getId());
 
             if (i != 3) {
                 List<String> activities = runtimeService.getActiveActivityIds(procId);
-                assertNotNull(activities);
-                assertEquals(3, activities.size());
+                assertThat(activities).hasSize(3);
             }
         }
 
@@ -648,17 +645,16 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
         for (int i = 0; i < 4; i++) {
             List<org.flowable.task.api.Task> tasks = query.list();
-            assertEquals(1, tasks.size());
-
-            assertEquals("task one", tasks.get(0).getName());
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("task one");
 
             taskService.complete(tasks.get(0).getId());
 
             // Last run, the execution no longer exists
             if (i != 3) {
                 List<String> activities = runtimeService.getActiveActivityIds(procId);
-                assertNotNull(activities);
-                assertEquals(2, activities.size());
+                assertThat(activities).hasSize(2);
             }
         }
 
@@ -678,20 +674,20 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         // Validate history
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> onlySubProcessInstances = historyService.createHistoricActivityInstanceQuery().activityType("subProcess").list();
-            assertEquals(4, onlySubProcessInstances.size());
+            assertThat(onlySubProcessInstances).hasSize(4);
 
             List<HistoricActivityInstance> historicInstances = historyService.createHistoricActivityInstanceQuery().activityType("subProcess").list();
-            assertEquals(4, historicInstances.size());
+            assertThat(historicInstances).hasSize(4);
             for (HistoricActivityInstance hai : historicInstances) {
-                assertNotNull(hai.getStartTime());
-                assertNotNull(hai.getEndTime());
+                assertThat(hai.getStartTime()).isNotNull();
+                assertThat(hai.getEndTime()).isNotNull();
             }
 
             historicInstances = historyService.createHistoricActivityInstanceQuery().activityType("userTask").list();
-            assertEquals(8, historicInstances.size());
+            assertThat(historicInstances).hasSize(8);
             for (HistoricActivityInstance hai : historicInstances) {
-                assertNotNull(hai.getStartTime());
-                assertNotNull(hai.getEndTime());
+                assertThat(hai.getStartTime()).isNotNull();
+                assertThat(hai.getEndTime()).isNotNull();
             }
         }
     }
@@ -703,11 +699,11 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         // Complete one subprocess
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
         tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         // Fire timer
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -715,7 +711,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
@@ -729,10 +725,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
         for (int i = 0; i < 3; i++) {
             List<org.flowable.task.api.Task> tasks = query.list();
-            assertEquals(2, tasks.size());
-
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("task one", "task two");
 
             taskService.complete(tasks.get(0).getId());
             taskService.complete(tasks.get(1).getId());
@@ -776,7 +771,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
@@ -787,7 +782,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testParallelSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocess").getId();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
 
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
@@ -807,10 +802,10 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         // Validate history
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("miSubProcess").list();
-            assertEquals(2, historicActivityInstances.size());
+            assertThat(historicActivityInstances).hasSize(2);
             for (HistoricActivityInstance hai : historicActivityInstances) {
-                assertNotNull(hai.getStartTime());
-                assertNotNull(hai.getEndTime());
+                assertThat(hai.getStartTime()).isNotNull();
+                assertThat(hai.getEndTime()).isNotNull();
             }
         }
     }
@@ -820,7 +815,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testParallelSubProcessWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessWithTimer").getId();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(6, tasks.size());
+        assertThat(tasks).hasSize(6);
 
         // Complete two tasks
         taskService.complete(tasks.get(0).getId());
@@ -832,7 +827,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
@@ -843,13 +838,13 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testParallelSubProcessCompletionCondition() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelSubprocessCompletionCondition").getId();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
 
         List<org.flowable.task.api.Task> subProcessTasks1 = taskService.createTaskQuery().taskDefinitionKey("subProcessTask1").list();
-        assertEquals(2, subProcessTasks1.size());
+        assertThat(subProcessTasks1).hasSize(2);
 
         List<org.flowable.task.api.Task> subProcessTasks2 = taskService.createTaskQuery().taskDefinitionKey("subProcessTask2").list();
-        assertEquals(2, subProcessTasks2.size());
+        assertThat(subProcessTasks2).hasSize(2);
 
         Execution taskExecution = runtimeService.createExecutionQuery().executionId(subProcessTasks1.get(0).getExecutionId()).singleResult();
         String parentExecutionId = taskExecution.getParentId();
@@ -863,7 +858,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             }
         }
 
-        assertNotNull(subProcessTask2);
+        assertThat(subProcessTask2).isNotNull();
         taskService.complete(tasks.get(0).getId());
         taskService.complete(subProcessTask2.getId());
 
@@ -877,15 +872,15 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         for (int i = 0; i < 5; i++) {
             List<Execution> waitSubExecutions = runtimeService.createExecutionQuery().activityId("subProcessWait").list();
-            assertTrue(waitSubExecutions.size() > 0);
+            assertThat(waitSubExecutions).isNotEmpty();
             runtimeService.trigger(waitSubExecutions.get(0).getId());
         }
 
         List<Execution> waitSubExecutions = runtimeService.createExecutionQuery().activityId("subProcessWait").list();
-        assertEquals(0, waitSubExecutions.size());
+        assertThat(waitSubExecutions).isEmpty();
 
         Execution waitState = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
-        assertEquals(10, runtimeService.getVariable(waitState.getId(), "sum"));
+        assertThat(runtimeService.getVariable(waitState.getId(), "sum")).isEqualTo(10);
 
         runtimeService.trigger(waitState.getId());
         assertProcessEnded(procId);
@@ -898,15 +893,15 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         for (int i = 0; i < 6; i++) {
             List<Execution> waitSubExecutions = runtimeService.createExecutionQuery().activityId("subProcessWait").list();
-            assertTrue(waitSubExecutions.size() > 0);
+            assertThat(waitSubExecutions).isNotEmpty();
             runtimeService.trigger(waitSubExecutions.get(0).getId());
         }
 
         List<Execution> waitSubExecutions = runtimeService.createExecutionQuery().activityId("subProcessWait").list();
-        assertEquals(0, waitSubExecutions.size());
+        assertThat(waitSubExecutions).isEmpty();
 
         Execution waitState = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
-        assertEquals(12, runtimeService.getVariable(procId, "sum"));
+        assertThat(runtimeService.getVariable(procId, "sum")).isEqualTo(12);
 
         runtimeService.trigger(waitState.getId());
         assertProcessEnded(procId);
@@ -917,7 +912,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testNestedParallelSubProcess() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedParallelSubProcess").getId();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(8, tasks.size());
+        assertThat(tasks).hasSize(8);
 
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
@@ -930,7 +925,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testNestedParallelSubProcessWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedParallelSubProcess").getId();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(12, tasks.size());
+        assertThat(tasks).hasSize(12);
 
         for (int i = 0; i < 3; i++) {
             taskService.complete(tasks.get(i).getId());
@@ -942,7 +937,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
@@ -957,21 +952,21 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         for (int i = 0; i < 4; i++) {
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-            assertEquals(2, tasks.size());
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
-            
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("task one", "task two");
+
             Map<String, Object> taskVariables = Collections.singletonMap("output", (Object) ("run" + i + 1));
             taskService.complete(tasks.get(0).getId(), taskVariables);
             taskService.complete(tasks.get(1).getId());
             
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(procId).singleResult();
-            assertNotNull(task);
-            assertEquals("task", task.getTaskDefinitionKey());
+            assertThat(task).isNotNull();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
             
             ExecutionEntity execution = (ExecutionEntity) runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task").singleResult();
-            assertEquals("run" + i + 1, runtimeService.getVariableLocal(execution.getId(), "output"));
-            assertNull(runtimeService.getVariable(procId, "output"));
+            assertThat(runtimeService.getVariableLocal(execution.getId(), "output")).isEqualTo("run" + i + 1);
+            assertThat(runtimeService.getVariable(procId, "output")).isNull();
             
             taskService.complete(task.getId());
         }
@@ -988,21 +983,21 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         
         for (int i = 0; i < 4; i++) {
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-            assertEquals(2, tasks.size());
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
-            
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("task one", "task two");
+
             Map<String, Object> taskVariables = Collections.singletonMap("output", (Object) ("run" + i + 1));
             taskService.complete(tasks.get(0).getId(), taskVariables);
             taskService.complete(tasks.get(1).getId());
             
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(procId).singleResult();
-            assertNotNull(task);
-            assertEquals("task", task.getTaskDefinitionKey());
+            assertThat(task).isNotNull();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
             
             ExecutionEntity execution = (ExecutionEntity) runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task").singleResult();
-            assertNull(runtimeService.getVariableLocal(execution.getId(), "output"));
-            assertEquals("run" + i + 1, runtimeService.getVariable(procId, "output"));
+            assertThat(runtimeService.getVariableLocal(execution.getId(), "output")).isNull();
+            assertThat(runtimeService.getVariable(procId, "output")).isEqualTo("run" + i + 1);
             
             taskService.complete(task.getId());
         }
@@ -1013,20 +1008,20 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     @Test
     @Deployment(resources = { "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivity.bpmn20.xml",
     "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml" })
-public void testSequentialCallActivity() {
-String procId = runtimeService.startProcessInstanceByKey("miSequentialCallActivity").getId();
+    public void testSequentialCallActivity() {
+        String procId = runtimeService.startProcessInstanceByKey("miSequentialCallActivity").getId();
 
-for (int i = 0; i < 3; i++) {
-    List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-    assertEquals(2, tasks.size());
-    assertEquals("task one", tasks.get(0).getName());
-    assertEquals("task two", tasks.get(1).getName());
-    taskService.complete(tasks.get(0).getId());
-    taskService.complete(tasks.get(1).getId());
-}
+        for (int i = 0; i < 3; i++) {
+            List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("task one", "task two");
+            taskService.complete(tasks.get(0).getId());
+            taskService.complete(tasks.get(1).getId());
+        }
 
-assertProcessEnded(procId);
-}
+        assertProcessEnded(procId);
+    }
 
     @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialCallActivityWithList.bpmn20.xml")
@@ -1043,8 +1038,8 @@ assertProcessEnded(procId);
         org.flowable.task.api.Task task1 = taskService.createTaskQuery().processVariableValueEquals("element", "one").singleResult();
         org.flowable.task.api.Task task2 = taskService.createTaskQuery().processVariableValueEquals("element", "two").singleResult();
 
-        assertNotNull(task1);
-        assertNotNull(task2);
+        assertThat(task1).isNotNull();
+        assertThat(task2).isNotNull();
 
         HashMap<String, Object> subVariables = new HashMap<>();
         subVariables.put("x", "y");
@@ -1053,11 +1048,11 @@ assertProcessEnded(procId);
         taskService.complete(task2.getId(), subVariables);
 
         org.flowable.task.api.Task task3 = taskService.createTaskQuery().processDefinitionKey("midProcess").singleResult();
-        assertNotNull(task3);
+        assertThat(task3).isNotNull();
         taskService.complete(task3.getId(), null);
 
         org.flowable.task.api.Task task4 = taskService.createTaskQuery().processDefinitionKey("parentProcess").singleResult();
-        assertNotNull(task4);
+        assertThat(task4).isNotNull();
         taskService.complete(task4.getId(), null);
 
         assertProcessEnded(procId);
@@ -1071,9 +1066,9 @@ assertProcessEnded(procId);
 
         // Complete first subprocess
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("task one", tasks.get(0).getName());
-        assertEquals("task two", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("task one", "task two");
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
 
@@ -1083,7 +1078,7 @@ assertProcessEnded(procId);
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
@@ -1095,7 +1090,7 @@ assertProcessEnded(procId);
     public void testParallelCallActivity() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelCallActivity").getId();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(12, tasks.size());
+        assertThat(tasks).hasSize(12);
         for (int i = 0; i < tasks.size(); i++) {
             taskService.complete(tasks.get(i).getId());
         }
@@ -1109,7 +1104,7 @@ assertProcessEnded(procId);
     public void testParallelCallActivityHistory() {
         runtimeService.startProcessInstanceByKey("miParallelCallActivity");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(12, tasks.size());
+        assertThat(tasks).hasSize(12);
         for (int i = 0; i < tasks.size(); i++) {
             taskService.complete(tasks.get(i).getId());
         }
@@ -1117,29 +1112,29 @@ assertProcessEnded(procId);
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // Validate historic processes
             List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
-            assertEquals(7, historicProcessInstances.size()); // 6 subprocesses
+            assertThat(historicProcessInstances).hasSize(7); // 6 subprocesses
                                                               // + main process
             for (HistoricProcessInstance hpi : historicProcessInstances) {
-                assertNotNull(hpi.getStartTime());
-                assertNotNull(hpi.getEndTime());
+                assertThat(hpi.getStartTime()).isNotNull();
+                assertThat(hpi.getEndTime()).isNotNull();
             }
 
             // Validate historic tasks
             List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
-            assertEquals(12, historicTaskInstances.size());
+            assertThat(historicTaskInstances).hasSize(12);
             for (HistoricTaskInstance hti : historicTaskInstances) {
-                assertNotNull(hti.getStartTime());
-                assertNotNull(hti.getEndTime());
-                assertNotNull(hti.getAssignee());
-                assertNull(hti.getDeleteReason());
+                assertThat(hti.getStartTime()).isNotNull();
+                assertThat(hti.getEndTime()).isNotNull();
+                assertThat(hti.getAssignee()).isNotNull();
+                assertThat(hti.getDeleteReason()).isNull();
             }
 
             // Validate historic activities
             List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityType("callActivity").list();
-            assertEquals(6, historicActivityInstances.size());
+            assertThat(historicActivityInstances).hasSize(6);
             for (HistoricActivityInstance hai : historicActivityInstances) {
-                assertNotNull(hai.getStartTime());
-                assertNotNull(hai.getEndTime());
+                assertThat(hai.getStartTime()).isNotNull();
+                assertThat(hai.getEndTime()).isNotNull();
             }
         }
     }
@@ -1150,7 +1145,7 @@ assertProcessEnded(procId);
     public void testParallelCallActivityWithTimer() {
         String procId = runtimeService.startProcessInstanceByKey("miParallelCallActivity").getId();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(6, tasks.size());
+        assertThat(tasks).hasSize(6);
         for (int i = 0; i < 2; i++) {
             taskService.complete(tasks.get(i).getId());
         }
@@ -1161,7 +1156,7 @@ assertProcessEnded(procId);
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
@@ -1175,9 +1170,9 @@ assertProcessEnded(procId);
 
         for (int i = 0; i < 4; i++) {
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-            assertEquals(2, tasks.size());
-            assertEquals("task one", tasks.get(0).getName());
-            assertEquals("task two", tasks.get(1).getName());
+            assertThat(tasks)
+                    .extracting(Task::getName)
+                    .containsExactly("task one", "task two");
             taskService.complete(tasks.get(0).getId());
             taskService.complete(tasks.get(1).getId());
         }
@@ -1193,15 +1188,15 @@ assertProcessEnded(procId);
 
         // first instance
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
-        assertEquals(2, tasks.size());
-        assertEquals("task one", tasks.get(0).getName());
-        assertEquals("task two", tasks.get(1).getName());
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("task one", "task two");
         taskService.complete(tasks.get(0).getId());
         taskService.complete(tasks.get(1).getId());
 
         // one task of second instance
         tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         taskService.complete(tasks.get(0).getId());
 
         // Fire timer
@@ -1210,7 +1205,7 @@ assertProcessEnded(procId);
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
@@ -1223,7 +1218,7 @@ assertProcessEnded(procId);
         String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivity").getId();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(14, tasks.size());
+        assertThat(tasks).hasSize(14);
         for (int i = 0; i < 14; i++) {
             taskService.complete(tasks.get(i).getId());
         }
@@ -1238,7 +1233,7 @@ assertProcessEnded(procId);
         String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivityWithTimer").getId();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(4, tasks.size());
+        assertThat(tasks).hasSize(4);
         for (int i = 0; i < 3; i++) {
             taskService.complete(tasks.get(i).getId());
         }
@@ -1249,7 +1244,7 @@ assertProcessEnded(procId);
         managementService.executeJob(timer.getId());
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
-        assertEquals("taskAfterTimer", taskAfterTimer.getTaskDefinitionKey());
+        assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
         taskService.complete(taskAfterTimer.getId());
 
         assertProcessEnded(procId);
@@ -1261,12 +1256,12 @@ assertProcessEnded(procId);
     public void testNestedParallelCallActivityCompletionCondition() {
         String procId = runtimeService.startProcessInstanceByKey("miNestedParallelCallActivityCompletionCondition").getId();
 
-        assertEquals(8, taskService.createTaskQuery().count());
+        assertThat(taskService.createTaskQuery().count()).isEqualTo(8);
 
         for (int i = 0; i < 2; i++) {
             ProcessInstance nextSubProcessInstance = runtimeService.createProcessInstanceQuery().processDefinitionKey("externalSubProcess").listPage(0, 1).get(0);
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(nextSubProcessInstance.getId()).list();
-            assertEquals(2, tasks.size());
+            assertThat(tasks).hasSize(2);
             for (org.flowable.task.api.Task task : tasks) {
                 taskService.complete(task.getId());
             }
@@ -1281,7 +1276,7 @@ assertProcessEnded(procId);
     public void testSequentialServiceTaskWithClass() {
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("multiInstanceServiceTask", CollectionUtil.singletonMap("result", 5));
         Integer result = (Integer) runtimeService.getVariable(procInst.getId(), "result");
-        assertEquals(160, result.intValue());
+        assertThat(result.intValue()).isEqualTo(160);
 
         Execution waitExecution = runtimeService.createExecutionQuery().processInstanceId(procInst.getId()).activityId("wait").singleResult();
         runtimeService.trigger(waitExecution.getId());
@@ -1298,7 +1293,7 @@ assertProcessEnded(procId);
 
         ProcessInstance procInst = runtimeService.startProcessInstanceByKey("multiInstanceServiceTask", vars);
         Integer result = (Integer) runtimeService.getVariable(procInst.getId(), "result");
-        assertEquals(720, result.intValue());
+        assertThat(result.intValue()).isEqualTo(720);
 
         Execution waitExecution = runtimeService.createExecutionQuery().processInstanceId(procInst.getId()).activityId("wait").singleResult();
         runtimeService.trigger(waitExecution.getId());
@@ -1317,7 +1312,7 @@ assertProcessEnded(procId);
 
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + 61000L)); // timer is set to one minute
         List<Job> timers = managementService.createTimerJobQuery().list();
-        assertEquals(5, timers.size());
+        assertThat(timers).hasSize(5);
 
         // Execute all timers one by one (single thread vs thread pool of job
         // executor, which leads to optimisticlockingexceptions!)
@@ -1328,7 +1323,7 @@ assertProcessEnded(procId);
 
         // All tasks should be canceled
         tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).orderByTaskName().asc().list();
-        assertEquals(0, tasks.size());
+        assertThat(tasks).isEmpty();
     }
 
     @Test
@@ -1341,7 +1336,7 @@ assertProcessEnded(procId);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process", variableMap);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
 
         // finish first call activity with error
         variableMap = new HashMap<>();
@@ -1349,12 +1344,12 @@ assertProcessEnded(procId);
         taskService.complete(tasks.get(0).getId(), variableMap);
 
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         taskService.complete(tasks.get(0).getId());
 
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("process").list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1368,7 +1363,7 @@ assertProcessEnded(procId);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process", variableMap);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         // finish first call activity with error
         variableMap = new HashMap<>();
@@ -1376,12 +1371,12 @@ assertProcessEnded(procId);
         taskService.complete(tasks.get(0).getId(), variableMap);
 
         tasks = taskService.createTaskQuery().list();
-        assertEquals(1, tasks.size());
+        assertThat(tasks).hasSize(1);
 
         taskService.complete(tasks.get(0).getId());
 
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("process").list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1390,7 +1385,7 @@ assertProcessEnded(procId);
     public void testMultiInstanceParallelReceiveTask() {
         runtimeService.startProcessInstanceByKey("multi-instance-receive");
         List<Execution> executions = runtimeService.createExecutionQuery().activityId("theReceiveTask").list();
-        assertEquals(4, executions.size());
+        assertThat(executions).hasSize(4);
 
         // Complete all four of the executions
         for (Execution execution : executions) {
@@ -1399,10 +1394,10 @@ assertProcessEnded(procId);
 
         // There is one task after the task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -1413,7 +1408,7 @@ assertProcessEnded(procId);
 
         runtimeService.startProcessInstanceByKey("multiInstanceReceiveWithTimer");
         List<Execution> executions = runtimeService.createExecutionQuery().activityId("theReceiveTask").list();
-        assertEquals(3, executions.size());
+        assertThat(executions).hasSize(3);
 
         // Signal only one execution. Then the timer will fire
         runtimeService.trigger(executions.get(1).getId());
@@ -1422,11 +1417,11 @@ assertProcessEnded(procId);
 
         // The process should now be in the task after the timer
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("Task after timer", task.getName());
+        assertThat(task.getName()).isEqualTo("Task after timer");
 
         // Completing it should end the process
         taskService.complete(task.getId());
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -1434,7 +1429,7 @@ assertProcessEnded(procId);
     public void testMultiInstanceSequentialReceiveTask() {
         runtimeService.startProcessInstanceByKey("multi-instance-receive");
         Execution execution = runtimeService.createExecutionQuery().activityId("theReceiveTask").singleResult();
-        assertNotNull(execution);
+        assertThat(execution).isNotNull();
 
         // Complete all four of the executions
         while (execution != null) {
@@ -1444,10 +1439,10 @@ assertProcessEnded(procId);
 
         // There is one task after the task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
 
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -1462,14 +1457,14 @@ assertProcessEnded(procId);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miNestedMultiInstanceTasks", variableMap);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertEquals(processes.size() * assignees.size(), tasks.size());
+        assertThat(tasks).hasSize(processes.size() * assignees.size());
 
         for (org.flowable.task.api.Task t : tasks) {
             taskService.complete(t.getId(), Collections.singletonMap("assignee", "1"));
         }
 
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("miNestedMultiInstanceTasks").list();
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1480,9 +1475,9 @@ assertProcessEnded(procId);
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSequentialSubProcessEmptyCollection", variableMap);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1493,9 +1488,9 @@ assertProcessEnded(procId);
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSequentialEmptyCollection", variableMap);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1506,9 +1501,9 @@ assertProcessEnded(procId);
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testSequentialEmptyCollection", variableMap);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -1520,9 +1515,9 @@ assertProcessEnded(procId);
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testParalellEmptyCollection", variableMap);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNull(task);
+        assertThat(task).isNull();
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1533,9 +1528,9 @@ assertProcessEnded(procId);
         Map<String, Object> variableMap = new HashMap<>();
         variableMap.put("collection", collection);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testParalellEmptyCollection", variableMap);
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertNotNull(task);
+        assertThat(task).isNotNull();
         taskService.complete(task.getId());
         assertProcessEnded(processInstance.getId());
     }
@@ -1557,7 +1552,7 @@ assertProcessEnded(procId);
             Map<String, Object> params = new HashMap<>();
             params.put("sampleValues", Arrays.asList("eins", "zwei", "drei"));
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("infiniteLoopTest", params);
-            assertNotNull(processInstance);
+            assertThat(processInstance).isNotNull();
 
         } finally {
 
@@ -1576,7 +1571,7 @@ assertProcessEnded(procId);
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelUserTaskMi", vars);
 
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).finished().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).finished().count()).isEqualTo(1L);
         }
     }
 
@@ -1587,7 +1582,7 @@ assertProcessEnded(procId);
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelUserTaskMi");
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).finished().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).finished().count()).isEqualTo(1L);
         }
     }
 
@@ -1600,7 +1595,7 @@ assertProcessEnded(procId);
             runtimeService.startProcessInstanceByKey("sequentialMiSubprocess", vars);
 
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1L);
         }
     }
 
@@ -1614,7 +1609,7 @@ assertProcessEnded(procId);
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
-            assertEquals(1L, historyService.createHistoricProcessInstanceQuery().finished().count());
+            assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(1L);
         }
     }
 
@@ -1630,11 +1625,11 @@ assertProcessEnded(procId);
         variableMap.put("assignees", assignees);
         runtimeService.startProcessInstanceByKey("MultiInstanceTest", variableMap);
 
-        assertEquals(3, TestStartExecutionListener.countWithLoopCounter.get());
-        assertEquals(3, TestEndExecutionListener.countWithLoopCounter.get());
+        assertThat(TestStartExecutionListener.countWithLoopCounter.get()).isEqualTo(3);
+        assertThat(TestEndExecutionListener.countWithLoopCounter.get()).isEqualTo(3);
 
-        assertEquals(1, TestStartExecutionListener.countWithoutLoopCounter.get());
-        assertEquals(1, TestEndExecutionListener.countWithoutLoopCounter.get());
+        assertThat(TestStartExecutionListener.countWithoutLoopCounter.get()).isEqualTo(1);
+        assertThat(TestEndExecutionListener.countWithoutLoopCounter.get()).isEqualTo(1);
     }
 
     @Test
@@ -1648,13 +1643,13 @@ assertProcessEnded(procId);
             taskService.complete(task.getId());
         }
 
-        assertEquals(4, TestTaskCompletionListener.count.get());
+        assertThat(TestTaskCompletionListener.count.get()).isEqualTo(4);
 
-        assertEquals(4, TestStartExecutionListener.countWithLoopCounter.get());
-        assertEquals(4, TestEndExecutionListener.countWithLoopCounter.get());
+        assertThat(TestStartExecutionListener.countWithLoopCounter.get()).isEqualTo(4);
+        assertThat(TestEndExecutionListener.countWithLoopCounter.get()).isEqualTo(4);
 
-        assertEquals(1, TestStartExecutionListener.countWithoutLoopCounter.get());
-        assertEquals(1, TestEndExecutionListener.countWithoutLoopCounter.get());
+        assertThat(TestStartExecutionListener.countWithoutLoopCounter.get()).isEqualTo(1);
+        assertThat(TestEndExecutionListener.countWithoutLoopCounter.get()).isEqualTo(1);
     }
 
     @Test
@@ -1664,7 +1659,7 @@ assertProcessEnded(procId);
         // Used to throw a nullpointer exception
 
         runtimeService.startProcessInstanceByKey("multiInstance");
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
     @Test
@@ -1678,19 +1673,19 @@ assertProcessEnded(procId);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceSubProcessParallelTasks");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
-        assertEquals("User Task 1", tasks.get(0).getName());
-        assertEquals("User Task 1", tasks.get(1).getName());
-        
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactly("User Task 1", "User Task 1");
+
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         // End time should not be set for the subprocess
         List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
-        assertEquals(2, historicActivityInstances.size());
+        assertThat(historicActivityInstances).hasSize(2);
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
             assertActivityInstancesAreSame(historicActivityInstance, runtimeService.createActivityInstanceQuery().activityInstanceId(historicActivityInstance.getId()).singleResult());
-            assertNotNull(historicActivityInstance.getStartTime());
-            assertNull(historicActivityInstance.getEndTime());
+            assertThat(historicActivityInstance.getStartTime()).isNotNull();
+            assertThat(historicActivityInstance.getEndTime()).isNull();
         }
 
         // Complete one of the user tasks. This should not trigger setting of end time of the subprocess, but due to a bug it did exactly that
@@ -1699,10 +1694,10 @@ assertProcessEnded(procId);
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
-        assertEquals(2, historicActivityInstances.size());
+        assertThat(historicActivityInstances).hasSize(2);
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
             assertActivityInstancesAreSame(historicActivityInstance, runtimeService.createActivityInstanceQuery().activityInstanceId(historicActivityInstance.getId()).singleResult());
-            assertNull(historicActivityInstance.getEndTime());
+            assertThat(historicActivityInstance.getEndTime()).isNull();
         }
 
         taskService.complete(tasks.get(1).getId());
@@ -1710,30 +1705,30 @@ assertProcessEnded(procId);
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
         historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
-        assertEquals(2, historicActivityInstances.size());
+        assertThat(historicActivityInstances).hasSize(2);
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
             assertActivityInstancesAreSame(historicActivityInstance, runtimeService.createActivityInstanceQuery().activityInstanceId(historicActivityInstance.getId()).singleResult());
-            assertNull(historicActivityInstance.getEndTime());
+            assertThat(historicActivityInstance.getEndTime()).isNull();
         }
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("User Task 3").list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
             historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
-            assertEquals(2, historicActivityInstances.size());
+            assertThat(historicActivityInstances).hasSize(2);
             for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
                 assertActivityInstancesAreSame(historicActivityInstance, runtimeService.createActivityInstanceQuery().activityInstanceId(historicActivityInstance.getId()).singleResult());
-                assertNull(historicActivityInstance.getEndTime());
+                assertThat(historicActivityInstance.getEndTime()).isNull();
             }
         }
 
         // Finishing the tasks should also set the end time
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
-        assertEquals(2, tasks.size());
+        assertThat(tasks).hasSize(2);
         for (org.flowable.task.api.Task task : tasks) {
             taskService.complete(task.getId());
         }
@@ -1741,9 +1736,9 @@ assertProcessEnded(procId);
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
         historicActivityInstances = historyService.createHistoricActivityInstanceQuery().activityId("subprocess1").list();
-        assertEquals(2, historicActivityInstances.size());
+        assertThat(historicActivityInstances).hasSize(2);
         for (HistoricActivityInstance historicActivityInstance : historicActivityInstances) {
-            assertNotNull(historicActivityInstance.getEndTime());
+            assertThat(historicActivityInstance.getEndTime()).isNotNull();
         }
     }
 
@@ -1753,13 +1748,13 @@ assertProcessEnded(procId);
         Map<String, Object> vars = new HashMap<>();
         vars.put("multi_users", Collections.singletonList("testuser"));
         ProcessInstance instance = runtimeService.startProcessInstanceByKey("test_multi", vars);
-        assertNotNull(instance);
+        assertThat(instance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        assertEquals("multi", task.getTaskDefinitionKey());
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("multi");
         vars.put("multi_users", new ArrayList<String>()); // <-- Problem here.
         taskService.complete(task.getId(), vars);
         List<ProcessInstance> instances = runtimeService.createProcessInstanceQuery().list();
-        assertEquals(0, instances.size());
+        assertThat(instances).isEmpty();
     }
 
     @Test
@@ -1769,7 +1764,7 @@ assertProcessEnded(procId);
             runtimeService.startProcessInstanceByKey("simple_multi");
             fail("Should have failed with missing collection variable");
         } catch (FlowableIllegalArgumentException e) {
-            assertEquals("Variable 'elements' was not found", e.getMessage());
+            assertThat(e.getMessage()).isEqualTo("Variable 'elements' was not found");
         }
     }
 
@@ -1783,7 +1778,7 @@ assertProcessEnded(procId);
             runtimeService.startProcessInstanceByKey("simple_multi", vars);
             fail("Should have failed with collection variable not a collection");
         } catch (FlowableIllegalArgumentException e) {
-            assertEquals("Variable 'elements':" + valueBean + " is not a Collection", e.getMessage());
+            assertThat(e.getMessage()).isEqualTo("Variable 'elements':" + valueBean + " is not a Collection");
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/parse/BpmnParseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/parse/BpmnParseTest.java
@@ -13,6 +13,9 @@
 
 package org.flowable.engine.test.bpmn.parse;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 
 import org.flowable.bpmn.exceptions.XMLException;
@@ -34,19 +37,18 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
 
     @Test
     public void testInvalidProcessDefinition() {
-        try {
+        assertThatThrownBy(() ->
+        {
             String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidProcessDefinition");
             repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
-            fail();
-        } catch (XMLException e) {
-            // expected exception
-        }
+        })
+                .isInstanceOf(XMLException.class);
     }
 
     @Test
     public void testParseWithBpmnNamespacePrefix() {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/parse/BpmnParseTest.testParseWithBpmnNamespacePrefix.bpmn20.xml").deploy();
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1);
 
         repositoryService.deleteDeployment(repositoryService.createDeploymentQuery().singleResult().getId(), true);
     }
@@ -54,7 +56,7 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
     @Test
     public void testParseWithMultipleDocumentation() {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/parse/BpmnParseTest.testParseWithMultipleDocumentation.bpmn20.xml").deploy();
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1);
 
         repositoryService.deleteDeployment(repositoryService.createDeploymentQuery().singleResult().getId(), true);
     }
@@ -69,7 +71,7 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
 
         // Check if diagram has been created based on Diagram Interchange when it's not a headless instance
         List<String> resourceNames = repositoryService.getDeploymentResourceNames(repositoryService.createProcessDefinitionQuery().singleResult().getDeploymentId());
-        assertEquals(2, resourceNames.size());
+        assertThat(resourceNames).hasSize(2);
 
         assertActivityBounds(bpmnModel, "theStart", 70, 255, 30, 30);
         assertActivityBounds(bpmnModel, "task1", 176, 230, 100, 80);
@@ -95,13 +97,13 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
 
         BpmnModel bpmnModel = repositoryService.getBpmnModel(repositoryService.createProcessDefinitionQuery().singleResult().getId());
         Process process = bpmnModel.getProcesses().get(0);
-        assertNotNull(process);
+        assertThat(process).isNotNull();
 
         SequenceFlow sequenceFlow = (SequenceFlow) process.getFlowElement("SequenceFlow_3");
-        assertEquals("#{approved}", sequenceFlow.getConditionExpression());
+        assertThat(sequenceFlow.getConditionExpression()).isEqualTo("#{approved}");
 
         sequenceFlow = (SequenceFlow) process.getFlowElement("SequenceFlow_4");
-        assertEquals("#{!approved}", sequenceFlow.getConditionExpression());
+        assertThat(sequenceFlow.getConditionExpression()).isEqualTo("#{!approved}");
 
     }
 
@@ -111,33 +113,33 @@ public class BpmnParseTest extends PluggableFlowableTestCase {
         ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("TestAnnotation").singleResult();
         BpmnModel model = repositoryService.getBpmnModel(processDefinition.getId());
         Process mainProcess = model.getMainProcess();
-        assertEquals(0, mainProcess.getExtensionElements().size());
+        assertThat(mainProcess.getExtensionElements()).isEmpty();
     }
 
     @Test
     public void testParseSwitchedSourceAndTargetRefsForAssociations() {
         repositoryService.createDeployment().addClasspathResource("org/flowable/engine/test/bpmn/parse/BpmnParseTest.testParseSwitchedSourceAndTargetRefsForAssociations.bpmn20.xml").deploy();
 
-        assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
+        assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1);
 
         repositoryService.deleteDeployment(repositoryService.createDeploymentQuery().singleResult().getId(), true);
     }
 
     protected void assertActivityBounds(BpmnModel bpmnModel, String activityId, Integer x, Integer y, Integer width, Integer height) {
-        assertEquals(x.doubleValue(), bpmnModel.getGraphicInfo(activityId).getX());
-        assertEquals(y.doubleValue(), bpmnModel.getGraphicInfo(activityId).getY());
-        assertEquals(width.doubleValue(), bpmnModel.getGraphicInfo(activityId).getWidth());
-        assertEquals(height.doubleValue(), bpmnModel.getGraphicInfo(activityId).getHeight());
+        assertThat(bpmnModel.getGraphicInfo(activityId).getX()).isEqualTo(x.doubleValue());
+        assertThat(bpmnModel.getGraphicInfo(activityId).getY()).isEqualTo(y.doubleValue());
+        assertThat(bpmnModel.getGraphicInfo(activityId).getWidth()).isEqualTo(width.doubleValue());
+        assertThat(bpmnModel.getGraphicInfo(activityId).getHeight()).isEqualTo(height.doubleValue());
     }
 
     protected void assertSequenceFlowWayPoints(BpmnModel bpmnModel, String sequenceFlowId, Integer... waypoints) {
         List<GraphicInfo> graphicInfos = bpmnModel.getFlowLocationGraphicInfo(sequenceFlowId);
-        assertEquals(waypoints.length / 2, graphicInfos.size());
+        assertThat(graphicInfos).hasSize(waypoints.length / 2);
         for (int i = 0; i < waypoints.length; i += 2) {
             Integer x = waypoints[i];
             Integer y = waypoints[i + 1];
-            assertEquals(x.doubleValue(), graphicInfos.get(i / 2).getX());
-            assertEquals(y.doubleValue(), graphicInfos.get(i / 2).getY());
+            assertThat(graphicInfos.get(i / 2).getX()).isEqualTo(x.doubleValue());
+            assertThat(graphicInfos.get(i / 2).getY()).isEqualTo(y.doubleValue());
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/ConditionalSequenceFlowTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/ConditionalSequenceFlowTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.sequenceflow;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,7 +42,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
-        assertEquals("task right", task.getName());
+        assertThat(task.getName()).isEqualTo("task right");
     }
 
     @Test
@@ -55,7 +57,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
-        assertEquals("task left", task.getName());
+        assertThat(task.getName()).isEqualTo("task left");
     }
     
     @Test
@@ -73,13 +75,13 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
-        assertEquals("task right", task.getName());
+        assertThat(task.getName()).isEqualTo("task right");
         
         dynamicBpmnService.removeEnableSkipExpression(infoNode);
         dynamicBpmnService.saveProcessDefinitionInfo(processDefinition.getId(), infoNode);
         infoNode = dynamicBpmnService.getProcessDefinitionInfo(processDefinition.getId());
-        assertTrue(infoNode.get("bpmn").has(DynamicBpmnConstants.GLOBAL_PROCESS_DEFINITION_PROPERTIES));
-        assertFalse(infoNode.get("bpmn").get(DynamicBpmnConstants.GLOBAL_PROCESS_DEFINITION_PROPERTIES).has(DynamicBpmnConstants.ENABLE_SKIP_EXPRESSION));
+        assertThat(infoNode.get("bpmn").has(DynamicBpmnConstants.GLOBAL_PROCESS_DEFINITION_PROPERTIES)).isTrue();
+        assertThat(infoNode.get("bpmn").get(DynamicBpmnConstants.GLOBAL_PROCESS_DEFINITION_PROPERTIES).has(DynamicBpmnConstants.ENABLE_SKIP_EXPRESSION)).isFalse();
         
         variables = new HashMap<>();
         variables.put("input", "left");
@@ -89,17 +91,17 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
-        assertEquals("task left", task.getName());
+        assertThat(task.getName()).isEqualTo("task left");
         
         dynamicBpmnService.enableSkipExpression(infoNode);
         dynamicBpmnService.changeSkipExpression("flow1", "${skipOtherLeftVar}", infoNode);
         dynamicBpmnService.changeSkipExpression("flow2", "${skipOtherRightVar}", infoNode);
         dynamicBpmnService.saveProcessDefinitionInfo(processDefinition.getId(), infoNode);
         infoNode = dynamicBpmnService.getProcessDefinitionInfo(processDefinition.getId());
-        assertTrue(infoNode.get("bpmn").has(DynamicBpmnConstants.GLOBAL_PROCESS_DEFINITION_PROPERTIES));
-        assertTrue(infoNode.get("bpmn").get(DynamicBpmnConstants.GLOBAL_PROCESS_DEFINITION_PROPERTIES).has(DynamicBpmnConstants.ENABLE_SKIP_EXPRESSION));
-        assertEquals("${skipOtherLeftVar}", infoNode.get("bpmn").get("flow1").get(DynamicBpmnConstants.TASK_SKIP_EXPRESSION).asText());
-        assertEquals("${skipOtherRightVar}", infoNode.get("bpmn").get("flow2").get(DynamicBpmnConstants.TASK_SKIP_EXPRESSION).asText());
+        assertThat(infoNode.get("bpmn").has(DynamicBpmnConstants.GLOBAL_PROCESS_DEFINITION_PROPERTIES)).isTrue();
+        assertThat(infoNode.get("bpmn").get(DynamicBpmnConstants.GLOBAL_PROCESS_DEFINITION_PROPERTIES).has(DynamicBpmnConstants.ENABLE_SKIP_EXPRESSION)).isTrue();
+        assertThat(infoNode.get("bpmn").get("flow1").get(DynamicBpmnConstants.TASK_SKIP_EXPRESSION).asText()).isEqualTo("${skipOtherLeftVar}");
+        assertThat(infoNode.get("bpmn").get("flow2").get(DynamicBpmnConstants.TASK_SKIP_EXPRESSION).asText()).isEqualTo("${skipOtherRightVar}");
         
         variables = new HashMap<>();
         variables.put("input", "left");
@@ -109,7 +111,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
-        assertEquals("task right", task.getName());
+        assertThat(task.getName()).isEqualTo("task right");
     }
 
     @Test
@@ -120,7 +122,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
-        assertEquals("task not left", task.getName());
+        assertThat(task.getName()).isEqualTo("task not left");
         taskService.complete(task.getId());
 
         ObjectNode infoNode = dynamicBpmnService.changeSequenceFlowCondition("flow1", "${input == 'right'}");
@@ -131,7 +133,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
-        assertEquals("task left", task.getName());
+        assertThat(task.getName()).isEqualTo("task left");
         taskService.complete(task.getId());
 
         variables = CollectionUtil.singletonMap("input", "right2");
@@ -139,7 +141,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
-        assertEquals("task not left", task.getName());
+        assertThat(task.getName()).isEqualTo("task not left");
         taskService.complete(task.getId());
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/DefaultSequenceFlowTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/DefaultSequenceFlowTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.bpmn.sequenceflow;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
@@ -30,13 +32,13 @@ public class DefaultSequenceFlowTest extends PluggableFlowableTestCase {
     @Deployment
     public void testDefaultSequenceFlowOnTask() {
         String procId = runtimeService.startProcessInstanceByKey("defaultSeqFlow", CollectionUtil.singletonMap("input", 2)).getId();
-        assertNotNull(runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task2").singleResult());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task2").singleResult()).isNotNull();
 
         procId = runtimeService.startProcessInstanceByKey("defaultSeqFlow", CollectionUtil.singletonMap("input", 3)).getId();
-        assertNotNull(runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task3").singleResult());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task3").singleResult()).isNotNull();
 
         procId = runtimeService.startProcessInstanceByKey("defaultSeqFlow", CollectionUtil.singletonMap("input", 123)).getId();
-        assertNotNull(runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task1").singleResult());
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(procId).activityId("task1").singleResult()).isNotNull();
     }
 
 }


### PR DESCRIPTION
These 13 files finish the conversion of the `org.flowable.engine.test.bpmn` package to assertj fluent style.
