### PR TITLE
Use helper method completeTask()

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/DeleteReasonTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/DeleteReasonTest.java
@@ -39,7 +39,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("deleteReasonProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("A");
-        taskService.complete(task.getId());
+        completeTask(task);
         runtimeService.deleteProcessInstance(processInstance.getId(), null);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -70,7 +70,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("deleteReasonProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("A");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Delete process instance with custom delete reason
         String customDeleteReason = "custom delete reason";
@@ -106,7 +106,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         while (!tasks.isEmpty()) {
             for (org.flowable.task.api.Task task : tasks) {
-                taskService.complete(task.getId());
+                completeTask(task);
             }
             tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         }
@@ -179,7 +179,7 @@ public class DeleteReasonTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("deleteReasonProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("A");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Timer firing should delete all tasks
         Job timerJob = managementService.createTimerJobQuery().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
@@ -127,7 +127,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Subprocess execution is created
         Execution execution = runtimeService.createExecutionQuery().parentId(processInstance.getId()).singleResult();
@@ -173,7 +173,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task subTask = taskService.createTaskQuery().processInstanceId(processInstance.getProcessInstanceId()).singleResult();
         assertThat(subTask).isNotNull();
 
-        taskService.complete(subTask.getId());
+        completeTask(subTask);
 
         assertThat(listener.getEventsReceived()).hasSize(10);
 
@@ -291,7 +291,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
 
         Execution executionWithSignalEvent = runtimeService.createExecutionQuery().activityId("shipOrder").singleResult();
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(listener.getEventsReceived()).hasSize(2);
 
         assertThat(listener.getEventsReceived().get(0)).isInstanceOf(FlowableSignalEvent.class);
@@ -414,7 +414,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("Wait");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Only a message events should be present, no signal-event, since the event-subprocess is
         // not signaled, but executed instead
@@ -458,7 +458,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertThat(task).isNotNull();
 
         // Complete task, next a compensation event will be thrown
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(listener.getEventsReceived()).hasSize(1);
 
@@ -705,7 +705,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("User Task");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(listener.getEventsReceived()).hasSize(2);
 
@@ -812,7 +812,7 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertThat(executionWithMessage).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(listener.getEventsReceived()).hasSize(2);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
@@ -116,7 +116,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertThat(runtimeService.getVariable(subprocessInstance.getId(), "FullName")).isEqualTo("Mary Smith");
 
         // complete user task so that external subprocess will flow to terminate end
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -126,7 +126,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Mary Smith");
 
         // complete user task so that parent process will terminate normally
-        taskService.complete(task.getId());
+        completeTask(task);
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(0);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
@@ -423,7 +423,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertThat(runtimeService.getVariable(subprocessInstance.getId(), "FullName")).isEqualTo("Mary Smith");
 
         // complete user task so that external subprocess will flow to terminate end
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
@@ -433,7 +433,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertThat(runtimeService.getVariable(processInstance.getId(), "Name")).isEqualTo("Mary Smith");
 
         // complete user task so that parent process will terminate normally
-        taskService.complete(task.getId());
+        completeTask(task);
 
         FlowableEntityEvent entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(0);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
@@ -720,15 +720,15 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("One");
 
         // Completing the task should trigger the event subprocess
-        taskService.complete(task.getId());
+        completeTask(task);
         Task subOneTask = taskService.createTaskQuery().taskName("sub one").singleResult();
         assertThat(subOneTask).isNotNull();
-        taskService.complete(subOneTask.getId());
+        completeTask(subOneTask);
 
         // Complete the last task
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("Two");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -743,10 +743,10 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("One");
 
         // Completing the task should trigger the event subprocess. This interupts the main flow.
-        taskService.complete(task.getId());
+        completeTask(task);
         Task subOneTask = taskService.createTaskQuery().taskName("sub one").singleResult();
         assertThat(subOneTask).isNotNull();
-        taskService.complete(subOneTask.getId());
+        completeTask(subOneTask);
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelUserTaskTest.java
@@ -115,7 +115,7 @@ public class CancelUserTaskTest extends PluggableFlowableTestCase {
         assertThat(userTask1).isNotNull();
 
         // complete task1 so we flow to terminate end
-        taskService.complete(userTask1.getId());
+        completeTask(userTask1);
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/JobEventsTest.java
@@ -324,7 +324,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         checkEventCount(1, FlowableEngineEventType.JOB_CANCELED);
     }
@@ -568,7 +568,7 @@ public class JobEventsTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("Outside Task");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/MultiInstanceUserTaskEventsTest.java
@@ -152,7 +152,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertThat(userTask1).isNotNull();
 
         // complete task1 so we flow to terminate end
-        taskService.complete(userTask1.getId());
+        completeTask(userTask1);
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
@@ -290,7 +290,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(2);
         org.flowable.task.api.Task task0 = tasks.get(0);
 
-        taskService.complete(task0.getId());
+        completeTask(task0);
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
@@ -397,7 +397,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         multiExecutions = runtimeService.createExecutionQuery().activityId("task").list();
         assertThat(multiExecutions).hasSize(2);
 
-        taskService.complete(task0.getId());
+        completeTask(task0);
 
         multiExecutions = runtimeService.createExecutionQuery().activityId("task").list();
         assertThat(multiExecutions).hasSize(1);
@@ -410,7 +410,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         taskEntity = (TaskEntity) entityEvent.getEntity();
         assertThat(taskEntity.getId()).isEqualTo(task0.getId());
 
-        taskService.complete(task1.getId());
+        completeTask(task1);
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
@@ -819,7 +819,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertThat(userTask1.getName()).isEqualTo("User Task1 in Parent");
 
         // complete task1 in parent so we flow to terminate end
-        taskService.complete(userTask1.getId());
+        completeTask(userTask1);
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
@@ -982,7 +982,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
         assertThat(userTask1).isNotNull();
 
         // complete task1 so we flow to terminate end
-        taskService.complete(userTask1.getId());
+        completeTask(userTask1);
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
@@ -1089,7 +1089,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
                 .extracting(Task::getName)
                 .containsExactly("Task A-0");
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         entityEvent = (FlowableEntityEvent) testListener.getEventsReceived().get(idx++);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
@@ -1106,7 +1106,7 @@ public class MultiInstanceUserTaskEventsTest extends PluggableFlowableTestCase {
                 .extracting(Task::getName)
                 .containsExactly("Task A-1");
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processId).list()).isEmpty();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -368,7 +368,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
     public void testProcessCompleted_NoEnd() throws Exception {
         ProcessInstance noEndProcess = this.runtimeService.startProcessInstanceByKey("noEndProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(noEndProcess.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED)).as("ActivitiEventType.PROCESS_COMPLETED was expected 1 time.").hasSize(1);
     }
@@ -492,7 +492,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<FlowableEvent> processCancelledEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
         assertThat(processCancelledEvents).as("There should be no FlowableEventType.PROCESS_CANCELLED event after process complete.").isEmpty();
@@ -508,7 +508,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(processInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_CANCELLED);
         assertThat(processTerminatedEvents).as("There should be no FlowableEventType.PROCESS_TERMINATED event after process complete.").isEmpty();
@@ -523,7 +523,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isEqualTo(3);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
         assertThat(processTerminatedEvents)
@@ -559,7 +559,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
@@ -578,7 +578,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventWithBoundary");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTermInnerTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
@@ -598,7 +598,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         // should terminate the called process and continue the parent
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         List<FlowableEvent> processTerminatedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_TERMINATE_END_EVENT);
@@ -656,7 +656,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
 
         // Completing the task will reach the end error event,
         // which is caught on the call activity boundary
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<FlowableEvent> processCompletedEvents = listener.filterEvents(FlowableEngineEventType.PROCESS_COMPLETED_WITH_ERROR_END_EVENT);
         assertThat(processCompletedEvents)
@@ -669,7 +669,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(pi.getId());
     }
 
@@ -760,7 +760,7 @@ public class ProcessInstanceEventsTest extends PluggableFlowableTestCase {
         // with the user task, boundary event and intermediate catch event defined in or
         // on subprocess1.
         assertThat(task2).isNotNull();
-        taskService.complete(task2.getId());
+        completeTask(task2);
 
         // Subprocess2 completed and transitioned to terminate end. We expect
         // ACTIVITY_CANCELLED for Subprocess1, task1 defined in subprocess1, boundary event defined on

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TaskEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TaskEventsTest.java
@@ -126,7 +126,7 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
         listener.clearEventsReceived();
 
         // Check delete-event on complete
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(listener.getEventsReceived()).hasSize(2);
         event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);
@@ -387,7 +387,7 @@ public class TaskEventsTest extends PluggableFlowableTestCase {
             listener.clearEventsReceived();
 
             // Complete task
-            taskService.complete(task.getId());
+            completeTask(task);
             assertThat(listener.getEventsReceived()).hasSize(2);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);
             assertThat(event.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
@@ -126,7 +126,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
                 .containsExactly(FlowableEngineEventType.VARIABLE_CREATED);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(listener.getEventsReceived()).hasSize(2);
         assertThat(listener.getEventsReceived().get(1).getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -61,7 +61,7 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableFlowa
             processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, String.valueOf(i), startMap).getId());
             if (i == 0) {
                 org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstanceIds.get(0)).singleResult();
-                taskService.complete(task.getId());
+                completeTask(task);
             }
         }
         startMap.clear();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
@@ -35,7 +35,7 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("historicProcessLocalization");
         String processInstanceId = processInstance.getId();
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricProcessInstance> processes = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).list();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
@@ -446,7 +446,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
             assertThat(tasks).hasSize(1);
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-            taskService.complete(task.getId());
+            completeTask(task);
 
             assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
@@ -731,7 +731,7 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableFlowableTestCase
     public void testQueryVariableExistsForCompletedTasks() {
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             taskService.createTaskQuery().list().forEach(
-                    task -> taskService.complete(task.getId())
+                    task -> completeTask(task)
             );
             testQueryVariableExists();
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryLevelServiceTest.java
@@ -56,7 +56,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
         taskService.setDueDate(task.getId(), new Date());
         taskService.setVariable(task.getId(), "var1", "test");
         taskService.setVariableLocal(task.getId(), "localVar1", "test2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
@@ -90,7 +90,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
         taskService.setDueDate(task.getId(), dueDateValue);
         taskService.setVariable(task.getId(), "var1", "test");
         taskService.setVariableLocal(task.getId(), "localVar1", "test2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
@@ -139,7 +139,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
         taskService.setDueDate(task.getId(), dueDateCalendar.getTime());
         taskService.setVariable(task.getId(), "var1", "test");
         taskService.setVariableLocal(task.getId(), "localVar1", "test2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
@@ -196,7 +196,7 @@ public class HistoryLevelServiceTest extends PluggableFlowableTestCase {
         taskService.setDueDate(task.getId(), dueDateValue);
         taskService.setVariable(task.getId(), "var1", "test");
         taskService.setVariableLocal(task.getId(), "localVar1", "test2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -71,7 +71,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         // Complete the task and check if the size is count 1
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
@@ -87,7 +87,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
@@ -122,7 +122,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 
@@ -970,7 +970,7 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 7000, 200);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/NonCascadeDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/NonCascadeDeleteTest.java
@@ -37,7 +37,7 @@ public class NonCascadeDeleteTest extends PluggableFlowableTestCase {
 
         processInstanceId = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY).getId();
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/ProcessInstanceLogQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/ProcessInstanceLogQueryTest.java
@@ -63,7 +63,7 @@ public class ProcessInstanceLogQueryTest extends PluggableFlowableTestCase {
 
         // Finish tasks
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdmTransactionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdmTransactionsTest.java
@@ -59,7 +59,7 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("testProcess");
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(identityService.createUserQuery().list()).hasSize(1);
 
     }
@@ -75,7 +75,7 @@ public class IdmTransactionsTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
 
         // Completing the task throws an exception
-        assertThatThrownBy(() -> taskService.complete(task.getId()));
+        assertThatThrownBy(() -> completeTask(task));
 
         // Should have rolled back to task
         assertThat(taskService.createTaskQuery().singleResult()).isNotNull();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/ProcessInstanceIdentityLinkTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/ProcessInstanceIdentityLinkTest.java
@@ -34,11 +34,11 @@ public class ProcessInstanceIdentityLinkTest extends PluggableFlowableTestCase {
         // There are two tasks
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         identityService.setAuthenticatedUserId("kermit");
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         identityService.setAuthenticatedUserId(null);
 
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
@@ -166,7 +166,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
         repositoryService.suspendProcessDefinitionById(processDefinition.getId());
 
         // Process should be able to continue
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
@@ -195,7 +195,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
 
         // Verify all process instances can't be continued
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
-            assertThatThrownBy(() -> taskService.complete(task.getId()))
+            assertThatThrownBy(() -> completeTask(task))
                     .as("A suspended task shouldn't be able to be continued")
                     .isInstanceOf(FlowableException.class);
         }
@@ -208,7 +208,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableFlowableTestCase {
 
         // Verify that all process instances can be completed
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
         assertThat(runtimeService.createProcessInstanceQuery().suspended().count()).isZero();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/InstanceInvolvementTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/InstanceInvolvementTest.java
@@ -79,7 +79,7 @@ public class InstanceInvolvementTest extends PluggableFlowableTestCase {
 
         // "user2" should still be involved with the new process instance even
         // after completing his task
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertInvolvement("user2", instanceId);
 
         // "user3" should be involved after completing a task even without

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
@@ -169,7 +169,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
 
         // Completing should end the process instance
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
@@ -194,7 +194,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         // Finish process
         while (taskService.createTaskQuery().count() > 0) {
             for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
-                taskService.complete(task.getId());
+                completeTask(task);
             }
         }
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
@@ -352,7 +352,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
         // to create separate tests for each of them.
 
         // Completing the task should fail
-        assertThatThrownBy(() -> taskService.complete(task.getId()))
+        assertThatThrownBy(() -> completeTask(task))
                 .as("It is not allowed to complete a task of a suspended process instance")
                 .isExactlyInstanceOf(FlowableException.class);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeActivityInstanceTest.java
@@ -330,7 +330,7 @@ public class RuntimeActivityInstanceTest extends PluggableFlowableTestCase {
         // Complete the task with the boundary-event on it
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
@@ -389,8 +389,8 @@ public class RuntimeActivityInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasksToComplete).hasSize(2);
 
         // Complete both tasks, second task-complete should end the fork-gateway and set time
-        taskService.complete(tasksToComplete.get(0).getId());
-        taskService.complete(tasksToComplete.get(1).getId());
+        completeTask(tasksToComplete.get(0));
+        completeTask(tasksToComplete.get(1));
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
@@ -491,7 +491,7 @@ public class RuntimeActivityInstanceTest extends PluggableFlowableTestCase {
         taskService.claim(task.getId(), "newAssignee");
 
         assertThatActivityInstancesAreSame("theTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -517,7 +517,7 @@ public class RuntimeActivityInstanceTest extends PluggableFlowableTestCase {
                     .isEqualTo(1);
         }
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
@@ -509,7 +509,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
                 parallelUserTask = task;
             }
         }
-        taskService.complete(parallelUserTask.getId());
+        completeTask(parallelUserTask);
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subprocess1WaitBeforeError")
                 .singleResult();
@@ -529,7 +529,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
                 beforeErrorUserTask = task;
             }
         }
-        taskService.complete(beforeErrorUserTask.getId());
+        completeTask(beforeErrorUserTask);
 
         activeActivities = runtimeService.getActiveActivityIds(processInstance.getId());
         assertThat(activeActivities).hasSize(2);
@@ -545,7 +545,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
                 afterErrorUserTask = task;
             }
         }
-        taskService.complete(afterErrorUserTask.getId());
+        completeTask(afterErrorUserTask);
 
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks)
@@ -556,7 +556,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         assertThat(activeActivities)
                 .containsOnly("MainUserTask");
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
@@ -59,7 +59,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
         assertThat(subProcessInstance).isNotNull();
@@ -81,7 +81,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(1);
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -92,14 +92,14 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
         assertThat(subProcessInstance).isNotNull();
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -118,7 +118,7 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(1);
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -146,14 +146,14 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -226,14 +226,14 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
                         tuple(processInstance.getId(), ScopeTypes.BPMN)
                 );
 
-        taskService.complete(firstSecondTask.getId());
+        completeTask(firstSecondTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         Task secondTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(secondTask.getTaskDefinitionKey()).isEqualTo("secondTask");
 
-        taskService.complete(secondTask.getId());
+        completeTask(secondTask);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -276,14 +276,14 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -333,14 +333,14 @@ public class ChangeStateForCallActivityTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
@@ -87,7 +87,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
-            taskService.complete(task1.get().getId());
+            completeTask(task1.get());
         }
 
         // Verify events
@@ -121,11 +121,11 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
 
         assertThat(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive()).isFalse();
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -137,7 +137,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -182,7 +182,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(1);
 
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -196,7 +196,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -217,7 +217,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -230,7 +230,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -243,7 +243,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete task1
         for (Task t : tasks) {
             if (t.getTaskDefinitionKey().equals("task1")) {
-                taskService.complete(t.getId());
+                completeTask(t);
             }
         }
 
@@ -266,7 +266,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -279,7 +279,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -301,7 +301,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(1);
@@ -309,7 +309,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -322,7 +322,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -333,7 +333,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
-            taskService.complete(task1.get().getId());
+            completeTask(task1.get());
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -357,7 +357,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -393,7 +393,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
-            taskService.complete(task1.get().getId());
+            completeTask(task1.get());
         }
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
@@ -407,11 +407,11 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
 
         assertThat(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive()).isFalse();
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -423,7 +423,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -444,7 +444,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(1);
 
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -458,7 +458,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -480,7 +480,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -493,7 +493,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -506,7 +506,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete task1
         for (Task t : tasks) {
             if (t.getTaskDefinitionKey().equals("task1")) {
-                taskService.complete(t.getId());
+                completeTask(t);
             }
         }
 
@@ -530,7 +530,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -543,7 +543,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -565,7 +565,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(1);
@@ -573,7 +573,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -586,7 +586,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -597,7 +597,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
-            taskService.complete(task1.get().getId());
+            completeTask(task1.get());
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -622,7 +622,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -655,7 +655,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
-            taskService.complete(task1.get().getId());
+            completeTask(task1.get());
         }
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
@@ -669,11 +669,11 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
 
         assertThat(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive()).isFalse();
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -685,7 +685,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -709,7 +709,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
 
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -723,7 +723,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -744,7 +744,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -757,7 +757,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -770,7 +770,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete task1
         for (Task t : tasks) {
             if (t.getTaskDefinitionKey().equals("task1")) {
-                taskService.complete(t.getId());
+                completeTask(t);
             }
         }
 
@@ -793,7 +793,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -806,7 +806,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -829,7 +829,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
 
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(1);
@@ -837,7 +837,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -850,7 +850,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -861,7 +861,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
-            taskService.complete(task1.get().getId());
+            completeTask(task1.get());
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -885,7 +885,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -918,7 +918,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
-            taskService.complete(task1.get().getId());
+            completeTask(task1.get());
         }
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
@@ -932,11 +932,11 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
 
         assertThat(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive()).isFalse();
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -948,7 +948,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -969,7 +969,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(1);
 
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -983,7 +983,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -1005,7 +1005,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1018,7 +1018,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -1031,7 +1031,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete task1
         for (Task t : tasks) {
             if (t.getTaskDefinitionKey().equals("task1")) {
-                taskService.complete(t.getId());
+                completeTask(t);
             }
         }
 
