### PR TITLE
Remove/fix javadoc comments about setCurrentTime(Date) method

### DIFF
--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/FlowableAppRule.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/FlowableAppRule.java
@@ -59,7 +59,7 @@ import org.junit.runners.model.Statement;
  * </p>
  * 
  * <p>
- * The FlowableRule also lets you {@link FlowableAppRule#setCurrentTime(Date) set the current time used by the process engine}. This can be handy to control the exact time that is used by the engine in
+ * The FlowableAppRule also lets you {@link #setCurrentTime(Date) set the current time used by the process engine}. This can be handy to control the exact time that is used by the engine in
  * order to verify e.g. e.g. due dates of timers. Or start, end and duration times in the history service. In the tearDown, the internal clock will automatically be reset to use the current system
  * time rather then the time that was set during a test method.
  * </p>

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/test/FlowableContentRule.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/test/FlowableContentRule.java
@@ -53,13 +53,7 @@ import org.junit.runners.model.Statement;
  * You can declare a deployment with the {@link FormDeploymentAnnotation} annotation. This base class will make sure that this deployment gets deployed before the setUp and
  * {@link RepositoryService#deleteDeployment(String, boolean) cascade deleted} after the tearDown.
  * </p>
- * 
- * <p>
- * The FlowableRule also lets you {@link FlowableContentRule#setCurrentTime(Date) set the current time used by the process engine}. This can be handy to control the exact time that is used by the
- * engine in order to verify e.g. e.g. due dates of timers. Or start, end and duration times in the history service. In the tearDown, the internal clock will automatically be reset to use the current
- * system time rather then the time that was set during a test method.
- * </p>
- * 
+ *
  * @author Tijs Rademakers
  */
 public class FlowableContentRule implements TestRule {

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/FlowableDmnRule.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/test/FlowableDmnRule.java
@@ -55,13 +55,7 @@ import org.junit.runners.model.Statement;
  * You can declare a deployment with the {@link DmnDeploymentAnnotation} annotation. This base class will make sure that this deployment gets deployed before the setUp and
  * {@link RepositoryService#deleteDeployment(String, boolean) cascade deleted} after the tearDown.
  * </p>
- * 
- * <p>
- * The FlowableRule also lets you {@link FlowableDmnRule#setCurrentTime(Date) set the current time used by the process engine}. This can be handy to control the exact time that is used by the engine
- * in order to verify e.g. e.g. due dates of timers. Or start, end and duration times in the history service. In the tearDown, the internal clock will automatically be reset to use the current system
- * time rather then the time that was set during a test method.
- * </p>
- * 
+ *
  * @author Tijs Rademakers
  */
 public class FlowableDmnRule implements TestRule {

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/FlowableEventRule.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/test/FlowableEventRule.java
@@ -54,13 +54,7 @@ import org.junit.runners.model.Statement;
  * You can declare a deployment with the {@link EventDeploymentAnnotation} annotation. This base class will make sure that this deployment gets deployed before the setUp and
  * {@link RepositoryService#deleteDeployment(String, boolean) cascade deleted} after the tearDown.
  * </p>
- * 
- * <p>
- * The FlowableRule also lets you {@link FlowableEventRule#setCurrentTime(Date) set the current time used by the process engine}. This can be handy to control the exact time that is used by the engine
- * in order to verify e.g. e.g. due dates of timers. Or start, end and duration times in the history service. In the tearDown, the internal clock will automatically be reset to use the current system
- * time rather then the time that was set during a test method.
- * </p>
- * 
+ *
  * @author Tijs Rademakers
  */
 public class FlowableEventRule implements TestRule {

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FlowableFormRule.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FlowableFormRule.java
@@ -55,12 +55,6 @@ import org.junit.runners.model.Statement;
  * {@link RepositoryService#deleteDeployment(String, boolean) cascade deleted} after the tearDown.
  * </p>
  * 
- * <p>
- * The FlowableRule also lets you {@link FlowableFormRule#setCurrentTime(Date) set the current time used by the process engine}. This can be handy to control the exact time that is used by the engine
- * in order to verify e.g. e.g. due dates of timers. Or start, end and duration times in the history service. In the tearDown, the internal clock will automatically be reset to use the current system
- * time rather then the time that was set during a test method.
- * </p>
- * 
  * @author Tijs Rademakers
  */
 public class FlowableFormRule implements TestRule {

--- a/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/test/FlowableIdmRule.java
+++ b/modules/flowable-idm-engine/src/main/java/org/flowable/idm/engine/test/FlowableIdmRule.java
@@ -54,12 +54,6 @@ import org.junit.runners.model.Statement;
  * {@link RepositoryService#deleteDeployment(String, boolean) cascade deleted} after the tearDown.
  * </p>
  * 
- * <p>
- * The Flowable also lets you {@link FlowableIdmRule#setCurrentTime(Date) set the current time used by the process engine}. This can be handy to control the exact time that is used by the engine in
- * order to verify e.g. e.g. due dates of timers. Or start, end and duration times in the history service. In the tearDown, the internal clock will automatically be reset to use the current system
- * time rather then the time that was set during a test method.
- * </p>
- * 
  * @author Tijs Rademakers
  */
 public class FlowableIdmRule implements TestRule {


### PR DESCRIPTION
Remove and/or fix Javadoc comments about `setCurrentTime(Date)` method in `Rule` classes.   The comments are removed when the method does not exist in the class.
