### PR TITLE
Misc fluent assertj updates

### DIFF
--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -154,7 +154,7 @@ public class SpringAutoDeployTest {
         String filePath = "org/flowable/spring/test/autodeployment/simple-case.cmmn";
         String originalCaseFileContent = IoUtil.readFileAsString(filePath);
         String updatedCaseFileContent = originalCaseFileContent.replace("Case 1", "My simple case");
-        assertThat(updatedCaseFileContent.length() > originalCaseFileContent.length()).isTrue();
+        assertThat(updatedCaseFileContent).hasSizeGreaterThan(originalCaseFileContent.length());
         IoUtil.writeStringToFile(updatedCaseFileContent, filePath);
 
         // Classic produced/consumer problem here:
@@ -197,7 +197,7 @@ public class SpringAutoDeployTest {
         assertThat(repositoryService.createCaseDefinitionQuery().list())
                 .extracting(CaseDefinition::getKey)
                 .isEmpty();
-        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
@@ -211,7 +211,7 @@ public class SpringAutoDeployTest {
         assertThat(repositoryService.createCaseDefinitionQuery().list())
                 .extracting(CaseDefinition::getKey)
                 .isEmpty();
-        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test
@@ -276,7 +276,7 @@ public class SpringAutoDeployTest {
         assertThat(repositoryService.createCaseDefinitionQuery().list())
                 .extracting(CaseDefinition::getKey)
                 .isEmpty();
-        assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+        assertThat(repositoryService.createDeploymentQuery().count()).isZero();
     }
 
     @Test

--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/el/SpringCustomBeanTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/el/SpringCustomBeanTest.java
@@ -55,7 +55,7 @@ public class SpringCustomBeanTest {
             
             // Triggering the task should start the child case instance
             cmmnRuntimeService.triggerPlanItemInstance(planItemInstance.getId());
-            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isEqualTo(0);
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
             
             assertThat(cmmnRule.getCmmnHistoryService().createHistoricVariableInstanceQuery()
                     .caseInstanceId(caseInstance.getId())

--- a/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/ContentItemTest.java
+++ b/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/ContentItemTest.java
@@ -100,7 +100,7 @@ public class ContentItemTest extends AbstractFlowableContentTest {
         assertThat(contentItem.getId()).isNotNull();
         assertThat(new File(contentEngineConfiguration.getContentRootFolder() + File.separator + "uncategorized" + File.separator +
                 contentItem.getContentStoreId().substring(contentItem.getContentStoreId().lastIndexOf('.') + 1)
-        ).exists()).isTrue();
+        )).exists();
 
         ContentItem dbContentItem = contentService.createContentItemQuery().id(contentItem.getId()).singleResult();
         assertThat(dbContentItem).isNotNull();
@@ -115,7 +115,7 @@ public class ContentItemTest extends AbstractFlowableContentTest {
 
         assertThat(new File(contentEngineConfiguration.getContentRootFolder() + File.separator + "uncategorized" + File.separator +
                 contentItem.getContentStoreId().substring(contentItem.getContentStoreId().lastIndexOf('.') + 1)
-        ).exists()).isFalse();
+        )).doesNotExist();
 
         assertThatThrownBy(() -> contentService.getContentItemData(contentItem.getId()))
                 .isInstanceOf(FlowableObjectNotFoundException.class);
@@ -136,7 +136,7 @@ public class ContentItemTest extends AbstractFlowableContentTest {
         assertThat(contentItem.getId()).isNotNull();
         assertThat(new File(contentEngineConfiguration.getContentRootFolder() + File.separator + "uncategorized" + File.separator +
                 contentItem.getContentStoreId().substring(contentItem.getContentStoreId().lastIndexOf('.') + 1)
-        ).exists()).isTrue();
+        )).exists();
 
         ContentItem dbContentItem = contentService.createContentItemQuery().id(contentItem.getId()).singleResult();
         assertThat(dbContentItem).isNotNull();
@@ -151,7 +151,7 @@ public class ContentItemTest extends AbstractFlowableContentTest {
 
         assertThat(new File(contentEngineConfiguration.getContentRootFolder() + File.separator + "uncategorized" + File.separator +
                 contentItem.getContentStoreId().substring(contentItem.getContentStoreId().lastIndexOf('.') + 1)
-        ).exists()).isFalse();
+        )).doesNotExist();
 
         assertThatThrownBy(() -> contentService.getContentItemData(contentItem.getId()))
                 .isInstanceOf(FlowableObjectNotFoundException.class);
@@ -194,14 +194,14 @@ public class ContentItemTest extends AbstractFlowableContentTest {
         assertThat(new File(contentEngineConfiguration.getContentRootFolder() + File.separator + typeFolder
                 + File.separator + idFolder + File.separator +
                 contentStoreId.substring(contentStoreId.lastIndexOf('.') + 1)
-        ).exists()).isTrue();
+        )).exists();
     }
 
     protected void assertMissingFile(String typeFolder, String idFolder, String contentStoreId) {
         assertThat(new File(contentEngineConfiguration.getContentRootFolder() + File.separator + typeFolder
                 + File.separator + idFolder + File.separator +
                 contentStoreId.substring(contentStoreId.lastIndexOf('.') + 1)
-        ).exists()).isFalse();
+        )).doesNotExist();
     }
 
     @Test
@@ -240,7 +240,7 @@ public class ContentItemTest extends AbstractFlowableContentTest {
 
         contentService.deleteContentItemsByScopeIdAndScopeType("testScopeId", "testScopeType");
 
-        assertThat(contentService.createContentItemQuery().scopeTypeLike("testScope%").list()).hasSize(0);
+        assertThat(contentService.createContentItemQuery().scopeTypeLike("testScope%").list()).isEmpty();
     }
 
     @Test

--- a/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/ForceCloseMybatisConnectionPoolTest.java
@@ -45,7 +45,7 @@ public class ForceCloseMybatisConnectionPoolTest {
         contentEngine.close();
 
         // the idle connections are closed
-        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
+        assertThat(state.getIdleConnectionCount()).isZero();
 
     }
 
@@ -71,7 +71,7 @@ public class ForceCloseMybatisConnectionPoolTest {
         // the idle connections are not closed
         assertThat(state.getIdleConnectionCount()).isPositive();
         pooledDataSource.forceCloseAll();
-        assertThat(state.getIdleConnectionCount()).isEqualTo(0);
+        assertThat(state.getIdleConnectionCount()).isZero();
     }
 
 }

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DecisionTaskTest.java
@@ -558,7 +558,7 @@ public class DecisionTaskTest {
         Map<String, Object> caseVariables = caseInstance.getCaseVariables();
         Object resultObject = caseVariables.get("DecisionTable");
         assertThat(resultObject).isNull();
-        assertThat(caseVariables.get("testOutput")).isEqualTo(2.0);
+        assertThat(caseVariables).containsEntry("testOutput", 2.0);
         this.cmmnRule.getCmmnEngineConfiguration().setAlwaysUseArraysForDmnMultiHitPolicies(true);
     }
 
