### PR TITLE
Fix deprecated methods

### DIFF
--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DecisionTableCollectionResource.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DecisionTableCollectionResource.java
@@ -45,6 +45,7 @@ import io.swagger.annotations.Authorization;
  *
  * @deprecated use {@link DecisionCollectionResource} instead.
  */
+@Deprecated
 @RestController
 @Api(tags = { "Decision Tables" }, description = "Manage Decision Tables", authorizations = { @Authorization(value = "basicAuth") })
 public class DecisionTableCollectionResource {

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DecisionTableModelResource.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DecisionTableModelResource.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Yvo Swillens
  *
- * @deprecated use {@link DecisionTableModelResource} instead.
+ * @deprecated use {@link DecisionModelResource} instead.
  */
 @Deprecated
 @RestController

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DecisionTableResource.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DecisionTableResource.java
@@ -28,8 +28,9 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * @author Yvo Swillens
  *
- * @deprecated use {@link DecisionTableResource} instead.
+ * @deprecated use {@link DecisionResource} instead.
  */
+@Deprecated
 @RestController
 @Api(tags = { "Decision Tables" }, description = "Manage Decision Tables", authorizations = { @Authorization(value = "basicAuth") })
 public class DecisionTableResource extends BaseDecisionResource {

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DecisionTableResourceDataResource.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DecisionTableResourceDataResource.java
@@ -29,8 +29,9 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * @author Yvo Swillens
  *
- * @deprecated use {@link DecisionTableResourceDataResource} instead.
+ * @deprecated use {@link DecisionResourceDataResource} instead.
  */
+@Deprecated
 @RestController
 @Api(tags = { "Decision Tables" }, description = "Manage Decision Tables", authorizations = { @Authorization(value = "basicAuth") })
 public class DecisionTableResourceDataResource extends BaseDecisionResource {


### PR DESCRIPTION
Add missing `@Deprecated`
Fix `@deprecated use {@link } instead.` javadoc as the link was pointing at the same file that it was located in.
