### PR TITLE
Update product name

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-frontend/src/main/resources/static/admin/i18n/en.json
+++ b/modules/flowable-ui-admin/flowable-ui-admin-frontend/src/main/resources/static/admin/i18n/en.json
@@ -19,7 +19,7 @@
             "SHOWLICENSE": "License info"
         },
         "TITLE": {
-            "MAIN": "Activiti Administrator",
+            "MAIN": "Flowable Administrator",
             "ACTIONS": "Actions",
             "FILTERS": "Filters"
         },
@@ -208,7 +208,7 @@
             "CREATE-VARIABLE": {
                 "TITLE": "Create Variable",
                 "NAME": "Variable name",
-                "TYPE": "Activiti variable type",
+                "TYPE": "Flowable variable type",
                 "VALUE": "Variable value",
                 "CREATE": "Create"
             },

--- a/modules/flowable-ui-admin/flowable-ui-admin-frontend/src/main/resources/static/admin/i18n/fr.json
+++ b/modules/flowable-ui-admin/flowable-ui-admin-frontend/src/main/resources/static/admin/i18n/fr.json
@@ -18,7 +18,7 @@
             "SHOWLICENSE": "Informations de licence"
         },
         "TITLE": {
-            "MAIN": "Activiti administrateur",
+            "MAIN": "Flowable administrateur",
             "ACTIONS": "Actions",
             "FILTERS": "Filtres"
         },

--- a/modules/flowable-ui-admin/flowable-ui-admin-frontend/src/main/resources/static/admin/i18n/pt-BR.json
+++ b/modules/flowable-ui-admin/flowable-ui-admin-frontend/src/main/resources/static/admin/i18n/pt-BR.json
@@ -18,7 +18,7 @@
       "SHOWLICENSE":"Informações da licença"
     },
     "TITLE":{
-      "MAIN":"Administrador Activiti",
+      "MAIN":"Administrador Flowable",
       "ACTIONS":"Ações",
       "FILTERS":"Filtros"
     },


### PR DESCRIPTION
The `en.json` file in the `flowable-ui-admin` module was originally committed on June 30, 2016.  In the process the name `Activiti` was not changed.  This PR corrects that oversight.  Better late than never.
