### PR TITLE
Remove unneeded public modifiers on interfaces

### DIFF
--- a/modules/flowable-app-engine-api/src/main/java/org/flowable/app/api/AppEngineConfigurationApi.java
+++ b/modules/flowable-app-engine-api/src/main/java/org/flowable/app/api/AppEngineConfigurationApi.java
@@ -14,6 +14,6 @@ package org.flowable.app.api;
 
 public interface AppEngineConfigurationApi {
 
-    public AppManagementService getAppManagementService();
-    public AppRepositoryService getAppRepositoryService();
+    AppManagementService getAppManagementService();
+    AppRepositoryService getAppRepositoryService();
 }

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/AppDeployment.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/AppDeployment.java
@@ -22,8 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AppDeployment {
 
-    public String[] resources() default {};
+    String[] resources() default {};
 
-    public String tenantId() default "";
+    String tenantId() default "";
     
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcessEvent.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/BusinessProcessEvent.java
@@ -29,41 +29,41 @@ public interface BusinessProcessEvent {
     /**
      * @return the process definition in which the event is happening / has happened
      */
-    public ProcessDefinition getProcessDefinition();
+    ProcessDefinition getProcessDefinition();
 
     /**
      * @return the id of the activity the process is currently in / was in at the moment the event was fired.
      */
-    public String getActivityId();
+    String getActivityId();
 
     /**
      * @return the name of the transition being taken / that was taken. (null, if this event is not of type {@link BusinessProcessEventType#TAKE}
      */
-    public String getTransitionName();
+    String getTransitionName();
 
     /**
      * @return the id of the {@link ProcessInstance} this event corresponds to
      */
-    public String getProcessInstanceId();
+    String getProcessInstanceId();
 
     /**
      * @return the id of the {@link Execution} this event corresponds to
      */
-    public String getExecutionId();
+    String getExecutionId();
 
     /**
      * @return the type of the event
      */
-    public BusinessProcessEventType getType();
+    BusinessProcessEventType getType();
 
     /**
      * @return the timestamp indicating the local time at which the event was fired.
      */
-    public Date getTimeStamp();
+    Date getTimeStamp();
 
     /**
      * @return the variable scope associated with the event
      */
-    public VariableScope getVariableScope();
+    VariableScope getVariableScope();
 
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/ProcessVariable.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/ProcessVariable.java
@@ -52,6 +52,6 @@ public @interface ProcessVariable {
      * The name of the process variable to look up. Defaults to the name of the annotated field or parameter
      */
     @Nonbinding
-    public String value() default "";
+    String value() default "";
 
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/AssignTask.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/AssignTask.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface AssignTask {
     /** the id of the task that has been assigned */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/CompleteTask.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/CompleteTask.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface CompleteTask {
     /** the id of the task that has been completed */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/CreateTask.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/CreateTask.java
@@ -32,6 +32,6 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface CreateTask {
     /** the id of the task that has been created */
-    public String value();
+    String value();
 
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/DeleteTask.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/DeleteTask.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface DeleteTask {
     /** the id of the task that has been deleted */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/EndActivity.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/EndActivity.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface EndActivity {
     /** the id of the activity that is being left / was left */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/StartActivity.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/StartActivity.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface StartActivity {
     /** the id of the activity that is being entered / was entered */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/TakeTransition.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/annotation/event/TakeTransition.java
@@ -32,5 +32,5 @@ import javax.inject.Qualifier;
 @Qualifier
 public @interface TakeTransition {
     /** the id of the transition that is being taken */
-    public String value();
+    String value();
 }

--- a/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/ContextAssociationManager.java
+++ b/modules/flowable-cdi/src/main/java/org/flowable/cdi/impl/context/ContextAssociationManager.java
@@ -33,17 +33,17 @@ public interface ContextAssociationManager {
      * @throws FlowableException
      *             if no process instance is currently associated
      */
-    public void disAssociate();
+    void disAssociate();
 
     /**
      * @return the id of the execution currently associated or null
      */
-    public String getExecutionId();
+    String getExecutionId();
 
     /**
      * get the current execution
      */
-    public Execution getExecution();
+    Execution getExecution();
 
     /**
      * associate with the provided execution
@@ -53,26 +53,26 @@ public interface ContextAssociationManager {
     /**
      * set a current task
      */
-    public void setTask(Task task);
+    void setTask(Task task);
 
     /**
      * get the current task
      */
-    public Task getTask();
+    Task getTask();
 
     /**
      * set a process variable
      */
-    public void setVariable(String variableName, Object value);
+    void setVariable(String variableName, Object value);
 
     /**
      * get a process variable
      */
-    public Object getVariable(String variableName);
+    Object getVariable(String variableName);
 
     /**
      * @return a map of process variables cached between flushes
      */
-    public Map<String, Object> getCachedVariables();
+    Map<String, Object> getCachedVariables();
 
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/CmmnDeployment.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/CmmnDeployment.java
@@ -22,8 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CmmnDeployment {
 
-    public String[] resources() default {};
+    String[] resources() default {};
 
-    public String tenantId() default "";
+    String tenantId() default "";
     
 }

--- a/modules/flowable-cmmn-image-generator/src/main/java/org/flowable/cmmn/image/CaseDiagramGenerator.java
+++ b/modules/flowable-cmmn-image-generator/src/main/java/org/flowable/cmmn/image/CaseDiagramGenerator.java
@@ -38,8 +38,8 @@ public interface CaseDiagramGenerator {
      * @param customClassLoader
      *            provide a custom classloader for retrieving icon images
      */
-    public InputStream generateDiagram(CmmnModel cmmnModel, String imageType, String activityFontName, String labelFontName, 
-                    String annotationFontName, ClassLoader customClassLoader, double scaleFactor);
+    InputStream generateDiagram(CmmnModel cmmnModel, String imageType, String activityFontName, String labelFontName,
+                                String annotationFontName, ClassLoader customClassLoader, double scaleFactor);
 
     /**
      * Generates a diagram of the given process definition, using the diagram interchange information of the process.
@@ -49,21 +49,21 @@ public interface CaseDiagramGenerator {
      * @param imageType
      *            type of the image to generate.
      */
-    public InputStream generateDiagram(CmmnModel cmmnModel, String imageType);
+    InputStream generateDiagram(CmmnModel cmmnModel, String imageType);
 
-    public InputStream generateDiagram(CmmnModel cmmnModel, String imageType, double scaleFactor);
+    InputStream generateDiagram(CmmnModel cmmnModel, String imageType, double scaleFactor);
 
-    public InputStream generateDiagram(CmmnModel cmmnModel, String imageType, String activityFontName, String labelFontName,
-            String annotationFontName, ClassLoader customClassLoader);
+    InputStream generateDiagram(CmmnModel cmmnModel, String imageType, String activityFontName, String labelFontName,
+                                String annotationFontName, ClassLoader customClassLoader);
 
-    public InputStream generatePngDiagram(CmmnModel cmmnModel);
+    InputStream generatePngDiagram(CmmnModel cmmnModel);
 
-    public InputStream generatePngDiagram(CmmnModel cmmnModel, double scaleFactor);
+    InputStream generatePngDiagram(CmmnModel cmmnModel, double scaleFactor);
 
-    public InputStream generateJpgDiagram(CmmnModel cmmnModel);
+    InputStream generateJpgDiagram(CmmnModel cmmnModel);
 
-    public InputStream generateJpgDiagram(CmmnModel cmmnModel, double scaleFactor);
+    InputStream generateJpgDiagram(CmmnModel cmmnModel, double scaleFactor);
 
-    public BufferedImage generatePngImage(CmmnModel cmmnModel, double scaleFactor);
+    BufferedImage generatePngImage(CmmnModel cmmnModel, double scaleFactor);
 
 }

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/HasAssociations.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/HasAssociations.java
@@ -19,16 +19,16 @@ import java.util.List;
  */
 public interface HasAssociations {
     
-    public void addIncomingAssociation(Association association);
+    void addIncomingAssociation(Association association);
     
-    public List<Association> getIncomingAssociations();
+    List<Association> getIncomingAssociations();
     
-    public void setIncomingAssociations(List<Association> incomingAssociations);
+    void setIncomingAssociations(List<Association> incomingAssociations);
     
-    public void addOutgoingAssociation(Association association);
+    void addOutgoingAssociation(Association association);
     
-    public List<Association> getOutgoingAssociations();
+    List<Association> getOutgoingAssociations();
     
-    public void setOutgoingAssociations(List<Association> outgoingAssociations);
+    void setOutgoingAssociations(List<Association> outgoingAssociations);
 
 }

--- a/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/CheckStatus.java
+++ b/modules/flowable-crystalball/src/test/java/org/flowable/crystalball/simulator/impl/playback/CheckStatus.java
@@ -20,6 +20,6 @@ import java.lang.annotation.RetentionPolicy;
 public @interface CheckStatus {
 
     /** Specify resources that make up the process definition. */
-    public String methodName() default "";
+    String methodName() default "";
 
 }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnDeployment.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnDeployment.java
@@ -49,6 +49,6 @@ import java.lang.annotation.RetentionPolicy;
 public @interface DmnDeployment {
 
     /** Specify resources that make up the process definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
 
 }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnDeploymentAnnotation.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/DmnDeploymentAnnotation.java
@@ -49,6 +49,6 @@ import java.lang.annotation.RetentionPolicy;
 public @interface DmnDeploymentAnnotation {
 
     /** Specify resources that make up the process definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
 
 }

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/ChannelDeploymentAnnotation.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/ChannelDeploymentAnnotation.java
@@ -50,8 +50,8 @@ import java.lang.annotation.RetentionPolicy;
 public @interface ChannelDeploymentAnnotation {
 
     /** Specify resources that make up the channel definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
     
-    public String tenantId() default "";
+    String tenantId() default "";
 
 }

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/EventDeploymentAnnotation.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/EventDeploymentAnnotation.java
@@ -50,8 +50,8 @@ import java.lang.annotation.RetentionPolicy;
 public @interface EventDeploymentAnnotation {
 
     /** Specify resources that make up the event definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
     
-    public String tenantId() default "";
+    String tenantId() default "";
 
 }

--- a/modules/flowable-form-api/src/main/java/org/flowable/form/api/FormEngineConfigurationApi.java
+++ b/modules/flowable-form-api/src/main/java/org/flowable/form/api/FormEngineConfigurationApi.java
@@ -14,7 +14,7 @@ package org.flowable.form.api;
 
 public interface FormEngineConfigurationApi {
 
-    public FormManagementService getFormManagementService();
-    public FormRepositoryService getFormRepositoryService();
-    public FormService getFormService();
+    FormManagementService getFormManagementService();
+    FormRepositoryService getFormRepositoryService();
+    FormService getFormService();
 }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FormDeploymentAnnotation.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FormDeploymentAnnotation.java
@@ -50,8 +50,8 @@ import java.lang.annotation.RetentionPolicy;
 public @interface FormDeploymentAnnotation {
 
     /** Specify resources that make up the process definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
     
-    public String tenantId() default "";
+    String tenantId() default "";
 
 }

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/ManagementAgent.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/ManagementAgent.java
@@ -85,8 +85,8 @@ public interface ManagementAgent {
      */
     void setMBeanServer(MBeanServer mbeanServer);
 
-    public void findAndRegisterMbeans() throws Exception;
+    void findAndRegisterMbeans() throws Exception;
 
-    public void doStart();
+    void doStart();
 
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AsyncExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AsyncExecutor.java
@@ -69,9 +69,9 @@ public interface AsyncExecutor {
 
     void setDefaultAsyncJobAcquireWaitTimeInMillis(int waitTimeInMillis);
 
-    public int getDefaultQueueSizeFullWaitTimeInMillis();
+    int getDefaultQueueSizeFullWaitTimeInMillis();
 
-    public void setDefaultQueueSizeFullWaitTimeInMillis(int defaultQueueSizeFullWaitTimeInMillis);
+    void setDefaultQueueSizeFullWaitTimeInMillis(int defaultQueueSizeFullWaitTimeInMillis);
 
     int getMaxAsyncJobsDuePerAcquisition();
 

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/FailedJobCommandFactory.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/FailedJobCommandFactory.java
@@ -16,6 +16,6 @@ import org.flowable.common.engine.impl.interceptor.Command;
 
 public interface FailedJobCommandFactory {
 
-    public Command<Object> getCommand(String jobId, Throwable exception);
+    Command<Object> getCommand(String jobId, Throwable exception);
 
 }

--- a/modules/flowable-job-spring-service/src/main/java/org/flowable/spring/job/service/SpringRejectedJobsHandler.java
+++ b/modules/flowable-job-spring-service/src/main/java/org/flowable/spring/job/service/SpringRejectedJobsHandler.java
@@ -25,5 +25,5 @@ import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
  */
 public interface SpringRejectedJobsHandler {
 
-    public void jobRejected(AsyncExecutor asyncExecutor, JobInfo job);
+    void jobRejected(AsyncExecutor asyncExecutor, JobInfo job);
 }

--- a/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/types/VariableType.java
+++ b/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/types/VariableType.java
@@ -20,7 +20,7 @@ public interface VariableType {
     /**
      * name of variable type (limited to 100 characters length)
      */
-    public String getTypeName();
+    String getTypeName();
 
     /**
      * <p>

--- a/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/types/VariableTypes.java
+++ b/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/types/VariableTypes.java
@@ -24,25 +24,25 @@ public interface VariableTypes {
     /**
      * @return the type for the given type name. Returns null if no type was found with the name.
      */
-    public VariableType getVariableType(String typeName);
+    VariableType getVariableType(String typeName);
 
     /**
      * @return the variable type to be used to store the given value as a variable.
      * @throws org.flowable.common.engine.api.FlowableException
      *             When no available type is capable of storing the value.
      */
-    public VariableType findVariableType(Object value);
+    VariableType findVariableType(Object value);
 
-    public VariableTypes addType(VariableType type);
+    VariableTypes addType(VariableType type);
 
     /**
      * Add type at the given index. The index is used when finding a type for an object. When different types can store a specific object value, the one with the smallest index will be used.
      */
-    public VariableTypes addType(VariableType type, int index);
+    VariableTypes addType(VariableType type, int index);
 
-    public int getTypeIndex(VariableType type);
+    int getTypeIndex(VariableType type);
 
-    public int getTypeIndex(String typeName);
+    int getTypeIndex(String typeName);
 
-    public VariableTypes removeType(VariableType type);
+    VariableTypes removeType(VariableType type);
 }


### PR DESCRIPTION
Typically the redundant modifiers are `public` or `static` for interfaces or interface components. Some of the files modified already had `public` removed for some of the items; this just completes and standardizes them.
