### PR TITLE
Remove unused import statements in flowable-ui-* modules

### DIFF
--- a/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/java/org/flowable/ui/admin/application/FlowableAdminApplication.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-app/src/main/java/org/flowable/ui/admin/application/FlowableAdminApplication.java
@@ -12,12 +12,9 @@
  */
 package org.flowable.ui.admin.application;
 
-import org.flowable.ui.admin.conf.ApplicationConfiguration;
-import org.flowable.ui.admin.conf.DispatcherServletConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
-import org.springframework.context.annotation.Import;
 
 /**
  * @author Filip Hrisafov

--- a/modules/flowable-ui-admin/flowable-ui-admin-conf/src/main/java/org/flowable/ui/admin/conf/DispatcherServletConfiguration.java
+++ b/modules/flowable-ui-admin/flowable-ui-admin-conf/src/main/java/org/flowable/ui/admin/conf/DispatcherServletConfiguration.java
@@ -14,12 +14,9 @@ package org.flowable.ui.admin.conf;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
-import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.multipart.MultipartResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;

--- a/modules/flowable-ui-idm/flowable-ui-idm-app/src/test/java/org/flowable/ui/idm/application/FlowableIdmApplicationDefaultAuthenticationTest.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-app/src/test/java/org/flowable/ui/idm/application/FlowableIdmApplicationDefaultAuthenticationTest.java
@@ -15,9 +15,7 @@ package org.flowable.ui.idm.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.idm.api.IdmIdentityService;
-import org.flowable.idm.api.Privilege;
 import org.flowable.idm.api.User;
-import org.flowable.ui.common.security.DefaultPrivileges;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +30,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/IdmPrivilegesResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/IdmPrivilegesResource.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.ui.idm.rest.app;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.Privilege;
 import org.flowable.idm.api.User;
@@ -23,17 +26,13 @@ import org.flowable.ui.idm.model.AddUserPrivilegeRepresentation;
 import org.flowable.ui.idm.model.PrivilegeRepresentation;
 import org.flowable.ui.idm.service.PrivilegeService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-
-import java.util.ArrayList;
-import java.util.List;
 /**
  * @author Joram Barrez
  */

--- a/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/IdmProfileResource.java
+++ b/modules/flowable-ui-idm/flowable-ui-idm-rest/src/main/java/org/flowable/ui/idm/rest/app/IdmProfileResource.java
@@ -12,6 +12,12 @@
  */
 package org.flowable.ui.idm.rest.app;
 
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.flowable.idm.api.Group;
 import org.flowable.idm.api.User;
@@ -25,21 +31,14 @@ import org.flowable.ui.idm.service.GroupService;
 import org.flowable.ui.idm.service.ProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.InputStream;
 /**
  *
  * @author Joram Barrez

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/ui/task/conf/FlowableTaskDefaultPropertiesEnvironmentPostProcessor.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/ui/task/conf/FlowableTaskDefaultPropertiesEnvironmentPostProcessor.java
@@ -16,7 +16,6 @@ import java.util.List;
 
 import org.flowable.spring.boot.environment.FlowableDefaultPropertiesEnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.context.config.ConfigFileApplicationListener;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.boot.env.PropertySourceLoader;
 import org.springframework.core.Ordered;

--- a/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/ui/task/conf/SecurityConfiguration.java
+++ b/modules/flowable-ui-task/flowable-ui-task-conf/src/main/java/org/flowable/ui/task/conf/SecurityConfiguration.java
@@ -13,7 +13,6 @@
 package org.flowable.ui.task.conf;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.flowable.ui.common.filter.FlowableCookieFilterRegistrationBean;
 import org.flowable.ui.common.properties.FlowableCommonAppProperties;


### PR DESCRIPTION
Changes made to:

- flowable-ui-admin-app
- flowable-ui-admin-conf
- flowable-ui-idm-app
- flowable-ui-idm-rest
- flowable-ui-task-conf

While in the files reordered the imports as needed.
