### PR TITLE
Use single parametrized constructor call

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/context/BpmnOverrideContext.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/context/BpmnOverrideContext.java
@@ -50,8 +50,7 @@ public class BpmnOverrideContext {
                         language, id, definitionInfoNode);
 
             } else {
-                HashSet<Locale> candidateLocales = new LinkedHashSet<>();
-                candidateLocales.addAll(resourceBundleControl.getCandidateLocales(id, Locale.forLanguageTag(language)));
+                HashSet<Locale> candidateLocales = new LinkedHashSet<>(resourceBundleControl.getCandidateLocales(id, Locale.forLanguageTag(language)));
                 for (Locale locale : candidateLocales) {
                     localizationProperties = CommandContextUtil.getProcessEngineConfiguration().getDynamicBpmnService().getLocalizationElementProperties(
                             locale.toLanguageTag(), id, definitionInfoNode);

--- a/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/AbstractClientResource.java
+++ b/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/AbstractClientResource.java
@@ -12,16 +12,17 @@
  */
 package org.flowable.ui.admin.rest.client;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.flowable.ui.admin.domain.EndpointType;
 import org.flowable.ui.admin.domain.ServerConfig;
 import org.flowable.ui.admin.repository.ServerConfigRepository;
 import org.flowable.ui.common.service.exception.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public abstract class AbstractClientResource {
 
@@ -46,8 +47,7 @@ public abstract class AbstractClientResource {
 
     protected Map<String, String[]> getRequestParametersWithoutServerId(HttpServletRequest request) {
         Map<String, String[]> parameterMap = request.getParameterMap();
-        Map<String, String[]> resultMap = new HashMap<>();
-        resultMap.putAll(parameterMap);
+        Map<String, String[]> resultMap = new HashMap<>(parameterMap);
         resultMap.remove(SERVER_ID);
         return resultMap;
     }

--- a/modules/flowable-ui/flowable-ui-task-logic/src/main/java/org/flowable/ui/task/service/runtime/FlowableAppDefinitionService.java
+++ b/modules/flowable-ui/flowable-ui-task-logic/src/main/java/org/flowable/ui/task/service/runtime/FlowableAppDefinitionService.java
@@ -304,9 +304,8 @@ public class FlowableAppDefinitionService implements InitializingBean {
     }
 
     protected List<String> convertToList(String commaSeperatedString) {
-        List<String> resultList = new ArrayList<>();
         String[] stringArray = commaSeperatedString.split(",");
-        resultList.addAll(Arrays.asList(stringArray));
+        List<String> resultList = new ArrayList<>(Arrays.asList(stringArray));
 
         return resultList;
     }

--- a/modules/flowable-ui/flowable-ui-task-logic/src/main/java/org/flowable/ui/task/service/runtime/FlowableCaseInstanceService.java
+++ b/modules/flowable-ui/flowable-ui-task-logic/src/main/java/org/flowable/ui/task/service/runtime/FlowableCaseInstanceService.java
@@ -38,14 +38,14 @@ import org.flowable.ui.common.model.ResultListDataRepresentation;
 import org.flowable.ui.common.security.SecurityUtils;
 import org.flowable.ui.common.service.exception.BadRequestException;
 import org.flowable.ui.common.service.exception.NotFoundException;
+import org.flowable.ui.common.service.idm.cache.UserCache;
+import org.flowable.ui.common.service.idm.cache.UserCache.CachedUser;
 import org.flowable.ui.task.model.runtime.CaseInstanceRepresentation;
 import org.flowable.ui.task.model.runtime.CreateCaseInstanceRepresentation;
 import org.flowable.ui.task.model.runtime.MilestoneRepresentation;
 import org.flowable.ui.task.model.runtime.PlanItemInstanceRepresentation;
 import org.flowable.ui.task.model.runtime.StageRepresentation;
 import org.flowable.ui.task.model.runtime.UserEventListenerRepresentation;
-import org.flowable.ui.common.service.idm.cache.UserCache;
-import org.flowable.ui.common.service.idm.cache.UserCache.CachedUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -192,14 +192,12 @@ public class FlowableCaseInstanceService {
             throw new NotFoundException("Case with id: " + caseInstanceId + " does not exist or is not available for this user");
         }
 
-        List<HistoricPlanItemInstance> milestones = new ArrayList<>();
-
         //Available
-        milestones.addAll(cmmnHistoryService.createHistoricPlanItemInstanceQuery()
-            .planItemInstanceCaseInstanceId(caseInstance.getId())
-            .planItemInstanceDefinitionType(PlanItemDefinitionType.MILESTONE)
-            .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
-            .list());
+        List<HistoricPlanItemInstance> milestones = new ArrayList<>(cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceCaseInstanceId(caseInstance.getId())
+                .planItemInstanceDefinitionType(PlanItemDefinitionType.MILESTONE)
+                .planItemInstanceState(PlanItemInstanceState.AVAILABLE)
+                .list());
 
         List<MilestoneRepresentation> milestoneRepresentations = milestones.stream()
             .map(p -> new MilestoneRepresentation(p.getName(), p.getState(), p.getCreateTime()))


### PR DESCRIPTION
Instead of using a `new` to allocate a collection then using `addAll()` or equivalent to add values, use a single parametrized constructor that also may be more performant.

A side effect is the reordering of some imports to match project standards.