@@ -1055,7 +1055,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1068,7 +1068,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -1090,7 +1090,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(1);
@@ -1098,7 +1098,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1111,7 +1111,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -1122,7 +1122,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         //Complete task1
         Optional<Task> task1 = tasks.stream().filter(t -> t.getTaskDefinitionKey().equals("task1")).findFirst();
         if (task1.isPresent()) {
-            taskService.complete(task1.get().getId());
+            completeTask(task1.get());
         }
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -1146,7 +1146,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1174,7 +1174,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Optional<Execution> parallelJoinExecution = executions.stream().filter(e -> e.getActivityId().equals("parallelJoin")).findFirst();
         assertThat(parallelJoinExecution).isNotPresent();
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(1);
@@ -1186,11 +1186,11 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(parallelJoinExecution).isPresent();
         assertThat(((ExecutionEntity) parallelJoinExecution.get()).isActive()).isFalse();
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1202,7 +1202,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -1224,7 +1224,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(1);
 
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1236,7 +1236,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -1264,7 +1264,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(subProcessExecution).isNotNull();
         assertThat(runtimeService.getVariableLocal(subProcessExecutionId, "subProcessVar")).isEqualTo("test");
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(1);
@@ -1272,11 +1272,11 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(3);
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1307,13 +1307,13 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(parallelJoinExecution).isNotPresent();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(3);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
@@ -1326,7 +1326,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(((ExecutionEntity) parallelJoinExecution.get()).isActive()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
@@ -1335,11 +1335,11 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1353,14 +1353,14 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive1").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(3);
@@ -1387,7 +1387,7 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1401,14 +1401,14 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive1").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(3);
@@ -1433,10 +1433,10 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(2);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(5);
@@ -1446,17 +1446,17 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(((ExecutionEntity) inclusiveJoinExecution.get()).isActive()).isFalse();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
@@ -93,7 +93,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
                 .containsExactly("seqTasks");
         assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isEqualTo(0);
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         //Second in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -115,9 +115,9 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isEqualTo(1);
 
         //Complete second and third
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         //After the MI
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -135,7 +135,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         //Complete the process
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -157,7 +157,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Second in the loop
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -174,7 +174,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -197,7 +197,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Second in the loop
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -215,7 +215,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -264,7 +264,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //        assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isNotNull()
 
         //Complete one execution
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         //Confirm new state
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -306,7 +306,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
 
         //Complete the process
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -325,7 +325,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(activeParallelTasks).hasSize(3);
 
         //Complete one of the tasks
-        taskService.complete(activeParallelTasks.get(1).getId());
+        completeTask(activeParallelTasks.get(1));
         parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(parallelExecutions).hasSize(4);
         activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
@@ -340,7 +340,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(parallelExecutions).hasSize(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -360,7 +360,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(activeParallelTasks).hasSize(3);
 
         //Complete one of the tasks
-        taskService.complete(activeParallelTasks.get(1).getId());
+        completeTask(activeParallelTasks.get(1));
         parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(parallelExecutions).hasSize(4);
         activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
@@ -376,7 +376,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(parallelExecutions).hasSize(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -412,7 +412,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //Complete one of the parallel subProcesses "subTask2"
         Task task = taskService.createTaskQuery().executionId(subTask2Executions.get(0).getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(executionsCount).isEqualTo(5);
@@ -440,7 +440,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete the rest of the SubProcesses
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
         assertThat(tasks).hasSize(2);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         //There's no multiInstance anymore
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
@@ -448,7 +448,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().active().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -486,7 +486,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete the parallel subProcesses "subTask2"
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         //There's no multiInstance anymore
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
@@ -494,7 +494,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         Task task = taskService.createTaskQuery().active().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -514,7 +514,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Start the nested subProcesses by completing the first task of the outer subProcess
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
         // 9 nestedSubProcess instances and 3 outerSubProcesses instances -> 12 executions
@@ -549,7 +549,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //Complete one of the outer subProcesses
         Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //One less task execution and one less nested instance
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
@@ -582,7 +582,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete all the nestedSubTask2
         tasks = taskService.createTaskQuery().taskDefinitionKey("nestedSubTask2").list();
         assertThat(tasks).hasSize(8);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         //Nested subProcesses have completed, only outer subProcess remain
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
@@ -595,14 +595,14 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete the outer subProcesses
         tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(totalChildExecutions).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -622,7 +622,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Start the nested subProcesses by completing the first task of the outer subProcess
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
         // 9 nestedSubProcess instances and 3 outerSubProcesses instances -> 12 executions
@@ -673,7 +673,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete all the nestedSubTask2
         tasks = taskService.createTaskQuery().taskDefinitionKey("nestedSubTask2").list();
         assertThat(tasks).hasSize(9);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         //Nested subProcesses have completed, only outer subProcess remain
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
@@ -686,14 +686,14 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete the outer subProcesses
         tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(totalChildExecutions).isEqualTo(1);
 
         Task task = taskService.createTaskQuery().active().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -715,7 +715,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //Complete one of the Tasks
         Task task = taskService.createTaskQuery().executionId(subTask1Executions.get(1).getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(executionsCount).isEqualTo(7);
@@ -746,7 +746,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().active().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -768,7 +768,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //Complete one of the Tasks
         Task task = taskService.createTaskQuery().executionId(subTask1Executions.get(1).getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(executionsCount).isEqualTo(7);
@@ -791,7 +791,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().active().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -811,7 +811,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Start the nested subProcesses by completing the first task of the outer subProcess
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
         // 9 nestedSubProcess instances and 3 outerSubProcesses instances -> 12 executions
@@ -844,7 +844,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //Complete one of the nested subProcesses
         Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //One less task execution and one less nested instance
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
@@ -884,14 +884,14 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete the outer subProcesses
         tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(totalChildExecutions).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -911,7 +911,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Start the nested subProcesses by completing the first task of the outer subProcess
         List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
         // 9 nestedSubProcess instances and 3 outerSubProcesses instances -> 12 executions
@@ -944,7 +944,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
 
         //Complete one of the nested subProcesses
         Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //One less task execution and one less nested instance
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
@@ -975,14 +975,14 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete the outer subProcesses
         tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
         assertThat(tasks).hasSize(3);
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(totalChildExecutions).isEqualTo(1);
 
         task = taskService.createTaskQuery().active().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1041,7 +1041,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Complete one of the tasks
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(totalChildExecutions).isEqualTo(5);
@@ -1054,14 +1054,14 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the rest since we cannot move out of a multiInstance subProcess
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(totalChildExecutions).isEqualTo(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1120,7 +1120,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Complete one of the tasks
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(totalChildExecutions).isEqualTo(5);
@@ -1133,14 +1133,14 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the rest since we cannot move out of a multiInstance subProcess
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
         assertThat(totalChildExecutions).isEqualTo(1);
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1187,7 +1187,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the remaining subProcesses tasks
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         //Only one execution and task remaining
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -1197,7 +1197,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Complete the process
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1293,7 +1293,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         //Complete remaining task3, the next inline test needs the task to be completed too
         for (Task t : tasks) {
             if (t.getTaskDefinitionKey().equals("taskInclusive3")) {
-                taskService.complete(t.getId());
+                completeTask(t);
             }
         }
 
@@ -1334,7 +1334,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
 
         //Finish the remaining subProcesses tasks
-        tasks.forEach(t -> taskService.complete(t.getId()));
+        tasks.forEach(t -> completeTask(t));
 
         //Only one execution and task remaining
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -1344,7 +1344,7 @@ public class ChangeStateForMultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Complete the process
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
@@ -62,7 +62,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityBackwardForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -92,11 +92,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -106,7 +106,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionBackwardForSimpleProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -135,11 +135,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -175,7 +175,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -210,7 +210,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -264,7 +264,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -314,7 +314,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -328,7 +328,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(timerJob).isNotNull();
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -371,11 +371,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -389,7 +389,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(timerJob).isNotNull();
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
@@ -431,11 +431,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -499,7 +499,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("thirdTask");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -509,7 +509,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityOutOfSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -547,15 +547,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -565,7 +565,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionOutOfSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -602,15 +602,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -662,11 +662,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -717,11 +717,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -780,11 +780,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -843,11 +843,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -857,7 +857,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityOutOfSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -907,7 +907,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -915,11 +915,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -929,7 +929,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionOutOfSubProcessWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -978,7 +978,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -986,11 +986,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1044,11 +1044,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1101,11 +1101,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1167,7 +1167,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityOutOfSubProcessTaskWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -1213,11 +1213,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1227,7 +1227,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionOutOfSubProcessTaskWithTimer() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -1272,11 +1272,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1328,15 +1328,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(4);
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1389,15 +1389,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1455,7 +1455,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1503,15 +1503,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1571,15 +1571,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1626,15 +1626,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1693,15 +1693,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1711,7 +1711,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityIntoNestedSubProcessExecutionFromOuter() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
@@ -1747,15 +1747,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1765,7 +1765,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityIntoNestedSubProcessExecutionFromOuterWithDataObject() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
@@ -1813,15 +1813,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1831,7 +1831,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionIntoNestedSubProcessExecutionFromOuter() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
@@ -1866,15 +1866,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1884,7 +1884,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionIntoNestedSubProcessExecutionFromOuterWithDataObject() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
 
@@ -1934,15 +1934,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1952,11 +1952,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityOutOfNestedSubProcessExecution() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
@@ -1994,11 +1994,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2008,11 +2008,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionOutOfNestedSubProcessExecution() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
@@ -2049,11 +2049,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2063,11 +2063,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityOutOfNestedSubProcessExecutionIntoContainingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
@@ -2104,19 +2104,19 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2126,11 +2126,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionOutOfNestedSubProcessExecutionIntoContainingSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
@@ -2166,19 +2166,19 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2188,7 +2188,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityFromSubProcessToAnotherSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoSubProcesses");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask");
@@ -2231,11 +2231,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2245,7 +2245,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionFromSubProcessToAnotherSubProcess() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoSubProcesses");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask");
@@ -2287,11 +2287,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
 
         assertThat(iterator.hasNext()).isFalse();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2301,7 +2301,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentActivityForSubProcessWithVariables() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -2369,15 +2369,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
                         "taskBefore"
                 );
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2387,7 +2387,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
     public void testSetCurrentExecutionForSubProcessWithVariables() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
@@ -2454,15 +2454,15 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
                         "taskBefore"
                 );
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2491,11 +2491,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(nameDataObject).isNotNull();
         assertThat(nameDataObject.getValue()).isEqualTo("John");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2525,11 +2525,11 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(nameDataObject).isNotNull();
         assertThat(nameDataObject.getValue()).isEqualTo("Joe");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -2581,7 +2581,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
 
     }
@@ -2633,7 +2633,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
 
     }
@@ -2648,7 +2648,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
 
         //Complete initial task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Process is waiting for event invocation
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -2681,7 +2681,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the task once more
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         //Process is waiting for signal again
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -2714,7 +2714,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -2728,7 +2728,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
 
         //Complete initial task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Process is waiting for event invocation
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -2760,7 +2760,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the task once more
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         //Process is waiting for signal again
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -2792,7 +2792,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -2845,7 +2845,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
 
     }
@@ -2898,7 +2898,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
 
     }
@@ -2913,7 +2913,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
 
         //Complete initial task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Process is waiting for event invocation
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -2946,7 +2946,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the task once more
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         //Process is waiting for signal again
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -2979,7 +2979,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -2993,7 +2993,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
 
         //Complete initial task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Process is waiting for event invocation
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -3025,7 +3025,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the task once more
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         //Process is waiting for signal again
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -3057,7 +3057,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
         assertThat(eventSubscriptions).isEmpty();
 
         //Complete the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationBatchTest.java
@@ -307,7 +307,7 @@ public class ProcessInstanceMigrationBatchTest extends PluggableFlowableTestCase
         // Set the instances to fail in a state where they won't map properly during validation and migration
         for (String processInstanceId : failedInstances) {
             Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         // Deploy second version of the process

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationMultiInstanceTest.java
@@ -103,7 +103,7 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
 
         //Complete one instance...
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Next instance in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -125,9 +125,9 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         //Complete this and the last
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Out of the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -216,7 +216,7 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         assertThat(tasks).extracting(aTask -> taskService.getVariable(aTask.getId(), "loopCounter")).isNotNull();
 
         //Complete one instance...
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
 
         //Next instance in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -580,7 +580,7 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         assertThat(tasks).extracting(aTask -> taskService.getVariable(aTask.getId(), "loopCounter")).isNotNull();
 
         //Complete one instance...
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
 
         //Next instance in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -744,7 +744,7 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
 
         //Complete one instance...
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Next instance in the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -766,9 +766,9 @@ public class ProcessInstanceMigrationMultiInstanceTest extends AbstractProcessIn
         assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
 
         //Complete this and the last
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Out of the loop
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
@@ -135,12 +135,12 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .containsExactly(tuple(version2ProcessDef.getId(), "userTask1Id")); //AutoMapped by Id
 
         //The first process version only had one activity, there should be a second activity in the process now
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks)
                 .extracting(Task::getTaskDefinitionKey)
                 .containsExactly("userTask2Id");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -197,11 +197,11 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         // complete intermediate task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // complete final task
         task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstanceToMigrate.getId());
     }
@@ -259,11 +259,11 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         // complete intermediate task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // complete final task
         task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstanceToMigrate.getId());
     }
@@ -327,19 +327,19 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         // complete before task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // complete parallel task 1
         task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // complete parallel task 2
         task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // complete final task
         task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstanceToMigrate.getId());
     }
@@ -407,11 +407,11 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         // complete sub task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // complete final task
         task = taskService.createTaskQuery().processInstanceId(processInstanceToMigrate.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstanceToMigrate.getId());
     }
@@ -487,13 +487,13 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .containsExactly(tuple(version2ProcessDef.getId(), "userTask1Id"));
 
         //This new process definition has two activities
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks)
                 .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
                 .containsExactly(tuple(version2ProcessDef.getId(), "userTask2Id"));
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -575,7 +575,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .containsExactly(tuple(version2ProcessDef.getId(), "userTask2Id"));
 
         //This new process definition has two activities, but we have mapped to the last activity explicitly
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
 
     }
@@ -620,7 +620,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .containsExactly(tuple(version1ProcessDef.getId(), "userTask1Id"));
 
         //We want to migrate from the next activity
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks)
                 .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
@@ -648,7 +648,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
                 .containsExactly(tuple(version2ProcessDef.getId(), "userTask1Id"));
 
         //This new process version only have one activity
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -735,13 +735,13 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         //The first process version only had one activity, there should be a second activity in the process now
-        taskService.complete(tasksAfter.get(0).getId());
+        completeTask(tasksAfter.get(0));
         tasksAfter = taskService.createTaskQuery().list();
         assertThat(tasksAfter)
                 .extracting(Task::getTaskDefinitionKey)
                 .containsExactly("userTask2Id");
 
-        taskService.complete(tasksAfter.get(0).getId());
+        completeTask(tasksAfter.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -832,13 +832,13 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         //The first process version only had one activity, there should be a second activity in the process now
-        taskService.complete(tasksAfter.get(0).getId());
+        completeTask(tasksAfter.get(0));
         tasksAfter = taskService.createTaskQuery().list();
         assertThat(tasksAfter)
                 .extracting(Task::getProcessDefinitionId, Task::getTaskDefinitionKey)
                 .containsExactly(tuple(version2ProcessDef.getId(), "userTask2Id"));
 
-        taskService.complete(tasksAfter.get(0).getId());
+        completeTask(tasksAfter.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1187,13 +1187,13 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         }
 
         //The first process version only had one activity, there should be a second activity in the process now
-        taskService.complete(tasksAfter.get(0).getId());
+        completeTask(tasksAfter.get(0));
         tasksAfter = taskService.createTaskQuery().list();
         assertThat(tasksAfter)
                 .extracting(Task::getTaskDefinitionKey)
                 .containsExactly("userTask2Id");
 
-        taskService.complete(tasksAfter.get(0).getId());
+        completeTask(tasksAfter.get(0));
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1344,7 +1344,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("BeforeSubProcess");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("InsideSimpleSubProcess1");
@@ -1408,7 +1408,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("BeforeSubProcess");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("InsideSimpleSubProcess1");
@@ -1743,7 +1743,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).extracting(Task::getTaskDefinitionKey).isEqualTo("taskBefore");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Confirm the state to migrate
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskBatchDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskBatchDeleteTest.java
@@ -40,7 +40,7 @@ public class TaskBatchDeleteTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task firstTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskOne").singleResult();
         assertThat(firstTask).isNotNull();
 
-        taskService.complete(firstTask.getId());
+        completeTask(firstTask);
 
         // Process should have ended fine
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -63,7 +63,7 @@ public class TaskBatchDeleteTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task firstTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("multiInstance").listPage(0, 1).get(0);
         assertThat(firstTask).isNotNull();
 
-        taskService.complete(firstTask.getId());
+        completeTask(firstTask);
 
         // Process should have ended fine
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskFindByProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskFindByProcessInstanceTest.java
@@ -75,7 +75,7 @@ class TaskFindByProcessInstanceTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery()
             .processInstanceId(processInstance.getId())
             .singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(taskService.createTaskQuery()
             .processInstanceId(processInstance.getId())

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskServiceTest.java
@@ -1095,7 +1095,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
         assertThat(task.getDueDate()).isNotNull();
 
         // Complete task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
@@ -2024,7 +2024,7 @@ public class TaskServiceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getFormKey()).isEqualTo("first-form.json");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getFormKey()).isEqualTo("form-abc.json");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
@@ -560,7 +560,7 @@ public class TenancyTest extends PluggableFlowableTestCase {
 
             // Complete all tasks
             for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
-                taskService.complete(task.getId());
+                completeTask(task);
             }
 
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6ExecutionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6ExecutionTest.java
@@ -66,7 +66,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getExecutionId()).isEqualTo(childExecution.getId());
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             List<HistoricActivityInstance> historicActivities = historyService.createHistoricActivityInstanceQuery()
@@ -115,7 +115,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getExecutionId()).isEqualTo(childExecution.getId());
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executionList = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(executionList).hasSize(3);
@@ -129,7 +129,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         assertThat(subProcessExecution.getActivityId()).isEqualTo("runSubProcess");
         assertThat(subProcessExecution.getParentId()).isEqualTo(rootProcessInstance.getId());
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executionList = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(executionList).hasSize(2);
@@ -142,7 +142,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
 
         assertThat(finalTaskExecution.getParentId()).isEqualTo(rootProcessInstance.getId());
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -202,7 +202,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getExecutionId()).isEqualTo(childExecution.getId());
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executionList = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(executionList).hasSize(4);
@@ -219,7 +219,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         Execution timerExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("timerEvent").singleResult();
         assertThat(timerExecution).isNotNull();
         
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executionList = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
         assertThat(executionList).hasSize(2);
@@ -232,7 +232,7 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
 
         assertThat(finalTaskExecution.getParentId()).isEqualTo(rootProcessInstance.getId());
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -277,15 +277,15 @@ public class Flowable6ExecutionTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("subProcessEvents");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess").singleResult();
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6Test.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/v6/Flowable6Test.java
@@ -64,7 +64,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("The famous task");
         assertThat(task.getAssignee()).isEqualTo("kermit");
 
-        taskService.complete(task.getId());
+        completeTask(task);
     }
 
     @Test
@@ -92,7 +92,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(tasks.get(1).getName()).isEqualTo("Task b");
 
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
@@ -113,7 +113,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(tasks.get(3).getName()).isEqualTo("Task c");
 
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
@@ -178,7 +178,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("Task after timer");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
@@ -193,7 +193,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("The famous task");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(managementService.createTimerJobQuery().count()).isZero();
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
@@ -220,7 +220,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
 
         // Completing them both should complete the process instance
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
@@ -235,7 +235,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
 
         tasks = taskService.createTaskQuery().orderByTaskName().desc().list(); // Not the desc() here: org.flowable.task.service.Task B, org.flowable.task.service.Task A will be the result (task b being associated with the child execution)
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
@@ -250,7 +250,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(processInstance.isEnded()).isFalse();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(tasks).hasSize(3);
@@ -259,13 +259,13 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(tasks.get(2).getName()).isEqualTo("C");
 
         for (org.flowable.task.api.Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
 
         // 2 conditions are true for input = 20
         runtimeService.startProcessInstanceByKey("testConditions", CollectionUtil.singletonMap("input", 20));
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(tasks).hasSize(2);
@@ -273,20 +273,20 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(tasks.get(1).getName()).isEqualTo("C");
 
         for (org.flowable.task.api.Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
 
         // 1 condition is true for input = 200
         runtimeService.startProcessInstanceByKey("testConditions", CollectionUtil.singletonMap("input", 200));
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).getName()).isEqualTo("C");
 
         for (org.flowable.task.api.Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
     }
     
@@ -340,7 +340,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         // Completing all tasks in this order should give the engine a bit
         // exercise (parent executions first)
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
@@ -362,7 +362,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(managementService.createTimerJobQuery().count()).isEqualTo(2);
 
         // Completing A
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
         assertThat(tasks)
                 .extracting(Task::getName)
@@ -370,7 +370,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
 
         // Completing B should end the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertThat(managementService.createTimerJobQuery().count()).isZero();
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
@@ -383,7 +383,7 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(managementService.createTimerJobQuery().count()).isEqualTo(2);
 
         // Completing B
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
         assertThat(tasks)
                 .extracting(Task::getName)
@@ -448,21 +448,21 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
 
         org.flowable.task.api.Task taskC = taskService.createTaskQuery().taskName("C").singleResult();
-        taskService.complete(taskC.getId());
+        completeTask(taskC);
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("A", "B", "E");
 
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("D", "E");
 
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
         // Use case 2 (tricky):
