### PR TITLE
Use assertj fluent style in flowable-engine module.

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cache/ProcessDefinitionCacheTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cache/ProcessDefinitionCacheTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.cache;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.flowable.engine.ProcessEngine;
@@ -60,16 +62,16 @@ public class ProcessDefinitionCacheTest extends AbstractTestCase {
         // verify existence of process definition
         List<ProcessDefinition> processDefinitions = processEngine.getRepositoryService().createProcessDefinitionQuery().list();
 
-        assertEquals(1, processDefinitions.size());
+        assertThat(processDefinitions).hasSize(1);
 
         // Start a new Process instance
         ProcessInstance processInstance = processEngine.getRuntimeService().startProcessInstanceById(processDefinitions.get(0).getId());
         String processInstanceId = processInstance.getId();
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Close the process engine
         processEngine.close();
-        assertNotNull(processEngine.getRuntimeService());
+        assertThat(processEngine.getRuntimeService()).isNotNull();
 
         // Reboot the process engine
         processEngine = new StandaloneProcessEngineConfiguration().setEngineName("reboot-test").setDatabaseSchemaUpdate(org.flowable.engine.ProcessEngineConfiguration.DB_SCHEMA_UPDATE_FALSE)
@@ -78,7 +80,7 @@ public class ProcessDefinitionCacheTest extends AbstractTestCase {
         // Check if the existing process instance is still alive
         processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
 
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // Complete the task. That will end the process instance
         TaskService taskService = processEngine.getTaskService();
@@ -89,11 +91,11 @@ public class ProcessDefinitionCacheTest extends AbstractTestCase {
         // process definition has re-loaded into the process definition cache
         processInstance = processEngine.getRuntimeService().createProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
 
-        assertNull(processInstance);
+        assertThat(processInstance).isNull();
 
         // Extra check to see if a new process instance can be started as well
         processInstance = processEngine.getRuntimeService().startProcessInstanceById(processDefinitions.get(0).getId());
-        assertNotNull(processInstance);
+        assertThat(processInstance).isNotNull();
 
         // close the process engine
         processEngine.close();
@@ -126,12 +128,12 @@ public class ProcessDefinitionCacheTest extends AbstractTestCase {
         String processDefinitionId = repositoryService2.createProcessDefinitionQuery().singleResult().getId();
         runtimeService2.startProcessInstanceById(processDefinitionId);
         org.flowable.task.api.Task task = taskService2.createTaskQuery().singleResult();
-        assertEquals("original task", task.getName());
+        assertThat(task.getName()).isEqualTo("original task");
 
         // Delete the deployment on second process engine
         repositoryService2.deleteDeployment(deploymentId, true);
-        assertEquals(0, repositoryService2.createDeploymentQuery().count());
-        assertEquals(0, runtimeService2.createProcessInstanceQuery().count());
+        assertThat(repositoryService2.createDeploymentQuery().count()).isZero();
+        assertThat(runtimeService2.createProcessInstanceQuery().count()).isZero();
 
         // deploy a revised version of the process: start->revisedTask->end on first process engine
         //
@@ -146,7 +148,7 @@ public class ProcessDefinitionCacheTest extends AbstractTestCase {
         repositoryService2.createProcessDefinitionQuery().singleResult().getId();
         runtimeService2.startProcessInstanceByKey("oneTaskProcess");
         task = taskService2.createTaskQuery().singleResult();
-        assertEquals("revised task", task.getName());
+        assertThat(task.getName()).isEqualTo("revised task");
 
         // cleanup
         repositoryService1.deleteDeployment(deploymentId, true);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/ConcurrentEngineUsageTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/ConcurrentEngineUsageTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.concurrency;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -63,15 +65,15 @@ public class ConcurrentEngineUsageTest extends PluggableFlowableTestCase {
                 executor.shutdownNow();
 
             }
-            assertEquals(0, executor.getActiveCount());
+            assertThat(executor.getActiveCount()).isZero();
 
             // Check there are no processes active anymore
-            assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+            assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
             if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
                 // Check if all processes and tasks are complete
-                assertEquals(numberOfProcessesPerThread * numberOfThreads, historyService.createHistoricProcessInstanceQuery().finished().count());
-                assertEquals(totalNumberOfTasks, historyService.createHistoricTaskInstanceQuery().finished().count());
+                assertThat(historyService.createHistoricProcessInstanceQuery().finished().count()).isEqualTo(numberOfProcessesPerThread * numberOfThreads);
+                assertThat(historyService.createHistoricTaskInstanceQuery().finished().count()).isEqualTo(totalNumberOfTasks);
             }
         }
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/OptimisticLockingExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/concurrency/OptimisticLockingExceptionTest.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.test.concurrency;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
@@ -26,7 +28,6 @@ import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -83,11 +84,11 @@ public class OptimisticLockingExceptionTest extends PluggableFlowableTestCase {
             }
 
             boolean processInstanceEnded = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count() == 0;
-            Assert.assertTrue(processInstanceEnded);
+            assertThat(processInstanceEnded).isTrue();
 
         }
 
-        Assert.assertTrue(optimisticLockingExceptionHappenedOnce);
+        assertThat(optimisticLockingExceptionHappenedOnce).isTrue();
 
     }
 


### PR DESCRIPTION
This finishes off the first pass of converting the `org.flowable.engine.test` package in the flowable-engine module.  Once all the PRs are merged I will make a second consistency pass.