@@ -663,7 +663,7 @@ public class DecisionTaskTest {
 
         // Triggering the task should end the case instance
         cmmnRule.getCmmnRuntimeService().triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnRule.getCmmnRuntimeService().createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRule.getCmmnRuntimeService().createCaseInstanceQuery().count()).isZero();
 
         assertThat(cmmnRule.getCmmnHistoryService().createHistoricVariableInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -684,7 +684,7 @@ public class DecisionTaskTest {
 
         // Triggering the task should end the case instance
         cmmnRule.getCmmnRuntimeService().triggerPlanItemInstance(planItemInstance.getId());
-        assertThat(cmmnRule.getCmmnRuntimeService().createCaseInstanceQuery().count()).isEqualTo(0);
+        assertThat(cmmnRule.getCmmnRuntimeService().createCaseInstanceQuery().count()).isZero();
     }
 
     protected void deleteAllDmnDeployments() {

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DmnTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DmnTaskTest.java
@@ -55,7 +55,7 @@ public class DmnTaskTest {
                 .variable("testInput", "second")
                 .start();
         Map<String, Object> processVariables = processInstance.getProcessVariables();
-        assertThat(processVariables.get("testOutput")).isEqualTo(2d);
+        assertThat(processVariables).containsEntry("testOutput", 2d);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class DmnTaskTest {
         Map<String, Object> processVariables = processInstance.getProcessVariables();
         Object resultObject = processVariables.get("DecisionTable");
         assertThat(resultObject).isNull();
-        assertThat(processVariables.get("testOutput")).isEqualTo(2.0);
+        assertThat(processVariables).containsEntry("testOutput", 2.0);
 
         processEngineConfiguration.setAlwaysUseArraysForDmnMultiHitPolicies(true);
     }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/deployment/DeploymentTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/deployment/DeploymentTest.java
@@ -294,13 +294,13 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
         assertThat(deployment).isNotNull();
 
         List<DmnDecision> decisionServices = repositoryService.createDecisionQuery().deploymentId(deployment.getId()).list();
-        assertThat(decisionServices.size()).isEqualTo(2);
+        assertThat(decisionServices).hasSize(2);
         assertThat(decisionServices)
             .extracting(DmnDecision::getDecisionType)
             .containsExactly("decision_service", "decision_service");
 
         List<DmnDecision> decisionServices2 = repositoryService.createDecisionQuery().decisionType(DecisionTypes.DECISION_SERVICE).list();
-        assertThat(decisionServices2.size()).isEqualTo(2);
+        assertThat(decisionServices2).hasSize(2);
     }
 
     @Test
@@ -310,7 +310,7 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
         assertThat(deployment).isNotNull();
 
         List<DmnDecision> decisionServices = repositoryService.createDecisionQuery().deploymentId(deployment.getId()).list();
-        assertThat(decisionServices.size()).isEqualTo(1);
+        assertThat(decisionServices).hasSize(1);
         assertThat(decisionServices.get(0).getDecisionType()).isEqualTo(DecisionTypes.DECISION_SERVICE);
     }
     

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomConfigRuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomConfigRuntimeTest.java
@@ -32,8 +32,6 @@ import org.junit.Test;
  */
 public class CustomConfigRuntimeTest {
 
-    public static final String H2_TEST_JDBC_URL = "jdbc:h2:mem:flowable;DB_CLOSE_DELAY=1000";
-
     protected static final String ENGINE_CONFIG_1 = "custom1.flowable.dmn.cfg.xml";
     protected static final String ENGINE_CONFIG_2 = "custom2.flowable.dmn.cfg.xml";
 
@@ -58,7 +56,7 @@ public class CustomConfigRuntimeTest {
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
 
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/DecisionTableExecutionFallBackTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/DecisionTableExecutionFallBackTest.java
@@ -59,7 +59,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
     @Test
     public void decisionKeyDeploymentIdTenantId() {
         Map<String, Object> result = executeDecision(TEST_TENANT_ID, TEST_PARENT_DEPLOYMENT_ID);
-        assertThat(result.get("outputVariable1")).isEqualTo("result2");
+        assertThat(result).containsEntry("outputVariable1", "result2");
     }
 
 
@@ -67,7 +67,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
     public void fallBackDecisionKeyDeploymentIdTenantIdWrongDeploymentId() {
         Map<String, Object> result = executeDecision(TEST_TENANT_ID, "WRONG_PARENT_DEPLOYMENT_ID");
 
-        assertThat(result.get("outputVariable1")).isEqualTo("result2");
+        assertThat(result).containsEntry("outputVariable1", "result2");
     }
 
     @Test
@@ -98,7 +98,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
         try {
             Map<String, Object> result = executeDecision(null, TEST_PARENT_DEPLOYMENT_ID);
 
-            assertThat(result.get("outputVariable1")).isEqualTo("result2");
+            assertThat(result).containsEntry("outputVariable1", "result2");
         } finally {
             dmnEngine.getDmnRepositoryService().deleteDeployment(localDeployment.getId());
         }
@@ -107,7 +107,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
     @Test
     public void decisionKeyTenantId() {
         Map<String, Object> result = executeDecision(TEST_TENANT_ID, null);
-        assertThat(result.get("outputVariable1")).isEqualTo("result2");
+        assertThat(result).containsEntry("outputVariable1", "result2");
     }
 
 
@@ -122,7 +122,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
         try {
             Map<String, Object> result = executeDecision(null, "WRONG_PARENT_DEPLOYMENT_ID");
 
-            assertThat(result.get("outputVariable1")).isEqualTo("result2");
+            assertThat(result).containsEntry("outputVariable1", "result2");
         } finally {
             dmnEngine.getDmnRepositoryService().deleteDeployment(localDeployment.getId());
         }
@@ -149,7 +149,7 @@ DecisionTableExecutionFallBackTest extends AbstractFlowableDmnTest {
                 .fallbackToDefaultTenant()
                 .executeWithSingleResult();
 
-            assertThat(result.get("outputVariable1")).isEqualTo("result2");
+            assertThat(result).containsEntry("outputVariable1", "result2");
         } finally {
             dmnEngine.getDmnRepositoryService().deleteDeployment(localDeployment.getId());
         }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyAnyTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyAnyTest.java
@@ -13,6 +13,7 @@
 package org.flowable.dmn.engine.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,8 +48,11 @@ public class HitPolicyAnyTest {
                 .variables(inputVariables)
                 .executeWithSingleResult();
 
-        assertThat(result.get("outputVariable1")).isEqualTo(10D);
-        assertThat(result.get("outputVariable2")).isEqualTo("result1");
+        assertThat(result)
+                .containsOnly(
+                        entry("outputVariable1", 10D),
+                        entry("outputVariable2", "result1")
+                );
     }
 
     @Test
@@ -114,9 +118,11 @@ public class HitPolicyAnyTest {
                 .executeWithAuditTrail();
 
         Map<String, Object> outputMap = result.getDecisionResult().iterator().next();
-        assertThat(outputMap.keySet()).hasSize(2);
-        assertThat(outputMap.get("outputVariable1")).isEqualTo(10D);
-        assertThat(outputMap.get("outputVariable2")).isEqualTo("result2");
+        assertThat(outputMap)
+                .containsOnly(
+                        entry("outputVariable1", 10D),
+                        entry("outputVariable2", "result2")
+                );
         assertThat(result.isFailed()).isFalse();
 
         assertThat(result.getExceptionMessage()).isNull();

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyCollectTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyCollectTest.java
@@ -13,6 +13,7 @@
 package org.flowable.dmn.engine.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.List;
 import java.util.Map;
@@ -120,8 +121,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(1);
-        assertThat(result.get("outputVariable1")).isEqualTo(90D);
+        assertThat(result)
+                .containsExactly(entry("outputVariable1", 90D));
     }
 
     @Test
@@ -136,8 +137,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(1);
-        assertThat(result.get("outputVariable1")).isEqualTo(60D);
+        assertThat(result)
+                .containsExactly(entry("outputVariable1", 60D));
     }
 
     @Test
@@ -152,8 +153,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(1);
-        assertThat(result.get("outputVariable1")).isEqualTo(10D);
+        assertThat(result)
+                .containsExactly(entry("outputVariable1", 10D));
     }
 
     @Test
@@ -168,8 +169,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(1);
-        assertThat(result.get("outputVariable1")).isEqualTo(30D);
+        assertThat(result)
+                .containsExactly(entry("outputVariable1", 30D));
     }
 
     @Test