@@ -477,8 +477,8 @@ public class Flowable6Test extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("A", "B", "C");
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         // C should still be open
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
@@ -488,15 +488,15 @@ public class Flowable6Test extends PluggableFlowableTestCase {
 
         // If C is now completed, the inclusive gateway should also be completed
         // and D and E should be open tasks
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("D", "E");
 
         // Completing them should just end the process instance
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/SerializableVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/SerializableVariableTest.java
@@ -48,7 +48,7 @@ public class SerializableVariableTest extends PluggableFlowableTestCase {
         // There is a task here, such the VariableInstanceEntityImpl is inserter first, and updated later
         // (instead of being inserted/updated in the same Tx)
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         TestSerializableVariable testSerializableVariable = (TestSerializableVariable) runtimeService.getVariable(processInstance.getId(), "myVar");
         assertThat(testSerializableVariable.getNumber()).isEqualTo(2);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/TransientVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/TransientVariablesTest.java
@@ -267,7 +267,7 @@ public class TransientVariablesTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task1");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/VariablesTest.java
@@ -145,7 +145,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         // Trying the same after moving the process
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
         String executionId = task.getExecutionId();
@@ -230,7 +230,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         // Trying the same after moving the process
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
         String executionId = task.getExecutionId();
@@ -257,7 +257,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         // Trying the same after moving the process
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
         String executionId = task.getExecutionId();
@@ -364,7 +364,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         // Trying the same after moving the process
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
         String executionId = task.getExecutionId();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataDeleteTest.java
@@ -86,7 +86,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             taskService.setVariableLocal(task.getId(), "taskVar", "taskValue");
-            taskService.complete(task.getId());
+            completeTask(task);
             if (processEngineConfiguration.isAsyncHistoryEnabled()) {
                 waitForHistoryJobExecutorToProcessAllJobs(7000, 300);
             }
@@ -143,7 +143,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             taskService.setVariableLocal(task.getId(), "taskVar", "taskValue");
-            taskService.complete(task.getId());
+            completeTask(task);
 
             if (processEngineConfiguration.isAsyncHistoryEnabled()) {
                 waitForHistoryJobExecutorToProcessAllJobs(7000, 300);
@@ -184,7 +184,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
             for (int i = 0; i < 10; i++) {
                 Task task = taskService.createTaskQuery().processInstanceId(processInstanceIds.get(i)).singleResult();
                 taskService.setVariableLocal(task.getId(), "taskVar", "taskValue" + (i + 1));
-                taskService.complete(task.getId());
+                completeTask(task);
             }
 
             if (processEngineConfiguration.isAsyncHistoryEnabled()) {
@@ -247,7 +247,7 @@ public class HistoricDataDeleteTest extends PluggableFlowableTestCase {
                 for (int i = 0; i < 10; i++) {
                     Task task = taskService.createTaskQuery().processInstanceId(processInstanceIds.get(i)).singleResult();
                     taskService.setVariableLocal(task.getId(), "taskVar", "taskValue" + (i + 1));
-                    taskService.complete(task.getId());
+                    completeTask(task);
                 }
 
                 if (processEngineConfiguration.isAsyncHistoryEnabled()) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataEngineDeleteTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/HistoricDataEngineDeleteTest.java
@@ -59,7 +59,7 @@ public class HistoricDataEngineDeleteTest extends ResourceFlowableTestCase {
                 for (int i = 0; i < 10; i++) {
                     Task task = taskService.createTaskQuery().processInstanceId(processInstanceIds.get(i)).singleResult();
                     taskService.setVariableLocal(task.getId(), "taskVar", "taskValue" + (i + 1));
-                    taskService.complete(task.getId());
+                    completeTask(task);
                 }
                 
                 assertThat(managementService.createTimerJobQuery().handlerType(BpmnHistoryCleanupJobHandler.TYPE).count()).isEqualTo(1);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncTaskTest.java
@@ -481,8 +481,7 @@ public class AsyncTaskTest extends PluggableFlowableTestCase {
         // and no more job
         assertThat(managementService.createJobQuery().count()).isZero();
 
-        String taskId = taskService.createTaskQuery().singleResult().getId();
-        taskService.complete(taskId);
+        completeTask(taskService.createTaskQuery().singleResult());
 
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/cache/CacheTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/cache/CacheTaskTest.java
@@ -129,7 +129,7 @@ public class CacheTaskTest extends PluggableFlowableTestCase {
 
         Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Map.Entry[] entries = {
                 entry("var1", "Hello"),

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -18,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -82,7 +82,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         Execution parentExecution = runtimeService.createExecutionQuery().executionId(childTask.getExecutionId()).singleResult();
 
         // Completing the task continues the process which leads to calling the subprocess
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
         Task taskInSubProcess = taskQuery.singleResult();
         assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess");
         Execution execution = runtimeService.createExecutionQuery().executionId(taskInSubProcess.getExecutionId()).singleResult();
@@ -190,7 +190,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(childTask.getId()).isEqualTo(taskInSubProcess.getId());
 
         // Completing the task in the subprocess, finishes the subprocess
-        taskService.complete(taskInSubProcess.getId());
+        completeTask(taskInSubProcess);
         Task taskAfterSubProcess = taskQuery.singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
         
@@ -198,7 +198,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(childTask.getId()).isEqualTo(taskAfterSubProcess.getId());
 
         // Completing this task end the process instance
-        taskService.complete(taskAfterSubProcess.getId());
+        completeTask(taskAfterSubProcess);
         assertProcessEnded(processInstance.getId());
 
         // Validate subprocess history
@@ -362,13 +362,13 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(childTask.getId()).isEqualTo(taskBeforeSubProcess.getId());
 
         // Completing the task continues the process which leads to calling the subprocess
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
         Task taskBeforeSubProcessInSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskBeforeSubProcessInSubProcess.getName()).isEqualTo("Task before subprocess");
         assertThat(taskBeforeSubProcessInSubProcess.getId()).isNotEqualTo(taskBeforeSubProcess.getId());
 
         // Completing the task continues the process which leads to calling the last subprocess
-        taskService.complete(taskBeforeSubProcessInSubProcess.getId());
+        completeTask(taskBeforeSubProcessInSubProcess);
         Task taskInLastSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskInLastSubProcess.getName()).isEqualTo("Task in subprocess");
 
@@ -466,12 +466,12 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         }
 
         // Completing the task in the second subprocess, finishes the second subprocess
-        taskService.complete(taskInLastSubProcess.getId());
+        completeTask(taskInLastSubProcess);
         Task taskAfterSubProcessInSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterSubProcessInSubProcess.getName()).isEqualTo("Task after subprocess");
 
-        // Completing this task finishes the first subproces
-        taskService.complete(taskAfterSubProcessInSubProcess.getId());
+        // Completing this task finishes the first subprocess
+        completeTask(taskAfterSubProcessInSubProcess);
         Task taskAfterSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
 
@@ -499,7 +499,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
                 );
 
         // Completing this task end the process instance
-        taskService.complete(taskAfterSubProcess.getId());
+        completeTask(taskAfterSubProcess);
         assertProcessEnded(rootInstanceId);
 
         // Validate subprocess history entity links
@@ -636,17 +636,17 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // Completing the task continues the process which leads to calling the
         // subprocess. The sub process we want to call is passed in as a variable into this task
         taskService.setVariable(taskBeforeSubProcess.getId(), "simpleSubProcessExpression", "simpleSubProcess");
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
         Task taskInSubProcess = taskQuery.singleResult();
         assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess");
 
         // Completing the task in the subprocess, finishes the subprocess
-        taskService.complete(taskInSubProcess.getId());
+        completeTask(taskInSubProcess);
         Task taskAfterSubProcess = taskQuery.singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
 
         // Completing this task end the process instance
-        taskService.complete(taskAfterSubProcess.getId());
+        completeTask(taskAfterSubProcess);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -665,7 +665,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(taskBeforeSubProcess.getName()).isEqualTo("Task in subprocess");
 
         // Completing this task ends the subprocess which leads to the end of the whole process instance
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
         assertProcessEnded(processInstance.getId());
         assertThat(runtimeService.createExecutionQuery().list()).isEmpty();
     }
@@ -686,11 +686,11 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         Task taskA = tasks.get(0);
         Task taskB = tasks.get(1);
         // Completing the first task should not end the subprocess
-        taskService.complete(taskA.getId());
+        completeTask(taskA);
         assertThat(taskQuery.list()).hasSize(1);
 
         // Completing the second task should end the subprocess and end the whole process instance
-        taskService.complete(taskB.getId());
+        completeTask(taskB);
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
@@ -712,17 +712,17 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // Completing the task continues the process which leads to calling the
         // subprocess. The sub process we want to call is passed in as a variable into this task
         taskService.setVariable(taskBeforeSubProcess.getId(), "simpleSubProcessExpression", "simpleSubProcess");
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
         Task taskInSubProcess = taskQuery.singleResult();
         assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess");
 
         // Completing the task in the subprocess, finishes the subprocess
-        taskService.complete(taskInSubProcess.getId());
+        completeTask(taskInSubProcess);
         Task taskAfterSubProcess = taskQuery.singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
 
         // Completing this task end the process instance
-        taskService.complete(taskAfterSubProcess.getId());
+        completeTask(taskAfterSubProcess);
 
         // SECOND sub process calls simpleSubProcess2
 
@@ -734,17 +734,17 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // Completing the task continues the process which leads to calling the
         // subprocess. The sub process we want to call is passed in as a variable into this task
         taskService.setVariable(taskBeforeSubProcess.getId(), "simpleSubProcessExpression", "simpleSubProcess2");
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
         taskInSubProcess = taskQuery.singleResult();
         assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess 2");
 
         // Completing the task in the subprocess, finishes the subprocess
-        taskService.complete(taskInSubProcess.getId());
+        completeTask(taskInSubProcess);
         taskAfterSubProcess = taskQuery.singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
 
         // Completing this task end the process instance
-        taskService.complete(taskAfterSubProcess.getId());
+        completeTask(taskAfterSubProcess);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -769,7 +769,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(escalatedTask.getName()).isEqualTo("Escalated Task");
 
         // Completing the task ends the complete process
-        taskService.complete(escalatedTask.getId());
+        completeTask(escalatedTask);
         assertThat(runtimeService.createExecutionQuery().list()).isEmpty();
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
@@ -808,7 +808,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
 
         // Completing this task ends the subprocess which leads to a task in the
         // super process
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
 
         // one task in the subprocess should be active after starting the
         // process instance
@@ -832,7 +832,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(taskService.getVariable(taskInSecondSubProcess.getId(), "y")).isEqualTo(10l);
 
         // Completing this task ends the subprocess which leads to a task in the super process
-        taskService.complete(taskInSecondSubProcess.getId());
+        completeTask(taskInSecondSubProcess);
 
         // one task in the subprocess should be active after starting the process instance
         Task taskAfterSecondSubProcess = taskQuery.singleResult();
@@ -841,7 +841,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(taskService.getVariable(taskAfterSecondSubProcess.getId(), "z")).isEqualTo(15l);
 
         // and end last task in Super process
-        taskService.complete(taskAfterSecondSubProcess.getId());
+        completeTask(taskAfterSecondSubProcess);
 
         assertProcessEnded(processInstance.getId());
         assertThat(runtimeService.createExecutionQuery().list()).isEmpty();
@@ -916,7 +916,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         Task taskBeforeSubProcess = taskQuery.singleResult();
         assertThat(taskBeforeSubProcess.getName()).isEqualTo("Task before subprocess");
         // Completing the task continues the process which leads to calling the subprocess
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
 
         ProcessInstance subProcess = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
 
@@ -937,7 +937,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
         Task taskBeforeSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskBeforeSubProcess.getName()).isEqualTo("Task before subprocess");
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
         Task taskInSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess");
         
@@ -949,7 +949,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(taskAfterSubProcess).isNotNull();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
         
-        taskService.complete(taskAfterSubProcess.getId());
+        completeTask(taskAfterSubProcess);
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
     
@@ -962,7 +962,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
         Task taskBeforeSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskBeforeSubProcess.getName()).isEqualTo("Task before subprocess");
-        taskService.complete(taskBeforeSubProcess.getId());
+        completeTask(taskBeforeSubProcess);
         Task taskInSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess");
 
@@ -1073,7 +1073,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
             assertThat(taskInSubProcess.getTenantId()).isEqualTo("someTenant");
     
             // Completing the task in the subprocess, finishes the subprocess
-            taskService.complete(taskInSubProcess.getId());
+            completeTask(taskInSubProcess);
             assertProcessEnded(processInstance.getId());
             
         } finally {
@@ -1103,7 +1103,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
             Task taskBeforeSubProcess = taskService.createTaskQuery().singleResult();
             assertThat(taskBeforeSubProcess.getName()).isEqualTo("Task before subprocess");
             assertThat(taskBeforeSubProcess.getTenantId()).isEqualTo("someTenant");
-            taskService.complete(taskBeforeSubProcess.getId());
+            completeTask(taskBeforeSubProcess);
             
             Task taskInSubProcess = taskService.createTaskQuery().singleResult();
             assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess");
@@ -1117,7 +1117,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
             assertThat(taskAfterSubProcess).isNotNull();
             assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
             
-            taskService.complete(taskAfterSubProcess.getId());
+            completeTask(taskAfterSubProcess);
             
             assertProcessEnded(processInstance.getId());
             
@@ -1155,7 +1155,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
             Task taskBeforeSubProcess = taskService.createTaskQuery().singleResult();
             assertThat(taskBeforeSubProcess.getName()).isEqualTo("Task before subprocess");
             assertThat(taskBeforeSubProcess.getTenantId()).isEqualTo("someTenant");
-            taskService.complete(taskBeforeSubProcess.getId());
+            completeTask(taskBeforeSubProcess);
 
             Task taskInSubProcess = taskService.createTaskQuery().singleResult();
             assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess");
@@ -1169,7 +1169,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
             assertThat(taskAfterSubProcess).isNotNull();
             assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
 
-            taskService.complete(taskAfterSubProcess.getId());
+            completeTask(taskAfterSubProcess);
 
             assertProcessEnded(processInstance.getId());
 
@@ -1263,21 +1263,21 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
 
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Job secondJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(secondJob.getId()).isNotSameAs(job.getId());
         managementService.executeJob(secondJob.getId());
 
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Job thirdJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(thirdJob.getId()).isNotSameAs(secondJob.getId());
         managementService.executeJob(thirdJob.getId());
 
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -1342,7 +1342,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(taskInSubProcess.getTenantId()).isEqualTo("flowable");
 
         // Completing the task in the subprocess, finishes the processes
-        taskService.complete(taskInSubProcess.getId());
+        completeTask(taskInSubProcess);
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityWithElementType.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityWithElementType.java
@@ -103,7 +103,7 @@ public class CallActivityWithElementType extends PluggableFlowableTestCase {
 
             // Completing the task continues the process which leads to calling the
             // subprocess
-            taskService.complete(taskBeforeSubProcess.getId());
+            completeTask(taskBeforeSubProcess);
             Task taskInSubProcess = taskQuery.singleResult();
             assertThat(taskInSubProcess.getName()).isEqualTo("Task in subprocess");
         } finally {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicBpmnInjectionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/dynamic/DynamicBpmnInjectionTest.java
@@ -56,7 +56,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         deploymentIdsForAutoCleanup.add(repositoryService.getProcessDefinition(tasks.get(0).getProcessDefinitionId()).getDeploymentId()); // For auto-cleanup
         
         for (Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
 
         assertProcessEnded(processInstance.getId());
@@ -88,7 +88,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
         for (Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
         assertProcessEnded(processInstance.getId());
     }
@@ -159,7 +159,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
         for (Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
         assertProcessEnded(processInstance.getId());  
     }
@@ -190,11 +190,11 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
         assertThat(tasks).hasSize(2);
         assertThat(tasks.get(0).getName()).isEqualTo(taskBuilder.getName());
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("The Task");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -234,7 +234,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
         for (Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
         
         assertProcessEnded(processInstance.getId());
@@ -281,17 +281,17 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
                 .containsExactly("five", "four", "one", "three", "two");
 
         for (Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
        
         // now task After B should be available
         Task afterBTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(afterBTask.getName()).isEqualTo("after B");
-        taskService.complete(afterBTask.getId());
+        completeTask(afterBTask);
 
         Task afterSubProcessTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(afterSubProcessTask.getName()).isEqualTo("after sub process");
-        taskService.complete(afterSubProcessTask.getId());
+        completeTask(afterSubProcessTask);
         assertProcessEnded(processInstance.getId());
     }
     
@@ -318,7 +318,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
         for (Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
         assertProcessEnded(processInstance.getId());
         
@@ -341,7 +341,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
         for (Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
         assertProcessEnded(processInstance.getId());
     }
@@ -373,10 +373,10 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
                 .extracting(Task::getName)
                 .containsExactly("five", "four", "one", "task A", "task B", "task C", "task D", "three", "two");
 
-        taskService.complete(taskB.getId());
+        completeTask(taskB);
         Task afterBTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("afterB").singleResult();
         assertThat(afterBTask.getId()).isNotNull();
-        taskService.complete(afterBTask.getId());
+        completeTask(afterBTask);
         
         // first complete the tasks from the original process definition and check that it continues to the next task (After sub process).
         taskService.complete(taskService.createTaskQuery().taskName("task A").singleResult().getId());
@@ -390,7 +390,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
 
         Task afterSubProcessTask = tasks.get(0);
         assertThat(afterSubProcessTask.getName()).isEqualTo("after sub process");
-        taskService.complete(afterSubProcessTask.getId());
+        completeTask(afterSubProcessTask);
         
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
         assertThat(tasks)
@@ -398,7 +398,7 @@ public class DynamicBpmnInjectionTest extends PluggableFlowableTestCase {
                 .containsExactly("five", "four", "one", "three", "two");
 
         for (Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertProcessEnded(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/EventSubProcessWithBoundaryEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/EventSubProcessWithBoundaryEventsTest.java
@@ -49,7 +49,7 @@ public class EventSubProcessWithBoundaryEventsTest extends PluggableFlowableTest
         assertThat(task).isNotNull();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskInEventSubProcess");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -73,7 +73,7 @@ public class EventSubProcessWithBoundaryEventsTest extends PluggableFlowableTest
         assertThat(task).isNotNull();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskInEventSubProcess");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -97,7 +97,7 @@ public class EventSubProcessWithBoundaryEventsTest extends PluggableFlowableTest
         assertThat(task).isNotNull();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskInEventSubProcess");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -110,7 +110,7 @@ public class EventSubProcessWithBoundaryEventsTest extends PluggableFlowableTest
         Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterSubProcessBoundary");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -125,7 +125,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("Manually undo book hotel");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Execution execution = runtimeService.createExecutionQuery().activityId("beforeEnd").singleResult();
         runtimeService.trigger(execution.getId());
@@ -145,7 +145,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("Manually undo book hotel");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -282,7 +282,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         // Triggering the task will trigger the compensation subprocess
         org.flowable.task.api.Task afterBookHotelTask = taskService.createTaskQuery().processInstanceId(processInstance.getId())
                 .taskDefinitionKey("afterBookHotel").singleResult();
-        taskService.complete(afterBookHotelTask.getId());
+        completeTask(afterBookHotelTask);
 
         org.flowable.task.api.Task compensationTask1 = taskService.createTaskQuery().processInstanceId(processInstance.getId())
                 .taskDefinitionKey("compensateTask1").singleResult();
@@ -292,13 +292,13 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
                 .taskDefinitionKey("compensateTask2").singleResult();
         assertThat(compensationTask2).isNotNull();
 
-        taskService.complete(compensationTask1.getId());
-        taskService.complete(compensationTask2.getId());
+        completeTask(compensationTask1);
+        completeTask(compensationTask2);
 
         org.flowable.task.api.Task compensationTask3 = taskService.createTaskQuery().processInstanceId(processInstance.getId())
                 .taskDefinitionKey("compensateTask3").singleResult();
         assertThat(compensationTask3).isNotNull();
-        taskService.complete(compensationTask3.getId());
+        completeTask(compensationTask3);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -315,7 +315,7 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task afterBookHotelTask = taskService.createTaskQuery().processInstanceId(processInstance.getId())
                 .taskDefinitionKey("afterBookHotel").singleResult();
-        taskService.complete(afterBookHotelTask.getId());
+        completeTask(afterBookHotelTask);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -328,11 +328,11 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         // Completing should trigger the compensations
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("afterNestedSubProcess").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         org.flowable.task.api.Task compensationTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("undoBookHotel").singleResult();
         assertThat(compensationTask).isNotNull();
-        taskService.complete(compensationTask.getId());
+        completeTask(compensationTask);
 
         assertProcessEnded(processInstance.getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/BoundaryConditionalEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/BoundaryConditionalEventTest.java
@@ -54,7 +54,7 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterConditionalCatch");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
     
@@ -71,7 +71,7 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
         assertThat(execution).isNotNull();
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(processInstance.getId());
     }
@@ -106,12 +106,12 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
         
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskAfterConditionalCatch").list();
         assertThat(tasks).hasSize(2);
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("subprocessTask");
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(processInstance.getId());
     }
@@ -129,7 +129,7 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
         assertThat(execution).isNotNull();
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(processInstance.getId());
     }
@@ -166,12 +166,12 @@ public class BoundaryConditionalEventTest extends PluggableFlowableTestCase {
         
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskAfterConditionalCatch").list();
         assertThat(tasks).hasSize(2);
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("subprocessTask");
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/ConditionalEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/ConditionalEventSubprocessTest.java
@@ -57,20 +57,20 @@ public class ConditionalEventSubprocessTest extends PluggableFlowableTestCase {
         
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // we still have 7 executions:
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(7);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -89,7 +89,7 @@ public class ConditionalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the task in the event subprocess
         Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -118,20 +118,20 @@ public class ConditionalEventSubprocessTest extends PluggableFlowableTestCase {
         
         // now let's first complete the task in the main flow:
         Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // we still have 8 executions:
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(8);
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -150,7 +150,7 @@ public class ConditionalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the task in the event subprocess
         Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -187,7 +187,7 @@ public class ConditionalEventSubprocessTest extends PluggableFlowableTestCase {
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask1").singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             assertThat(historyService.createHistoricActivityInstanceQuery().list())

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/ConditionalIntermediateCatchEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/conditional/ConditionalIntermediateCatchEventTest.java
@@ -38,7 +38,7 @@ public class ConditionalIntermediateCatchEventTest extends PluggableFlowableTest
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBeforeConditionalCatch");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
         assertThat(execution).isNotNull();
@@ -54,7 +54,7 @@ public class ConditionalIntermediateCatchEventTest extends PluggableFlowableTest
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterConditionalCatch");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
     
@@ -68,7 +68,7 @@ public class ConditionalIntermediateCatchEventTest extends PluggableFlowableTest
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBeforeConditionalCatch");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("catchConditional").singleResult();
         assertThat(execution).isNotNull();
@@ -82,7 +82,7 @@ public class ConditionalIntermediateCatchEventTest extends PluggableFlowableTest
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfterConditionalCatch");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -90,7 +90,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isEqualTo(3);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -108,7 +108,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         
@@ -122,7 +122,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -144,7 +144,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isEqualTo(4);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -163,11 +163,11 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Completing the task -> terminal end event -> subprocess ends
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -185,7 +185,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Completing the task -> terminal end event -> all ends (terminate all)
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -209,7 +209,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(subProcessInstance).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTerminateEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -233,7 +233,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId())
                 .taskDefinitionKey("preTerminateEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -295,7 +295,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(5);
 
         for (int i = 0; i < 5; i++) {
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
             assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count()).isGreaterThan(0);
         }
 
@@ -350,7 +350,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -399,7 +399,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Complete sub process task that leads to a terminate end event
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTermInnerTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // 'preEndInnerTask' task in subprocess should have been terminated, only outerTask should exist
         assertThat(taskService.createTaskQuery().processInstanceId(pi.getId()).count()).isEqualTo(1);
@@ -409,7 +409,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // complete outerTask
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("outerTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -426,7 +426,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Complete sub process task that leads to a terminate end event
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preTermInnerTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -441,7 +441,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -464,7 +464,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(2);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskName("User Task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -482,14 +482,14 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntitiesCount).isEqualTo(9);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         executionEntitiesCount = runtimeService.createExecutionQuery().count();
         assertThat(executionEntitiesCount).isEqualTo(8);
 
         tasks = taskService.createTaskQuery().list();
         for (org.flowable.task.api.Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
 
         assertProcessEnded(pi.getId());
@@ -502,13 +502,13 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance pi = runtimeService.startProcessInstanceByKey("terminateEndEventExample");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).taskName("User Task").list();
         assertThat(tasks).hasSize(3);
 
         for (org.flowable.task.api.Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
 
         assertProcessEnded(pi.getId());
@@ -534,7 +534,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // WHEN - complete -> terminate end event
         org.flowable.task.api.Task preTerminate = taskService.createTaskQuery().taskName("preTerminate").singleResult();
-        taskService.complete(preTerminate.getId());
+        completeTask(preTerminate);
 
         // THEN - super process is not finished together
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).count()).isEqualTo(1);
@@ -549,7 +549,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -569,7 +569,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(serviceTaskInvokedCount2).isEqualTo(3);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // last task remaining
         assertProcessEnded(pi.getId());
@@ -597,7 +597,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -616,7 +616,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -645,7 +645,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -666,7 +666,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         int bTasksCompleted = 0;
         for (org.flowable.task.api.Task bTask : bTasks) {
 
-            taskService.complete(bTask.getId());
+            completeTask(bTask);
             bTasksCompleted++;
 
             aTasks = taskService.createTaskQuery().taskName("A").list();
@@ -676,7 +676,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("After call activity");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
@@ -700,7 +700,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
             org.flowable.task.api.Task bTask = taskService.createTaskQuery().taskName("B").singleResult();
 
-            taskService.complete(bTask.getId());
+            completeTask(bTask);
             
             HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, managementService, 20000, 200);
 
@@ -716,7 +716,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("After call activity");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
@@ -747,7 +747,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         assertThat(executionEntities).isGreaterThan(0);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("preNormalEnd").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(pi.getId());
         assertHistoricProcessInstanceDetails(pi);
@@ -774,25 +774,25 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
                 .containsExactly("A", "B", "D", "E", "F");
 
         // Completing E should finish the lower subprocess and make 'H' active
-        taskService.complete(tasks.get(3).getId());
+        completeTask(tasks.get(3));
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult();
         assertThat(task).isNotNull();
 
         // Completing A should make C active
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").singleResult();
         assertThat(task).isNotNull();
 
         // Completing C should make I active
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult();
         assertThat(task).isNotNull();
 
         // Completing I and B should make G active
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("G").singleResult();
         assertThat(task).isNull();
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("G").singleResult();
         assertThat(task).isNotNull();
     }
@@ -804,7 +804,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").singleResult();
 
         // Completing E leads to a terminate end event with terminate all set to true
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
     }
@@ -816,9 +816,9 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("A").singleResult();
 
         // Completing A and C leads to a terminate end event with terminate all set to true
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -836,7 +836,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Completing these should lead to task I being active
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("I").singleResult();
@@ -848,7 +848,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
 
         // Completing these should make H active
         for (org.flowable.task.api.Task t : tasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult();
         assertThat(task).isNotNull();
@@ -865,7 +865,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         for (int i = 0; i < 7; i++) {
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").singleResult();
             assertThat(task).isNotNull();
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         // I should be active now
@@ -880,7 +880,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
             taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("F").singleResult().getId());
 
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").singleResult();
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("H").singleResult()).isNotNull();
@@ -891,7 +891,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateNestedMiSubprocessesTerminateAll1() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
     }
@@ -902,7 +902,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
         taskService.complete(taskService.createTaskQuery().taskName("A").singleResult().getId());
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
     }
@@ -912,7 +912,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
     public void testTerminateNestedMiSubprocessesTerminateAll3() { // Same as 1, but sequential Multi-Instance
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("E").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
     }
@@ -923,7 +923,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("TestTerminateNestedMiSubprocesses");
         taskService.complete(taskService.createTaskQuery().taskName("A").singleResult().getId());
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("C").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
     }
@@ -938,20 +938,20 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
                 Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
 
         // Completing 'before c'
-        taskService.complete(tasks.get(9).getId());
+        completeTask(tasks.get(9));
         tasks = assertTaskNames(processInstance,
                 Arrays.asList("After C", "B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B"));
 
         // Completing 'before A' of one instance
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("task_subprocess_1").singleResult();
         assertThat(task).isNull();
-        taskService.complete(tasks.get(5).getId());
+        completeTask(tasks.get(5));
 
         // Multi instance call activity is sequential, so expecting 5 more times the same task
         for (int i = 0; i < 6; i++) {
             task = taskService.createTaskQuery().taskName("subprocess1_task").singleResult();
             assertThat(task).isNotNull();
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         tasks = assertTaskNames(processInstance,
@@ -969,7 +969,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
                 Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
 
         // Completing 'Before B' should lead to process instance termination
-        taskService.complete(tasks.get(8).getId());
+        completeTask(tasks.get(8));
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
 
@@ -977,7 +977,7 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("TestNestedCallActivities");
         tasks = assertTaskNames(processInstance,
                 Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
-        taskService.complete(tasks.get(9).getId());
+        completeTask(tasks.get(9));
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
 
@@ -985,10 +985,10 @@ public class TerminateEndEventTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("TestNestedCallActivities");
         tasks = assertTaskNames(processInstance,
                 Arrays.asList("B", "B", "B", "B", "Before A", "Before A", "Before A", "Before A", "Before B", "Before C"));
-        taskService.complete(tasks.get(5).getId());
+        completeTask(tasks.get(5));
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("subprocess1_task").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertHistoricProcessInstanceDetails(processInstance);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/end/TerminateMultiInstanceEndEventTest.java
@@ -35,7 +35,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
 
         org.flowable.task.api.Task aTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(aTask.getId());
+        completeTask(aTask);
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(bTasks).hasSize(8);
@@ -53,7 +53,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
 
         org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(afterMiTask.getName()).isEqualTo("AfterMi");
-        taskService.complete(afterMiTask.getId());
+        completeTask(afterMiTask);
 
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
@@ -64,7 +64,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
 
         org.flowable.task.api.Task aTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(aTask.getId());
+        completeTask(aTask);
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(bTasks).hasSize(1);
@@ -72,7 +72,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
 
         List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
         assertThat(cTasks).hasSize(1);
-        taskService.complete(cTasks.get(0).getId());
+        completeTask(cTasks.get(0));
 
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
         assertThat(bTasks).hasSize(1);
@@ -80,7 +80,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
 
         org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(afterMiTask.getName()).isEqualTo("AfterMi");
-        taskService.complete(afterMiTask.getId());
+        completeTask(afterMiTask);
 
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
@@ -91,13 +91,13 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
 
         org.flowable.task.api.Task aTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(aTask.getId());
+        completeTask(aTask);
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(bTasks).hasSize(5);
 
         // Complete one b task to get one C and D
-        taskService.complete(bTasks.get(0).getId());
+        completeTask(bTasks.get(0));
 
         // C and D should now be active
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
@@ -107,11 +107,11 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertThat(tasks.get(5).getName()).isEqualTo("D");
 
         // Completing C should terminate the multi instance
-        taskService.complete(tasks.get(4).getId());
+        completeTask(tasks.get(4));
 
         org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(afterMiTask.getName()).isEqualTo("AfterMi");
-        taskService.complete(afterMiTask.getId());
+        completeTask(afterMiTask);
 
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
@@ -122,13 +122,13 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("terminateMi");
 
         org.flowable.task.api.Task aTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(aTask.getId());
+        completeTask(aTask);
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(bTasks).hasSize(1);
 
         // Complete one b task to get one C and D
-        taskService.complete(bTasks.get(0).getId());
+        completeTask(bTasks.get(0));
 
         // C and D should now be active
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
@@ -137,11 +137,11 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
                 .containsExactly("C", "D");
 
         // Completing C should terminate the multi instance
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         org.flowable.task.api.Task afterMiTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(afterMiTask.getName()).isEqualTo("AfterMi");
-        taskService.complete(afterMiTask.getId());
+        completeTask(afterMiTask);
 
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
@@ -156,7 +156,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
 
         org.flowable.task.api.Task taskA = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(taskA.getName()).isEqualTo("A");
-        taskService.complete(taskA.getId());
+        completeTask(taskA);
 
         // After completing A, four B's should be active (due to the call activity)
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
@@ -164,7 +164,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
 
         // Completing 3 B tasks, giving 3 C's and D's
         for (int i = 0; i < 3; i++) {
-            taskService.complete(bTasks.get(i).getId());
+            completeTask(bTasks.get(i));
         }
 
         List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
@@ -173,7 +173,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertThat(dTasks).hasSize(3);
 
         // Completing one of the C tasks should terminate the whole multi instance
-        taskService.complete(cTasks.get(0).getId());
+        completeTask(cTasks.get(0));
 
         List<org.flowable.task.api.Task> afterMiTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
         assertThat(afterMiTasks)
@@ -191,11 +191,11 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
 
         org.flowable.task.api.Task taskA = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(taskA.getName()).isEqualTo("A");
-        taskService.complete(taskA.getId());
+        completeTask(taskA);
 
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().taskName("B").list();
         assertThat(bTasks).hasSize(1);
-        taskService.complete(bTasks.get(0).getId());
+        completeTask(bTasks.get(0));
 
         List<org.flowable.task.api.Task> cTasks = taskService.createTaskQuery().taskName("C").list();
         assertThat(cTasks).hasSize(1);
@@ -203,7 +203,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertThat(dTasks).hasSize(1);
 
         // Completing one of the C tasks should terminate the whole multi instance
-        taskService.complete(cTasks.get(0).getId());
+        completeTask(cTasks.get(0));
 
         List<org.flowable.task.api.Task> afterMiTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).orderByTaskName().asc().list();
         assertThat(afterMiTasks)
@@ -225,7 +225,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         // Completing a few B's will create a subprocess with some C's
         int nrOfBTasksCompleted = 3;
         for (int i = 0; i < nrOfBTasksCompleted; i++) {
-            taskService.complete(bTasks.get(i).getId());
+            completeTask(bTasks.get(i));
         }
 
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
@@ -246,13 +246,13 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertThat(afterInnerMiTasks).hasSize(1);
 
         for (org.flowable.task.api.Task aTask : aTasks) {
-            taskService.complete(aTask.getId());
+            completeTask(aTask);
         }
 
         // Finish
         List<org.flowable.task.api.Task> nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         while (nextTasks != null && nextTasks.size() > 0) {
-            taskService.complete(nextTasks.get(0).getId());
+            completeTask(nextTasks.get(0));
             nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         }
 
@@ -283,7 +283,7 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         List<org.flowable.task.api.Task> bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
         assertThat(bTasks).hasSize(1);
 
-        taskService.complete(bTasks.get(0).getId());
+        completeTask(bTasks.get(0));
         bTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("B").list();
         assertThat(bTasks).isEmpty();
 
@@ -301,13 +301,13 @@ public class TerminateMultiInstanceEndEventTest extends PluggableFlowableTestCas
         assertThat(afterInnerMiTasks).hasSize(1);
 
         for (org.flowable.task.api.Task aTask : aTasks) {
-            taskService.complete(aTask.getId());
+            completeTask(aTask);
         }
 
         // Finish
         List<org.flowable.task.api.Task> nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         while (nextTasks != null && nextTasks.size() > 0) {
-            taskService.complete(nextTasks.get(0).getId());
+            completeTask(nextTasks.get(0));
             nextTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
@@ -46,7 +46,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("subprocessTask");
 
         // After task completion, error end event is reached and caught
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("task after catching the error");
     }
@@ -81,7 +81,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
                 .containsExactly("Inner subprocess task 1", "Inner subprocess task 2");
 
         // Completing task 2, will cause the end error event to throw error with code 123
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
         taskService.createTaskQuery().list();
         org.flowable.task.api.Task taskAfterError = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterError.getName()).isEqualTo("task outside subprocess");
@@ -106,10 +106,10 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("task A", "task B");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("task D");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
 
         // Completing task B will lead to task C
@@ -118,17 +118,17 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("task A", "task B");
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
 
         tasks = taskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("task A", "task C");
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("task A");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("task D");
     }
@@ -154,7 +154,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         taskService.complete(task.getId(), CollectionUtil.singletonMap("input", 2));
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("task after catch");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
     }
 
@@ -192,12 +192,12 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
 
         // Completing the task will reach the end error event,
         // which is caught on the call activity boundary
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
     }
     
@@ -209,7 +209,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("specificErrorTask");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(procId);
     }
@@ -222,7 +222,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("emptyErrorTask");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(procId);
     }
@@ -235,7 +235,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("specificErrorTask");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(procId);
     }
