### PR TITLE
Value is already assigned

### DIFF
--- a/modules/flowable-ui/flowable-ui-modeler-conf/src/main/java/org/flowable/ui/modeler/conf/ModelerBootstrapper.java
+++ b/modules/flowable-ui/flowable-ui-modeler-conf/src/main/java/org/flowable/ui/modeler/conf/ModelerBootstrapper.java
@@ -54,7 +54,7 @@ public class ModelerBootstrapper implements ApplicationListener<ContextRefreshed
         List<Model> decisionTableModels = modelRepository.findByModelType(AbstractModel.MODEL_TYPE_DECISION_TABLE, ModelSort.NAME_ASC);
 
         decisionTableModels.forEach(decisionTableModel -> {
-            decisionTableModel = DecisionTableModelConversionUtil.convertModelToV3(decisionTableModel);
+            DecisionTableModelConversionUtil.convertModelToV3(decisionTableModel);
             modelRepository.save(decisionTableModel);
         });
     }

--- a/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableDecisionServiceService.java
+++ b/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableDecisionServiceService.java
@@ -234,7 +234,7 @@ public class FlowableDecisionServiceService extends BaseFlowableModelService {
         Model decisionTableModel = getModel(decisionTableId, true, false);
 
         // convert to new model version
-        decisionTableModel = DecisionTableModelConversionUtil.convertModel(decisionTableModel);
+        DecisionTableModelConversionUtil.convertModel(decisionTableModel);
 
         return decisionTableModel;
     }

--- a/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableDecisionTableService.java
+++ b/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/FlowableDecisionTableService.java
@@ -239,7 +239,7 @@ public class FlowableDecisionTableService extends BaseFlowableModelService {
         Model decisionTableModel = getModel(decisionTableId, true, false);
 
         // convert to new model version
-        decisionTableModel = DecisionTableModelConversionUtil.convertModel(decisionTableModel);
+        DecisionTableModelConversionUtil.convertModel(decisionTableModel);
 
         return decisionTableModel;
     }


### PR DESCRIPTION
There is no need to assign the result to `decisionTableModel` as the method `DecisionTableModelConversionUtil.convertModelToV3` internally resets the parameter to that value.   It is all the more confusing as the method does set the variable and does return the variable.

The only other use of the method (found [here](https://github.com/flowable/flowable-engine/blob/master/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionImportService.java#L314))  does not use the returned variable value.

Found two other similar method calls this time for the `DecisionTableModelConversionUtil.convertModel` method; made the same type of change.