@@ -184,8 +185,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(1);
-        assertThat(result.get("outputVariable1")).isEqualTo(4D);
+        assertThat(result)
+                .containsExactly(entry("outputVariable1", 4D));
     }
 
     @Test
@@ -200,8 +201,8 @@ public class HitPolicyCollectTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(1);
-        assertThat(result.get("outputVariable1")).isEqualTo(3D);
+        assertThat(result)
+                .containsExactly(entry("outputVariable1", 3D));
     }
 
     @Test

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyFirstTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyFirstTest.java
@@ -13,6 +13,7 @@
 package org.flowable.dmn.engine.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Map;
 
@@ -43,7 +44,10 @@ public class HitPolicyFirstTest {
                 .variable("inputVariable1", 11)
                 .executeWithSingleResult();
 
-        assertThat(result.get("outputVariable1")).isEqualTo("gt 10");
-        assertThat(result.get("outputVariable2")).isEqualTo("result2");
+        assertThat(result)
+                .contains(
+                        entry("outputVariable1", "gt 10"),
+                        entry("outputVariable2", "result2")
+                );
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyPriorityTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyPriorityTest.java
@@ -13,6 +13,7 @@
 package org.flowable.dmn.engine.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Map;
 
@@ -44,8 +45,8 @@ public class HitPolicyPriorityTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(1);
-        assertThat(result.get("outputVariable1")).isEqualTo("OUTPUT2");
+        assertThat(result)
+                .containsOnly(entry("outputVariable1", "OUTPUT2"));
     }
 
     @Test
@@ -60,9 +61,11 @@ public class HitPolicyPriorityTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(2);
-        assertThat(result.get("outputVariable1")).isEqualTo("REFER");
-        assertThat(result.get("outputVariable2")).isEqualTo("LEVEL 2");
+        assertThat(result)
+                .containsOnly(
+                        entry("outputVariable1", "REFER"),
+                        entry("outputVariable2", "LEVEL 2")
+                );
     }
 
     @Test
@@ -77,9 +80,11 @@ public class HitPolicyPriorityTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(2);
-        assertThat(result.get("outputVariable1")).isEqualTo("REFER");
-        assertThat(result.get("outputVariable2")).isEqualTo("LEVEL 1");
+        assertThat(result)
+                .containsOnly(
+                        entry("outputVariable1", "REFER"),
+                        entry("outputVariable2", "LEVEL 1")
+                );
     }
 
     @Test
@@ -94,9 +99,11 @@ public class HitPolicyPriorityTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(2);
-        assertThat(result.get("outputVariable1")).isEqualTo("REFER");
-        assertThat(result.get("outputVariable2")).isEqualTo("LEVEL 2");
+        assertThat(result)
+                .containsOnly(
+                        entry("outputVariable1", "REFER"),
+                        entry("outputVariable2", "LEVEL 2")
+                );
     }
 
     @Test
@@ -132,9 +139,11 @@ public class HitPolicyPriorityTest {
 
         assertThat(result.getDecisionResult()).hasSize(1);
         Map<String, Object> outputMap = result.getDecisionResult().iterator().next();
-        assertThat(outputMap.keySet()).hasSize(2);
-        assertThat(outputMap.get("outputVariable1")).isEqualTo("ACCEPT");
-        assertThat(outputMap.get("outputVariable2")).isEqualTo("NONE");
+        assertThat(outputMap)
+                .containsOnly(
+                        entry("outputVariable1", "ACCEPT"),
+                        entry("outputVariable2", "NONE")
+                );
 
         assertThat(result.isFailed()).isFalse();
         assertThat(result.getExceptionMessage()).isNull();
@@ -156,7 +165,7 @@ public class HitPolicyPriorityTest {
                 .variable("inputVariable1", 5)
                 .executeWithSingleResult();
 
-        assertThat(result.keySet()).hasSize(1);
-        assertThat(result.get("outputVariable1")).isEqualTo(20D);
+        assertThat(result)
+                .containsOnly(entry("outputVariable1", 20D));
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyUniqueTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyUniqueTest.java
@@ -13,6 +13,7 @@
 package org.flowable.dmn.engine.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Map;
 
@@ -43,7 +44,8 @@ public class HitPolicyUniqueTest {
                 .variable("inputVariable1", 10)
                 .executeWithSingleResult();
 
-        assertThat(result.get("outputVariable1")).isEqualTo("eq 10");
+        assertThat(result)
+                .containsEntry("outputVariable1", "eq 10");
     }
 
     @Test
@@ -86,8 +88,12 @@ public class HitPolicyUniqueTest {
 
         Map<String, Object> outputMap = result.getDecisionResult().iterator().next();
 
-        assertThat(outputMap.get("outputVariable1")).isEqualTo("lt 20");
-        assertThat(outputMap.get("outputVariable2")).isEqualTo(10D);
+        assertThat(outputMap)
+                .containsOnly(
+                        entry("outputVariable1", "lt 20"),
+                        entry("outputVariable2", 10D)
+                );
+
         assertThat(result.isFailed()).isFalse();
 
         assertThat(result.getExceptionMessage()).isNull();

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
@@ -13,6 +13,7 @@
 package org.flowable.dmn.engine.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.HashMap;
@@ -45,9 +46,9 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variable("input1", 10)
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
-        assertThat(result.get("output1")).isEqualTo("test3");
+        assertThat(result).containsEntry("output1", "test3");
         assertThat(result.get("output2").getClass()).isSameAs(Double.class);
-        assertThat(result.get("output2")).isEqualTo(3D);
+        assertThat(result).containsEntry("output2", 3D);
     }
 
     @Test
@@ -61,7 +62,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test
@@ -75,7 +76,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test
@@ -89,7 +90,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test
@@ -103,7 +104,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variable("input1", localDate.toDate())
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test
@@ -117,7 +118,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variable("input1", localDate)
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test
@@ -129,7 +130,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .executeWithSingleResult();
         assertThat(result).isNotNull();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
-        assertThat(result.get("output1")).isEqualTo("test1");
+        assertThat(result).containsEntry("output1", "test1");
     }
 
     @Test
@@ -145,7 +146,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variables(processVariablesInput)
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test
@@ -177,11 +178,11 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
 
         assertThat(result).hasSize(3);
         assertThat(result.get(0)).hasSize(1);
-        assertThat(result.get(0).get("output1")).isEqualTo(11d);
+        assertThat(result.get(0)).containsEntry("output1", 11d);
         assertThat(result.get(1)).hasSize(1);
-        assertThat(result.get(1).get("output2")).isEqualTo(11d);
+        assertThat(result.get(1)).containsEntry("output2", 11d);
         assertThat(result.get(2)).hasSize(1);
-        assertThat(result.get(2).get("output3")).isEqualTo(11d);
+        assertThat(result.get(2)).containsEntry("output3", 11d);
     }
 
     @Test