@@ -248,7 +248,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("emptyErrorTask");
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(procId);
     }
@@ -261,7 +261,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Task in subprocess");
 
         // Completing the task will reach the end error event, which is never caught in the process
-        assertThatThrownBy(() -> taskService.complete(task.getId()))
+        assertThatThrownBy(() -> completeTask(task))
                 .isExactlyInstanceOf(BpmnError.class)
                 .hasMessage("No catching boundary event found for error with errorCode 'myError', neither in same process nor in parent process");
     }
@@ -275,7 +275,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Task in subprocess");
 
         // Completing the task will reach the end error event, which is never caught in the process
-        assertThatThrownBy(() -> taskService.complete(task.getId()))
+        assertThatThrownBy(() -> completeTask(task))
                 .isExactlyInstanceOf(BpmnError.class)
                 .hasMessage("No catching boundary event found for error with errorCode 'myError', neither in same process nor in parent process");
     }
@@ -290,12 +290,12 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
 
         // Completing the task will reach the end error event,
         // which is caught on the call activity boundary
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
     }
 
@@ -308,13 +308,13 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("Task in subprocess");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
     }
 
@@ -480,7 +480,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ErrorEventSubProcessTest.java
@@ -58,7 +58,7 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
 
     }
@@ -159,7 +159,7 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             assertThat(historyService.createHistoricActivityInstanceQuery().list())
@@ -239,7 +239,7 @@ public class ErrorEventSubProcessTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the org.flowable.task.service.Task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
@@ -34,7 +34,7 @@ public class BoundaryEscalationEventTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("subprocessTask");
 
         // After task completion, escalation end event is reached and caught
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("task after catching the escalation");
     }
@@ -49,12 +49,12 @@ public class BoundaryEscalationEventTest extends PluggableFlowableTestCase {
 
         // Completing the task will reach the end error event,
         // which is caught on the call activity boundary
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/EscalationEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/EscalationEventSubProcessTest.java
@@ -44,7 +44,7 @@ public class EscalationEventSubProcessTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
 
     }
@@ -64,7 +64,7 @@ public class EscalationEventSubProcessTest extends PluggableFlowableTestCase {
         
         // task in sub process
         Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThatEscalationHasBeenCaught(procId);
     }
@@ -78,17 +78,17 @@ public class EscalationEventSubProcessTest extends PluggableFlowableTestCase {
         // task before in sub process
         Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
-        taskService.complete(task.getId());
+        completeTask(task);
         
         task = taskService.createTaskQuery().processInstanceId(task.getProcessInstanceId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
         
         Task escalationTask = taskService.createTaskQuery().processInstanceId(procId).singleResult();
         assertThat(escalationTask.getName()).isEqualTo("Escalated Task");
-        taskService.complete(escalationTask.getId());
+        completeTask(escalationTask);
         
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(procId).count()).isEqualTo(1);
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertProcessEnded(procId);
     }
@@ -101,7 +101,7 @@ public class EscalationEventSubProcessTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the org.flowable.task.service.Task will end the process instance
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(procId);
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -54,7 +54,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 2nd. case: complete the user task cancels the message subscription
@@ -63,7 +63,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
         assertThat(execution).isNull();
@@ -71,7 +71,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
     }
@@ -114,7 +114,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_1");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // ///////////////////////////////////////////////////////////////////
@@ -124,7 +124,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
         assertThat(execution1).isNull();
@@ -134,7 +134,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
@@ -169,7 +169,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_1");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertProcessEnded(processInstance.getId());
 
         // /////////////////////////////////////////////////////////////////////////////////
@@ -195,7 +195,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // as long as tasks exists, the message subscriptions exist
         for (int i = 0; i < userTasks.size() - 1; i++) {
             org.flowable.task.api.Task task = userTasks.get(i);
-            taskService.complete(task.getId());
+            completeTask(task);
 
             execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
             assertThat(execution1).isNotNull();
@@ -206,7 +206,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // only one task left
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // after last task is completed, no message subscriptions left
         execution1 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_1").singleResult();
@@ -218,7 +218,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -247,7 +247,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // /////////////////////////////////////////////////
@@ -257,7 +257,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
         assertThat(execution).isNull();
@@ -265,7 +265,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 
@@ -295,7 +295,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // ///////////////////////////////////////////////////////////
         // first case: we complete the inner usertask.
 
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
@@ -310,7 +310,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThat(execution).isNotNull();
 
         // now complete the second usertask
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // now the outer event subscription is cancelled as well
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
@@ -321,7 +321,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubprocess");
 
         // now complete the outer usertask
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // ///////////////////////////////////////////////////////////
         // second case: we signal the inner message event
@@ -344,7 +344,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThat(execution).isNotNull();
 
         // now complete the second usertask
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // now the outer event subscription is cancelled as well
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName2").singleResult();
@@ -355,7 +355,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubprocess");
 
         // now complete the outer usertask
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // ///////////////////////////////////////////////////////////
         // third case: we signal the outer message event
@@ -378,7 +378,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThat(execution).isNull();
 
         // now complete the second usertask
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // and we are done
 
@@ -404,7 +404,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_one");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 2nd. case: message two received cancels the task
@@ -419,7 +419,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage_two");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
         // 3rd. case: complete the user task cancels the message subscription
@@ -428,7 +428,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         executionMessageOne = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_one").singleResult();
         assertThat(executionMessageOne).isNull();
@@ -439,7 +439,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterSubProcess");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
     }
@@ -483,7 +483,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterOuterMessageBoundary");
 
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // and we are done
 
@@ -531,13 +531,13 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         // Verify and complete the first task
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         assertThat(userTask).isNotNull();
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // ///////////////////////////////////
         // Complete the after timer task
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskTimer").singleResult();
         assertThat(userTask).isNotNull();
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // Timer job of boundary event of task should be deleted and timer job
         // of task timer boundary event should be created.
@@ -564,7 +564,7 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
 
         // ///////////////////////////////////
         // Complete the first task (again).
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
@@ -605,19 +605,19 @@ public class MessageBoundaryEventTest extends PluggableFlowableTestCase {
         final List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("taskAfterTaskTimer").list();
         assertThat(tasks).hasSize(2);
 
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         // ///////////////////////////////////
         // Complete the second task
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // ///////////////////////////////////
         // Complete the third task
         userTask = taskService.createTaskQuery().singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTaskAfterTask");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // ///////////////////////////////////
         // We should be done at this point

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
@@ -63,7 +63,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(createEventSubscriptionQuery().count()).isZero();
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertProcessEnded(processInstance.getId());
@@ -76,7 +76,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("eventSubProcessTask");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertThat(createEventSubscriptionQuery().count()).isZero();
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -101,7 +101,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(createEventSubscriptionQuery().count()).isZero();
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
@@ -118,14 +118,14 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // we still have 3 executions:
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // now let's complete the task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -143,7 +143,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
@@ -151,7 +151,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -182,7 +182,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isZero();
 
@@ -191,13 +191,13 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -228,7 +228,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isZero();
 
@@ -237,13 +237,13 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -268,7 +268,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the task in the event subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -292,7 +292,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
@@ -315,22 +315,22 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -354,19 +354,19 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -382,7 +382,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
@@ -398,13 +398,13 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
@@ -430,19 +430,19 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(createEventSubscriptionQuery().count()).isZero();
         
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("additionalTask").list();
         assertThat(tasks).hasSize(2);
         
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         
         assertThat(createEventSubscriptionQuery().count()).isZero();
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -466,7 +466,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
@@ -480,12 +480,12 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -509,7 +509,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
@@ -532,7 +532,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -571,7 +571,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask1").singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
             .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
@@ -644,7 +644,7 @@ public class MessageEventSubprocessTest extends PluggableFlowableTestCase {
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask1").singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             assertThat(historyService.createHistoricActivityInstanceQuery().list())

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -59,7 +59,7 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
     }
 
@@ -83,7 +83,7 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
     }
 
     @Test
