### PR TITLE
Remove redundant cast to String in equals() method call

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/MybatisSentryPartInstanceDataManagerImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/data/impl/MybatisSentryPartInstanceDataManagerImpl.java
@@ -72,7 +72,7 @@ public class MybatisSentryPartInstanceDataManagerImpl extends AbstractCmmnDataMa
         @Override
         public boolean isRetained(SentryPartInstanceEntity sentryPartInstanceEntity, Object param) {
             return sentryPartInstanceEntity.getPlanItemInstanceId() == null
-                    && sentryPartInstanceEntity.getCaseInstanceId().equals((String) param);
+                    && sentryPartInstanceEntity.getCaseInstanceId().equals(param);
         }
         
     }
@@ -82,7 +82,7 @@ public class MybatisSentryPartInstanceDataManagerImpl extends AbstractCmmnDataMa
         @Override
         public boolean isRetained(SentryPartInstanceEntity sentryPartInstanceEntity, Object param) {
             return sentryPartInstanceEntity.getPlanItemInstanceId() != null
-                    && sentryPartInstanceEntity.getPlanItemInstanceId().equals((String) param);
+                    && sentryPartInstanceEntity.getPlanItemInstanceId().equals(param);
         }
         
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/ExecutionByProcessInstanceMatcher.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/ExecutionByProcessInstanceMatcher.java
@@ -22,7 +22,7 @@ public class ExecutionByProcessInstanceMatcher extends CachedEntityMatcherAdapte
 
     @Override
     public boolean isRetained(ExecutionEntity entity, Object parameter) {
-        return entity.getProcessInstanceId() != null && entity.getProcessInstanceId().equals((String) parameter);
+        return entity.getProcessInstanceId() != null && entity.getProcessInstanceId().equals(parameter);
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/ExecutionsByParentExecutionIdEntityMatcher.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/ExecutionsByParentExecutionIdEntityMatcher.java
@@ -23,7 +23,7 @@ public class ExecutionsByParentExecutionIdEntityMatcher extends CachedEntityMatc
     @Override
     public boolean isRetained(ExecutionEntity entity, Object parameter) {
         // parameter = parent execution id
-        return entity.getParentId() != null && entity.getParentId().equals((String) parameter);
+        return entity.getParentId() != null && entity.getParentId().equals(parameter);
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/ExecutionsByProcessInstanceIdEntityMatcher.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/ExecutionsByProcessInstanceIdEntityMatcher.java
@@ -24,7 +24,7 @@ public class ExecutionsByProcessInstanceIdEntityMatcher extends CachedEntityMatc
     public boolean isRetained(ExecutionEntity entity, Object parameter) {
         // parameter = process instance execution id
         return entity.getProcessInstanceId() != null
-                && entity.getProcessInstanceId().equals((String) parameter)
+                && entity.getProcessInstanceId().equals(parameter)
                 && entity.getParentId() != null;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/ExecutionsByRootProcessInstanceMatcher.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/ExecutionsByRootProcessInstanceMatcher.java
@@ -22,7 +22,7 @@ public class ExecutionsByRootProcessInstanceMatcher extends CachedEntityMatcherA
 
     @Override
     public boolean isRetained(ExecutionEntity entity, Object parameter) {
-        return entity.getRootProcessInstanceId() != null && entity.getRootProcessInstanceId().equals((String) parameter);
+        return entity.getRootProcessInstanceId() != null && entity.getRootProcessInstanceId().equals(parameter);
     }
 
 }

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsByExecutionIdMatcher.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsByExecutionIdMatcher.java
@@ -22,7 +22,7 @@ public class EventSubscriptionsByExecutionIdMatcher extends CachedEntityMatcherA
 
     @Override
     public boolean isRetained(EventSubscriptionEntity eventSubscriptionEntity, Object parameter) {
-        return eventSubscriptionEntity.getExecutionId() != null && eventSubscriptionEntity.getExecutionId().equals((String) parameter);
+        return eventSubscriptionEntity.getExecutionId() != null && eventSubscriptionEntity.getExecutionId().equals(parameter);
     }
 
 }

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsBySubScopeIdMatcher.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsBySubScopeIdMatcher.java
@@ -19,7 +19,7 @@ public class EventSubscriptionsBySubScopeIdMatcher extends CachedEntityMatcherAd
 
     @Override
     public boolean isRetained(EventSubscriptionEntity eventSubscriptionEntity, Object parameter) {
-        return eventSubscriptionEntity.getSubScopeId() != null && eventSubscriptionEntity.getSubScopeId().equals((String) parameter);
+        return eventSubscriptionEntity.getSubScopeId() != null && eventSubscriptionEntity.getSubScopeId().equals(parameter);
     }
 
 }

--- a/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/data/impl/cachematcher/HistoricIdentityLinksByProcInstMatcher.java
+++ b/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/data/impl/cachematcher/HistoricIdentityLinksByProcInstMatcher.java
@@ -23,7 +23,7 @@ public class HistoricIdentityLinksByProcInstMatcher extends CachedEntityMatcherA
     @Override
     public boolean isRetained(HistoricIdentityLinkEntity historicIdentityLinkEntity, Object parameter) {
         return historicIdentityLinkEntity.getProcessInstanceId() != null
-                && historicIdentityLinkEntity.getProcessInstanceId().equals((String) parameter);
+                && historicIdentityLinkEntity.getProcessInstanceId().equals(parameter);
     }
 
 }