@@ -192,7 +193,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variable("input1", "blablatest")
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(Double.class);
-        assertThat(result.get("output1")).isEqualTo(5D);
+        assertThat(result).containsEntry("output1", 5D);
     }
 
     @Test
@@ -248,7 +249,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variables(processVariablesInput)
                 .executeWithSingleResult();
 
-        assertThat(result.get("output1")).isEqualTo(200D);
+        assertThat(result).containsEntry("output1", 200D);
     }
 
     @Test
@@ -278,7 +279,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("input1", null)
                 .executeWithSingleResult();
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test
@@ -291,7 +292,7 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .decisionKey("decision")
                 .variable("date", localDate.toDate())
                 .executeWithSingleResult();
-        assertThat(result.get("output1")).isEqualTo("test2");
+        assertThat(result).containsEntry("output1", "test2");
     }
 
     @Test
@@ -370,8 +371,11 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variables(processVariablesInput)
                 .executeWithSingleResult();
 
-        assertThat(result.get("total")).isEqualTo(500D);
-        assertThat(result.get("discount")).isEqualTo(0D);
+        assertThat(result)
+                .containsOnly(
+                        entry("total", 500D),
+                        entry("discount", 0D)
+                );
     }
 
     @Test
@@ -407,6 +411,6 @@ public class RuntimeTest extends AbstractFlowableDmnTest {
                 .variables(processVariablesInput)
                 .executeWithSingleResult();
 
-        assertThat(result.get("outputVariable1")).isEqualTo("result2");
+        assertThat(result).containsEntry("outputVariable1", "result2");
     }
 }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/StandaloneRuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/StandaloneRuntimeTest.java