@@ -113,7 +113,7 @@ public class MessageIntermediateEventTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
@@ -51,7 +51,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableFlowableTe
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessage").singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         // send a message a second time
@@ -65,14 +65,14 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableFlowableTe
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessage").singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterMessage");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1);
 
         // now complete the user task with the message boundary event
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         assertThat(userTask).isNotNull();
 
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         // event subscription removed
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
@@ -81,7 +81,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableFlowableTe
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterTask").singleResult();
         assertThat(userTask).isNotNull();
 
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
@@ -91,7 +91,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableFlowableTe
 
         userTask = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
         assertThat(userTask).isNotNull();
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
 
         execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName").singleResult();
         assertThat(execution).isNull();
@@ -99,7 +99,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableFlowableTe
         userTask = taskService.createTaskQuery().taskDefinitionKey("taskAfterTask").singleResult();
         assertThat(userTask).isNotNull();
         assertThat(userTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");
-        taskService.complete(userTask.getId());
+        completeTask(userTask);
         assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageStartEventTest.java
@@ -114,7 +114,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -127,7 +127,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
         
@@ -142,7 +142,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -179,7 +179,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("taskAfterNoneStart").singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -192,7 +192,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessageStart").singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -211,7 +211,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessageStart").singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -224,7 +224,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessageStart2").singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -234,7 +234,7 @@ public class MessageStartEventTest extends PluggableFlowableTestCase {
         assertThat(processInstance.isEnded()).isFalse();
         task = taskService.createTaskQuery().taskDefinitionKey("taskAfterMessageStart").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventSubprocessTest.java
@@ -63,7 +63,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(createEventSubscriptionQuery().count()).isZero();
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertProcessEnded(processInstance.getId());
@@ -76,7 +76,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("eventSubProcessTask");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertThat(createEventSubscriptionQuery().count()).isZero();
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -101,7 +101,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(createEventSubscriptionQuery().count()).isZero();
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
@@ -118,14 +118,14 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // we still have 3 executions:
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // now let's complete the task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -144,7 +144,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
 
@@ -152,7 +152,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -183,7 +183,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isZero();
 
@@ -192,13 +192,13 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -229,7 +229,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isZero();
 
@@ -238,13 +238,13 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -269,7 +269,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the task in the event subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -293,7 +293,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
@@ -316,22 +316,22 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -355,19 +355,19 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -383,7 +383,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
@@ -399,13 +399,13 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
@@ -431,19 +431,19 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(createEventSubscriptionQuery().count()).isZero();
         
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKey("additionalTask").list();
         assertThat(tasks).hasSize(2);
         
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         
         assertThat(createEventSubscriptionQuery().count()).isZero();
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -467,7 +467,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
@@ -481,12 +481,12 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -510,7 +510,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isEqualTo(2);
 
@@ -533,7 +533,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -570,7 +570,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask1").singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
             .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
@@ -641,7 +641,7 @@ public class SignalEventSubprocessTest extends PluggableFlowableTestCase {
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask1").singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             assertThat(historyService.createHistoricActivityInstanceQuery().list())

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventTest.java
@@ -272,7 +272,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterAbort = taskService.createTaskQuery().taskAssignee("gonzo").singleResult();
         assertThat(taskAfterAbort).isNotNull();
-        taskService.complete(taskAfterAbort.getId());
+        completeTask(taskAfterAbort);
 
         runtimeService.startProcessInstanceByKey("throwSignal");
 
@@ -472,13 +472,13 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         
         Task beforeThrowTask = taskService.createTaskQuery().processInstanceId(throwingProcessInstance.getId()).singleResult();
         assertThat(beforeThrowTask.getTaskDefinitionKey()).isEqualTo("beforeThrowTask");
-        taskService.complete(beforeThrowTask.getId());
+        completeTask(beforeThrowTask);
         
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(throwingProcessInstance.getId()).count()).isZero();
         
         Task afterSignalReceiveTask = taskService.createTaskQuery().processInstanceId(processInstanceCatch.getId()).singleResult();
         assertThat(afterSignalReceiveTask.getTaskDefinitionKey()).isEqualTo("userTaskAfterSignalCatch");
-        taskService.complete(afterSignalReceiveTask.getId());
+        completeTask(afterSignalReceiveTask);
         
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstanceCatch.getId()).count()).isZero();
     }
@@ -720,7 +720,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("usertask1").singleResult();
         taskService.claim(task.getId(), "user");
-        taskService.complete(task.getId());
+        completeTask(task);
         
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // trigger history comment handling when necessary
@@ -915,7 +915,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         // create the file
         FileExistsMock.getInstance().touchFile();
         
-        taskService.complete(firstTask.getId());
+        completeTask(firstTask);
         
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             // trigger history comment handling when necessary

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationAndEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationAndEndTest.java
@@ -59,7 +59,7 @@ public class BoundaryTimerEventRepeatWithDurationAndEndTest extends PluggableFlo
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).hasSize(1);
@@ -107,7 +107,7 @@ public class BoundaryTimerEventRepeatWithDurationAndEndTest extends PluggableFlo
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Task B");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).isEmpty();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithDurationTest.java
@@ -56,7 +56,7 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).hasSize(1);
@@ -104,7 +104,7 @@ public class BoundaryTimerEventRepeatWithDurationTest extends PluggableFlowableT
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Task B");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).isEmpty();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEndTest.java
@@ -65,7 +65,7 @@ public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCa
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).hasSize(1);
@@ -104,7 +104,7 @@ public class BoundaryTimerEventRepeatWithEndTest extends PluggableFlowableTestCa
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Task B");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).isEmpty();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithStartAndDurationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithStartAndDurationTest.java
@@ -60,7 +60,7 @@ public class BoundaryTimerEventRepeatWithStartAndDurationTest extends PluggableF
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).hasSize(1);
@@ -108,7 +108,7 @@ public class BoundaryTimerEventRepeatWithStartAndDurationTest extends PluggableF
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Task B");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).isEmpty();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -906,7 +906,7 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
 
         tasks = taskService.createTaskQuery().taskName("Reminder Task").list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         
         assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -69,7 +69,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
                 .containsExactly("First Task", "Escalation Task 1");
 
         // complete the task and end the forked execution
-        taskService.complete(taskList.get(1).getId());
+        completeTask(taskList.get(1));
 
         // but we still have the original executions
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
@@ -90,14 +90,14 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
                 .containsExactly("First Task", "Escalation Task 2");
 
         // This time we end the main task
-        taskService.complete(taskList.get(0).getId());
+        completeTask(taskList.get(0));
 
         // but we still have the escalation task
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         org.flowable.task.api.Task escalationTask = taskService.createTaskQuery().singleResult();
         assertThat(escalationTask.getName()).isEqualTo("Escalation Task 2");
 
-        taskService.complete(escalationTask.getId());
+        completeTask(escalationTask);
 
         // now we are really done :-)
         assertProcessEnded(pi.getId());
@@ -129,7 +129,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // end the first
-        taskService.complete(task1.getId());
+        completeTask(task1);
 
         // we now have one task left
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
@@ -137,7 +137,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertThat(task2.getName()).isEqualTo("Escalation Task");
 
         // complete the task, the parallel gateway should fire
-        taskService.complete(task2.getId());
+        completeTask(task2);
 
         // and the process has ended
         assertProcessEnded(pi.getId());
@@ -156,12 +156,12 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // Complete task that was reached by non interrupting timer
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // Complete other tasks
         for (org.flowable.task.api.Task t : taskService.createTaskQuery().list()) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
         assertProcessEnded(procId);
     }
@@ -180,14 +180,14 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // Complete 2 tasks that will trigger the join
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("firstTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().taskDefinitionKey("secondTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // Finally, complete the task that was created due to the timer
         task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(procId);
     }
@@ -213,7 +213,7 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertThat(managementService.createTimerJobQuery().processInstanceId(processInstanceId).count()).isEqualTo(1);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         moveByMinutes(60);
         assertThatCode(() -> { waitForJobExecutorToProcessAllJobs(2000, 100); })
@@ -244,8 +244,8 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         List<org.flowable.task.api.Task> tasks = tq.list();
 
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         assertProcessEnded(id);
     }
@@ -301,18 +301,18 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
 
         // Complete 4 tasks that will trigger the join
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("sub1task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().taskDefinitionKey("sub1task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().taskDefinitionKey("sub2task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().taskDefinitionKey("sub2task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // Finally, complete the task that was created due to the timer
         task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(procId);
     }
@@ -329,18 +329,18 @@ public class BoundaryTimerNonInterruptingEventTest extends PluggableFlowableTest
         assertThat(taskService.createTaskQuery().count()).isEqualTo(5);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("sub1task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().taskDefinitionKey("sub1task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // complete the task that was created due to the timer
         task = taskService.createTaskQuery().taskDefinitionKey("timerFiredTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().taskDefinitionKey("sub2task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().taskDefinitionKey("sub2task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(taskService.createTaskQuery().count()).isZero();
 
         assertProcessEnded(procId);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventRepeatWithEndTest.java
@@ -80,7 +80,7 @@ public class IntermediateTimerEventRepeatWithEndTest extends PluggableFlowableTe
                 .containsExactly("Task A");
 
         // Test Timer Catch Intermediate Events after completing org.flowable.task.service.Task A (endDate not reached but it will be executed according to the expression)
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(timerJob).isNotNull();
@@ -107,7 +107,7 @@ public class IntermediateTimerEventRepeatWithEndTest extends PluggableFlowableTe
                 .containsExactly("Task C");
 
         // Test Timer Catch Intermediate Events after completing org.flowable.task.service.Task C
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         nextTimeCal.add(Calendar.HOUR, 1); // after 1 hour and 5 minutes the timer event should be executed.
         nextTimeCal.add(Calendar.MINUTE, 5);
         processEngineConfiguration.getClock().setCurrentTime(nextTimeCal.getTime());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -78,7 +78,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
 
         Date startDate = new Date();
         runtimeService.setVariable(pi.getId(), "StartDate", startDate);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         assertThat(jobQuery.count()).isEqualTo(1);
@@ -100,7 +100,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Task B");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         assertProcessEnded(pi.getProcessInstanceId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndExpressionTest.java
@@ -179,7 +179,7 @@ public class StartTimerEventRepeatWithEndExpressionTest extends PluggableFlowabl
             assertThat(tasks)
                     .extracting(Task::getName)
                     .containsExactly("Task A");
-            taskService.complete(tasks.get(0).getId());
+            completeTask(tasks.get(0));
         }
 
         // now All the process instances should be completed

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithEndTest.java
@@ -184,7 +184,7 @@ public class StartTimerEventRepeatWithEndTest extends PluggableFlowableTestCase 
             assertThat(tasks)
                     .extracting(Task::getName)
                     .containsExactly("Task A");
-            taskService.complete(tasks.get(0).getId());
+            completeTask(tasks.get(0));
         }
 
         // now All the process instances should be completed

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutEndDateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutEndDateTest.java
@@ -184,7 +184,7 @@ public class StartTimerEventRepeatWithoutEndDateTest extends PluggableFlowableTe
             assertThat(tasks)
                     .extracting(Task::getName)
                     .containsExactly("Task A");
-            taskService.complete(tasks.get(0).getId());
+            completeTask(tasks.get(0));
         }
 
         // now All the process instances should be completed

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/TimerEventSubprocessTest.java
@@ -47,7 +47,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         // if we trigger the usertask, the process terminates and the timer job is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -62,7 +62,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("eventSubProcessTask");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
         assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -82,7 +82,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         // if we trigger the usertask, the process terminates and the event subscription is removed:
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
 
@@ -97,14 +97,14 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // we still have 3 executions:
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         // now let's complete the task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -120,7 +120,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
@@ -128,7 +128,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
 
         task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -161,7 +161,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
@@ -170,13 +170,13 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -201,7 +201,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's complete the task in the event subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -221,7 +221,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
         assertThat(jobs).hasSize(2);
@@ -244,22 +244,22 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -278,7 +278,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
         assertThat(jobs).hasSize(2);
@@ -286,14 +286,14 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
         assertThat(jobs).hasSize(1);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -311,7 +311,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
@@ -330,14 +330,14 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("subTask1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).isNotNull();
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).isNotNull();
@@ -349,12 +349,12 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).count()).isZero();
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -374,7 +374,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
         assertThat(jobs).hasSize(2);
@@ -392,12 +392,12 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalSubTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("task2").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -417,7 +417,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task1").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Job> jobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
         assertThat(jobs).hasSize(2);
@@ -440,7 +440,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
         
         task = taskService.createTaskQuery().taskDefinitionKey("additionalTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -480,7 +480,7 @@ public class TimerEventSubprocessTest extends PluggableFlowableTestCase {
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask1").singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
             .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/BoundaryTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/BoundaryTimerEventRepeatCompatibilityTest.java
@@ -59,7 +59,7 @@ public class BoundaryTimerEventRepeatCompatibilityTest extends TimerEventCompati
 
         // Test Boundary Events
         // complete will cause timer to be created
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         List<Job> jobs = managementService.createTimerJobQuery().list();
         assertThat(jobs).hasSize(1);
@@ -98,7 +98,7 @@ public class BoundaryTimerEventRepeatCompatibilityTest extends TimerEventCompati
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsOnly("Task B");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         assertThatCode(() -> { waitForJobExecutorToProcessAllJobs(7000, 500); })
                 .as("No jobs should be active here.")

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/IntermediateTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/IntermediateTimerEventRepeatCompatibilityTest.java
@@ -70,7 +70,7 @@ public class IntermediateTimerEventRepeatCompatibilityTest extends TimerEventCom
 
         // Test Timer Catch Intermediate Events after completing org.flowable.task.service.Task B (endDate
         // not reached but it will be executed according to the expression)
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         waitForJobExecutorToProcessAllJobs(2000, 500);
         // Expected that job isn't executed because the timer is in t0
@@ -91,7 +91,7 @@ public class IntermediateTimerEventRepeatCompatibilityTest extends TimerEventCom
                 .containsOnly("Task C");
 
         // Test Timer Catch Intermediate Events after completing org.flowable.task.service.Task C
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         nextTimeInstant = nextTimeInstant.plus(1, ChronoUnit.HOURS); // after 1H 40 minutes from process start, the timer will trigger because of the endDate
         processEngineConfiguration.getClock().setCurrentTime(Date.from(nextTimeInstant));
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/StartTimerEventRepeatCompatibilityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/compatibility/StartTimerEventRepeatCompatibilityTest.java
@@ -173,7 +173,7 @@ public class StartTimerEventRepeatCompatibilityTest extends TimerEventCompatibil
             assertThat(tasks)
                     .extracting(Task::getName)
                     .containsOnly("Task A");
-            taskService.complete(tasks.get(0).getId());
+            completeTask(tasks.get(0));
         }
 
         // now All the process instances should be completed

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/EventBasedGatewayTest.java
@@ -54,7 +54,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("afterSignal").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
@@ -85,7 +85,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
@@ -123,7 +123,7 @@ public class EventBasedGatewayTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("afterMessage").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -101,7 +101,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task partialTask = taskService.createTaskQuery().singleResult();
         assertThat(partialTask.getTaskDefinitionKey()).isEqualTo("partialTask");
 
-        taskService.complete(partialTask.getId());
+        completeTask(partialTask);
 
         org.flowable.task.api.Task fullTask = taskService.createTaskQuery().singleResult();
         assertThat(fullTask.getTaskDefinitionKey()).isEqualTo("theTask");
@@ -132,7 +132,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertThat(firstTasks).hasSize(2);
 
         for (org.flowable.task.api.Task t : firstTasks) {
-            taskService.complete(t.getId());
+            completeTask(t);
         }
 
         // start second round of tasks
@@ -141,7 +141,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
 
         // complete one task
         org.flowable.task.api.Task task = secondTasks.get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<Execution> executionsAfter = runtimeService.createExecutionQuery().list();
         assertThat(executionsAfter).hasSize(2);
@@ -160,7 +160,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         // Completing last task should finish the process instance
 
         org.flowable.task.api.Task lastTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(lastTask.getId());
+        completeTask(lastTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().active().count()).isZero();
     }
@@ -309,7 +309,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("task C");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(taskService.createTaskQuery().count()).isZero();
         
         assertThat(runtimeService.createExecutionQuery().count())
@@ -331,14 +331,14 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskAssignee("c").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(processInstance).isNull();
@@ -354,11 +354,11 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getAssignee)
                 .containsExactly("a");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         task = taskService.createTaskQuery().taskAssignee("c").singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(processInstance).isNull();
@@ -379,7 +379,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertThat(task).isNotNull();
         assertThat(task.getName()).isEqualTo("Task1");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Execution execution = runtimeService.createExecutionQuery()
                 .processInstanceId(processInstance.getId())
@@ -410,27 +410,27 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         // inclusive gateway should wait for the "Task B" and "Task C"
         org.flowable.task.api.Task taskA = taskService.createTaskQuery().taskName("Task A").singleResult();
         assertThat(taskA).isNotNull();
-        taskService.complete(taskA.getId());
+        completeTask(taskA);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
 
         // now complete task B and check number of remaining tasks
         // inclusive gateway should wait for "Task C"
         org.flowable.task.api.Task taskB = taskService.createTaskQuery().taskName("Task B").singleResult();
         assertThat(taskB).isNotNull();
-        taskService.complete(taskB.getId());
+        completeTask(taskB);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // now complete task C. Gateway activates and "Task C" remains
         org.flowable.task.api.Task taskC = taskService.createTaskQuery().taskName("Task C").singleResult();
         assertThat(taskC).isNotNull();
-        taskService.complete(taskC.getId());
+        completeTask(taskC);
         assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
         // check that remaining task is in fact task D
         org.flowable.task.api.Task taskD = taskService.createTaskQuery().taskName("Task D").singleResult();
         assertThat(taskD).isNotNull();
         assertThat(taskD.getName()).isEqualTo("Task D");
-        taskService.complete(taskD.getId());
+        completeTask(taskD);
 
         processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(processInstance).isNull();
@@ -453,7 +453,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask1");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         varMap = new HashMap<>();
@@ -461,8 +461,8 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwDirectSequenceFlow", varMap);
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(2);
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         varMap = new HashMap<>();
@@ -481,7 +481,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask1");
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         varMap = new HashMap<>();
@@ -490,8 +490,8 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         processInstance = runtimeService.startProcessInstanceByKey("inclusiveGwSkipExpression", varMap);
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(2);
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
 
         varMap = new HashMap<>();
@@ -566,7 +566,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertThat(getInactiveExecutionsInActivityId("inclusiveGw")).hasSize(2);
 
         // Completing C of PI 1 should not trigger C
-        taskService.complete(taskCInPi1.getId());
+        completeTask(taskCInPi1);
 
         // Verify structure after complete.
         // Before bugfix: in BOTH process instances the inactive execution was removed (result was 0)
@@ -579,7 +579,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         while (tasks.size() > 0) {
             for (org.flowable.task.api.Task task : tasks) {
-                taskService.complete(task.getId());
+                completeTask(task);
             }
             tasks = taskService.createTaskQuery().list();
         }
@@ -729,7 +729,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Finish the process
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
@@ -796,7 +796,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //Last task of this multiInstance subProcess instance
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //The next sequence should start
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -823,7 +823,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         //last task of the sequence
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //Last Sequence
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -833,7 +833,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         tasks.forEach(this::completeTask);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("postForkTask");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         //last task of the process, after the multiInstance subProcess
         childExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
@@ -842,7 +842,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Finish the process
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
     }
@@ -1107,7 +1107,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
 
         //Finish the process
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ParallelGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/ParallelGatewayTest.java
@@ -91,21 +91,21 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 .containsExactly("Task 0");
 
         // Completing task 0 will create org.flowable.task.service.Task A and B
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = query.list();
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Task A", "Task B");
 
         // Completing task A should not trigger any new tasks
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = query.list();
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Task B");
 
         // Completing task B creates tasks B1 and B2
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         tasks = query.list();
         assertThat(tasks)
                 .extracting(Task::getName)
@@ -113,8 +113,8 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
 
         // Completing B1 and B2 will activate both joins, and process reaches
         // task C
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         tasks = query.list();
         assertThat(tasks)
                 .extracting(Task::getName)
@@ -139,7 +139,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
 
         // we complete the task from the parent process, the root execution is
         // recycled, the task in the sub process is still there
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
         tasks = query.list();
         assertThat(tasks)
                 .extracting(Task::getName)
@@ -147,7 +147,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
 
         // we end the task in the sub process and the sub process instance end
         // is propagated to the parent process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertThat(taskService.createTaskQuery().count()).isZero();
 
         // There is a QA config without history, so we cannot work with this:
@@ -238,7 +238,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 return subs.get(0).getExecutionId();
             }
         });
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         tasks = taskService.createTaskQuery()
                 .processInstanceId(processInstance.getProcessInstanceId())
@@ -246,7 +246,7 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 .list();
         assertThat(tasks).hasSize(1);
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getProcessInstanceId()).list();
         assertThat(tasks).hasSize(1);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/DynamicMultiInstanceTest.java
