### PR TITLE
Remove duplicate dependency

### DIFF
--- a/modules/flowable-event-registry-rest/pom.xml
+++ b/modules/flowable-event-registry-rest/pom.xml
@@ -241,11 +241,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.javacrumbs.json-unit</groupId>
-            <artifactId>json-unit-assertj</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
         </dependency>


### PR DESCRIPTION
The net.javacrumbs.json-unit:json-unit-assertj:jar was defined in the pom.xml twice; removing the extra copy.