@@ -47,6 +47,6 @@ public class StandaloneRuntimeTest {
                 .variables(inputVariables)
                 .executeWithSingleResult();
 
-        assertThat(result.get("outputVariable1")).isEqualTo("result2");
+        assertThat(result).containsEntry("outputVariable1", "result2");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.api.event;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
@@ -228,12 +229,10 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         dispatcher.addEventListener(secondListener);
 
         FlowableEngineEventImpl event = new FlowableProcessEventImpl(FlowableEngineEventType.ENTITY_CREATED);
-        try {
+        assertThatCode(() -> {
             dispatcher.dispatchEvent(event);
-            assertThat(secondListener.getEventsReceived()).hasSize(1);
-        } catch (Throwable t) {
-            fail("No exception expected");
-        }
+        }).doesNotThrowAnyException();
+        assertThat(secondListener.getEventsReceived()).hasSize(1);
 
         // Remove listeners
         dispatcher.removeEventListener(listener);
@@ -262,30 +261,30 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
         // Check with empty null
         FlowableEngineEventType[] types = FlowableEngineEventType.getTypesFromString(null);
         assertThat(types).isNotNull();
-        assertThat(types.length).isZero();
+        assertThat(types).isEmpty();
 
         // Check with empty string
         types = FlowableEngineEventType.getTypesFromString("");
         assertThat(types).isNotNull();
-        assertThat(types.length).isZero();
+        assertThat(types).isEmpty();
 
         // Single value
         types = FlowableEngineEventType.getTypesFromString("ENTITY_CREATED");
         assertThat(types).isNotNull();
-        assertThat(types.length).isEqualTo(1);
+        assertThat(types).hasSize(1);
         assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
 
         // Multiple value
         types = FlowableEngineEventType.getTypesFromString("ENTITY_CREATED,ENTITY_DELETED");
         assertThat(types).isNotNull();
-        assertThat(types.length).isEqualTo(2);
+        assertThat(types).hasSize(2);
         assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         assertThat(types[1]).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
 
         // Additional separators should be ignored
         types = FlowableEngineEventType.getTypesFromString(",ENTITY_CREATED,,ENTITY_DELETED,,,");
         assertThat(types).isNotNull();
-        assertThat(types.length).isEqualTo(2);
+        assertThat(types).hasSize(2);
         assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         assertThat(types[1]).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
@@ -549,11 +549,10 @@ public class JobEventsTest extends PluggableFlowableTestCase {
 
         // Process Cancelled event should not be sent for the subprocess
         List<FlowableEvent> eventsReceived = activitiEventListener.getEventsReceived();
-        for (FlowableEvent eventReceived : eventsReceived) {
-            if (FlowableEngineEventType.PROCESS_CANCELLED == eventReceived.getType()) {
-                fail("Should not have received PROCESS_CANCELLED event");
-            }
-        }
+        assertThat(eventsReceived)
+                .extracting(FlowableEvent::getType)
+                .as("Should not have received PROCESS_CANCELLED event")
+                .doesNotContain(FlowableEngineEventType.PROCESS_CANCELLED);
 
         // validate the activityType string
         for (FlowableEvent eventReceived : eventsReceived) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
@@ -223,7 +223,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceCompleteCondition.bpmn20.xml" })
     public void testMultiInstanceCompleteCondition() throws Exception {
         Map<String, Object> variables = new HashMap<>();
-        variables.put("percentageCompleted", Float.valueOf(.5f));
+        variables.put("percentageCompleted", .5f);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents", variables);
         assertThat(processInstance).isNotNull();
 
@@ -326,7 +326,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
     @Deployment(resources = { "org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.testMultiInstanceCompleteCondition.bpmn20.xml" })
     public void testMultiInstanceComplete() throws Exception {
         Map<String, Object> variables = new HashMap<>();
-        variables.put("percentageCompleted", Float.valueOf(2));
+        variables.put("percentageCompleted", 2f);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("multiInstanceUserTaskEvents", variables);
         assertThat(processInstance).isNotNull();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionScopedEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessDefinitionScopedEventListenerTest.java
@@ -14,8 +14,6 @@ package org.flowable.engine.test.api.event;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Map;
-
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.common.engine.impl.event.FlowableEventSupport;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
@@ -31,9 +29,6 @@ import org.junit.jupiter.api.Test;
  * @author Frederik Heremans
  */
 public class ProcessDefinitionScopedEventListenerTest extends PluggableFlowableTestCase {
-
-    protected TestFlowableEventListener testListenerAsBean;
-    protected Map<Object, Object> oldBeans;
 
     /**
      * Test to verify listeners on a process-definition are only called for events related to that definition.

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -526,23 +526,27 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertThat(processTerminatedEvents).hasSize(1)
-                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.");
+        assertThat(processTerminatedEvents)
+                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.")
+                .hasSize(1);
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processTerminatedEvents.get(0);
         assertThat(processCompletedEvent.getProcessInstanceId()).isEqualTo(pi.getProcessInstanceId());
 
         List<FlowableEvent> activityTerminatedEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertThat(activityTerminatedEvents).hasSize(1)
-                .as("There should be exactly two FlowableEventType.ACTIVITY_CANCELLED event after the task complete.");
+        assertThat(activityTerminatedEvents)
+                .as("There should be exactly two FlowableEventType.ACTIVITY_CANCELLED event after the task complete.")
+                .hasSize(1);
 
         for (FlowableEvent event : activityTerminatedEvents) {
 
             FlowableActivityCancelledEventImpl activityEvent = (FlowableActivityCancelledEventImpl) event;
             if (activityEvent.getActivityId().equals("preNormalTerminateTask")) {
-                assertThat(activityEvent.getActivityId()).isEqualTo("preNormalTerminateTask")
-                        .as("The user task must be terminated");
-                assertThat(((FlowNode) activityEvent.getCause()).getId()).isEqualTo("EndEvent_2")
-                        .as("The cause must be terminate end event");
+                assertThat(activityEvent.getActivityId())
+                        .as("The user task must be terminated")
+                        .isEqualTo("preNormalTerminateTask");
+                assertThat(((FlowNode) activityEvent.getCause()).getId())
+                        .as("The cause must be terminate end event")
+                        .isEqualTo("EndEvent_2");
             }
         }
 
@@ -559,8 +563,9 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertThat(processTerminatedEvents).hasSize(1)
-                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.");
+        assertThat(processTerminatedEvents)
+                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.")
+                .hasSize(1);
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processTerminatedEvents.get(0);
         assertThat(pi.getProcessInstanceId()).isNotEqualTo(processCompletedEvent.getProcessInstanceId());
         assertThat(processCompletedEvent.getProcessDefinitionId()).contains("terminateEndEventSubprocessExample");
@@ -577,8 +582,9 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertThat(processTerminatedEvents).hasSize(1)
-                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.");
+        assertThat(processTerminatedEvents)
+                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.")
+                .hasSize(1);
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processTerminatedEvents.get(0);
         assertThat(processCompletedEvent.getProcessInstanceId()).isEqualTo(pi.getProcessInstanceId());
 
@@ -596,14 +602,17 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
-        assertThat(processTerminatedEvents).hasSize(1)
-                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.");
+        assertThat(processTerminatedEvents)
+                .as("There should be exactly one FlowableEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT event after the task complete.")
+                .hasSize(1);
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processTerminatedEvents.get(0);
         assertThat(processCompletedEvent.getProcessInstanceId()).isEqualTo(pi.getProcessInstanceId());
         assertThat(processCompletedEvent.getProcessDefinitionId()).contains("terminateParentProcess");
 
         List<FlowableEvent> activityTerminatedEvents = listener.filterEvents(FlowableEngineEventType.ACTIVITY_CANCELLED);
-        assertThat(activityTerminatedEvents).hasSize(2).as("Two activities must be cancelled.");
+        assertThat(activityTerminatedEvents)
+                .as("Two activities must be cancelled.")
+                .hasSize(2);
 
         for (FlowableEvent event : activityTerminatedEvents) {
 
@@ -611,14 +620,21 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
             if (activityEvent.getActivityId().equals("theTask")) {
 
-                assertThat(activityEvent.getActivityId()).isEqualTo("theTask").as("The user task must be terminated in the called sub process.");
-                assertThat(((FlowNode) activityEvent.getCause()).getId()).isEqualTo("EndEvent_3").as("The cause must be terminate end event");
+                assertThat(activityEvent.getActivityId())
+                        .as("The user task must be terminated in the called sub process.")
+                        .isEqualTo("theTask");
+                assertThat(((FlowNode) activityEvent.getCause()).getId())
+                        .as("The cause must be terminate end event")
+                        .isEqualTo("EndEvent_3");
 
             } else if (activityEvent.getActivityId().equals("CallActivity_1")) {
 
-                assertThat(activityEvent.getActivityId()).isEqualTo("CallActivity_1").as("The call activity must be terminated");
-                assertThat(((FlowNode) activityEvent.getCause()).getId()).isEqualTo("EndEvent_3").as("The cause must be terminate end event");
-
+                assertThat(activityEvent.getActivityId())
+                        .as("The call activity must be terminated")
+                        .isEqualTo("CallActivity_1");
+                assertThat(((FlowNode) activityEvent.getCause()).getId())
+                        .as("The cause must be terminate end event")
+                        .isEqualTo("EndEvent_3");
             }
 
         }
@@ -643,8 +659,9 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId());
 
         List<FlowableEvent> processCompletedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_ERROR_END_EVENT);
-        assertThat(processCompletedEvents).hasSize(1)
-                .as("There should be exactly an FlowableEventType.PROCESS_COMPLETED_WITH_ERROR_END_EVENT event after the task complete.");
+        assertThat(processCompletedEvents)
+                .as("There should be exactly an FlowableEventType.PROCESS_COMPLETED_WITH_ERROR_END_EVENT event after the task complete.")
+                .hasSize(1);
         FlowableEngineEntityEvent processCompletedEvent = (FlowableEngineEntityEvent) processCompletedEvents.get(0);
         assertThat(processCompletedEvent.getExecutionId()).isEqualTo(subProcesses.get(0).getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
@@ -95,8 +95,8 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
             // During the async history execution it is possible that some historic jobs are inserted again (to be retried) therefore using hasSizeGreaterThan
             assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_CREATED.name())).hasSizeGreaterThanOrEqualTo(historyCreatedEvents);
             assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_INITIALIZED.name())).hasSizeGreaterThanOrEqualTo(historyCreatedEvents);
-            assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.PROCESS_STARTED.name())).isNull();
-            assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.TASK_CREATED.name())).isNull();
+            assertThat(TestTransactionEventListener.eventsReceived).doesNotContainKey(FlowableEngineEventType.PROCESS_STARTED.name());
+            assertThat(TestTransactionEventListener.eventsReceived).doesNotContainKey(FlowableEngineEventType.TASK_CREATED.name());
 
         } else {
             assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_CREATED.name())).hasSize(expectedCreatedEvents);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ExternalWorkerJobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ExternalWorkerJobQueryTest.java
@@ -320,7 +320,7 @@ public class ExternalWorkerJobQueryTest extends PluggableFlowableTestCase {
         assertThat(job.getId()).isEqualTo(workerJob.getId());
         assertThat(job.getCorrelationId()).isEqualTo(workerJob.getCorrelationId());
 
-        assertThat(managementService.createExternalWorkerJobQuery().correlationId("invalid").singleResult());
+        assertThat(managementService.createExternalWorkerJobQuery().correlationId("invalid").singleResult()).isNull();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/JobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/JobQueryTest.java
@@ -519,7 +519,7 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         assertThat(failedJob).isNotNull();
         assertThat(failedJob.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(failedJob.getExceptionMessage()).isNotNull();
-        assertTextPresent(EXCEPTION_MESSAGE, failedJob.getExceptionMessage());
+        assertThat(failedJob.getExceptionMessage()).containsSequence(EXCEPTION_MESSAGE);
     }
 
     private void verifyQueryResults(JobQuery query, int countExpected) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/TimerJobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/TimerJobQueryTest.java
@@ -110,7 +110,8 @@ public class TimerJobQueryTest extends PluggableFlowableTestCase {
         // Executing the async job throws an exception -> job retry + creation of timer
         Job asyncJob = managementService.createJobQuery().singleResult();
         assertThat(asyncJob).isNotNull();
-        assertThatThrownBy(() -> managementService.executeJob(asyncJob.getId()));
+        assertThatThrownBy(() -> managementService.executeJob(asyncJob.getId()))
+                .isInstanceOf(Exception.class);
 
         assertThat(managementService.createJobQuery().count()).isZero();
         assertThat(managementService.createTimerJobQuery().timers().count()).isEqualTo(3);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeployInvalidXmlTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/DeployInvalidXmlTest.java
@@ -94,12 +94,14 @@ public class DeployInvalidXmlTest extends PluggableFlowableTestCase {
         @Override
         public void run() {
             try {
-                String deploymentId = repositoryService.createDeployment().addString("test.bpmn20.xml", UNSAFE_XML).deploy().getId();
-                assertThat(repositoryService.createProcessDefinitionQuery().singleResult()).isEqualTo(1);
-                repositoryService.deleteDeployment(deploymentId, true);
-            } catch (Exception e) {
-                // Exception is expected
-            } finally {
+                assertThatThrownBy(() -> {
+                    String deploymentId = repositoryService.createDeployment().addString("test.bpmn20.xml", UNSAFE_XML).deploy().getId();
+                    assertThat(repositoryService.createProcessDefinitionQuery().singleResult()).isEqualTo(1);
+                    repositoryService.deleteDeployment(deploymentId, true);
+                })
+                        .isInstanceOf(Exception.class);
+            }
+            finally {
                 finished = true;
             }
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ModelQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ModelQueryTest.java
@@ -104,7 +104,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
     @Test
     public void testQueryByInvalidNameLike() {
         ModelQuery query = repositoryService.createModelQuery().modelNameLike("%invalid%");
-        assertNull(query.singleResult());
+        assertThat(query.singleResult()).isNull();
         assertThat(query.list()).isEmpty();
         assertThat(query.count()).isZero();
     }
@@ -261,7 +261,7 @@ public class ModelQueryTest extends PluggableFlowableTestCase {
                 .extracting(Model::getName, Model::getId)
                 .containsExactly(tuple("my model", modelOneId));
 
-        models = repositoryService.createModelQuery().modelNameLike("%model%").orderByModelName().asc().list();;
+        models = repositoryService.createModelQuery().modelNameLike("%model%").orderByModelName().asc().list();
         assertThat(models)
                 .extracting(Model::getName, Model::getId)
                 .containsExactly(tuple("my model", modelOneId));

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/RepositoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/RepositoryServiceTest.java
@@ -294,7 +294,7 @@ public class RepositoryServiceTest extends PluggableFlowableTestCase {
             new ObjectOutputStream(baos).writeObject(processDefinition);
 
             byte[] bytes = baos.toByteArray();
-            assertThat(bytes.length).isGreaterThan(0);
+            assertThat(bytes).isNotEmpty();
         })
                 .doesNotThrowAnyException();
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceCommentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceCommentTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.api.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -49,11 +50,9 @@ public class ProcessInstanceCommentTest extends PluggableFlowableTestCase {
 
             // Suspend process instance
             runtimeService.suspendProcessInstanceById(processInstance.getId());
-            try {
-                taskService.addComment(null, processInstance.getId(), "Hello World 2");
-            } catch (FlowableException e) {
-                assertTextPresent("Cannot add a comment to a suspended execution", e.getMessage());
-            }
+            assertThatThrownBy(() -> taskService.addComment(null, processInstance.getId(), "Hello World 2"))
+                    .isInstanceOf(FlowableException.class)
+                    .hasMessageContaining("Cannot add a comment to a suspended execution");
 
             // Delete comments again
             taskService.deleteComments(null, processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryAndWithExceptionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryAndWithExceptionTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.api.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -89,11 +90,8 @@ public class ProcessInstanceQueryAndWithExceptionTest extends PluggableFlowableT
                 .list();
 
         for (Job job : jobList) {
-            try {
-                managementService.executeJob(job.getId());
-                fail("RuntimeException");
-            } catch (RuntimeException re) {
-            }
+            assertThatThrownBy(() -> managementService.executeJob(job.getId()))
+                    .isInstanceOf(RuntimeException.class);
         }
         return processInstance;
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationCallActivityTest.java
@@ -102,14 +102,10 @@ public class ProcessInstanceMigrationCallActivityTest extends PluggableFlowableT
         assertThat(processInstanceMigrationValidationResult.getValidationMessages()).isEqualTo(Collections.singletonList(
                 "Call activity 'callActivity' does not exist in the new model. It must be mapped explicitly for migration (or all its child activities)"));
 
-        try {
-            processInstanceMigrationBuilder.migrate(processInstance.getId());
-            fail("Migration should not be possible");
-        } catch (FlowableException e) {
-            assertTextPresent(
-                    "Call activity 'callActivity' does not exist in the new model. It must be mapped explicitly for migration (or all its child activities)",
-                    e.getMessage());
-        }
+        assertThatThrownBy(() -> processInstanceMigrationBuilder.migrate(processInstance.getId()))
+                .as("Migration should not be possible")
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("Call activity 'callActivity' does not exist in the new model. It must be mapped explicitly for migration (or all its child activities)");
 
         completeProcessInstanceTasks(subProcessInstance.getId());
         completeProcessInstanceTasks(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationMultiInstanceTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.api.runtime.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Collections;
@@ -312,7 +313,8 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
                 .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
                 .containsExactly("seqTasks", procSequentialMultiInst.getId());
         Map<String, Object> miTaskVars = taskService.getVariables(task.getId());
-        assertThat(miTaskVars).extracting("loopCounter").isEqualTo(0);
+        assertThat(miTaskVars)
+                .contains(entry("loopCounter", 0));
 
         //Complete one...
         completeTask(task);
@@ -518,7 +520,8 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
                 .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
                 .containsExactly("seqTasks", procSequentialMultiInst.getId());
         Map<String, Object> miTaskVars = taskService.getVariables(task.getId());
-        assertThat(miTaskVars).extracting("loopCounter").isEqualTo(0);
+        assertThat(miTaskVars)
+                .contains(entry("loopCounter", 0));
 
         //Complete one...
         completeTask(task);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/DelegateTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/DelegateTaskTest.java
@@ -72,7 +72,7 @@ public class DelegateTaskTest extends PluggableFlowableTestCase {
         }
 
         // After completion, the task category should be changed in the script listener working on the delegate task
-        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(0);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
         for (HistoricTaskInstance historicTaskInstance : historyService.createHistoricTaskInstanceQuery().list()) {
             assertThat(historicTaskInstance.getCategory()).isEqualTo("approved");
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
@@ -126,7 +126,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().includeTaskLocalVariables().taskCandidateUser("kermit").list();
         assertThat(tasks).hasSize(2);
         assertThat(tasks.get(0).getTaskLocalVariables()).hasSize(2);
-        assertThat(tasks.get(0).getTaskLocalVariables().get("test")).isEqualTo("test");
+        assertThat(tasks.get(0).getTaskLocalVariables()).containsEntry("test", "test");
         assertThat(tasks.get(0).getProcessVariables()).isEmpty();
 
         tasks = taskService.createTaskQuery().includeProcessVariables().taskCandidateUser("kermit").list();
@@ -373,7 +373,7 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
         query1 = query1.endOr();
         org.flowable.task.api.Task task = query1.singleResult();
         assertThat(task.getProcessVariables()).hasSize(2);
-        assertThat(task.getProcessVariables().get("anotherProcessVar")).isEqualTo(123);
+        assertThat(task.getProcessVariables()).containsEntry("anotherProcessVar", 123);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
@@ -673,15 +673,11 @@ public class TenancyTest extends PluggableFlowableTestCase {
         repositoryService.suspendProcessDefinitionByKey("oneTaskProcess", tenantB);
 
         // Shouldn't be able to start proc defs for tenant B
-        try {
-            runtimeService.startProcessInstanceById(procDefIdB);
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceById(procDefIdB))
+                .isInstanceOf(FlowableException.class);
 
-        try {
-            runtimeService.startProcessInstanceById(procDefIdB2);
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceById(procDefIdB2))
+                .isInstanceOf(FlowableException.class);
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceById(procDefIdA);
         assertThat(processInstance).isNotNull();
@@ -700,10 +696,8 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
         // Suspending with NO tenant id should give an error, cause they both
         // have tenants
-        try {
-            repositoryService.suspendProcessDefinitionByKey("oneTaskProcess");
-        } catch (FlowableException e) {
-        }
+        assertThatThrownBy(() -> repositoryService.suspendProcessDefinitionByKey("oneTaskProcess"))
+                .isInstanceOf(FlowableException.class);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityWithElementType.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityWithElementType.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.bpmn.callactivity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -82,15 +83,12 @@ public class CallActivityWithElementType extends PluggableFlowableTestCase {
     @Deployment(resources =
         "org/flowable/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml")
     public void testCallSimpleSubProcessWithUnrecognizedElementType() throws IOException {
-        try {
-            assertThatSubProcessIsCalled(
+        assertThatThrownBy(() -> assertThatSubProcessIsCalled(
                 createCallProcess("unrecognizedElementType", "simpleSubProcess"),
-                Collections.singletonMap("subProcessDefinitionKey", "simpleSubProcess")
-            );
-            fail("Flowable exception expected");
-        } catch (FlowableException e) {
-            assertThat(e).hasMessage("Unrecognized calledElementType [unrecognizedElementType]");
-        }
+                        Collections.singletonMap("subProcessDefinitionKey", "simpleSubProcess")))
+                .as("Flowable exception expected")
+                .isInstanceOf(FlowableException.class)
+                .hasMessage("Unrecognized calledElementType [unrecognizedElementType]");
     }
 
     protected void assertThatSubProcessIsCalled(String deploymentId, Map<String, Object> variables) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.bpmn.multiinstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -429,14 +430,11 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(procId).list();
             assertThat(tasks).hasSize(8);
-            
-            try {
-                runtimeService.addMultiInstanceExecution("miSubProcess", procId, null);
-                fail("Expected exception because multiple multi instance executions are present");
-            } catch (FlowableException e) {
-                // expected
-            }
-            
+
+            assertThatThrownBy(() -> runtimeService.addMultiInstanceExecution("miSubProcess", procId, null))
+                    .as("Expected exception because multiple multi instance executions are present")
+                    .isInstanceOf(FlowableException.class);
+
             List<Execution> miExecutions = runtimeService.createExecutionQuery().activityId("nesting1").list();
             assertThat(miExecutions).hasSize(4);
             

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.bpmn.multiinstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1760,12 +1761,10 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     @Test
     @Deployment(resources = "org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.simpleMultiInstanceWithCollectionVariable.bpmn20.xml")
     public void testCollectionVariableMissing() {
-        try {
-            runtimeService.startProcessInstanceByKey("simple_multi");
-            fail("Should have failed with missing collection variable");
-        } catch (FlowableIllegalArgumentException e) {
-            assertThat(e.getMessage()).isEqualTo("Variable 'elements' was not found");
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("simple_multi"))
+                .as("Should have failed with missing collection variable")
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("Variable 'elements' was not found");
     }
 
     @Test
@@ -1774,12 +1773,10 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         Map<String, Object> vars = new HashMap<>();
         ValueBean valueBean = new ValueBean("test");
         vars.put("elements", valueBean);
-        try {
-            runtimeService.startProcessInstanceByKey("simple_multi", vars);
-            fail("Should have failed with collection variable not a collection");
-        } catch (FlowableIllegalArgumentException e) {
-            assertThat(e.getMessage()).isEqualTo("Variable 'elements':" + valueBean + " is not a Collection");
-        }
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("simple_multi", vars))
+                .as("Should have failed with collection variable not a collection")
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage("Variable 'elements':" + valueBean + " is not a Collection");
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/RetryInterceptorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/RetryInterceptorTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.test.cfg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +28,6 @@ import org.flowable.common.engine.impl.interceptor.RetryInterceptor;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,12 +61,9 @@ public class RetryInterceptorTest {
     @Test
     public void testRetryInterceptor() {
 
-        try {
-            processEngine.getManagementService().executeCommand(new CommandThrowingOptimisticLockingException());
-            Assert.fail("ActivitiException expected.");
-        } catch (FlowableException e) {
-            assertThat(e.getMessage()).contains(retryInterceptor.getNumOfRetries() + " retries failed");
-        }
+        assertThatThrownBy(() -> processEngine.getManagementService().executeCommand(new CommandThrowingOptimisticLockingException()))
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining(retryInterceptor.getNumOfRetries() + " retries failed");
 
         assertThat(counter.get()).isEqualTo(retryInterceptor.getNumOfRetries() + 1); // +1, we retry 3 times, so one extra for the regular execution
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
@@ -626,7 +626,9 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
     protected void assertDatabaseSelects(String commandClass, Object... expectedSelects) {
         CommandStats stats = getStats(commandClass);
 
-        assertThat(stats.getDbSelects()).as("Unexpected number of database selects for " + commandClass + ". ").hasSize(expectedSelects.length / 2);
+        assertThat(stats.getDbSelects())
+                .as("Unexpected number of database selects for " + commandClass + ". ")
+                .hasSize(expectedSelects.length / 2);
 
         for (int i = 0; i < expectedSelects.length; i += 2) {
             String dbSelect = (String) expectedSelects[i];
@@ -640,7 +642,9 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
 
     protected void assertDatabaseUpdates(String commandClass, Object... expectedUpdates) {
         CommandStats stats = getStats(commandClass);
-        assertThat(stats.getDbUpdates()).as("Unexpected number of database updates for " + commandClass + ". ").hasSize(expectedUpdates.length / 2);
+        assertThat(stats.getDbUpdates())
+                .as("Unexpected number of database updates for " + commandClass + ". ")
+                .hasSize(expectedUpdates.length / 2);
 
         for (int i = 0; i < expectedUpdates.length; i += 2) {
             String dbUpdate = (String) expectedUpdates[i];
@@ -655,9 +659,9 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
     protected void assertDatabaseInserts(String commandClass, Object... expectedInserts) {
         CommandStats stats = getStats(commandClass);
 
-        if (expectedInserts.length / 2 != stats.getDbInserts().size()) {
-            Assert.fail("Unexpected number of database inserts : " + stats.getDbInserts().size() + ", but expected " + expectedInserts.length / 2);
-        }
+        assertThat(stats.getDbInserts())
+                .as("Unexpected number of database inserts : " + stats.getDbInserts().size() + ", but expected " + expectedInserts.length / 2)
+                .hasSize(expectedInserts.length / 2);
 
         for (int i = 0; i < expectedInserts.length; i += 2) {
             String dbInsert = (String) expectedInserts[i];
@@ -672,9 +676,9 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
     protected void assertDatabaseDeletes(String commandClass, Object... expectedDeletes) {
         CommandStats stats = getStats(commandClass);
 
-        if (expectedDeletes.length / 2 != stats.getDbDeletes().size()) {
-            Assert.fail("Unexpected number of database deletes : " + stats.getDbDeletes().size() + ", expected: " + (expectedDeletes.length/2));
-        }
+        assertThat(stats.getDbDeletes())
+                .as("Unexpected number of database deletes : " + stats.getDbDeletes().size() + ", expected: " + (expectedDeletes.length/2))
+                .hasSize(expectedDeletes.length / 2);
 
         for (int i = 0; i < expectedDeletes.length; i += 2) {
             String dbDelete = (String) expectedDeletes[i];

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/ProcessValidationExecutedAfterDeployTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/regression/ProcessValidationExecutedAfterDeployTest.java
@@ -12,9 +12,11 @@
  */
 package org.flowable.engine.test.regression;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import java.util.List;
 
-import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.validation.ProcessValidator;
@@ -80,15 +82,14 @@ public class ProcessValidationExecutedAfterDeployTest extends PluggableFlowableT
         clearDeploymentCache();
 
         ProcessDefinition definition = getLatestProcessDefinitionVersionByKey("testProcess1");
-        if (definition == null) {
-            fail("Error occurred in fetching process model.");
-        }
-        try {
+        assertThat(definition)
+                .as("Error occurred in fetching process model.")
+                .isNotNull();
+        assertThatCode(() -> {
             repositoryService.getProcessModel(definition.getId());
-            assertTrue(true);
-        } catch (FlowableException e) {
-            fail("Error occurred in fetching process model.");
-        }
+        })
+                .as("Error occurred in fetching process model.")
+                .doesNotThrowAnyException();
 
         for (org.flowable.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId());
@@ -104,15 +105,14 @@ public class ProcessValidationExecutedAfterDeployTest extends PluggableFlowableT
         clearDeploymentCache();
 
         ProcessDefinition definition = getLatestProcessDefinitionVersionByKey("testProcess1");
-        if (definition == null) {
-            fail("Error occurred in fetching process model.");
-        }
-        try {
+        assertThat(definition)
+                .as("Error occurred in fetching process model.")
+                .isNotNull();
+        assertThatCode(() -> {
             formService.getStartFormData(definition.getId());
-            assertTrue(true);
-        } catch (FlowableException e) {
-            fail("Error occurred in fetching start form data:");
-        }
+        })
+                .as("Error occurred in fetching start form data")
+                .doesNotThrowAnyException();
 
         for (org.flowable.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId());

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -234,7 +234,6 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
     @Test
     @Deployment
     public void testFailStatusCodes() {
-        ProcessInstance process = null;
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("failStatusCodes"))
                 .isExactlyInstanceOf(FlowableException.class)
                 .hasMessage("HTTP400");
@@ -562,7 +561,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
     private void assertKeysEquals(final String processInstanceId, final Map<String, Object> vars) {
         for (String key : vars.keySet()) {
             if (key.contains("Headers")) {
-                assertTextPresent((String) vars.get(key), (String) runtimeService.getVariable(processInstanceId, key));
+                assertThat((String) runtimeService.getVariable(processInstanceId, key)).containsSequence((String) vars.get(key));
             } else {
                 assertThat(runtimeService.getVariable(processInstanceId, key)).isEqualTo(vars.get(key));
             }

--- a/modules/flowable-http/src/test/java/org/flowable/http/cmmn/CmmnHttpTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/cmmn/CmmnHttpTaskTest.java
@@ -161,7 +161,7 @@ public class CmmnHttpTaskTest {
 
         assertThat(caseInstance).isNotNull();
         Map<String, Object> variables = cmmnRule.getCmmnRuntimeService().getVariables(caseInstance.getId());
-        assertThat(variables.get("httpGetResponseStatusCode")).isEqualTo(302);
+        assertThat(variables).containsEntry("httpGetResponseStatusCode", 302);
     }
 
     @Test


### PR DESCRIPTION
Various small-ish changes; things like:

- hasSize()
- isEmpty()
- hasSizeGreaterThan()
- isZero()
- exists()
- doesNotExist()
- containsEntry()
- assertThatThrownBy()
- assertThatCode()

Also corrected ordering of use of `as()` after the conditional test and at least one incomplete assertion.

More of this type to come but I figured this was enough to get started for a review.