@@ -53,23 +53,23 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             
             runtimeService.addMultiInstanceExecution("miTasks", procId, null);
             
-            taskService.complete(task.getId());
+            completeTask(task);
     
             task = taskService.createTaskQuery().singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
             assertThat(task.getAssignee()).isEqualTo("kermit_1");
-            taskService.complete(task.getId());
+            completeTask(task);
     
             task = taskService.createTaskQuery().singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
             assertThat(task.getAssignee()).isEqualTo("kermit_2");
-            taskService.complete(task.getId());
+            completeTask(task);
             
             // another mi execution was added
             task = taskService.createTaskQuery().singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
             assertThat(task.getAssignee()).isEqualTo("kermit_3");
-            taskService.complete(task.getId());
+            completeTask(task);
     
             assertThat(taskService.createTaskQuery().singleResult()).isNull();
             assertProcessEnded(procId);
@@ -94,12 +94,12 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             runtimeService.setVariable(procId, "taskUserList", userList);
             runtimeService.addMultiInstanceExecution("miTasks", procId, CollectionUtil.singletonMap("taskUser", "hr"));
 
-            taskService.complete(task.getId());
+            completeTask(task);
 
             task = taskService.createTaskQuery().singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
             assertThat(task.getAssignee()).isEqualTo("hr");
-            taskService.complete(task.getId());
+            completeTask(task);
 
             assertThat(taskService.createTaskQuery().singleResult()).isNull();
             assertProcessEnded(procId);
@@ -121,12 +121,12 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             task = taskService.createTaskQuery().singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
             assertThat(task.getAssignee()).isEqualTo("kermit_0");
-            taskService.complete(task.getId());
+            completeTask(task);
     
             task = taskService.createTaskQuery().singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
             assertThat(task.getAssignee()).isEqualTo("kermit_1");
-            taskService.complete(task.getId());
+            completeTask(task);
     
             assertThat(taskService.createTaskQuery().singleResult()).isNull();
             assertProcessEnded(procId);
@@ -148,12 +148,12 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             task = taskService.createTaskQuery().singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
             assertThat(task.getAssignee()).isEqualTo("kermit_1");
-            taskService.complete(task.getId());
+            completeTask(task);
     
             task = taskService.createTaskQuery().singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
             assertThat(task.getAssignee()).isEqualTo("kermit_2");
-            taskService.complete(task.getId());
+            completeTask(task);
     
             assertThat(taskService.createTaskQuery().singleResult()).isNull();
             assertProcessEnded(procId);
@@ -178,10 +178,10 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
                     .extracting(Task::getName)
                     .containsExactly("My Task 0", "My Task 1", "My Task 2", "My Task 3");
 
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
-            taskService.complete(tasks.get(2).getId());
-            taskService.complete(tasks.get(3).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
+            completeTask(tasks.get(2));
+            completeTask(tasks.get(3));
             assertProcessEnded(procId);
         }
     }
@@ -204,8 +204,8 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
                     .extracting(Task::getName)
                     .containsExactly("My Task 0", "My Task 2");
     
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
             assertProcessEnded(procId);
         }
     }
@@ -227,9 +227,9 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(tasks).hasSize(6);
         
             // Completing 3 tasks will not yet trigger completion condition
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
-            taskService.complete(tasks.get(2).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
+            completeTask(tasks.get(2));
             
             assertThat(taskService.createTaskQuery().count()).isEqualTo(3);
             
@@ -237,7 +237,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(newTask).isNotNull();
             
             // Completing task will trigger completion condition
-            taskService.complete(newTask.getId());
+            completeTask(newTask);
             
             assertThat(taskService.createTaskQuery().count()).isZero();
             assertProcessEnded(procId);
@@ -260,7 +260,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(tasks).hasSize(16);
             
             for (int i = 0; i < 16; i++) {
-                taskService.complete(tasks.get(i).getId());
+                completeTask(tasks.get(i));
             }
             
             assertProcessEnded(procId);
@@ -293,7 +293,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(tasks).hasSize(12);
             
             for (int i = 0; i < 12; i++) {
-                taskService.complete(tasks.get(i).getId());
+                completeTask(tasks.get(i));
             }
             
             assertProcessEnded(procId);
@@ -315,8 +315,8 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
                         .extracting(Task::getName)
                         .containsExactly("task one", "task two");
     
-                taskService.complete(tasks.get(0).getId());
-                taskService.complete(tasks.get(1).getId());
+                completeTask(tasks.get(0));
+                completeTask(tasks.get(1));
             }
     
             assertProcessEnded(procId);
@@ -351,8 +351,8 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
                         .extracting(Task::getName)
                         .containsExactly("task one", "task two");
     
-                taskService.complete(tasks.get(0).getId());
-                taskService.complete(tasks.get(1).getId());
+                completeTask(tasks.get(0));
+                completeTask(tasks.get(1));
             }
     
             assertProcessEnded(procId);
@@ -387,8 +387,8 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
                         .extracting(Task::getName)
                         .containsExactly("task one", "task two");
     
-                taskService.complete(tasks.get(0).getId());
-                taskService.complete(tasks.get(1).getId());
+                completeTask(tasks.get(0));
+                completeTask(tasks.get(1));
             }
     
             assertProcessEnded(procId);
@@ -414,8 +414,8 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
                         .extracting(Task::getName)
                         .containsExactly("task one", "task two");
     
-                taskService.complete(tasks.get(0).getId());
-                taskService.complete(tasks.get(1).getId());
+                completeTask(tasks.get(0));
+                completeTask(tasks.get(1));
             }
     
             assertProcessEnded(procId);
@@ -449,7 +449,7 @@ public class DynamicMultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(tasks).hasSize(11);
             
             for (org.flowable.task.api.Task task : tasks) {
-                taskService.complete(task.getId());
+                completeTask(task);
             }
             
             assertProcessEnded(procId);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.java
@@ -72,17 +72,17 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("My Task");
         assertThat(task.getAssignee()).isEqualTo("kermit_0");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("My Task");
         assertThat(task.getAssignee()).isEqualTo("kermit_1");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("My Task");
         assertThat(task.getAssignee()).isEqualTo("kermit_2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(taskService.createTaskQuery().singleResult()).isNull();
         assertProcessEnded(procId);
@@ -135,7 +135,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
         assertProcessEnded(procId);
     }
 
@@ -147,7 +147,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         // 10 tasks are to be created, but completionCondition stops them at 5
         for (int i = 0; i < 5; i++) {
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-            taskService.complete(task.getId());
+            completeTask(task);
         }
         assertThat(taskService.createTaskQuery().singleResult()).isNull();
         assertProcessEnded(procId);
@@ -161,7 +161,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         for (int i = 0; i < 3; i++) {
             org.flowable.task.api.Task task = taskService.createTaskQuery().taskAssignee("kermit").singleResult();
             assertThat(task.getName()).isEqualTo("My Task");
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertProcessEnded(procId);
@@ -177,9 +177,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                 .extracting(Task::getName)
                 .containsExactly("My Task 0", "My Task 1", "My Task 2");
 
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
-        taskService.complete(tasks.get(2).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
+        completeTask(tasks.get(2));
         assertProcessEnded(procId);
     }
 
@@ -191,7 +191,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(3);
         for (int i = 0; i < tasks.size(); i++) {
             assertThat(tasks.get(i).getName()).isEqualTo("My Task " + i);
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
         }
 
         // Validate history
@@ -222,7 +222,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         String procId = runtimeService.startProcessInstanceByKey("miParallelUserTasksWithTimer").getId();
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         // Fire timer
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -231,7 +231,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
         assertProcessEnded(procId);
     }
 
@@ -246,7 +246,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         // completionCondition
         for (int i = 0; i < 3; i++) {
             assertThat(taskService.createTaskQuery().count()).isEqualTo(5 - i);
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
         }
         assertProcessEnded(procId);
     }
@@ -263,9 +263,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                 .containsExactly("bubba", "fozzie", "gonzo", "kermit", "mispiggy");
 
         // Completing 3 tasks will trigger completioncondition
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
-        taskService.complete(tasks.get(2).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
+        completeTask(tasks.get(2));
         assertThat(taskService.createTaskQuery().count()).isZero();
         assertProcessEnded(procId);
     }
@@ -296,8 +296,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                 .containsExactly("My Task 0", "My Task 1");
 
         // Completing 3 tasks will trigger completion condition
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         assertThat(taskService.createTaskQuery().count()).isZero();
         assertProcessEnded(processInstance.getProcessInstanceId());
     }
@@ -382,9 +382,9 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                 .containsExactly("fozzie", "gonzo", "kermit");
 
         // Completing 3 tasks will trigger completion condition
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
-        taskService.complete(tasks.get(2).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
+        completeTask(tasks.get(2));
         assertThat(taskService.createTaskQuery().count()).isZero();
         assertProcessEnded(processInstance.getProcessInstanceId());
     }
@@ -395,7 +395,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelUserTasks");
         List<Task> tasks = taskService.createTaskQuery().list();
         for (Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         Execution waitState = runtimeService.createExecutionQuery().activityId("waitState").singleResult();
@@ -428,7 +428,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         for (Task task : tasks){
             assertThat(taskService.getVariable(task.getId(), "csAssignee")).isEqualTo(task.getAssignee());
             taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
-            taskService.complete(task.getId());
+            completeTask(task);
             
             HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
                             processEngineConfiguration.getManagementService(), 7000, 200);
@@ -456,7 +456,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().singleResult();
         assertThat(taskService.getVariable(task.getId(), "csAssignee")).isEqualTo(task.getAssignee());
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
-        taskService.complete(task.getId());
+        completeTask(task);
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
                         processEngineConfiguration.getManagementService(), 7000, 200);
@@ -464,7 +464,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().singleResult();
         assertThat(taskService.getVariable(task.getId(), "csAssignee")).isEqualTo(task.getAssignee());
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
-        taskService.complete(task.getId());
+        completeTask(task);
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
                         processEngineConfiguration.getManagementService(), 7000, 200);
@@ -472,7 +472,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().singleResult();
         assertThat(taskService.getVariable(task.getId(), "csAssignee")).isEqualTo(task.getAssignee());
         taskService.setVariableLocal(task.getId(), "csApproveResult", "pass");
-        taskService.complete(task.getId());
+        completeTask(task);
         
         HistoryTestHelper.waitForJobExecutorToProcessAllHistoryJobs(processEngineConfiguration, 
                         processEngineConfiguration.getManagementService(), 7000, 200);
@@ -488,7 +488,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
         for (org.flowable.task.api.Task task : tasks) {
             assertThat(task.getName()).isEqualTo("My Task");
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertProcessEnded(procId);
@@ -625,8 +625,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                     .extracting(Task::getName)
                     .containsExactly("task one", "task two");
 
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
 
             if (i != 3) {
                 List<String> activities = runtimeService.getActiveActivityIds(procId);
@@ -650,7 +650,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                     .extracting(Task::getName)
                     .containsExactly("task one");
 
-            taskService.complete(tasks.get(0).getId());
+            completeTask(tasks.get(0));
 
             // Last run, the execution no longer exists
             if (i != 3) {
@@ -668,8 +668,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("miSequentialSubprocess");
         for (int i = 0; i < 4; i++) {
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
         }
 
         // Validate history
@@ -701,8 +701,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         // Complete one subprocess
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(2);
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(2);
 
@@ -713,7 +713,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(procId);
     }
@@ -730,8 +730,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
                     .extracting(Task::getName)
                     .containsExactly("task one", "task two");
 
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
         }
 
         assertProcessEnded(procId);
@@ -744,8 +744,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         for (int i = 0; i < 3; i++) {
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
         }
 
         assertProcessEnded(procId);
@@ -758,13 +758,13 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         for (int i = 0; i < 2; i++) {
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
         }
 
         // Complete one task, to make it a bit more trickier
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("kermit").list();
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         // Fire timer
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -773,7 +773,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(procId);
     }
@@ -786,7 +786,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(4);
 
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertProcessEnded(procId);
@@ -797,7 +797,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
     public void testParallelSubProcessHistory() {
         runtimeService.startProcessInstanceByKey("miParallelSubprocess");
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         // Validate history
@@ -819,8 +819,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(6);
 
         // Complete two tasks
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         // Fire timer
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -829,7 +829,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(procId);
     }
@@ -860,8 +860,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
 
         assertThat(subProcessTask2).isNotNull();
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(subProcessTask2.getId());
+        completeTask(tasks.get(0));
+        completeTask(subProcessTask2);
 
         assertProcessEnded(procId);
     }
@@ -916,7 +916,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(8);
 
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
         assertProcessEnded(procId);
     }
@@ -929,7 +929,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasks).hasSize(12);
 
         for (int i = 0; i < 3; i++) {
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
         }
 
         // Fire timer
@@ -939,7 +939,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(procId);
     }
@@ -959,7 +959,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
             Map<String, Object> taskVariables = Collections.singletonMap("output", (Object) ("run" + i + 1));
             taskService.complete(tasks.get(0).getId(), taskVariables);
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(1));
             
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(procId).singleResult();
             assertThat(task).isNotNull();
@@ -969,7 +969,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(runtimeService.getVariableLocal(execution.getId(), "output")).isEqualTo("run" + i + 1);
             assertThat(runtimeService.getVariable(procId, "output")).isNull();
             
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertProcessEnded(procId);
@@ -990,7 +990,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
             Map<String, Object> taskVariables = Collections.singletonMap("output", (Object) ("run" + i + 1));
             taskService.complete(tasks.get(0).getId(), taskVariables);
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(1));
             
             org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(procId).singleResult();
             assertThat(task).isNotNull();
@@ -1000,7 +1000,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(runtimeService.getVariableLocal(execution.getId(), "output")).isNull();
             assertThat(runtimeService.getVariable(procId, "output")).isEqualTo("run" + i + 1);
             
-            taskService.complete(task.getId());
+            completeTask(task);
         }
         
         assertProcessEnded(procId);
@@ -1017,8 +1017,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(tasks)
                     .extracting(Task::getName)
                     .containsExactly("task one", "task two");
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
         }
 
         assertProcessEnded(procId);
@@ -1070,8 +1070,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("task one", "task two");
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         // Fire timer
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -1080,7 +1080,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(procId);
     }
@@ -1093,7 +1093,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(12);
         for (int i = 0; i < tasks.size(); i++) {
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
         }
 
         assertProcessEnded(procId);
@@ -1107,7 +1107,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(12);
         for (int i = 0; i < tasks.size(); i++) {
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
         }
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
@@ -1148,7 +1148,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(6);
         for (int i = 0; i < 2; i++) {
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
         }
 
         // Fire timer
@@ -1158,7 +1158,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(procId);
     }
@@ -1174,8 +1174,8 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(tasks)
                     .extracting(Task::getName)
                     .containsExactly("task one", "task two");
-            taskService.complete(tasks.get(0).getId());
-            taskService.complete(tasks.get(1).getId());
+            completeTask(tasks.get(0));
+            completeTask(tasks.get(1));
         }
 
         assertProcessEnded(procId);
@@ -1192,13 +1192,13 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("task one", "task two");
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         // one task of second instance
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(2);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         // Fire timer
         Job timer = managementService.createTimerJobQuery().singleResult();
@@ -1207,7 +1207,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(procId);
     }
@@ -1221,7 +1221,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(14);
         for (int i = 0; i < 14; i++) {
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
         }
 
         assertProcessEnded(procId);
@@ -1236,7 +1236,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(4);
         for (int i = 0; i < 3; i++) {
-            taskService.complete(tasks.get(i).getId());
+            completeTask(tasks.get(i));
         }
 
         // Fire timer
@@ -1246,7 +1246,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task taskAfterTimer = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterTimer.getTaskDefinitionKey()).isEqualTo("taskAfterTimer");
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(procId);
     }
@@ -1264,7 +1264,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(nextSubProcessInstance.getId()).list();
             assertThat(tasks).hasSize(2);
             for (org.flowable.task.api.Task task : tasks) {
-                taskService.complete(task.getId());
+                completeTask(task);
             }
         }
 
@@ -1347,7 +1347,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(1);
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("process").list();
         assertThat(processInstances).isEmpty();
@@ -1374,7 +1374,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(1);
 
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("process").list();
         assertThat(processInstances).isEmpty();
@@ -1396,7 +1396,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         // There is one task after the task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
@@ -1421,7 +1421,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Task after timer");
 
         // Completing it should end the process
-        taskService.complete(task.getId());
+        completeTask(task);
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
 
@@ -1441,7 +1441,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         // There is one task after the task
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().count()).isZero();
     }
@@ -1505,7 +1505,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(processInstance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1532,7 +1532,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         assertThat(processInstance).isNotNull();
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 
@@ -1641,7 +1641,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         assertThat(TestTaskCompletionListener.count.get()).isEqualTo(4);
@@ -1690,7 +1690,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         }
 
         // Complete one of the user tasks. This should not trigger setting of end time of the subprocess, but due to a bug it did exactly that
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
@@ -1701,7 +1701,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
             assertThat(historicActivityInstance.getEndTime()).isNull();
         }
 
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
@@ -1715,7 +1715,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskName("User Task 3").list();
         assertThat(tasks).hasSize(2);
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
             
             waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
             
@@ -1731,7 +1731,7 @@ public class MultiInstanceTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         assertThat(tasks).hasSize(2);
         for (org.flowable.task.api.Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/ConditionalSequenceFlowTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/sequenceflow/ConditionalSequenceFlowTest.java
@@ -123,7 +123,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
         assertThat(task.getName()).isEqualTo("task not left");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         ObjectNode infoNode = dynamicBpmnService.changeSequenceFlowCondition("flow1", "${input == 'right'}");
         dynamicBpmnService.changeSequenceFlowCondition("flow2", "${input != 'right'}", infoNode);
@@ -134,7 +134,7 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
         assertThat(task.getName()).isEqualTo("task left");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         variables = CollectionUtil.singletonMap("input", "right2");
         pi = runtimeService.startProcessInstanceByKey("condSeqFlowUelExpr", variables);
@@ -142,6 +142,6 @@ public class ConditionalSequenceFlowTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
         assertThat(task.getName()).isEqualTo("task not left");
-        taskService.complete(task.getId());
+        completeTask(task);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/DynamicServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/DynamicServiceTaskTest.java
@@ -43,13 +43,13 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTask", varMap);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.getVariable(processInstance.getId(), "count")).isEqualTo(1);
         assertThat(runtimeService.getVariable(processInstance.getId(), "count2")).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -64,13 +64,13 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId, infoNode);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.getVariable(processInstance.getId(), "count")).isEqualTo(0);
         assertThat(runtimeService.getVariable(processInstance.getId(), "count2")).isEqualTo(1);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -85,7 +85,7 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTask", varMap);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
@@ -109,7 +109,7 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId, infoNode);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
@@ -133,7 +133,7 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTask", varMap);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
@@ -157,7 +157,7 @@ public class DynamicServiceTaskTest extends PluggableFlowableTestCase {
         dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId, infoNode);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskDelegateExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/servicetask/ServiceTaskDelegateExpressionTest.java
@@ -94,7 +94,7 @@ public class ServiceTaskDelegateExpressionTest extends PluggableFlowableTestCase
 
             @Override
             public Void execute(CommandContext commandContext) {
-                taskService.complete(task.getId());
+                completeTask(task);
                 
                 ActivityInstanceEntityManager activityInstanceEntityManager = processEngineConfiguration.getActivityInstanceEntityManager();
                 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/SubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/SubProcessTest.java
@@ -66,7 +66,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         // After completing the task in the subprocess,
         // the subprocess scope is destroyed and the complete process ends
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
 
@@ -138,8 +138,8 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertThat(taskAfterTimer2.getName()).isEqualTo("Task after timer 2");
 
         // Completing the two tasks should end the process instance
-        taskService.complete(taskAfterTimer1.getId());
-        taskService.complete(taskAfterTimer2.getId());
+        completeTask(taskAfterTimer1);
+        completeTask(taskAfterTimer2);
         assertProcessEnded(pi.getId());
     }
 
@@ -161,11 +161,11 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         // After completing the task in the subprocess,
         // both subprocesses are destroyed and the task after the subprocess should be active
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
         org.flowable.task.api.Task taskAfterSubProcesses = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(taskAfterSubProcesses).isNotNull();
         assertThat(taskAfterSubProcesses.getName()).isEqualTo("Task after subprocesses");
-        taskService.complete(taskAfterSubProcesses.getId());
+        completeTask(taskAfterSubProcesses);
 
         assertProcessEnded(pi.getId());
     }
@@ -192,7 +192,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         // Completing the escalated task, destroys the outer scope and activates
         // the task after the subprocess
-        taskService.complete(escalationTask.getId());
+        completeTask(escalationTask);
         org.flowable.task.api.Task taskAfterSubProcess = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocesses");
     }
@@ -211,7 +211,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         // After completing the task in the subprocess,
         // both subprocesses are destroyed and the task after the subprocess
         // should be active
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
         org.flowable.task.api.Task taskAfterSubProcesses = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(taskAfterSubProcesses.getName()).isEqualTo("Task after subprocesses");
     }
@@ -232,8 +232,8 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         // Completing both tasks, should destroy the subprocess and activate the
         // task after the subprocess
-        taskService.complete(taskA.getId());
-        taskService.complete(taskB.getId());
+        completeTask(taskA);
+        completeTask(taskB);
         org.flowable.task.api.Task taskAfterSubProcess = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after sub process");
     }
