### PR TITLE
Remove unneeded modifiers on interfaces

### DIFF
--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngine.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngine.java
@@ -25,7 +25,7 @@ import org.flowable.common.engine.impl.FlowableVersions;
 public interface AppEngine extends Engine {
     
     /** the version of the flowable CMMN library */
-    public static String VERSION = FlowableVersions.CURRENT_VERSION;
+    String VERSION = FlowableVersions.CURRENT_VERSION;
 
     AppManagementService getAppManagementService();
     

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngine.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngine.java
@@ -30,7 +30,7 @@ import org.flowable.common.engine.impl.FlowableVersions;
 public interface CmmnEngine extends Engine {
     
     /** the version of the flowable CMMN library */
-    public static String VERSION = FlowableVersions.CURRENT_VERSION;
+    String VERSION = FlowableVersions.CURRENT_VERSION;
 
     /**
      * Starts the execuctors (async and async history), if they are configured to be auto-actived.

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngine.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngine.java
@@ -21,7 +21,7 @@ public interface ContentEngine {
     /**
      * the version of the flowable content library
      */
-    public static String VERSION = FlowableVersions.CURRENT_VERSION;
+    String VERSION = FlowableVersions.CURRENT_VERSION;
 
     /**
      * The name as specified in 'content-engine-name' in the flowable.content.cfg.xml configuration file. The default name for a process engine is 'default

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngine.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngine.java
@@ -24,7 +24,7 @@ public interface DmnEngine extends Engine {
     /**
      * the version of the flowable dmn library
      */
-    public static String VERSION = FlowableVersions.CURRENT_VERSION;
+    String VERSION = FlowableVersions.CURRENT_VERSION;
 
     DmnManagementService getDmnManagementService();
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/ScriptingEngineAwareEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/ScriptingEngineAwareEngineConfiguration.java
@@ -23,7 +23,7 @@ import org.flowable.common.engine.impl.scripting.ScriptingEngines;
  */
 public interface ScriptingEngineAwareEngineConfiguration {
 
-    public ScriptingEngines getScriptingEngines();
+    ScriptingEngines getScriptingEngines();
 
-    public AbstractEngineConfiguration setScriptingEngines(ScriptingEngines scriptingEngines);
+    AbstractEngineConfiguration setScriptingEngines(ScriptingEngines scriptingEngines);
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/ListQueryParameterObject.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/ListQueryParameterObject.java
@@ -27,7 +27,7 @@ import org.flowable.common.engine.impl.Direction;
  */
 public class ListQueryParameterObject {
     
-    public static enum ResultType {
+    public enum ResultType {
         LIST, LIST_PAGE, SINGLE_RESULT, COUNT
     }
     

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/SuspensionState.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/SuspensionState.java
@@ -26,7 +26,7 @@ public interface SuspensionState {
 
     // default implementation ///////////////////////////////////////////////////
 
-    static class SuspensionStateImpl implements SuspensionState {
+    class SuspensionStateImpl implements SuspensionState {
 
         public final int stateCode;
         protected final String name;

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/de/odysseus/el/ExpressionFactoryImpl.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/de/odysseus/el/ExpressionFactoryImpl.java
@@ -82,7 +82,7 @@ public class ExpressionFactoryImpl extends ExpressionFactory {
 	 * 
 	 * @since 2.2
 	 */
-	public static enum Profile {
+	public enum Profile {
 		/**
 		 * JEE5: none
 		 */

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/de/odysseus/el/tree/impl/Builder.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/de/odysseus/el/tree/impl/Builder.java
@@ -43,7 +43,7 @@ public class Builder implements TreeBuilder {
 	/**
 	 * Feature enumeration type.
 	 */
-	public static enum Feature {
+	public enum Feature {
 		/**
 		 * Method invocations as in <code>${foo.bar(1)}</code> as specified in JSR 245,
 		 * maintenance release 2.

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/AbstractVariableComparatorExpressionFunction.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/AbstractVariableComparatorExpressionFunction.java
@@ -21,7 +21,7 @@ import org.flowable.common.engine.api.variable.VariableContainer;
  */
 public abstract class AbstractVariableComparatorExpressionFunction extends AbstractFlowableVariableExpressionFunction {
     
-    protected static enum OPERATOR { LT, LTE, GT, GTE, EQ };
+    protected enum OPERATOR { LT, LTE, GT, GTE, EQ };
 
     public AbstractVariableComparatorExpressionFunction(List<String> functionNameOptions, String functionName) {
         super(functionNameOptions, functionName);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/javax/el/ELContextListener.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/javax/el/ELContextListener.java
@@ -25,5 +25,5 @@ public interface ELContextListener extends java.util.EventListener {
 	 * @param ece
 	 *            the notification event.
 	 */
-	public void contextCreated(ELContextEvent ece);
+    void contextCreated(ELContextEvent ece);
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
@@ -22,7 +22,7 @@ public abstract class BaseNativeQuery<T extends NativeQuery<?, ?>, U> implements
 
     private static final long serialVersionUID = 1L;
 
-    protected static enum ResultType {
+    protected enum ResultType {
         LIST, LIST_PAGE, SINGLE_RESULT, COUNT
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngine.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngine.java
@@ -37,7 +37,7 @@ import org.flowable.common.engine.impl.FlowableVersions;
 public interface ProcessEngine extends Engine {
 
     /** the version of the flowable library */
-    public static String VERSION = FlowableVersions.CURRENT_VERSION;
+    String VERSION = FlowableVersions.CURRENT_VERSION;
 
     /**
      * Starts the execuctors (async and async history), if they are configured to be auto-actived.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/RepositoryService.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/RepositoryService.java
@@ -390,7 +390,7 @@ public interface RepositoryService {
     /**
      * Creates a new model. The model is transient and must be saved using {@link #saveModel(Model)}.
      */
-    public Model newModel();
+    Model newModel();
 
     /**
      * Saves the model. If the model already existed, the model is updated otherwise a new model is created.
@@ -398,13 +398,13 @@ public interface RepositoryService {
      * @param model
      *            model to save, cannot be null.
      */
-    public void saveModel(Model model);
+    void saveModel(Model model);
 
     /**
      * @param modelId
      *            id of model to delete, cannot be null. When an id is passed for a non-existent model, this operation is ignored.
      */
-    public void deleteModel(String modelId);
+    void deleteModel(String modelId);
 
     /**
      * Saves the model editor source for a model
@@ -412,7 +412,7 @@ public interface RepositoryService {
      * @param modelId
      *            id of model to delete, cannot be null. When an id is passed for a non-existent model, this operation is ignored.
      */
-    public void addModelEditorSource(String modelId, byte[] bytes);
+    void addModelEditorSource(String modelId, byte[] bytes);
 
     /**
      * Saves the model editor source extra for a model
@@ -420,10 +420,10 @@ public interface RepositoryService {
      * @param modelId
      *            id of model to delete, cannot be null. When an id is passed for an unexisting model, this operation is ignored.
      */
-    public void addModelEditorSourceExtra(String modelId, byte[] bytes);
+    void addModelEditorSourceExtra(String modelId, byte[] bytes);
 
     /** Query models. */
-    public ModelQuery createModelQuery();
+    ModelQuery createModelQuery();
 
     /**
      * Returns a new {@link org.flowable.common.engine.api.query.NativeQuery} for process definitions.
@@ -436,7 +436,7 @@ public interface RepositoryService {
      * @param modelId
      *            id of model
      */
-    public Model getModel(String modelId);
+    Model getModel(String modelId);
 
     /**
      * Returns the model editor source as a byte array
@@ -444,7 +444,7 @@ public interface RepositoryService {
      * @param modelId
      *            id of model
      */
-    public byte[] getModelEditorSource(String modelId);
+    byte[] getModelEditorSource(String modelId);
 
     /**
      * Returns the model editor source extra as a byte array
@@ -452,7 +452,7 @@ public interface RepositoryService {
      * @param modelId
      *            id of model
      */
-    public byte[] getModelEditorSourceExtra(String modelId);
+    byte[] getModelEditorSourceExtra(String modelId);
 
     /**
      * Authorizes a candidate user for a process definition.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableCancelledEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableCancelledEvent.java
@@ -20,5 +20,5 @@ public interface FlowableCancelledEvent extends FlowableEngineEvent {
     /**
      * @return the cause of the cancel event. Returns null, if no specific cause has been specified.
      */
-    public Object getCause();
+    Object getCause();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableConditionalEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableConditionalEvent.java
@@ -22,6 +22,6 @@ public interface FlowableConditionalEvent extends FlowableActivityEvent {
     /**
      * @return the condition expression of the conditional event.
      */
-    public String getConditionExpression();
+    String getConditionExpression();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableErrorEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableErrorEvent.java
@@ -24,8 +24,8 @@ public interface FlowableErrorEvent extends FlowableActivityEvent {
     /**
      * @return the error-code of the error. Returns null, if no specific error-code has been specified when the error was thrown.
      */
-    public String getErrorCode();
+    String getErrorCode();
 
-    public String getErrorId();
+    String getErrorId();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableEscalationEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableEscalationEvent.java
@@ -22,11 +22,11 @@ public interface FlowableEscalationEvent extends FlowableActivityEvent {
     /**
      * @return the code of the escalation. Returns null, if no specific escalation code has been specified.
      */
-    public String getEscalationCode();
+    String getEscalationCode();
 
     /**
      * @return the name of the escalation. Returns null, if no specific escalation name has been specified.
      */
-    public String getEscalationName();
+    String getEscalationName();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableJobRescheduledEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableJobRescheduledEvent.java
@@ -18,5 +18,5 @@ public interface FlowableJobRescheduledEvent extends FlowableEntityEvent {
     /**
      * @return the job id of the original job that was rescheduled
      */
-    public String getRescheduledJobId();
+    String getRescheduledJobId();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMessageEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMessageEvent.java
@@ -24,11 +24,11 @@ public interface FlowableMessageEvent extends FlowableActivityEvent {
     /**
      * @return the name of the message.
      */
-    public String getMessageName();
+    String getMessageName();
 
     /**
      * @return the payload that was passed when sending the message. Returns null, if no payload was passed.
      */
-    public Object getMessageData();
+    Object getMessageData();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMultiInstanceActivityCompletedEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMultiInstanceActivityCompletedEvent.java
@@ -13,9 +13,9 @@
 package org.flowable.engine.delegate.event;
 
 public interface FlowableMultiInstanceActivityCompletedEvent extends FlowableMultiInstanceActivityEvent {
-    public int getNumberOfInstances();
+    int getNumberOfInstances();
 
-    public int getNumberOfActiveInstances();
+    int getNumberOfActiveInstances();
 
-    public int getNumberOfCompletedInstances();
+    int getNumberOfCompletedInstances();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMultiInstanceActivityEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableMultiInstanceActivityEvent.java
@@ -20,5 +20,5 @@ import org.flowable.common.engine.api.delegate.event.FlowableEvent;
  * @author Robert Hafner
  */
 public interface FlowableMultiInstanceActivityEvent extends FlowableActivityEvent {
-    public boolean isSequential();
+    boolean isSequential();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessTerminatedEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessTerminatedEvent.java
@@ -23,5 +23,5 @@ public interface FlowableProcessTerminatedEvent extends FlowableEntityEvent {
     /**
      * @return the cause of the cancel event. Returns null, if no specific cause has been specified.
      */
-    public Object getCause();
+    Object getCause();
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableSignalEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableSignalEvent.java
@@ -24,11 +24,11 @@ public interface FlowableSignalEvent extends FlowableActivityEvent {
     /**
      * @return the name of the signal. Returns null, if no specific signal name has been specified when signaling.
      */
-    public String getSignalName();
+    String getSignalName();
 
     /**
      * @return the payload that was passed when signaling. Returns null, if no payload was passed.
      */
-    public Object getSignalData();
+    Object getSignalData();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ClassDelegateFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ClassDelegateFactory.java
@@ -20,8 +20,8 @@ import org.flowable.engine.impl.bpmn.parser.FieldDeclaration;
 
 /** Constructs {@link ClassDelegate}s. */
 public interface ClassDelegateFactory {
-    public ClassDelegate create(String id, String className, List<FieldDeclaration> fieldDeclarations,
-            boolean triggerable, Expression skipExpression, List<MapExceptionEntry> mapExceptions);
+    ClassDelegate create(String id, String className, List<FieldDeclaration> fieldDeclarations,
+                         boolean triggerable, Expression skipExpression, List<MapExceptionEntry> mapExceptions);
 
-    public ClassDelegate create(String className, List<FieldDeclaration> fieldDeclarations);
+    ClassDelegate create(String className, List<FieldDeclaration> fieldDeclarations);
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/ActivityBehaviorFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/ActivityBehaviorFactory.java
@@ -131,146 +131,146 @@ import org.flowable.engine.impl.delegate.ActivityBehavior;
  */
 public interface ActivityBehaviorFactory {
 
-    public abstract NoneStartEventActivityBehavior createNoneStartEventActivityBehavior(StartEvent startEvent);
+    NoneStartEventActivityBehavior createNoneStartEventActivityBehavior(StartEvent startEvent);
 
-    public abstract TaskActivityBehavior createTaskActivityBehavior(Task task);
+    TaskActivityBehavior createTaskActivityBehavior(Task task);
 
-    public abstract ManualTaskActivityBehavior createManualTaskActivityBehavior(ManualTask manualTask);
+    ManualTaskActivityBehavior createManualTaskActivityBehavior(ManualTask manualTask);
 
-    public abstract ReceiveTaskActivityBehavior createReceiveTaskActivityBehavior(ReceiveTask receiveTask);
+    ReceiveTaskActivityBehavior createReceiveTaskActivityBehavior(ReceiveTask receiveTask);
 
-    public abstract ReceiveEventTaskActivityBehavior createReceiveEventTaskActivityBehavior(ReceiveTask receiveTask, String eventDefinitionKey);
+    ReceiveEventTaskActivityBehavior createReceiveEventTaskActivityBehavior(ReceiveTask receiveTask, String eventDefinitionKey);
 
-    public abstract UserTaskActivityBehavior createUserTaskActivityBehavior(UserTask userTask);
+    UserTaskActivityBehavior createUserTaskActivityBehavior(UserTask userTask);
 
-    public abstract ClassDelegate createClassDelegateServiceTask(ServiceTask serviceTask);
+    ClassDelegate createClassDelegateServiceTask(ServiceTask serviceTask);
 
-    public abstract ServiceTaskDelegateExpressionActivityBehavior createServiceTaskDelegateExpressionActivityBehavior(ServiceTask serviceTask);
+    ServiceTaskDelegateExpressionActivityBehavior createServiceTaskDelegateExpressionActivityBehavior(ServiceTask serviceTask);
 
-    public abstract ServiceTaskExpressionActivityBehavior createServiceTaskExpressionActivityBehavior(ServiceTask serviceTask);
+    ServiceTaskExpressionActivityBehavior createServiceTaskExpressionActivityBehavior(ServiceTask serviceTask);
 
-    public abstract WebServiceActivityBehavior createWebServiceActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel);
+    WebServiceActivityBehavior createWebServiceActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel);
 
-    public abstract WebServiceActivityBehavior createWebServiceActivityBehavior(SendTask sendTask, BpmnModel bpmnModel);
+    WebServiceActivityBehavior createWebServiceActivityBehavior(SendTask sendTask, BpmnModel bpmnModel);
 
-    public abstract MailActivityBehavior createMailActivityBehavior(ServiceTask serviceTask);
+    MailActivityBehavior createMailActivityBehavior(ServiceTask serviceTask);
 
-    public abstract MailActivityBehavior createMailActivityBehavior(SendTask sendTask);
+    MailActivityBehavior createMailActivityBehavior(SendTask sendTask);
 
     // We do not want a hard dependency on the Mule module, hence we return
     // ActivityBehavior and instantiate the delegate instance using a string instead of the Class itself.
-    public abstract ActivityBehavior createMuleActivityBehavior(ServiceTask serviceTask);
+    ActivityBehavior createMuleActivityBehavior(ServiceTask serviceTask);
 
-    public abstract ActivityBehavior createMuleActivityBehavior(SendTask sendTask);
+    ActivityBehavior createMuleActivityBehavior(SendTask sendTask);
 
-    public abstract ActivityBehavior createCamelActivityBehavior(ServiceTask serviceTask);
+    ActivityBehavior createCamelActivityBehavior(ServiceTask serviceTask);
 
-    public abstract ActivityBehavior createCamelActivityBehavior(SendTask sendTask);
+    ActivityBehavior createCamelActivityBehavior(SendTask sendTask);
 
-    public abstract ActivityBehavior createDmnActivityBehavior(ServiceTask serviceTask);
+    ActivityBehavior createDmnActivityBehavior(ServiceTask serviceTask);
 
-    public abstract ActivityBehavior createDmnActivityBehavior(SendTask sendTask);
+    ActivityBehavior createDmnActivityBehavior(SendTask sendTask);
 
-    public abstract ActivityBehavior createHttpActivityBehavior(ServiceTask serviceTask);
+    ActivityBehavior createHttpActivityBehavior(ServiceTask serviceTask);
 
-    public abstract ShellActivityBehavior createShellActivityBehavior(ServiceTask serviceTask);
+    ShellActivityBehavior createShellActivityBehavior(ServiceTask serviceTask);
 
-    public abstract ActivityBehavior createBusinessRuleTaskActivityBehavior(BusinessRuleTask businessRuleTask);
+    ActivityBehavior createBusinessRuleTaskActivityBehavior(BusinessRuleTask businessRuleTask);
 
-    public abstract ScriptTaskActivityBehavior createScriptTaskActivityBehavior(ScriptTask scriptTask);
+    ScriptTaskActivityBehavior createScriptTaskActivityBehavior(ScriptTask scriptTask);
     
-    public abstract SendEventTaskActivityBehavior createSendEventTaskBehavior(SendEventServiceTask sendEventServiceTask);
+    SendEventTaskActivityBehavior createSendEventTaskBehavior(SendEventServiceTask sendEventServiceTask);
 
-    public abstract ExternalWorkerTaskActivityBehavior createExternalWorkerTaskBehavior(ExternalWorkerServiceTask externalWorkerServiceTask);
+    ExternalWorkerTaskActivityBehavior createExternalWorkerTaskBehavior(ExternalWorkerServiceTask externalWorkerServiceTask);
 
-    public abstract ExclusiveGatewayActivityBehavior createExclusiveGatewayActivityBehavior(ExclusiveGateway exclusiveGateway);
+    ExclusiveGatewayActivityBehavior createExclusiveGatewayActivityBehavior(ExclusiveGateway exclusiveGateway);
 
-    public abstract ParallelGatewayActivityBehavior createParallelGatewayActivityBehavior(ParallelGateway parallelGateway);
+    ParallelGatewayActivityBehavior createParallelGatewayActivityBehavior(ParallelGateway parallelGateway);
 
-    public abstract InclusiveGatewayActivityBehavior createInclusiveGatewayActivityBehavior(InclusiveGateway inclusiveGateway);
+    InclusiveGatewayActivityBehavior createInclusiveGatewayActivityBehavior(InclusiveGateway inclusiveGateway);
 
-    public abstract EventBasedGatewayActivityBehavior createEventBasedGatewayActivityBehavior(EventGateway eventGateway);
+    EventBasedGatewayActivityBehavior createEventBasedGatewayActivityBehavior(EventGateway eventGateway);
 
-    public abstract SequentialMultiInstanceBehavior createSequentialMultiInstanceBehavior(Activity activity, AbstractBpmnActivityBehavior innerActivityBehavior);
+    SequentialMultiInstanceBehavior createSequentialMultiInstanceBehavior(Activity activity, AbstractBpmnActivityBehavior innerActivityBehavior);
 
-    public abstract ParallelMultiInstanceBehavior createParallelMultiInstanceBehavior(Activity activity, AbstractBpmnActivityBehavior innerActivityBehavior);
+    ParallelMultiInstanceBehavior createParallelMultiInstanceBehavior(Activity activity, AbstractBpmnActivityBehavior innerActivityBehavior);
 
-    public abstract SubProcessActivityBehavior createSubprocessActivityBehavior(SubProcess subProcess);
+    SubProcessActivityBehavior createSubprocessActivityBehavior(SubProcess subProcess);
 
-    public abstract EventSubProcessActivityBehavior createEventSubprocessActivityBehavior(EventSubProcess eventSubProcess); 
+    EventSubProcessActivityBehavior createEventSubprocessActivityBehavior(EventSubProcess eventSubProcess);
     
-    public abstract EventSubProcessConditionalStartEventActivityBehavior createEventSubProcessConditionalStartEventActivityBehavior(StartEvent startEvent,
-                    ConditionalEventDefinition conditionalEventDefinition, String conditionExpression);
+    EventSubProcessConditionalStartEventActivityBehavior createEventSubProcessConditionalStartEventActivityBehavior(StartEvent startEvent,
+                                                                                                                    ConditionalEventDefinition conditionalEventDefinition, String conditionExpression);
 
-    public abstract EventSubProcessErrorStartEventActivityBehavior createEventSubProcessErrorStartEventActivityBehavior(StartEvent startEvent);
+    EventSubProcessErrorStartEventActivityBehavior createEventSubProcessErrorStartEventActivityBehavior(StartEvent startEvent);
     
-    public abstract EventSubProcessEscalationStartEventActivityBehavior createEventSubProcessEscalationStartEventActivityBehavior(StartEvent startEvent);
+    EventSubProcessEscalationStartEventActivityBehavior createEventSubProcessEscalationStartEventActivityBehavior(StartEvent startEvent);
 
-    public abstract EventSubProcessMessageStartEventActivityBehavior createEventSubProcessMessageStartEventActivityBehavior(StartEvent startEvent, MessageEventDefinition messageEventDefinition);
+    EventSubProcessMessageStartEventActivityBehavior createEventSubProcessMessageStartEventActivityBehavior(StartEvent startEvent, MessageEventDefinition messageEventDefinition);
 
-    public abstract EventSubProcessSignalStartEventActivityBehavior createEventSubProcessSignalStartEventActivityBehavior(StartEvent startEvent, SignalEventDefinition signalEventDefinition, Signal signal);
+    EventSubProcessSignalStartEventActivityBehavior createEventSubProcessSignalStartEventActivityBehavior(StartEvent startEvent, SignalEventDefinition signalEventDefinition, Signal signal);
 
-    public abstract EventSubProcessTimerStartEventActivityBehavior createEventSubProcessTimerStartEventActivityBehavior(StartEvent startEvent, TimerEventDefinition timerEventDefinition);
+    EventSubProcessTimerStartEventActivityBehavior createEventSubProcessTimerStartEventActivityBehavior(StartEvent startEvent, TimerEventDefinition timerEventDefinition);
     
-    public abstract EventSubProcessEventRegistryStartEventActivityBehavior createEventSubProcessEventRegistryStartEventActivityBehavior(StartEvent startEvent, String eventDefinitionKey);
+    EventSubProcessEventRegistryStartEventActivityBehavior createEventSubProcessEventRegistryStartEventActivityBehavior(StartEvent startEvent, String eventDefinitionKey);
 
-    public abstract AdhocSubProcessActivityBehavior createAdhocSubprocessActivityBehavior(SubProcess subProcess);
+    AdhocSubProcessActivityBehavior createAdhocSubprocessActivityBehavior(SubProcess subProcess);
 
-    public abstract CallActivityBehavior createCallActivityBehavior(CallActivity callActivity);
+    CallActivityBehavior createCallActivityBehavior(CallActivity callActivity);
     
-    public abstract CaseTaskActivityBehavior createCaseTaskBehavior(CaseServiceTask caseServiceTask);
+    CaseTaskActivityBehavior createCaseTaskBehavior(CaseServiceTask caseServiceTask);
 
-    public abstract TransactionActivityBehavior createTransactionActivityBehavior(Transaction transaction);
+    TransactionActivityBehavior createTransactionActivityBehavior(Transaction transaction);
 
-    public abstract IntermediateCatchEventActivityBehavior createIntermediateCatchEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent);
+    IntermediateCatchEventActivityBehavior createIntermediateCatchEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent);
 
-    public abstract IntermediateCatchMessageEventActivityBehavior createIntermediateCatchMessageEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent,
-            MessageEventDefinition messageEventDefinition);
+    IntermediateCatchMessageEventActivityBehavior createIntermediateCatchMessageEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent,
+                                                                                                      MessageEventDefinition messageEventDefinition);
     
-    public abstract IntermediateCatchConditionalEventActivityBehavior createIntermediateCatchConditionalEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent,
-                    ConditionalEventDefinition conditionalEventDefinition, String conditionExpression);
+    IntermediateCatchConditionalEventActivityBehavior createIntermediateCatchConditionalEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent,
+                                                                                                              ConditionalEventDefinition conditionalEventDefinition, String conditionExpression);
 
-    public abstract IntermediateCatchTimerEventActivityBehavior createIntermediateCatchTimerEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent, TimerEventDefinition timerEventDefinition);
+    IntermediateCatchTimerEventActivityBehavior createIntermediateCatchTimerEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent, TimerEventDefinition timerEventDefinition);
 
-    public abstract IntermediateCatchEventRegistryEventActivityBehavior createIntermediateCatchEventRegistryEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent, String eventDefinitionKey);
+    IntermediateCatchEventRegistryEventActivityBehavior createIntermediateCatchEventRegistryEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent, String eventDefinitionKey);
 
-    public abstract IntermediateCatchSignalEventActivityBehavior createIntermediateCatchSignalEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent,
-            SignalEventDefinition signalEventDefinition, Signal signal);
+    IntermediateCatchSignalEventActivityBehavior createIntermediateCatchSignalEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent,
+                                                                                                    SignalEventDefinition signalEventDefinition, Signal signal);
     
-    public abstract IntermediateThrowNoneEventActivityBehavior createIntermediateThrowNoneEventActivityBehavior(ThrowEvent throwEvent);
+    IntermediateThrowNoneEventActivityBehavior createIntermediateThrowNoneEventActivityBehavior(ThrowEvent throwEvent);
 
-    public abstract IntermediateThrowSignalEventActivityBehavior createIntermediateThrowSignalEventActivityBehavior(ThrowEvent throwEvent, SignalEventDefinition signalEventDefinition, Signal signal);
+    IntermediateThrowSignalEventActivityBehavior createIntermediateThrowSignalEventActivityBehavior(ThrowEvent throwEvent, SignalEventDefinition signalEventDefinition, Signal signal);
     
-    public abstract IntermediateThrowEscalationEventActivityBehavior createIntermediateThrowEscalationEventActivityBehavior(ThrowEvent throwEvent, EscalationEventDefinition escalationEventDefinition, Escalation escalation);
+    IntermediateThrowEscalationEventActivityBehavior createIntermediateThrowEscalationEventActivityBehavior(ThrowEvent throwEvent, EscalationEventDefinition escalationEventDefinition, Escalation escalation);
 
-    public abstract IntermediateThrowCompensationEventActivityBehavior createIntermediateThrowCompensationEventActivityBehavior(ThrowEvent throwEvent, CompensateEventDefinition compensateEventDefinition);
+    IntermediateThrowCompensationEventActivityBehavior createIntermediateThrowCompensationEventActivityBehavior(ThrowEvent throwEvent, CompensateEventDefinition compensateEventDefinition);
 
-    public abstract NoneEndEventActivityBehavior createNoneEndEventActivityBehavior(EndEvent endEvent);
+    NoneEndEventActivityBehavior createNoneEndEventActivityBehavior(EndEvent endEvent);
 
-    public abstract ErrorEndEventActivityBehavior createErrorEndEventActivityBehavior(EndEvent endEvent, ErrorEventDefinition errorEventDefinition);
+    ErrorEndEventActivityBehavior createErrorEndEventActivityBehavior(EndEvent endEvent, ErrorEventDefinition errorEventDefinition);
     
-    public abstract EscalationEndEventActivityBehavior createEscalationEndEventActivityBehavior(EndEvent endEvent, EscalationEventDefinition escalationEventDefinition, Escalation escalation);
+    EscalationEndEventActivityBehavior createEscalationEndEventActivityBehavior(EndEvent endEvent, EscalationEventDefinition escalationEventDefinition, Escalation escalation);
 
-    public abstract CancelEndEventActivityBehavior createCancelEndEventActivityBehavior(EndEvent endEvent);
+    CancelEndEventActivityBehavior createCancelEndEventActivityBehavior(EndEvent endEvent);
 
-    public abstract TerminateEndEventActivityBehavior createTerminateEndEventActivityBehavior(EndEvent endEvent);
+    TerminateEndEventActivityBehavior createTerminateEndEventActivityBehavior(EndEvent endEvent);
 
-    public abstract BoundaryEventActivityBehavior createBoundaryEventActivityBehavior(BoundaryEvent boundaryEvent, boolean interrupting);
+    BoundaryEventActivityBehavior createBoundaryEventActivityBehavior(BoundaryEvent boundaryEvent, boolean interrupting);
 
-    public abstract BoundaryCancelEventActivityBehavior createBoundaryCancelEventActivityBehavior(CancelEventDefinition cancelEventDefinition);
+    BoundaryCancelEventActivityBehavior createBoundaryCancelEventActivityBehavior(CancelEventDefinition cancelEventDefinition);
 
-    public abstract BoundaryTimerEventActivityBehavior createBoundaryTimerEventActivityBehavior(BoundaryEvent boundaryEvent, TimerEventDefinition timerEventDefinition, boolean interrupting);
+    BoundaryTimerEventActivityBehavior createBoundaryTimerEventActivityBehavior(BoundaryEvent boundaryEvent, TimerEventDefinition timerEventDefinition, boolean interrupting);
 
-    public abstract BoundarySignalEventActivityBehavior createBoundarySignalEventActivityBehavior(BoundaryEvent boundaryEvent, SignalEventDefinition signalEventDefinition, Signal signal, boolean interrupting);
+    BoundarySignalEventActivityBehavior createBoundarySignalEventActivityBehavior(BoundaryEvent boundaryEvent, SignalEventDefinition signalEventDefinition, Signal signal, boolean interrupting);
 
-    public abstract BoundaryMessageEventActivityBehavior createBoundaryMessageEventActivityBehavior(BoundaryEvent boundaryEvent, MessageEventDefinition messageEventDefinition, boolean interrupting);
+    BoundaryMessageEventActivityBehavior createBoundaryMessageEventActivityBehavior(BoundaryEvent boundaryEvent, MessageEventDefinition messageEventDefinition, boolean interrupting);
     
-    public abstract BoundaryConditionalEventActivityBehavior createBoundaryConditionalEventActivityBehavior(BoundaryEvent boundaryEvent, ConditionalEventDefinition conditionalEventDefinition, 
-                    String conditionExpression, boolean interrupting);
+    BoundaryConditionalEventActivityBehavior createBoundaryConditionalEventActivityBehavior(BoundaryEvent boundaryEvent, ConditionalEventDefinition conditionalEventDefinition,
+                                                                                            String conditionExpression, boolean interrupting);
     
-    public abstract BoundaryEscalationEventActivityBehavior createBoundaryEscalationEventActivityBehavior(BoundaryEvent boundaryEvent, EscalationEventDefinition escalationEventDefinition, Escalation escalation, boolean interrupting);
+    BoundaryEscalationEventActivityBehavior createBoundaryEscalationEventActivityBehavior(BoundaryEvent boundaryEvent, EscalationEventDefinition escalationEventDefinition, Escalation escalation, boolean interrupting);
 
-    public abstract BoundaryCompensateEventActivityBehavior createBoundaryCompensateEventActivityBehavior(BoundaryEvent boundaryEvent, CompensateEventDefinition compensateEventDefinition, boolean interrupting);
+    BoundaryCompensateEventActivityBehavior createBoundaryCompensateEventActivityBehavior(BoundaryEvent boundaryEvent, CompensateEventDefinition compensateEventDefinition, boolean interrupting);
     
-    public abstract BoundaryEventRegistryEventActivityBehavior createBoundaryEventRegistryEventActivityBehavior(BoundaryEvent boundaryEvent, String eventDefinitionKey, boolean interrupting);
+    BoundaryEventRegistryEventActivityBehavior createBoundaryEventRegistryEventActivityBehavior(BoundaryEvent boundaryEvent, String eventDefinitionKey, boolean interrupting);
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/XMLImporterFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/XMLImporterFactory.java
@@ -29,5 +29,5 @@ import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
  */
 public interface XMLImporterFactory {
 
-    public XMLImporter createXMLImporter(Import theImport) throws FlowableException;
+    XMLImporter createXMLImporter(Import theImport) throws FlowableException;
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/event/EventHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/event/EventHandler.java
@@ -21,8 +21,8 @@ import org.flowable.eventsubscription.service.impl.persistence.entity.EventSubsc
  */
 public interface EventHandler {
 
-    public String getEventHandlerType();
+    String getEventHandlerType();
 
-    public void handleEvent(EventSubscriptionEntity eventSubscription, Object payload, CommandContext commandContext);
+    void handleEvent(EventSubscriptionEntity eventSubscription, Object payload, CommandContext commandContext);
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/DelegateInterceptor.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/interceptor/DelegateInterceptor.java
@@ -30,6 +30,6 @@ import org.flowable.engine.impl.delegate.invocation.DelegateInvocation;
  */
 public interface DelegateInterceptor {
 
-    public void handleInvocation(DelegateInvocation invocation);
+    void handleInvocation(DelegateInvocation invocation);
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/DataObject.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/DataObject.java
@@ -21,7 +21,7 @@ public interface DataObject {
     /**
      * The unique id of this Data Object.
      */
-    public String getId();
+    String getId();
 
     /**
      /**

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/Deployment.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/Deployment.java
@@ -61,8 +61,8 @@ import java.lang.annotation.RetentionPolicy;
 public @interface Deployment {
 
     /** Specify resources that make up the process definition. */
-    public String[] resources() default {};
+    String[] resources() default {};
 
     /** Specify tenantId to deploy for */
-    public String tenantId() default "";
+    String tenantId() default "";
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTask.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTask.java
@@ -24,11 +24,11 @@ import java.lang.annotation.RetentionPolicy;
 @Repeatable(MockServiceTasks.class)
 public @interface MockServiceTask {
 
-    public String id() default "";
+    String id() default "";
 
-    public String originalClassName() default "";
+    String originalClassName() default "";
 
-    public String mockedClassName() default "";
+    String mockedClassName() default "";
 
     Class<?> mockedClass() default Void.class;
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTasks.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockServiceTasks.java
@@ -22,6 +22,6 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MockServiceTasks {
 
-    public MockServiceTask[] value();
+    MockServiceTask[] value();
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/NoOpServiceTasks.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/NoOpServiceTasks.java
@@ -22,12 +22,12 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface NoOpServiceTasks {
 
-    public String value() default "";
+    String value() default "";
 
-    public String[] ids() default {};
+    String[] ids() default {};
 
-    public Class<?>[] classes() default {};
+    Class<?>[] classes() default {};
 
-    public String[] classNames() default {};
+    String[] classNames() default {};
 
 }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/FormEngine.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/FormEngine.java
@@ -23,7 +23,7 @@ public interface FormEngine extends Engine {
     /**
      * the version of the flowable form library
      */
-    public static String VERSION = FlowableVersions.CURRENT_VERSION;
+    String VERSION = FlowableVersions.CURRENT_VERSION;
 
     FormManagementService getFormManagementService();
 

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/IdmEngine.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/IdmEngine.java
@@ -22,7 +22,7 @@ public interface IdmEngine extends Engine {
     /**
      * the version of the flowable idm library
      */
-    public static String VERSION = FlowableVersions.CURRENT_VERSION;
+    String VERSION = FlowableVersions.CURRENT_VERSION;
 
     IdmIdentityService getIdmIdentityService();
 

--- a/modules/flowable-image-generator/src/main/java/org/flowable/image/ProcessDiagramGenerator.java
+++ b/modules/flowable-image-generator/src/main/java/org/flowable/image/ProcessDiagramGenerator.java
@@ -46,8 +46,8 @@ public interface ProcessDiagramGenerator {
      * @param drawSequenceFlowNameWithNoLabelDI
      *            provide a option to also include the sequence flow name in case there's no Label DI
      */
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows,
-            String activityFontName, String labelFontName, String annotationFontName, ClassLoader customClassLoader, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows,
+                                String activityFontName, String labelFontName, String annotationFontName, ClassLoader customClassLoader, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
     /**
      * Generates a diagram of the given process definition, using the diagram interchange information of the process.
@@ -63,28 +63,28 @@ public interface ProcessDiagramGenerator {
      * @param drawSequenceFlowNameWithNoLabelDI
      *            provide a option to also include the sequence flow name in case there's no Label DI
      */
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, List<String> highLightedFlows, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, List<String> highLightedActivities, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, String activityFontName, String labelFontName,
-            String annotationFontName, ClassLoader customClassLoader,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, String activityFontName, String labelFontName,
+                                String annotationFontName, ClassLoader customClassLoader, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateDiagram(BpmnModel bpmnModel, String imageType, String activityFontName, String labelFontName,
-            String annotationFontName, ClassLoader customClassLoader, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateDiagram(BpmnModel bpmnModel, String imageType, String activityFontName, String labelFontName,
+                                String annotationFontName, ClassLoader customClassLoader, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generatePngDiagram(BpmnModel bpmnModel,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generatePngDiagram(BpmnModel bpmnModel, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generatePngDiagram(BpmnModel bpmnModel, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generatePngDiagram(BpmnModel bpmnModel, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public InputStream generateJpgDiagram(BpmnModel bpmnModel);
+    InputStream generateJpgDiagram(BpmnModel bpmnModel);
 
-    public InputStream generateJpgDiagram(BpmnModel bpmnModel, double scaleFactor,boolean drawSequenceFlowNameWithNoLabelDI);
+    InputStream generateJpgDiagram(BpmnModel bpmnModel, double scaleFactor, boolean drawSequenceFlowNameWithNoLabelDI);
 
-    public BufferedImage generatePngImage(BpmnModel bpmnModel, double scaleFactor);
+    BufferedImage generatePngImage(BpmnModel bpmnModel, double scaleFactor);
 
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/message/AsyncJobMessageHandler.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/message/AsyncJobMessageHandler.java
@@ -30,6 +30,6 @@ public interface AsyncJobMessageHandler {
      * Returning true will delete the job.
      * Returning false will unacquire the job and decrement the retries.
      */
-    public abstract boolean handleJob(JobEntity job);
+    boolean handleJob(JobEntity job);
     
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/history/async/message/AsyncHistoryJobMessageHandler.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/history/async/message/AsyncHistoryJobMessageHandler.java
@@ -30,6 +30,6 @@ public interface AsyncHistoryJobMessageHandler {
      * Returning true will delete the job.
      * Returning false will unacquire the job and decrement the retries.
      */
-    public abstract boolean handleJob(HistoryJobEntity historyJobEntity, JsonNode historyData);
+    boolean handleJob(HistoryJobEntity historyJobEntity, JsonNode historyData);
     
 }

--- a/modules/flowable-ui/flowable-ui-common/src/main/java/org/flowable/ui/common/service/idm/cache/UserCache.java
+++ b/modules/flowable-ui/flowable-ui-common/src/main/java/org/flowable/ui/common/service/idm/cache/UserCache.java
@@ -32,7 +32,7 @@ public interface UserCache {
 
     void invalidate(String userId);
 
-    public static class CachedUser {
+    class CachedUser {
 
         private Collection<GrantedAuthority> grantedAuthorities;
 

--- a/modules/flowable-ui/flowable-ui-common/src/main/java/org/flowable/ui/common/tenant/TenantProvider.java
+++ b/modules/flowable-ui/flowable-ui-common/src/main/java/org/flowable/ui/common/tenant/TenantProvider.java
@@ -14,5 +14,5 @@ package org.flowable.ui.common.tenant;
 
 
 public interface TenantProvider {
-    public String getTenantId();
+    String getTenantId();
 }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/CacheableVariable.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/CacheableVariable.java
@@ -21,5 +21,5 @@ package org.flowable.variable.service.impl.types;
  */
 public interface CacheableVariable {
 
-    public void setForceCacheable(boolean forceCachedValue);
+    void setForceCacheable(boolean forceCachedValue);
 }


### PR DESCRIPTION
Typically the redundant modifiers are public or static for interfaces or interface components. Some of the files modified already had public removed for some of the items; this just completes and standardizes them.

This is part two of [PR 2515](https://github.com/flowable/flowable-engine/pull/2515).