--- a/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/data/impl/cachematcher/IdentityLinksByProcessInstanceMatcher.java
+++ b/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/data/impl/cachematcher/IdentityLinksByProcessInstanceMatcher.java
@@ -22,7 +22,7 @@ public class IdentityLinksByProcessInstanceMatcher extends CachedEntityMatcherAd
 
     @Override
     public boolean isRetained(IdentityLinkEntity entity, Object parameter) {
-        return entity.getProcessInstanceId() != null && entity.getProcessInstanceId().equals((String) parameter);
+        return entity.getProcessInstanceId() != null && entity.getProcessInstanceId().equals(parameter);
     }
 
 }

--- a/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/data/impl/cachematcher/IdentityLinksByTaskIdMatcher.java
+++ b/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/data/impl/cachematcher/IdentityLinksByTaskIdMatcher.java
@@ -22,7 +22,7 @@ public class IdentityLinksByTaskIdMatcher extends CachedEntityMatcherAdapter<Ide
 
     @Override
     public boolean isRetained(IdentityLinkEntity entity, Object parameter) {
-        return entity.getTaskId() != null && entity.getTaskId().equals((String) parameter);
+        return entity.getTaskId() != null && entity.getTaskId().equals(parameter);
     }
 
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/data/impl/cachematcher/ExternalWorkerJobsByExecutionIdMatcher.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/data/impl/cachematcher/ExternalWorkerJobsByExecutionIdMatcher.java
@@ -22,7 +22,7 @@ public class ExternalWorkerJobsByExecutionIdMatcher extends CachedEntityMatcherA
 
     @Override
     public boolean isRetained(ExternalWorkerJobEntity jobEntity, Object parameter) {
-        return jobEntity.getExecutionId() != null && jobEntity.getExecutionId().equals((String) parameter);
+        return jobEntity.getExecutionId() != null && jobEntity.getExecutionId().equals(parameter);
     }
 
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/data/impl/cachematcher/JobsByExecutionIdMatcher.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/data/impl/cachematcher/JobsByExecutionIdMatcher.java
@@ -22,7 +22,7 @@ public class JobsByExecutionIdMatcher extends CachedEntityMatcherAdapter<JobEnti
 
     @Override
     public boolean isRetained(JobEntity jobEntity, Object parameter) {
-        return jobEntity.getExecutionId() != null && jobEntity.getExecutionId().equals((String) parameter);
+        return jobEntity.getExecutionId() != null && jobEntity.getExecutionId().equals(parameter);
     }
 
 }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/data/impl/cachematcher/HistoricVariableInstanceByProcInstMatcher.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/data/impl/cachematcher/HistoricVariableInstanceByProcInstMatcher.java
@@ -23,7 +23,7 @@ public class HistoricVariableInstanceByProcInstMatcher extends CachedEntityMatch
     @Override
     public boolean isRetained(HistoricVariableInstanceEntity historicVariableInstanceEntity, Object parameter) {
         return historicVariableInstanceEntity.getProcessInstanceId() != null
-                && historicVariableInstanceEntity.getProcessInstanceId().equals((String) parameter);
+                && historicVariableInstanceEntity.getProcessInstanceId().equals(parameter);
     }
 
 }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/data/impl/cachematcher/HistoricVariableInstanceByTaskIdMatcher.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/data/impl/cachematcher/HistoricVariableInstanceByTaskIdMatcher.java
@@ -23,7 +23,7 @@ public class HistoricVariableInstanceByTaskIdMatcher extends CachedEntityMatcher
     @Override
     public boolean isRetained(HistoricVariableInstanceEntity historicVariableInstanceEntity, Object parameter) {
         return historicVariableInstanceEntity.getTaskId() != null
-                && historicVariableInstanceEntity.getTaskId().equals((String) parameter);
+                && historicVariableInstanceEntity.getTaskId().equals(parameter);
     }
 
 }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/data/impl/cachematcher/VariableInstanceByExecutionIdMatcher.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/data/impl/cachematcher/VariableInstanceByExecutionIdMatcher.java
@@ -23,7 +23,7 @@ public class VariableInstanceByExecutionIdMatcher extends CachedEntityMatcherAda
     @Override
     public boolean isRetained(VariableInstanceEntity variableInstanceEntity, Object parameter) {
         return variableInstanceEntity.getExecutionId() != null
-                && variableInstanceEntity.getExecutionId().equals((String) parameter);
+                && variableInstanceEntity.getExecutionId().equals(parameter);
     }
 
 }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/data/impl/cachematcher/VariableInstanceByTaskIdMatcher.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/data/impl/cachematcher/VariableInstanceByTaskIdMatcher.java
@@ -23,7 +23,7 @@ public class VariableInstanceByTaskIdMatcher extends CachedEntityMatcherAdapter<
     @Override
     public boolean isRetained(VariableInstanceEntity variableInstanceEntity, Object parameter) {
         return variableInstanceEntity.getTaskId() != null
-                && variableInstanceEntity.getTaskId().equals((String) parameter);
+                && variableInstanceEntity.getTaskId().equals(parameter);
     }
 
 }


### PR DESCRIPTION
Remove the redundant cast to `String` in `equals()` method called on a string value.  The `equals` method ensures the value is of a `String` type.