@@ -262,7 +262,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertThat(taskAfterTimer.getName()).isEqualTo("Task after timer");
 
         // Completing the task after the timer ends the process instance
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -280,13 +280,13 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         // Completing both tasks should active the tasks outside the
         // subprocesses
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         tasks = taskQuery.list();
         assertThat(tasks.get(0).getName()).isEqualTo("Task after subprocess A");
         assertThat(tasks.get(1).getName()).isEqualTo("Task in subprocess B");
 
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
 
         tasks = taskQuery.list();
 
@@ -294,8 +294,8 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertThat(tasks.get(1).getName()).isEqualTo("Task after subprocess B");
 
         // Completing these tasks should end the process
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         assertProcessEnded(pi.getId());
     }
@@ -314,14 +314,14 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertThat(taskB.getName()).isEqualTo("Task in subprocess B");
 
         // Completing both tasks should active the tasks outside the subprocesses
-        taskService.complete(taskA.getId());
-        taskService.complete(taskB.getId());
+        completeTask(taskA);
+        completeTask(taskB);
 
         org.flowable.task.api.Task taskAfterSubProcess = taskQuery.singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");
 
         // Completing this task should end the process
-        taskService.complete(taskAfterSubProcess.getId());
+        completeTask(taskAfterSubProcess);
         assertProcessEnded(pi.getId());
     }
 
@@ -352,7 +352,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         assertThat(taskAfterTimer.getName()).isEqualTo("Task after timer");
 
         // Completing the task should end the process instance
-        taskService.complete(taskAfterTimer.getId());
+        completeTask(taskAfterTimer);
         assertProcessEnded(pi.getId());
     }
 
@@ -411,7 +411,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         // After completing the task in the main process, the subprocess scope
         // initiates
-        taskService.complete(currentTask.getId());
+        completeTask(currentTask);
 
         // get subprocess task
         currentTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
@@ -428,7 +428,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
                 );
 
         // After completing the task in the subprocess, the subprocess scope is destroyed and the main process continues
-        taskService.complete(currentTask.getId());
+        completeTask(currentTask);
 
         // verify main process scoped variables
         variables = runtimeService.getVariables(pi.getId());
@@ -448,7 +448,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         currentTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(currentTask.getName()).isEqualTo("Complete Task B");
 
-        taskService.complete(currentTask.getId());
+        completeTask(currentTask);
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
 
@@ -469,7 +469,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         String variable = (String) runtimeService.getVariable(task.getExecutionId(), "counter");
         assertThat(variable).isEqualTo("one");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Job secondJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(secondJob.getId()).isNotSameAs(job.getId());
@@ -477,7 +477,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat((String) runtimeService.getVariable(task.getExecutionId(), "counter")).isEqualTo("two");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Job thirdJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(thirdJob.getId()).isNotSameAs(secondJob.getId());
@@ -485,7 +485,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat((String) runtimeService.getVariable(task.getExecutionId(), "counter")).isEqualTo("three");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -504,7 +504,7 @@ public class SubProcessTest extends PluggableFlowableTestCase {
         jobs.forEach(job -> managementService.executeJob(job.getId()));
 
         assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(3);
-        taskService.createTaskQuery().processInstanceId(processInstance.getId()).list().forEach(task -> taskService.complete(task.getId()));
+        taskService.createTaskQuery().processInstanceId(processInstance.getId()).list().forEach(task -> completeTask(task));
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/adhoc/AdhocSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/adhoc/AdhocSubProcessTest.java
@@ -53,7 +53,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task subProcessTask = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("subProcessTask").singleResult();
         assertThat(subProcessTask.getName()).isEqualTo("Task in subprocess");
 
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
 
         enabledActivities = runtimeService.getEnabledActivitiesFromAdhocSubProcess(execution.getId());
         assertThat(enabledActivities).hasSize(2);
@@ -63,7 +63,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
@@ -85,7 +85,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task subProcessTask = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("subProcessTask").singleResult();
         assertThat(subProcessTask.getName()).isEqualTo("Task in subprocess");
 
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
 
         executions = runtimeService.getAdhocSubProcessExecutions(pi.getId());
         assertThat(executions).hasSize(1);
@@ -101,7 +101,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
@@ -125,7 +125,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task subProcessTask = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("subProcessTask").singleResult();
         assertThat(subProcessTask.getName()).isEqualTo("Task in subprocess");
 
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
 
         enabledActivities = runtimeService.getEnabledActivitiesFromAdhocSubProcess(execution.getId());
         assertThat(enabledActivities).hasSize(2);
@@ -142,7 +142,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
 
@@ -189,7 +189,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
@@ -214,7 +214,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
                 .as("exception expected because can only enable one activity in a sequential ad-hoc sub process")
                 .isInstanceOf(FlowableException.class);
 
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
 
         // now we can enable the activity
         runtimeService.executeActivityInAdhocSubProcess(execution.getId(), "subProcessTask2");
@@ -229,7 +229,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
@@ -250,7 +250,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task subProcessTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(subProcessTask.getName()).isEqualTo("Task in subprocess");
 
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
 
         assertThatThrownBy(() -> runtimeService.executeActivityInAdhocSubProcess(execution.getId(), "subProcessTask2"))
                 .as("exception expected because can only enable one activity in a sequential ad-hoc sub process")
@@ -266,7 +266,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
@@ -294,7 +294,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
@@ -320,7 +320,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task subProcessTask2 = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("subProcessTask2").singleResult();
         assertThat(subProcessTask2.getName()).isEqualTo("Task2 in subprocess");
-        taskService.complete(subProcessTask2.getId());
+        completeTask(subProcessTask2);
 
         subProcessTask2 = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("sequentialTask2").singleResult();
         assertThat(subProcessTask2.getName()).isEqualTo("The next task2");
@@ -335,7 +335,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
@@ -368,13 +368,13 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         subProcessTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(subProcessTask.getName()).isEqualTo("Task2 in subprocess");
 
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
 
         // with no remaining executions the ad-hoc sub process will be completed
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }
@@ -400,7 +400,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task subProcessTask2 = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("subProcessTask2").singleResult();
         assertThat(subProcessTask2.getName()).isEqualTo("Task2 in subprocess");
-        taskService.complete(subProcessTask2.getId());
+        completeTask(subProcessTask2);
 
         subProcessTask2 = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("sequentialTask2").singleResult();
         assertThat(subProcessTask2.getName()).isEqualTo("The next task2");
@@ -437,7 +437,7 @@ public class AdhocSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task afterTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(afterTask.getName()).isEqualTo("After task");
 
-        taskService.complete(afterTask.getId());
+        completeTask(afterTask);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.java
@@ -49,7 +49,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
 
         // making the tx succeed:
         taskService.setVariable(task.getId(), "confirmed", true);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // now the process instance execution is sitting in the 'afterSuccess' task
         // -> has left the transaction using the "normal" sequence flow
@@ -98,7 +98,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
 
         // making the tx fail:
         taskService.setVariable(task.getId(), "confirmed", false);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // now the process instance execution is sitting in the 'afterCancellation' task
         // -> has left the transaction using the cancel boundary event
@@ -145,7 +145,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
 
         // making the tx fail:
         taskService.setVariable(task.getId(), "confirmed", false);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // now the process instance execution is sitting in the 'afterCancellation' task
         // -> has left the transaction using the cancel boundary event
@@ -191,7 +191,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
 
         // making the tx fail:
         taskService.setVariable(taskInner.getId(), "confirmed", false);
-        taskService.complete(taskInner.getId());
+        completeTask(taskInner);
 
         // now the process instance execution is sitting in the
         // 'afterInnerCancellation' task
@@ -217,7 +217,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         }
 
         // complete the task in the outer tx
-        taskService.complete(taskOuter.getId());
+        completeTask(taskOuter);
 
         // end the process instance (signal the execution still sitting in afterInnerCancellation)
         runtimeService.trigger(runtimeService.createExecutionQuery().activityId("afterInnerCancellation").singleResult().getId());
@@ -244,7 +244,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         assertThat(taskOuter).isNotNull();
 
         // making the outer tx fail (invokes cancel end event)
-        taskService.complete(taskOuter.getId());
+        completeTask(taskOuter);
 
         // now the process instance is sitting in 'afterOuterCancellation'
         List<String> activeActivityIds = runtimeService.getActiveActivityIds(processInstance.getId());
@@ -292,7 +292,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
 
         // canceling one instance triggers compensation for all other instances:
         taskService.setVariable(task.getId(), "confirmed", false);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isZero();
 
@@ -321,7 +321,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         for (org.flowable.task.api.Task task : tasks) {
             taskService.setVariable(task.getId(), "confirmed", true);
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         // now complete the inner receive tasks
@@ -376,7 +376,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         taskService.setVariable(task.getId(), "confirmed", false);
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -387,7 +387,7 @@ public class TransactionSubProcessTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().singleResult();
         taskService.setVariable(task.getId(), "confirmed", true);
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DisabledDefinitionInfoCacheTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DisabledDefinitionInfoCacheTest.java
@@ -43,7 +43,7 @@ public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getFormKey()).isEqualTo("test");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -55,7 +55,7 @@ public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getFormKey()).isEqualTo("test");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -70,13 +70,13 @@ public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dynamicServiceTask", varMap);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.getVariable(processInstance.getId(), "count")).isEqualTo(1);
         assertThat(runtimeService.getVariable(processInstance.getId(), "count2")).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -91,13 +91,13 @@ public class DisabledDefinitionInfoCacheTest extends ResourceFlowableTestCase {
         dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId, infoNode);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.getVariable(processInstance.getId(), "count")).isEqualTo(1);
         assertThat(runtimeService.getVariable(processInstance.getId(), "count2")).isEqualTo(0);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/DynamicUserTaskTest.java
@@ -42,7 +42,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getAssignee()).isEqualTo("test");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -54,7 +54,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getAssignee()).isEqualTo("test2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -68,7 +68,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getOwner()).isEqualTo("ownerTest");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -80,7 +80,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getOwner()).isEqualTo("ownerTest2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -103,7 +103,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
             }
         }
         assertThat(candidateUserTestFound).isFalse();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -124,7 +124,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
             }
         }
         assertThat(candidateUserTestFound).isTrue();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         infoNode = dynamicBpmnService.getProcessDefinitionInfo(processDefinitionId);
         dynamicBpmnService.changeUserTaskCandidateUser("task1", "test2", false, infoNode);
@@ -147,7 +147,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         }
         assertThat(candidateUserTestFound).isTrue();
         assertThat(candidateUserTest2Found).isTrue();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -170,7 +170,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
             }
         }
         assertThat(candidateGroupTestFound).isFalse();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -191,7 +191,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
             }
         }
         assertThat(candidateGroupTestFound).isTrue();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         infoNode = dynamicBpmnService.getProcessDefinitionInfo(processDefinitionId);
         dynamicBpmnService.changeUserTaskCandidateGroup("task1", "test2", false, infoNode);
@@ -214,7 +214,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         }
         assertThat(candidateGroupTestFound).isTrue();
         assertThat(candidateGroupTest2Found).isTrue();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -243,7 +243,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         }
         assertThat(candidateUserTestFound).isFalse();
         assertThat(candidateGroupTestFound).isFalse();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -271,7 +271,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         }
         assertThat(candidateUserTestFound).isTrue();
         assertThat(candidateGroupTestFound).isTrue();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         infoNode = dynamicBpmnService.getProcessDefinitionInfo(processDefinitionId);
         dynamicBpmnService.changeUserTaskCandidateGroup("task1", "test2", false, infoNode);
@@ -305,7 +305,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         assertThat(candidateUserTestFound2).isTrue();
         assertThat(candidateGroupTestFound).isTrue();
         assertThat(candidateGroupTest2Found).isTrue();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -320,7 +320,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isNull();
         assertThat(task.getDescription()).isNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -334,7 +334,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("Task name test");
         assertThat(task.getDescription()).isEqualTo("Task description test");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -349,7 +349,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getPriority()).isEqualTo(50);
         assertThat(task.getCategory()).isNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -363,7 +363,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getPriority()).isEqualTo(99);
         assertThat(task.getCategory()).isEqualTo("categoryTest");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -377,7 +377,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getFormKey()).isEqualTo("test");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -389,7 +389,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getFormKey()).isEqualTo("test2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }
@@ -405,7 +405,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getFormKey()).isEqualTo("test");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -419,7 +419,7 @@ public class DynamicUserTaskTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getFormKey()).isEqualTo("test2");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentCandidateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskAssignmentCandidateTest.java
@@ -53,13 +53,13 @@ public class TaskAssignmentCandidateTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getTaskDefinitionKey)
                 .containsExactly("theTask");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         tasks = taskService.createTaskQuery().taskCandidateGroup("accounting").list();
         assertThat(tasks)
                 .extracting(Task::getTaskDefinitionKey)
                 .containsExactly("theOtherTask");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
@@ -119,7 +119,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
 
         // attempt to complete the task and get PersistenceException pointing to
         // "referential integrity constraint violation"
-        taskService.complete(task.getId());
+        completeTask(task);
     }
 
     @Test
@@ -155,7 +155,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().taskCategory(testCategory).count()).isZero();
 
         // Complete task and verify history
