### PR TITLE
Use parametrized log messages instead of concatenation

### DIFF
--- a/modules/flowable-dmn-json-converter/src/main/java/org/flowable/dmn/editor/converter/DmnJsonConverter.java
+++ b/modules/flowable-dmn-json-converter/src/main/java/org/flowable/dmn/editor/converter/DmnJsonConverter.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.flowable.dmn.editor.constants.DmnJsonConstants;
+import org.flowable.dmn.editor.constants.DmnStencilConstants;
 import org.flowable.dmn.model.BuiltinAggregator;
 import org.flowable.dmn.model.Decision;
 import org.flowable.dmn.model.DecisionRule;
@@ -47,8 +49,6 @@ import org.flowable.dmn.model.OutputClause;
 import org.flowable.dmn.model.RuleInputClauseContainer;
 import org.flowable.dmn.model.RuleOutputClauseContainer;
 import org.flowable.dmn.model.UnaryTests;
-import org.flowable.dmn.editor.constants.DmnJsonConstants;
-import org.flowable.dmn.editor.constants.DmnStencilConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -738,10 +738,10 @@ public class DmnJsonConverter implements DmnJsonConstants, DmnStencilConstants {
 
                             processDecisionTable(decisionTableNode, decisionTable);
                         } catch (Exception ex) {
-                            LOGGER.error("Error while parsing decision table editor JSON: " + decisionTableEditorJson);
+                            LOGGER.error("Error while parsing decision table editor JSON: {}", decisionTableEditorJson);
                         }
                     } else {
-                        LOGGER.warn("Could not find decision table for key: " + decisionTableKey);
+                        LOGGER.warn("Could not find decision table for key: {}", decisionTableKey);
                     }
                 }
             }

--- a/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/AbstractModelBpmnResource.java
+++ b/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/AbstractModelBpmnResource.java
@@ -67,7 +67,7 @@ public class AbstractModelBpmnResource {
         try {
             encodedName = "UTF-8''" + URLEncoder.encode(name, "UTF-8");
         } catch (Exception e) {
-            LOGGER.warn("Failed to encode name " + name);
+            LOGGER.warn("Failed to encode name {}", name);
         }
 
         String contentDispositionValue = "attachment; filename=" + name;


### PR DESCRIPTION
Using parametrized log messages are more efficient that using concatenation. 

A side effect of this change is the proper ordering of imports in one of the files.
