### PR TITLE
Use assertj fluent styte in flowable-dmn-spring-configurator module.

### DIFF
--- a/modules/flowable-dmn-spring-configurator/pom.xml
+++ b/modules/flowable-dmn-spring-configurator/pom.xml
@@ -67,6 +67,11 @@
 			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/modules/flowable-dmn-spring-configurator/src/test/java/org/flowable/dmn/spring/configurator/test/DecisionTaskWithSpringBeanTest.java
+++ b/modules/flowable-dmn-spring-configurator/src/test/java/org/flowable/dmn/spring/configurator/test/DecisionTaskWithSpringBeanTest.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.dmn.spring.configurator.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,7 +40,7 @@ public class DecisionTaskWithSpringBeanTest extends SpringDmnFlowableTestCase {
                         .get(EngineConfigurationConstants.KEY_DMN_ENGINE_CONFIG);
         
         DmnDeployment dmnDeployment = dmnEngineConfiguration.getDmnRepositoryService().createDeploymentQuery().singleResult();
-        assertNotNull(dmnDeployment);
+        assertThat(dmnDeployment).isNotNull();
         
         try {
             Map<String, Object> variables = new HashMap<>();


### PR DESCRIPTION
Use assertj in `flowable-dmn-spring-configurator` module.
