### PR TITLE
Use assertj fluent style in flowable-crystalball module.

### DIFF
--- a/modules/flowable-crystalball/pom.xml
+++ b/modules/flowable-crystalball/pom.xml
@@ -121,6 +121,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/examples/tutorial/step01/FirstSimulationRunTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/examples/tutorial/step01/FirstSimulationRunTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.crystalball.examples.tutorial.step01;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
@@ -35,10 +34,10 @@ public class FirstSimulationRunTest extends ResourceFlowableTestCase {
     public void testSimulationRun() {
         runtimeService.startProcessInstanceByKey("basicSimulationRun");
         // all simulationManager executions are finished
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         // simulation run check (Simulation run has side effect. The counter value is increased)
-        assertThat(Counter.value.get(), is(1l));
+        assertThat(Counter.value.get()).isEqualTo(1);
     }
 
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/process/SimulationRunTaskTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/process/SimulationRunTaskTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.crystalball.process;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,7 @@ public class SimulationRunTaskTest extends ResourceFlowableTestCase {
     public void testBasicSimulationRun() {
         runtimeService.startProcessInstanceByKey("basicSimulationRun");
         // all executions are finished
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimpleEventCalendarTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimpleEventCalendarTest.java
@@ -12,10 +12,8 @@
  */
 package org.flowable.crystalball.simulator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Comparator;
 import java.util.Date;
@@ -40,9 +38,9 @@ public class SimpleEventCalendarTest {
     @Test
     public void testIsEmpty() throws Exception {
         EventCalendar calendar = new SimpleEventCalendar(clock, comparator);
-        assertTrue(calendar.isEmpty());
+        assertThat(calendar.isEmpty()).isTrue();
         SimulationEvent event = calendar.removeFirstEvent();
-        assertNull(event);
+        assertThat(event).isNull();
     }
 
     @Test
@@ -56,11 +54,11 @@ public class SimpleEventCalendarTest {
         calendar.addEvent(event1);
 
         SimulationEvent event = calendar.removeFirstEvent();
-        assertEquals(event1, event);
+        assertThat(event).isEqualTo(event1);
         event = calendar.removeFirstEvent();
-        assertEquals(event1, event);
+        assertThat(event).isEqualTo(event1);
         event = calendar.removeFirstEvent();
-        assertEquals(event2, event);
+        assertThat(event).isEqualTo(event2);
     }
 
     @Test
@@ -71,8 +69,8 @@ public class SimpleEventCalendarTest {
         calendar.addEvent(event1);
 
         calendar.clear();
-        assertTrue(calendar.isEmpty());
-        assertNull(calendar.removeFirstEvent());
+        assertThat(calendar.isEmpty()).isTrue();
+        assertThat(calendar.removeFirstEvent()).isNull();
     }
 
     @Test(expected = RuntimeException.class)

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimpleSimulationRunTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimpleSimulationRunTest.java
@@ -12,10 +12,8 @@
  */
 package org.flowable.crystalball.simulator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -124,9 +122,9 @@ public class SimpleSimulationRunTest {
 
     private void step2Check(RuntimeService runtimeService, TaskService taskService) {
         ProcessInstance procInstance = runtimeService.createProcessInstanceQuery().active().processInstanceBusinessKey("oneTaskProcessBusinessKey").singleResult();
-        assertNull(procInstance);
+        assertThat(procInstance).isNull();
         Task t = taskService.createTaskQuery().active().taskDefinitionKey("userTask").singleResult();
-        assertNull(t);
+        assertThat(t).isNull();
     }
 
     @Test
@@ -144,7 +142,7 @@ public class SimpleSimulationRunTest {
 
         simDebugger.runTo(0);
         ProcessInstance procInstance = runtimeService.createProcessInstanceQuery().active().processInstanceBusinessKey("oneTaskProcessBusinessKey").singleResult();
-        assertNull(procInstance);
+        assertThat(procInstance).isNull();
 
         // debugger step - deploy process
         simDebugger.runTo(1);
@@ -168,15 +166,16 @@ public class SimpleSimulationRunTest {
         ProcessEngines.destroy();
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testRunToTimeInThePast() throws Exception {
+    @Test
+    public void testRunToTimeInThePast() {
 
         recordEvents();
         SimulationDebugger simDebugger = createDebugger();
         simDebugger.init(new NoExecutionVariableScope());
         try {
-            simDebugger.runTo(-1);
-            fail("RuntimeException expected - unable to execute event from the past");
+            assertThatThrownBy(() -> simDebugger.runTo(-1))
+                    .as("RuntimeException expected - unable to execute event from the past")
+                    .isInstanceOf(RuntimeException.class);
         } finally {
             simDebugger.close();
             ProcessEngines.destroy();
@@ -199,15 +198,18 @@ public class SimpleSimulationRunTest {
         }
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testRunToNonExistingEvent() throws Exception {
+    @Test
+    public void testRunToNonExistingEvent() {
 
         recordEvents();
         SimulationDebugger simDebugger = createDebugger();
         simDebugger.init(new NoExecutionVariableScope());
         try {
-            simDebugger.runTo("");
-            checkStatus(SimulationRunContext.getHistoryService());
+            assertThatThrownBy(() -> {
+                simDebugger.runTo("");
+                checkStatus(SimulationRunContext.getHistoryService());
+            })
+                    .isInstanceOf(RuntimeException.class);
         } finally {
             simDebugger.close();
             ProcessEngines.destroy();
@@ -217,15 +219,14 @@ public class SimpleSimulationRunTest {
     private void step0Check(RepositoryService repositoryService) {
         Deployment deployment;
         deployment = repositoryService.createDeploymentQuery().singleResult();
-        assertNotNull(deployment);
-    }
+        assertThat(deployment).isNotNull();    }
 
     private void step1Check(RuntimeService runtimeService, TaskService taskService) {
         ProcessInstance procInstance;
         procInstance = runtimeService.createProcessInstanceQuery().active().processInstanceBusinessKey("oneTaskProcessBusinessKey").singleResult();
-        assertNotNull(procInstance);
+        assertThat(procInstance).isNotNull();
         Task t = taskService.createTaskQuery().active().taskDefinitionKey("userTask").singleResult();
-        assertNotNull(t);
+        assertThat(t).isNotNull();
     }
 
     @Test
@@ -258,10 +259,10 @@ public class SimpleSimulationRunTest {
 
     private void checkStatus(HistoryService historyService) {
         final HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().finished().singleResult();
-        assertNotNull(historicProcessInstance);
-        assertEquals("oneTaskProcessBusinessKey", historicProcessInstance.getBusinessKey());
+        assertThat(historicProcessInstance).isNotNull();
+        assertThat(historicProcessInstance.getBusinessKey()).isEqualTo("oneTaskProcessBusinessKey");
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("userTask").singleResult();
-        assertEquals("user1", historicTaskInstance.getAssignee());
+        assertThat(historicTaskInstance.getAssignee()).isEqualTo("user1");
     }
 
     private void recordEvents() {

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimulationEventComparatorTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/SimulationEventComparatorTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.crystalball.simulator;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Comparator;
 
@@ -31,12 +31,12 @@ public class SimulationEventComparatorTest {
         SimulationEvent eq1_0 = new SimulationEvent.Builder("type").simulationTime(0).build();
         SimulationEvent event1_1 = new SimulationEvent.Builder("type").simulationTime(0).priority(1).build();
         SimulationEvent event2 = new SimulationEvent.Builder("type").simulationTime(1).build();
-        assertEquals(0, comparator.compare(event1_0, eq1_0));
-        assertEquals(-1, comparator.compare(event1_0, event2));
-        assertEquals(1, comparator.compare(event2, event1_0));
-        assertEquals(-1, comparator.compare(event1_0, event1_1));
-        assertEquals(1, comparator.compare(event1_1, event1_0));
-        assertEquals(-1, comparator.compare(event1_1, event2));
-        assertEquals(1, comparator.compare(event2, event1_1));
+        assertThat(comparator.compare(event1_0, eq1_0)).isZero();
+        assertThat(comparator.compare(event1_0, event2)).isEqualTo(-1);
+        assertThat(comparator.compare(event2, event1_0)).isEqualTo(1);
+        assertThat(comparator.compare(event1_0, event1_1)).isEqualTo(-1);
+        assertThat(comparator.compare(event1_1, event1_0)).isEqualTo(1);
+        assertThat(comparator.compare(event1_1, event2)).isEqualTo(-1);
+        assertThat(comparator.compare(event2, event1_1)).isEqualTo(1);
     }
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/MultiInstanceScriptEventHandlerTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/MultiInstanceScriptEventHandlerTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.crystalball.simulator.impl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -36,25 +35,25 @@ public class MultiInstanceScriptEventHandlerTest extends ResourceFlowableTestCas
     public void testSequentialSimulationRun() throws Exception {
         ProcessInstance simulationExperiment = runtimeService.startProcessInstanceByKey("multiInstanceResultVariablesSimulationRun");
         // all simulationManager executions are finished
-        assertEquals(2, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(2);
 
         // simulation run check - process variables has to be set to the value. "Hello worldX!"
         String simulationRunResult = (String) runtimeService.getVariable(simulationExperiment.getProcessInstanceId(), "simulationRunResult-0");
-        assertThat(simulationRunResult, is("Hello world0!"));
+        assertThat(simulationRunResult).isEqualTo("Hello world0!");
         simulationRunResult = (String) runtimeService.getVariable(simulationExperiment.getProcessInstanceId(), "simulationRunResult-1");
-        assertThat(simulationRunResult, is("Hello world1!"));
+        assertThat(simulationRunResult).isEqualTo("Hello world1!");
         simulationRunResult = (String) runtimeService.getVariable(simulationExperiment.getProcessInstanceId(), "simulationRunResult-2");
-        assertThat(simulationRunResult, is("Hello world2!"));
+        assertThat(simulationRunResult).isEqualTo("Hello world2!");
         simulationRunResult = (String) runtimeService.getVariable(simulationExperiment.getProcessInstanceId(), "simulationRunResult-3");
-        assertThat(simulationRunResult, is("Hello world3!"));
+        assertThat(simulationRunResult).isEqualTo("Hello world3!");
         simulationRunResult = (String) runtimeService.getVariable(simulationExperiment.getProcessInstanceId(), "simulationRunResult-4");
-        assertThat(simulationRunResult, is("Hello world4!"));
+        assertThat(simulationRunResult).isEqualTo("Hello world4!");
 
         // process end
         runtimeService.trigger(runtimeService.createExecutionQuery()
                 .onlyChildExecutions().singleResult().getId());
         // no process instance is running
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/ScriptEventHandlerTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/ScriptEventHandlerTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.crystalball.simulator.impl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -36,17 +35,17 @@ public class ScriptEventHandlerTest extends ResourceFlowableTestCase {
     public void testSimpleScriptExecution() throws Exception {
         ProcessInstance simulationExperiment = runtimeService.startProcessInstanceByKey("resultVariableSimulationRun");
         // all simulationManager executions are finished
-        assertEquals(2, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isEqualTo(2);
 
         String simulationRunResult = (String) runtimeService.getVariable(simulationExperiment.getProcessInstanceId(), "simulationRunResult");
         // simulation run check - process variable has to be set to the value.
-        assertThat(simulationRunResult, is("Hello world!"));
+        assertThat(simulationRunResult).isEqualTo("Hello world!");
 
         // process end
         runtimeService.trigger(runtimeService.createExecutionQuery().processInstanceId(simulationExperiment.getId())
                 .onlyChildExecutions().singleResult().getId());
         // no process instance is running
-        assertEquals(0, runtimeService.createExecutionQuery().count());
+        assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/PlaybackProcessStartTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/PlaybackProcessStartTest.java
@@ -13,6 +13,7 @@
 package org.flowable.crystalball.simulator.impl.playback;
 
 import static org.apache.commons.lang3.StringUtils.startsWith;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -45,14 +46,14 @@ public class PlaybackProcessStartTest extends AbstractPlaybackTest {
 
     public void demoCheckStatus() {
         final HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().finished().includeProcessVariables().singleResult();
-        assertNotNull(historicProcessInstance);
+        assertThat(historicProcessInstance).isNotNull();
         RepositoryService repositoryService = processEngine.getRepositoryService();
         final ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionId(historicProcessInstance.getProcessDefinitionId()).singleResult();
-        assertEquals(SIMPLEST_PROCESS, processDefinition.getKey());
+        assertThat(processDefinition.getKey()).isEqualTo(SIMPLEST_PROCESS);
 
-        assertEquals(1, historicProcessInstance.getProcessVariables().size());
-        assertEquals(TEST_VALUE, historicProcessInstance.getProcessVariables().get(TEST_VARIABLE));
-        assertEquals(BUSINESS_KEY, historicProcessInstance.getBusinessKey());
+        assertThat(historicProcessInstance.getProcessVariables()).hasSize(1);
+        assertThat(historicProcessInstance.getProcessVariables()).containsEntry(TEST_VARIABLE, TEST_VALUE);
+        assertThat(historicProcessInstance.getBusinessKey()).isEqualTo(BUSINESS_KEY);
     }
 
     @CheckStatus(methodName = "messageProcessStartCheckStatus")
@@ -64,8 +65,8 @@ public class PlaybackProcessStartTest extends AbstractPlaybackTest {
 
     public void messageProcessStartCheckStatus() {
         final HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().finished().singleResult();
-        assertNotNull(historicProcessInstance);
-        assertTrue(startsWith(historicProcessInstance.getProcessDefinitionId(), "messageStartEventProcess"));
+        assertThat(historicProcessInstance).isNotNull();
+        assertThat(startsWith(historicProcessInstance.getProcessDefinitionId(), "messageStartEventProcess")).isTrue();
     }
 
     @Deployment
@@ -78,8 +79,8 @@ public class PlaybackProcessStartTest extends AbstractPlaybackTest {
 
     public void checkStatus() {
         final List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().finished().list();
-        assertNotNull(historicProcessInstances);
-        assertEquals(2, historicProcessInstances.size());
+        assertThat(historicProcessInstances).isNotNull();
+        assertThat(historicProcessInstances).hasSize(2);
     }
 
     @Deployment
@@ -93,9 +94,9 @@ public class PlaybackProcessStartTest extends AbstractPlaybackTest {
 
     public void userTaskCheckStatus() {
         final HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().finished().singleResult();
-        assertNotNull(historicProcessInstance);
-        assertEquals("oneTaskProcessBusinessKey", historicProcessInstance.getBusinessKey());
+        assertThat(historicProcessInstance).isNotNull();
+        assertThat(historicProcessInstance.getBusinessKey()).isEqualTo("oneTaskProcessBusinessKey");
         HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskDefinitionKey("userTask").singleResult();
-        assertEquals("user1", historicTaskInstance.getAssignee());
+        assertThat(historicTaskInstance.getAssignee()).isEqualTo("user1");
     }
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/PlaybackRunTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/PlaybackRunTest.java
@@ -12,8 +12,7 @@
  */
 package org.flowable.crystalball.simulator.impl.playback;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -122,14 +121,14 @@ public class PlaybackRunTest {
     private void checkStatus(ProcessEngine processEngine) {
         HistoryService historyService = processEngine.getHistoryService();
         final HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().finished().includeProcessVariables().singleResult();
-        assertNotNull(historicProcessInstance);
+        assertThat(historicProcessInstance).isNotNull();
         RepositoryService repositoryService = processEngine.getRepositoryService();
         final ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionId(historicProcessInstance.getProcessDefinitionId()).singleResult();
-        assertEquals(SIMPLEST_PROCESS, processDefinition.getKey());
+        assertThat(processDefinition.getKey()).isEqualTo(SIMPLEST_PROCESS);
 
-        assertEquals(1, historicProcessInstance.getProcessVariables().size());
-        assertEquals(TEST_VALUE, historicProcessInstance.getProcessVariables().get(TEST_VARIABLE));
-        assertEquals(BUSINESS_KEY, historicProcessInstance.getBusinessKey());
+        assertThat(historicProcessInstance.getProcessVariables()).hasSize(1);
+        assertThat(historicProcessInstance.getProcessVariables()).containsEntry(TEST_VARIABLE, TEST_VALUE);
+        assertThat(historicProcessInstance.getBusinessKey()).isEqualTo(BUSINESS_KEY);
     }
 
     private List<Function<FlowableEvent, SimulationEvent>> getTransformers() {

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayEventLogTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayEventLogTest.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.crystalball.simulator.impl.replay;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -104,8 +102,8 @@ public class ReplayEventLogTest {
         simRun.init(new NoExecutionVariableScope());
 
         // original process is finished - there should not be any running process instance/task
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count());
-        assertEquals(0, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskDefinitionKey("userTask").count()).isZero();
 
         simRun.step();
 
@@ -113,23 +111,23 @@ public class ReplayEventLogTest {
         ProcessInstance replayProcessInstance = runtimeService.createProcessInstanceQuery()
                 .processDefinitionKey(USERTASK_PROCESS)
                 .singleResult();
-        assertNotNull(replayProcessInstance);
-        assertNotEquals(replayProcessInstance.getId(), processInstance.getId());
-        assertEquals(TEST_VALUE, runtimeService.getVariable(replayProcessInstance.getId(), TEST_VARIABLE));
+        assertThat(replayProcessInstance).isNotNull();
+        assertThat(processInstance.getId()).isNotEqualTo(replayProcessInstance.getId());
+        assertThat(runtimeService.getVariable(replayProcessInstance.getId(), TEST_VARIABLE)).isEqualTo(TEST_VALUE);
         // there should be one task
-        assertEquals(1, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+        assertThat(taskService.createTaskQuery().taskDefinitionKey("userTask").count()).isEqualTo(1);
 
         simRun.step();
 
         // userTask was completed - replay process was finished
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count());
-        assertEquals(0, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskDefinitionKey("userTask").count()).isZero();
         HistoricVariableInstance variableInstance = historyService.createHistoricVariableInstanceQuery()
                 .processInstanceId(replayProcessInstance.getId())
                 .variableName(TASK_TEST_VARIABLE)
                 .singleResult();
-        assertNotNull(variableInstance);
-        assertEquals(TASK_TEST_VALUE, variableInstance.getValue());
+        assertThat(variableInstance).isNotNull();
+        assertThat(variableInstance.getValue()).isEqualTo(TASK_TEST_VALUE);
 
         // close simulation
         simRun.close();

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayRunTest.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/replay/ReplayRunTest.java
@@ -12,7 +12,7 @@
  */
 package org.flowable.crystalball.simulator.impl.replay;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -88,21 +88,21 @@ public class ReplayRunTest {
         simRun.init(new NoExecutionVariableScope());
 
         // original process is finished - there should not be any running process instance/task
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count());
-        assertEquals(0, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskDefinitionKey("userTask").count()).isZero();
 
         simRun.step();
 
         // replay process was started
-        assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count()).isEqualTo(1);
         // there should be one task
-        assertEquals(1, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+        assertThat(taskService.createTaskQuery().taskDefinitionKey("userTask").count()).isEqualTo(1);
 
         simRun.step();
 
         // userTask was completed - replay process was finished
-        assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count());
-        assertEquals(0, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+        assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskDefinitionKey("userTask").count()).isZero();
 
         simRun.close();
         processEngine.close();


### PR DESCRIPTION
Convert multiple styles in the `flowable-crystalball` module to fluent assertj.