-        taskService.complete(task.getId());
+        completeTask(task);
             
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/ChangeConfigAndRebootEngineTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/ChangeConfigAndRebootEngineTest.java
@@ -136,9 +136,9 @@ public class ChangeConfigAndRebootEngineTest extends ResourceFlowableTestCase {
 
     protected void finishProcessInstance(ProcessInstance processInstance) {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
@@ -320,7 +320,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process-usertask-01.bpmn20.xml", "process-usertask-01", false);
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-            taskService.complete(task.getId());
+            completeTask(task);
             stopProfiling();
 
             assertExecutedCommands("StartProcessInstanceCmd", "org.flowable.task.service.impl.TaskQueryImpl", "CompleteTaskCmd");
@@ -392,7 +392,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
         if (!processEngineConfiguration.isAsyncHistoryEnabled()) {
             deployStartProcessInstanceAndProfile("process-usertask-02.bpmn20.xml", "process-usertask-02", false);
             org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-            taskService.complete(task.getId());
+            completeTask(task);
             stopProfiling();
 
             assertExecutedCommands("StartProcessInstanceCmd", "org.flowable.task.service.impl.TaskQueryImpl", "CompleteTaskCmd");
@@ -448,7 +448,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
             taskService.removeVariablesLocal(task.getId(), vars.keySet());
             taskService.removeVariablesLocal(task.getId(), vars.keySet());
 
-            taskService.complete(task.getId());
+            completeTask(task);
             stopProfiling();
 
             assertExecutedCommands("StartProcessInstanceCmd", "org.flowable.task.service.impl.TaskQueryImpl", "SetTaskVariablesCmd", "RemoveTaskVariablesCmd",
@@ -471,7 +471,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
             taskService.claim(task.getId(), "firstUser");
             taskService.unclaim(task.getId());
 
-            taskService.complete(task.getId());
+            completeTask(task);
             stopProfiling();
 
             assertExecutedCommands("StartProcessInstanceCmd", "org.flowable.task.service.impl.TaskQueryImpl", "ClaimTaskCmd", "CompleteTaskCmd");
@@ -505,7 +505,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
             taskService.deleteCandidateUser(task.getId(), "user03");
             taskService.deleteCandidateUser(task.getId(), "user04");
 
-            taskService.complete(task.getId());
+            completeTask(task);
             stopProfiling();
 
             assertExecutedCommands("StartProcessInstanceCmd", "org.flowable.task.service.impl.TaskQueryImpl", "AddIdentityLinkCmd", "DeleteIdentityLinkCmd",
@@ -561,7 +561,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
             taskService.deleteCandidateGroup(task.getId(), "group03");
             taskService.deleteCandidateGroup(task.getId(), "group04");
 
-            taskService.complete(task.getId());
+            completeTask(task);
             stopProfiling();
 
             assertExecutedCommands("StartProcessInstanceCmd", "org.flowable.task.service.impl.TaskQueryImpl", "AddIdentityLinkCmd", "DeleteIdentityLinkCmd",

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
@@ -37,7 +37,6 @@ import org.flowable.engine.test.profiler.ProfilingDbSqlSessionFactory;
 import org.flowable.engine.test.profiler.TotalExecutionTimeCommandInterceptor;
 import org.flowable.job.api.Job;
 import org.flowable.task.service.TaskServiceConfiguration;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/taskcount/ChangeTaskCountConfigAndRebootEngineTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/taskcount/ChangeTaskCountConfigAndRebootEngineTest.java
@@ -91,7 +91,7 @@ public class ChangeTaskCountConfigAndRebootEngineTest extends ResourceFlowableTe
         assertTaskCountFlag(firstTask, false);
 
         // complete the first task, move to the next one
-        taskService.complete(firstTask.getId());
+        completeTask(firstTask);
 
         // second task created with the new flag (true)
         org.flowable.task.api.Task secondTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -117,7 +117,7 @@ public class ChangeTaskCountConfigAndRebootEngineTest extends ResourceFlowableTe
         assertTaskCountFlag(firstTask, false);
 
         // complete the first task, move to the next one
-        taskService.complete(firstTask.getId());
+        completeTask(firstTask);
 
         // second task created with flag false
         org.flowable.task.api.Task secondTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -141,7 +141,7 @@ public class ChangeTaskCountConfigAndRebootEngineTest extends ResourceFlowableTe
         assertTaskCountFlag(firstTask, enableTaskCountFlag);
 
         // The second task should have the same count flag
-        taskService.complete(firstTask.getId());
+        completeTask(firstTask);
         org.flowable.task.api.Task secondTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertTaskCountFlag(secondTask, enableTaskCountFlag);
 
@@ -169,7 +169,7 @@ public class ChangeTaskCountConfigAndRebootEngineTest extends ResourceFlowableTe
 
     protected void finishProcessInstance(ProcessInstance processInstance) {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         assertProcessEnded(processInstance.getId());
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceMigrationTest.java
@@ -261,7 +261,7 @@ public class ProcessInstanceMigrationTest extends PluggableFlowableTestCase {
             }
 
             // continue
-            taskService.complete(task.getId());
+            completeTask(task);
 
             assertProcessEnded(pi.getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceSuspensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceSuspensionTest.java
@@ -104,7 +104,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
 
         // the acquire jobs command sees the job:
         List<TimerJobEntity> acquiredJobs = executeAcquireJobsCommand();
-        assertThat(acquiredJobs).hasSize(1);;
+        assertThat(acquiredJobs).hasSize(1);
 
         // suspend the process instance:
         repositoryService.suspendProcessDefinitionById(pd.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/VariableScopeTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/VariableScopeTest.java
@@ -88,7 +88,7 @@ public class VariableScopeTest extends PluggableFlowableTestCase {
 
         // After completing the task in the subprocess,
         // the subprocess scope is destroyed and the complete process ends
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
     }
 
     /**
@@ -150,7 +150,7 @@ public class VariableScopeTest extends PluggableFlowableTestCase {
         assertThat(result)
                 .contains("subProcessLocalVariable", "helloWorld", "mainProcessLocalVariable");
 
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
     }
 
     @Test
@@ -200,7 +200,7 @@ public class VariableScopeTest extends PluggableFlowableTestCase {
 
         // After completing the task in the subprocess,
         // the subprocess scope is destroyed and the complete process ends
-        taskService.complete(subProcessTask.getId());
+        completeTask(subProcessTask);
 
         List<org.flowable.task.api.Task> subProcessTasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
 
@@ -232,7 +232,7 @@ public class VariableScopeTest extends PluggableFlowableTestCase {
 
         // finish process
         for (org.flowable.task.api.Task subProcTask : subProcessTasks) {
-            taskService.complete(subProcTask.getId());
+            completeTask(subProcTask);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/debugger/DebugProcessOperationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/debugger/DebugProcessOperationTest.java
@@ -49,8 +49,7 @@ public class DebugProcessOperationTest extends ResourceFlowableTestCase {
 
         assertThat(this.taskService.createTaskQuery().count()).as("User task has to be created.").isEqualTo(1);
         assertProcessActivityId("The execution is still on the user task.", oneTaskProcess, "theTask");
-        String taskId = this.taskService.createTaskQuery().processInstanceId(oneTaskProcess.getProcessInstanceId()).singleResult().getId();
-        this.taskService.complete(taskId);
+        completeTask(this.taskService.createTaskQuery().processInstanceId(oneTaskProcess.getProcessInstanceId()).singleResult());
 
         assertProcessActivityId("The execution must stop on the end event.", oneTaskProcess, "theEnd");
         triggerBreakPoint();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/BpmnEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/BpmnEventRegistryConsumerTest.java
@@ -112,7 +112,7 @@ public class BpmnEventRegistryConsumerTest extends FlowableEventRegistryBpmnTest
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task");
 
-        taskService.complete(task.getId());
+        completeTask(task);
         
         Task afterTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(afterTask.getTaskDefinitionKey()).isEqualTo("taskAfterTask");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryEventSubprocessTest.java
@@ -118,7 +118,7 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
 
         // now let's first complete the task in the main flow:
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("task").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(createEventSubscriptionQuery().count()).isZero();
 
@@ -127,13 +127,13 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
 
         // now let's complete the first task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(4);
 
         // complete the second task in the event subprocess
         task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -174,7 +174,7 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         assertThat(runtimeService.createActivityInstanceQuery().list())
             .extracting(ActivityInstance::getActivityType, ActivityInstance::getActivityId)
@@ -243,7 +243,7 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
 
         // now let's complete the task in the event subprocess
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").list().get(0);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // done!
         assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
@@ -284,7 +284,7 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
         // Complete the user task in the event sub process
         Task eventSubProcessTask = taskService.createTaskQuery().taskDefinitionKey("eventSubProcessTask").singleResult();
         assertThat(eventSubProcessTask).isNotNull();
-        taskService.complete(eventSubProcessTask.getId());
+        completeTask(eventSubProcessTask);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             assertThat(historyService.createHistoricActivityInstanceQuery().list())

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/MultiTenantSendEventTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/MultiTenantSendEventTaskTest.java
@@ -170,7 +170,7 @@ public class MultiTenantSendEventTaskTest extends FlowableEventRegistryBpmnTestC
     private void validateEventSent(ProcessInstance processInstance, String property) throws JsonProcessingException {
         assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Job job = managementService.createJobQuery().jobTenantId(processInstance.getTenantId()).singleResult();
         assertThat(job.getTenantId()).isEqualTo(processInstance.getTenantId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendEventTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendEventTaskTest.java
@@ -123,7 +123,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).isNotNull();
@@ -153,7 +153,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).isNull();
@@ -185,7 +185,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).isNotNull();
@@ -216,7 +216,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(eventSubscription).isNotNull();
@@ -264,7 +264,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
@@ -294,7 +294,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(eventSubscription).isNotNull();
@@ -341,7 +341,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
         
-        taskService.complete(task.getId());
+        completeTask(task);
         
         EventSubscription eventSubscription = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(eventSubscription).isNotNull();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendInternalEventTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendInternalEventTaskTest.java
@@ -71,7 +71,7 @@ public class SendInternalEventTaskTest extends FlowableEventRegistryBpmnTestCase
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createProcessInstanceQuery().list())
                 .extracting(ProcessInstance::getProcessDefinitionKey)
@@ -111,7 +111,7 @@ public class SendInternalEventTaskTest extends FlowableEventRegistryBpmnTestCase
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).isNotNull();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
@@ -376,7 +376,7 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         // Complete the task with the boundary-event on it
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
         
@@ -435,8 +435,8 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
         assertThat(tasksToComplete).hasSize(2);
 
         // Complete both tasks, second task-complete should end the fork-gateway and set time
-        taskService.complete(tasksToComplete.get(0).getId());
-        taskService.complete(tasksToComplete.get(1).getId());
+        completeTask(tasksToComplete.get(0));
+        completeTask(tasksToComplete.get(1));
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricProcessInstanceTest.java
@@ -82,7 +82,7 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
         // user completes the task (yes! he must be almost as fast as me)
         Date twentyFiveSecsAfterNoon = new Date(noon.getTime() + 25 * 1000);
         processEngineConfiguration.getClock().setCurrentTime(twentyFiveSecsAfterNoon);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
 
@@ -348,12 +348,12 @@ public class HistoricProcessInstanceTest extends PluggableFlowableTestCase {
 
         // First complete process instance 2
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().processInstanceId(processInstance2.getId()).list()) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         // Then process instance 1
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().processInstanceId(processInstance1.getId()).list()) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
@@ -321,7 +321,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         List<Task> tasks = taskService.createTaskQuery().processInstanceId(finishedInstance.getId()).list();
         for (Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
@@ -737,7 +737,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertThat(historyService.createHistoricTaskInstanceQuery().processFinished().count()).isZero();
 
         // Finished and running task on running process should be available
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
@@ -746,7 +746,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
 
         // 2 finished tasks are found for finished process after completing last task of process
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
@@ -840,7 +840,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertThat(foundCustom).isTrue();
 
         // Now complete the task and check if links are still there
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
@@ -888,7 +888,7 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
             runtimeService.setVariable(task.getExecutionId(), "procVar", i);
         }
 
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceUpdateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceUpdateTest.java
@@ -40,7 +40,7 @@ public class HistoricTaskInstanceUpdateTest extends PluggableFlowableTestCase {
         task.setAssignee("gonzo");
         taskService.saveTask(task);
 
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         
@@ -62,7 +62,7 @@ public class HistoricTaskInstanceUpdateTest extends PluggableFlowableTestCase {
         task.setAssignee(null);
         taskService.saveTask(task);
 
-        taskService.complete(task.getId());
+        completeTask(task);
         
         waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
         

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -696,7 +696,7 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             // there are now 3 historic variables, so the following does not work
             assertThat(getHistoricVariable("secondVar").getValue()).isEqualTo("789");
 
-            taskService.complete(task.getId());
+            completeTask(task);
 
             assertProcessEnded(processInstance.getId());
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoryManagerInvocationsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoryManagerInvocationsTest.java
@@ -45,7 +45,7 @@ public class HistoryManagerInvocationsTest extends CustomConfigurationFlowableTe
     public void testSingleTaskCreateAndComplete() {
         ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionId(deployOneTaskTestProcess()).start();
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         verify(mockHistoryManager, times(1)).recordTaskCreated(any(), any());
         verify(mockHistoryManager, times(1)).recordTaskEnd(any(), any(), any(), any());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
@@ -59,7 +59,7 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 
         // Finish tasks
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().list()) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/event/error/BoundaryErrorEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/event/error/BoundaryErrorEventTest.java
@@ -57,7 +57,7 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("Provide new sales lead");
 
         // After completing the task, the review subprocess will be active
-        taskService.complete(task.getId());
+        completeTask(task);
         org.flowable.task.api.Task ratingTask = taskService.createTaskQuery().taskCandidateGroup("accountancy").singleResult();
         assertThat(ratingTask.getName()).isEqualTo("Review customer rating");
         org.flowable.task.api.Task profitabilityTask = taskService.createTaskQuery().taskCandidateGroup("management").singleResult();
@@ -75,14 +75,14 @@ public class BoundaryErrorEventTest extends PluggableFlowableTestCase {
 
         // Providing more details (ie. completing the task), will activate the
         // subprocess again
-        taskService.complete(provideDetailsTask.getId());
+        completeTask(provideDetailsTask);
         List<org.flowable.task.api.Task> reviewTasks = taskService.createTaskQuery().orderByTaskName().asc().list();
         assertThat(reviewTasks)
                 .extracting(Task::getName)
                 .containsExactly("Review customer rating", "Review profitability");
 
         // Completing both tasks normally ends the process
-        taskService.complete(reviewTasks.get(0).getId());
+        completeTask(reviewTasks.get(0));
         variables.put("notEnoughInformation", false);
         taskService.complete(reviewTasks.get(1).getId(), variables);
         assertProcessEnded(procId);

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
@@ -54,7 +54,7 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         // Transition take executionListener will set 2 variables
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         varSetInExecutionListener = (String) runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
 
@@ -66,7 +66,7 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // First usertask uses a method-expression as executionListener:
         // ${myPojo.myMethod(execution.eventName)}
@@ -76,7 +76,7 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 
@@ -155,7 +155,7 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         RecorderExecutionListener.clear();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(processInstance.getId());
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/ParallelGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/gateway/ParallelGatewayTest.java
@@ -43,8 +43,8 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 .containsExactly("Receive Payment", "Ship Order");
 
         // Completing both tasks will join the concurrent executions
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         tasks = query.list();
         assertThat(tasks)
@@ -66,10 +66,10 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
                 .containsExactly("Task 1", "Task 2", "Task 3");
 
         // Completing the first task should *not* trigger the join
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         // Completing the second task should trigger the first join
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(1));
 
         tasks = query.list();
         assertThat(tasks)
@@ -78,8 +78,8 @@ public class ParallelGatewayTest extends PluggableFlowableTestCase {
 
         // Completing the remaining tasks should trigger the second join and end
         // the process
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         assertProcessEnded(pi.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/subprocess/SubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/subprocess/SubProcessTest.java
@@ -45,8 +45,8 @@ public class SubProcessTest extends PluggableFlowableTestCase {
 
         // Completing both the tasks finishes the subprocess and enables the
         // task after the subprocess
-        taskService.complete(tasks.get(0).getId());
-        taskService.complete(tasks.get(1).getId());
+        completeTask(tasks.get(0));
+        completeTask(tasks.get(1));
 
         org.flowable.task.api.Task writeReportTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
         assertThat(writeReportTask.getName()).isEqualTo("Write report");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
@@ -34,7 +34,7 @@ public class ScriptTaskListenerTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).as("Name does not match").isEqualTo("All your base are belong to us");
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerOnTransactionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerOnTransactionTest.java
@@ -47,11 +47,11 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
 
         // task 1 has committed listener
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // task 2 has rolled-back listener
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<CurrentTaskTransactionDependentTaskListener.CurrentTask> currentTasks = CurrentTaskTransactionDependentTaskListener.getCurrentTasks();
         assertThat(currentTasks)
@@ -77,17 +77,17 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
 
         // task 1 has before-commit listener
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // task 2 has rolled-back listener
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // task 3 has rolled-back listener
         task = taskService.createTaskQuery().singleResult();
 
         try {
-            taskService.complete(task.getId());
+            completeTask(task);
         } catch (Exception ex) {
 
         }
@@ -113,11 +113,11 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
 
         // task 1 has committed listener
         Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // task 2 has committed listener
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<CurrentTaskTransactionDependentTaskListener.CurrentTask> currentTasks = CurrentTaskTransactionDependentTaskListener.getCurrentTasks();
         assertThat(currentTasks)
@@ -155,7 +155,7 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         ProcessInstance secondProcessInstance = runtimeService.startProcessInstanceByKey("secondTransactionDependentTaskListenerProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertProcessEnded(secondProcessInstance.getId());
 
@@ -184,7 +184,7 @@ public class TaskListenerOnTransactionTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("transactionDependentTaskListenerProcess");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<CurrentTaskTransactionDependentTaskListener.CurrentTask> currentTasks = CurrentTaskTransactionDependentTaskListener.getCurrentTasks();
         assertThat(currentTasks)

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
@@ -163,7 +163,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         // Completing first task will change the description
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.getVariable(processInstance.getId(), "greeting")).isEqualTo("Hello from The Process");
         assertThat(runtimeService.getVariable(processInstance.getId(), "shortName")).isEqualTo("Act");
@@ -177,7 +177,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         // Completing first task will change the description
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(runtimeService.getVariable(processInstance.getId(), "greeting2")).isEqualTo("Write meeting notes");
     }
@@ -190,7 +190,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         // Set assignee and complete task
         taskService.setAssignee(task.getId(), "kermit");
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Verify the all-listener has received all events
         String eventsReceived = (String) runtimeService.getVariable(task.getProcessInstanceId(), "events");
@@ -215,7 +215,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         assertThat(TaskDeleteListener.getCurrentMessages()).isEmpty();
         assertThat(TaskSimpleCompleteListener.getCurrentMessages()).isEmpty();
 
-        taskService.complete(task.getId());
+        completeTask(task);
 
         tasks = taskService.createTaskQuery().list();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/FinancialReportProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/FinancialReportProcessTest.java
@@ -56,13 +56,12 @@ public class FinancialReportProcessTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Write monthly financial report");
-        String taskId = tasks.get(0).getId();
 
-        taskService.claim(taskId, "fozzie");
+        taskService.claim(tasks.get(0).getId(), "fozzie");
         tasks = taskService.createTaskQuery().taskAssignee("fozzie").list();
 
         assertThat(tasks).hasSize(1);
-        taskService.complete(taskId);
+        completeTask(tasks.get(0));
 
         tasks = taskService.createTaskQuery().taskCandidateUser("fozzie").list();
         assertThat(tasks).isEmpty();
@@ -70,7 +69,7 @@ public class FinancialReportProcessTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Verify monthly financial report");
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/SkipExpressionUserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/SkipExpressionUserTaskTest.java
@@ -43,7 +43,7 @@ public class SkipExpressionUserTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("skipExpressionUserTask");
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertThat(taskService.createTaskQuery().list()).isEmpty();
 
         Map<String, Object> variables2 = new HashMap<>();
@@ -52,7 +52,7 @@ public class SkipExpressionUserTaskTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("skipExpressionUserTask", variables2);
         List<org.flowable.task.api.Task> tasks2 = taskService.createTaskQuery().list();
         assertThat(tasks2).hasSize(1);
-        taskService.complete(tasks2.get(0).getId());
+        completeTask(tasks2.get(0));
         assertThat(taskService.createTaskQuery().list()).isEmpty();
 
         Map<String, Object> variables3 = new HashMap<>();
@@ -103,7 +103,7 @@ public class SkipExpressionUserTaskTest extends PluggableFlowableTestCase {
         assertThat(eventListener.getCompletedEvents()).isEmpty();
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertThat(eventListener.getCompletedEvents()).hasSize(1);
         assertThat(taskService.createTaskQuery().list()).isEmpty();
         

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskassignee/TaskAssigneeTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskassignee/TaskAssigneeTest.java
@@ -44,7 +44,7 @@ public class TaskAssigneeTest extends PluggableFlowableTestCase {
                 .containsExactly(tuple("Schedule meeting", "Schedule an engineering meeting for next week with the new hire."));
 
         // Complete task. Process is now finished
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         // assert if the process instance completed
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskcandidate/TaskCandidateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/usertask/taskcandidate/TaskCandidateTest.java
@@ -99,10 +99,9 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
         assertThat(tasks)
                 .extracting(Task::getName)
                 .containsExactly("Pay out expenses");
-        taskId = tasks.get(0).getId();
 
         // Completing the task ends the process
-        taskService.complete(taskId);
+        completeTask(tasks.get(0));
 
         assertProcessEnded(processInstance.getId());
     }
@@ -149,7 +148,7 @@ public class TaskCandidateTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().taskAssignee(KERMIT).count()).isZero();
 
         // Completing the task ends the process
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
 
         assertProcessEnded(processInstance.getId());
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/runtime/WatchDogAgendaTest.java
@@ -34,7 +34,7 @@ public class WatchDogAgendaTest extends ResourceFlowableTestCase {
     public void testWatchDogWithOneTaskProcess() {
         this.runtimeService.startProcessInstanceByKey("oneTaskProcess");
         org.flowable.task.api.Task task = this.taskService.createTaskQuery().singleResult();
-        this.taskService.complete(task.getId());
+        this.completeTask(task);
         assertThat(this.runtimeService.createProcessInstanceQuery().count()).isZero();
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -192,7 +192,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertThat(newValue).isEqualTo("a value");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
     }
 
     @Test
@@ -1904,7 +1904,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertThat(resultVar).isEqualTo("434");
 
         task = taskService.createTaskQuery().singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // If no variable is given, no variable should be set and script test should throw exception
         processInstance = runtimeService.startProcessInstanceByKey("taskAssigneeProcess");

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricProcessInstanceQueryEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricProcessInstanceQueryEscapeClauseTest.java
@@ -65,10 +65,10 @@ public class HistoricProcessInstanceQueryEscapeClauseTest extends AbstractEscape
         runtimeService.setProcessInstanceName(processInstance2.getId(), "Two_");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricVariableInstanceEscapeClauseTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/escapeclause/HistoricVariableInstanceEscapeClauseTest.java
@@ -62,10 +62,10 @@ public class HistoricVariableInstanceEscapeClauseTest extends AbstractEscapeClau
         runtimeService.setProcessInstanceName(processInstance2.getId(), "Two_");
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         task = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/event/ProcessDefinitionScopedEventListenerDefinitionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/event/ProcessDefinitionScopedEventListenerDefinitionTest.java
@@ -53,7 +53,7 @@ public class ProcessDefinitionScopedEventListenerDefinitionTest extends Resource
         assertThat(testListenerBean).isNotNull();
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Check if the listener (defined as bean) received events (only creation, not other events)
         assertThat(testListenerBean.getEventsReceived()).isNotEmpty();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/BulkDeleteNoHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/BulkDeleteNoHistoryTest.java
@@ -46,7 +46,7 @@ public class BulkDeleteNoHistoryTest extends ResourceFlowableTestCase {
         assertThat(task).isNotNull();
 
         // Completing the task will cause a bulk delete of 4001 entities
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Check if process is gone
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
@@ -409,7 +409,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         // end process instance
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
 
         // check for historic process variables set
@@ -574,7 +574,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         // end process instance
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(1);
-        taskService.complete(tasks.get(0).getId());
+        completeTask(tasks.get(0));
         assertProcessEnded(processInstance.getId());
 
         assertThat(historyService.createHistoricVariableInstanceQuery().count()).isEqualTo(2);
@@ -824,7 +824,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         taskService.setVariableLocal(task.getId(), "anotherTaskVar", "value");
 
         // Finish the task, this end the process-instance
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(1);
         assertThat(historyService.createHistoricActivityInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(5);
@@ -1287,7 +1287,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(executionId).taskName("my task").singleResult();
 
         runtimeService.setVariable(executionId, variableName, entity);
-        taskService.complete(task.getId());
+        completeTask(task);
 
         List<HistoricDetail> variableUpdates = historyService.createHistoricDetailQuery().processInstanceId(executionId).variableUpdates().list();
 
@@ -1313,7 +1313,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         taskService.setVariableLocal(task.getId(), "binaryTaskVariable", (Object) "It is I, le binary".getBytes());
 
         // Complete task
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Query task, including processVariables
         HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).includeProcessVariables().singleResult();
@@ -1343,7 +1343,7 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertThat(task).isNotNull();
 
         // Complete task to end process
-        taskService.complete(task.getId());
+        completeTask(task);
 
         // Query task, including processVariables
         HistoricProcessInstance historicProcess = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId())

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryTest.java
@@ -585,7 +585,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         taskService.deleteGroupIdentityLink(task.getId(), "testGroup", IdentityLinkType.PARTICIPANT);
         runtimeService.suspendProcessInstanceById(oneTaskProcess.getId());
         runtimeService.activateProcessInstanceById(oneTaskProcess.getId());
-        taskService.complete(task.getId());
+        completeTask(task);
 
         assertThat(historyService.createHistoricTaskLogEntryQuery().count()).isZero();
         assertThat(managementService.createHistoryJobQuery().count()).isEqualTo(12l);
@@ -645,7 +645,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         assertThat(tasks).extracting(Task::getName).containsExactly("Always", "Always");
 
         for (Task task : tasks) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         waitForHistoryJobExecutorToProcessAllJobs(10000, 200);
@@ -681,7 +681,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
     }
 
     protected void finishOneTaskProcess(Task task) {
-        taskService.complete(task.getId());
+        completeTask(task);
         waitForHistoryJobExecutorToProcessAllJobs(7000L, 100L);
         assertThat(managementService.createHistoryJobQuery().singleResult()).isNull();
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryUpgradeTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryUpgradeTest.java
@@ -386,7 +386,7 @@ public class AsyncHistoryUpgradeTest extends CustomConfigurationFlowableTestCase
     }
 
     protected void finishOneTaskProcess(Task task) {
-        taskService.complete(task.getId());
+        completeTask(task);
         waitForHistoryJobExecutorToProcessAllJobs(10_000L, 100L);
         assertThat(managementService.createHistoryJobQuery().singleResult()).isNull();
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/idgenerator/UsePrefixIdTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/idgenerator/UsePrefixIdTest.java
@@ -70,7 +70,7 @@ public class UsePrefixIdTest extends ResourceFlowableTestCase {
                 List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
                 for (org.flowable.task.api.Task task : tasks) {
                     assertThat(task.getId()).startsWith("TSK-");
-                    taskService.complete(task.getId());
+                    completeTask(task);
                 }
 
                 tasksFound = taskService.createTaskQuery().count() > 0;

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/idgenerator/UuidGeneratorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/idgenerator/UuidGeneratorTest.java
@@ -62,7 +62,7 @@ public class UuidGeneratorTest extends ResourceFlowableTestCase {
 
                     List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
                     for (org.flowable.task.api.Task task : tasks) {
-                        taskService.complete(task.getId());
+                        completeTask(task);
                     }
 
                     tasksFound = taskService.createTaskQuery().count() > 0;

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/HistoricJPAVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/HistoricJPAVariableTest.java
@@ -85,7 +85,7 @@ public class HistoricJPAVariableTest extends ResourceFlowableTestCase {
         this.processInstanceId = runtimeService.startProcessInstanceByKey("JPAVariableProcess", variables).getId();
 
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().includeTaskLocalVariables().list()) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         // Get JPAEntity Variable by HistoricVariableInstanceQuery
@@ -112,7 +112,7 @@ public class HistoricJPAVariableTest extends ResourceFlowableTestCase {
 
         // Finish tasks
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().includeTaskLocalVariables().list()) {
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         // Get JPAEntity Variable by ProcessInstanceHistoryLogQuery
@@ -144,7 +144,7 @@ public class HistoricJPAVariableTest extends ResourceFlowableTestCase {
         // Finish tasks
         for (org.flowable.task.api.Task task : taskService.createTaskQuery().includeProcessVariables().list()) {
             taskService.setVariable(task.getId(), "simpleEntityFieldAccess", simpleEntityFieldAccess);
-            taskService.complete(task.getId());
+            completeTask(task);
         }
 
         // Get JPAEntity Variable by ProcessInstanceHistoryLogQuery


### PR DESCRIPTION
In `AbstractFlowableTestCase` which is the base class for many unit tests there is a helper method `completeTask(Task task)` that was used in some but not all situations in the tests so for consistency this PR uses the method were appropriate.  

In another PR I'll add a `completeTasks(List<Task> tasks)` method that will replace multiple sequential calls to `completeTask()`.

