### PR TITLE
When querying for variable not equals different types and null should be properly handled

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/CaseInstance.xml
+++ b/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/CaseInstance.xml
@@ -519,17 +519,16 @@
                           <!-- Match-all variable-names when name is null -->
                           and A${index}.NAME_= #{queryVariableValue.name}
                         </if>
-                        <if test="!queryVariableValue.type.equals('null')">
-                        <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                        <if test="queryVariableValue.needsTypeCheck()">
                           and A${index}.TYPE_ = #{queryVariableValue.type}
                         </if>
                         <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                           <choose>
                             <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                              and lower(A${index}.TEXT_)
+                              and (lower(A${index}.TEXT_)
                             </when>
                             <otherwise>
-                              and A${index}.TEXT_
+                              and (A${index}.TEXT_
                             </otherwise>
                           </choose>
                           <choose>
@@ -540,6 +539,10 @@
                           <choose>
                             <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                           </choose>
+                          <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                              or A${index}.TEXT_ is null
+                          </if>
+                          )
                         </if>
                         <if test="queryVariableValue.textValue2 != null">
                         and A${index}.TEXT2_
@@ -553,14 +556,22 @@
                           </choose>
                         </if>
                         <if test="queryVariableValue.longValue != null">
-                            and A${index}.LONG_
+                            and (A${index}.LONG_
                             <include refid="variableOperator" />
                             #{queryVariableValue.longValue}
+                            <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                or A${index}.LONG_ is null
+                            </if>
+                            )
                         </if>
                         <if test="queryVariableValue.doubleValue != null">
-                            and A${index}.DOUBLE_
+                            and (A${index}.DOUBLE_
                             <include refid="variableOperator" />
                             #{queryVariableValue.doubleValue}
+                            <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                or A${index}.DOUBLE_ is null
+                            </if>
+                            )
                         </if>
                         <!-- Null variable type -->
                         <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
@@ -696,17 +707,16 @@
                                         <!-- Match-all variable-names when name is null -->
                                         and A_OR${orIndex}.NAME_= #{queryVariableValue.name}
                                     </if>
-                                    <if test="!queryVariableValue.type.equals('null')">
-                                        <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                                    <if test="queryVariableValue.needsTypeCheck()">
                                         and A_OR${orIndex}.TYPE_ = #{queryVariableValue.type}
                                     </if>
                                     <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                                         <choose>
                                             <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                                                and lower(A_OR${orIndex}.TEXT_)
+                                                and (lower(A_OR${orIndex}.TEXT_)
                                             </when>
                                             <otherwise>
-                                                and A_OR${orIndex}.TEXT_
+                                                and (A_OR${orIndex}.TEXT_
                                             </otherwise>
                                         </choose>
                                         <choose>
@@ -723,6 +733,10 @@
                                                 ${wildcardEscapeClause}
                                             </when>
                                         </choose>
+                                        <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                            or A_OR${index}.TEXT_ is null
+                                        </if>
+                                        )
                                     </if>
                                     <if test="queryVariableValue.textValue2 != null">
                                         and A_OR${orIndex}.TEXT2_
@@ -738,14 +752,22 @@
                                         </choose>
                                     </if>
                                     <if test="queryVariableValue.longValue != null">
-                                        and A_OR${orIndex}.LONG_
+                                        and (A_OR${orIndex}.LONG_
                                         <include refid="variableOperator"/>
                                         #{queryVariableValue.longValue}
+                                        <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                            or A_OR${index}.LONG_ is null
+                                        </if>
+                                        )
                                     </if>
                                     <if test="queryVariableValue.doubleValue != null">
-                                        and A_OR${orIndex}.DOUBLE_
+                                        and (A_OR${orIndex}.DOUBLE_
                                         <include refid="variableOperator"/>
                                         #{queryVariableValue.doubleValue}
+                                        <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                            or A_OR${index}.DOUBLE_ is null
+                                        </if>
+                                        )
                                     </if>
                                     <!-- Null variable type -->
                                     <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">

--- a/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/HistoricCaseInstance.xml
+++ b/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/HistoricCaseInstance.xml
@@ -408,17 +408,16 @@
                           <!-- Match-all variable-names when name is null -->
                           and A${index}.NAME_= #{queryVariableValue.name}
                         </if>
-                        <if test="!queryVariableValue.type.equals('null')">
-                        <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                        <if test="queryVariableValue.needsTypeCheck()">
                           and A${index}.VAR_TYPE_ = #{queryVariableValue.type}
                         </if>
                         <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                           <choose>
                             <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                              and lower(A${index}.TEXT_)
+                              and (lower(A${index}.TEXT_)
                             </when>
                             <otherwise>
-                              and A${index}.TEXT_
+                              and (A${index}.TEXT_
                             </otherwise>
                           </choose>
                           <choose>
@@ -429,6 +428,10 @@
                           <choose>
                             <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                           </choose>
+                            <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                or A${index}.TEXT_ is null
+                            </if>
+                            )
                         </if>
                         <if test="queryVariableValue.textValue2 != null">
                         and A${index}.TEXT2_
@@ -442,14 +445,22 @@
                           </choose>
                         </if>
                         <if test="queryVariableValue.longValue != null">
-                            and A${index}.LONG_
+                            and (A${index}.LONG_
                             <include refid="variableOperator" />
                             #{queryVariableValue.longValue}
+                            <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                or A${index}.LONG_ is null
+                            </if>
+                            )
                         </if>
                         <if test="queryVariableValue.doubleValue != null">
-                            and A${index}.DOUBLE_
+                            and (A${index}.DOUBLE_
                             <include refid="variableOperator" />
                             #{queryVariableValue.doubleValue}
+                            <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                or A${index}.DOUBLE_ is null
+                            </if>
+                            )
                         </if>
                         <!-- Null variable type -->
                         <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
@@ -518,17 +529,16 @@
                                     <!-- Match-all variable-names when name is null -->
                                     and A_OR${orIndex}.NAME_= #{queryVariableValue.name}
                                 </if>
-                                <if test="!queryVariableValue.type.equals('null')">
-                                    <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                                <if test="queryVariableValue.needsTypeCheck()">
                                     and A_OR${orIndex}.VAR_TYPE_ = #{queryVariableValue.type}
                                 </if>
                                 <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                                     <choose>
                                         <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                                            and lower(A_OR${orIndex}.TEXT_)
+                                            and (lower(A_OR${orIndex}.TEXT_)
                                         </when>
                                         <otherwise>
-                                            and A_OR${orIndex}.TEXT_
+                                            and (A_OR${orIndex}.TEXT_
                                         </otherwise>
                                     </choose>
                                     <choose>
@@ -541,6 +551,10 @@
                                     <choose>
                                         <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                                     </choose>
+                                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                        or A_OR${index}.TEXT_ is null
+                                    </if>
+                                    )
                                 </if>
                                 <if test="queryVariableValue.textValue2 != null">
                                     and A_OR${orIndex}.TEXT2_
@@ -554,14 +568,22 @@
                                     </choose>
                                 </if>
                                 <if test="queryVariableValue.longValue != null">
-                                    and A_OR${orIndex}.LONG_
+                                    and (A_OR${orIndex}.LONG_
                                     <include refid="variableOperator" />
                                     #{queryVariableValue.longValue}
+                                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                        or A_OR${index}.LONG_ is null
+                                    </if>
+                                    )
                                 </if>
                                 <if test="queryVariableValue.doubleValue != null">
-                                    and A_OR${index}.DOUBLE_
+                                    and (A_OR${index}.DOUBLE_
                                     <include refid="variableOperator" />
                                     #{queryVariableValue.doubleValue}
+                                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                                        or A_OR${index}.DOUBLE_ is null
+                                    </if>
+                                    )
                                 </if>
                                 <!-- Null variable type -->
                                 <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">

--- a/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/PlanItemInstance.xml
+++ b/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/PlanItemInstance.xml
@@ -552,17 +552,16 @@
                   <!-- Match-all variable-names when name is null -->
                   and A${index}.NAME_= #{queryVariableValue.name}
                 </if>
-                <if test="!queryVariableValue.type.equals('null')">
-                <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                <if test="queryVariableValue.needsTypeCheck()">
                   and A${index}.TYPE_ = #{queryVariableValue.type}
                 </if>
                 <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                   <choose>
                     <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                      and lower(A${index}.TEXT_)
+                      and (lower(A${index}.TEXT_)
                     </when>
                     <otherwise>
-                      and A${index}.TEXT_
+                      and (A${index}.TEXT_
                     </otherwise>
                   </choose>
                   <choose>
@@ -573,6 +572,10 @@
                   <choose>
                     <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                   </choose>
+                  <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.TEXT_ is null
+                  </if>
+                  )
                 </if>
                 <if test="queryVariableValue.textValue2 != null">
                   and A${index}.TEXT2_
@@ -586,14 +589,22 @@
                   </choose>
                 </if>
                 <if test="queryVariableValue.longValue != null">
-                  and A${index}.LONG_
+                  and (A${index}.LONG_
                   <include refid="variableOperator" />
                   #{queryVariableValue.longValue}
+                  <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.LONG_ is null
+                  </if>
+                  )
                 </if>
                 <if test="queryVariableValue.doubleValue != null">
-                  and A${index}.DOUBLE_
+                  and (A${index}.DOUBLE_
                   <include refid="variableOperator" />
                   #{queryVariableValue.doubleValue}
+                  <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.DOUBLE_ is null
+                  </if>
+                  )
                 </if>
                 <!-- Null variable type -->
                 <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceQueryImplTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/HistoricCaseInstanceQueryImplTest.java
@@ -14,6 +14,7 @@ package org.flowable.cmmn.test.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -1041,6 +1042,94 @@ public class HistoricCaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         assertThat(historicCaseInstance.getCaseVariables()).containsOnly(
                 entry("stringVar","test")
         );
+    }
+
+    @Test
+    public void testQueryVariableValueEqualsAndNotEquals() {
+        CaseInstance caseWithStringValue = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("With string value")
+                .variable("var", "TEST")
+                .start();
+
+        CaseInstance caseWithNullValue = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("With null value")
+                .variable("var", null)
+                .start();
+
+        CaseInstance caseWithLongValue = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("With long value")
+                .variable("var", 100L)
+                .start();
+
+        CaseInstance caseWithDoubleValue = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("With double value")
+                .variable("var", 45.55)
+                .start();
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueNotEquals("var", "TEST").list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", caseWithNullValue.getId()),
+                        tuple("With long value", caseWithLongValue.getId()),
+                        tuple("With double value", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var", "TEST").list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseWithStringValue.getId())
+                );
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueNotEquals("var", 100L).list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseWithStringValue.getId()),
+                        tuple("With null value", caseWithNullValue.getId()),
+                        tuple("With double value", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var", 100L).list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With long value", caseWithLongValue.getId())
+                );
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueNotEquals("var", 45.55).list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseWithStringValue.getId()),
+                        tuple("With null value", caseWithNullValue.getId()),
+                        tuple("With long value", caseWithLongValue.getId())
+                );
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var", 45.55).list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With double value", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueNotEquals("var", "test").list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseWithStringValue.getId()),
+                        tuple("With null value", caseWithNullValue.getId()),
+                        tuple("With long value", caseWithLongValue.getId()),
+                        tuple("With double value", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEquals("var", "test").list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .isEmpty();
+
+        assertThat(cmmnHistoryService.createHistoricCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "test").list())
+                .extracting(HistoricCaseInstance::getName, HistoricCaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseWithStringValue.getId())
+                );
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceQueryImplTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceQueryImplTest.java
@@ -14,6 +14,7 @@ package org.flowable.cmmn.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -1255,5 +1256,102 @@ public class CaseInstanceQueryImplTest extends FlowableCmmnTestCase {
         assertThat(caseInstance.getCaseVariables()).containsOnly(
                 entry("stringVar","test")
         );
+    }
+
+
+    @Test
+    public void testQueryVariableValueEqualsAndNotEquals() {
+        CaseInstance caseInstance1 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("With string value")
+                .variable("var", "TEST")
+                .start();
+
+        CaseInstance caseInstance2 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("With null value")
+                .variable("var", null)
+                .start();
+
+        CaseInstance caseInstance3 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("With long value")
+                .variable("var", 100L)
+                .start();
+
+        CaseInstance caseInstance4 = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .name("With double value")
+                .variable("var", 45.55)
+                .start();
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEquals("var", "TEST").list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", caseInstance2.getId()),
+                        tuple("With long value", caseInstance3.getId()),
+                        tuple("With double value", caseInstance4.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", "TEST").list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseInstance1.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEquals("var", 100L).list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseInstance1.getId()),
+                        tuple("With null value", caseInstance2.getId()),
+                        tuple("With double value", caseInstance4.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", 100L).list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With long value", caseInstance3.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEquals("var", 45.55).list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseInstance1.getId()),
+                        tuple("With null value", caseInstance2.getId()),
+                        tuple("With long value", caseInstance3.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", 45.55).list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With double value", caseInstance4.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEquals("var", "test").list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseInstance1.getId()),
+                        tuple("With null value", caseInstance2.getId()),
+                        tuple("With long value", caseInstance3.getId()),
+                        tuple("With double value", caseInstance4.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueNotEqualsIgnoreCase("var", "test").list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", caseInstance2.getId()),
+                        tuple("With long value", caseInstance3.getId()),
+                        tuple("With double value", caseInstance4.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueEquals("var", "test").list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .isEmpty();
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().variableValueEqualsIgnoreCase("var", "test").list())
+                .extracting(CaseInstance::getName, CaseInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", caseInstance1.getId())
+                );
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemInstanceQueryTest.java
@@ -650,6 +650,134 @@ public class PlanItemInstanceQueryTest extends FlowableCmmnTestCase {
                 );
     }
 
+    @Test
+    public void testQueryVariableValueEqualsAndNotEquals() {
+        CaseInstance caseWithStringValue = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("testPlanItemInstanceQuery")
+                .name("With string value")
+                .start();
+
+        CaseInstance caseWithNullValue = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("testPlanItemInstanceQuery")
+                .name("With null value")
+                .start();
+
+        CaseInstance caseWithLongValue = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("testPlanItemInstanceQuery")
+                .name("With long value")
+                .start();
+
+        CaseInstance caseWithDoubleValue = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("testPlanItemInstanceQuery")
+                .name("With double value")
+                .start();
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().planItemInstanceName("Stage one").list())
+                .hasSize(4);
+
+        PlanItemInstance planItemWithStringValue = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .caseInstanceId(caseWithStringValue.getId())
+                .planItemInstanceName("Stage one")
+                .singleResult();
+
+        assertThat(planItemWithStringValue).isNotNull();
+
+        PlanItemInstance planItemWithNullValue = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .caseInstanceId(caseWithNullValue.getId())
+                .planItemInstanceName("Stage one")
+                .singleResult();
+
+        assertThat(planItemWithNullValue).isNotNull();
+
+        PlanItemInstance planItemWithLongValue = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .caseInstanceId(caseWithLongValue.getId())
+                .planItemInstanceName("Stage one")
+                .singleResult();
+
+        assertThat(planItemWithLongValue).isNotNull();
+
+        PlanItemInstance planItemWithDoubleValue = cmmnRuntimeService.createPlanItemInstanceQuery()
+                .caseInstanceId(caseWithDoubleValue.getId())
+                .planItemInstanceName("Stage one")
+                .singleResult();
+
+        assertThat(planItemWithDoubleValue).isNotNull();
+
+        cmmnRuntimeService.setLocalVariable(planItemWithStringValue.getId(), "var", "TEST");
+        cmmnRuntimeService.setLocalVariable(planItemWithNullValue.getId(), "var", null);
+        cmmnRuntimeService.setLocalVariable(planItemWithLongValue.getId(), "var", 100L);
+        cmmnRuntimeService.setLocalVariable(planItemWithDoubleValue.getId(), "var", 45.55);
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("var", "TEST").list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithNullValue.getId()),
+                        tuple("Stage one", caseWithLongValue.getId()),
+                        tuple("Stage one", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("var", "TEST").list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithStringValue.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("var", 100L).list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithStringValue.getId()),
+                        tuple("Stage one", caseWithNullValue.getId()),
+                        tuple("Stage one", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("var", 100L).list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithLongValue.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("var", 45.55).list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithStringValue.getId()),
+                        tuple("Stage one", caseWithNullValue.getId()),
+                        tuple("Stage one", caseWithLongValue.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("var", 45.55).list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEquals("var", "test").list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithStringValue.getId()),
+                        tuple("Stage one", caseWithNullValue.getId()),
+                        tuple("Stage one", caseWithLongValue.getId()),
+                        tuple("Stage one", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueNotEqualsIgnoreCase("var", "test").list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithNullValue.getId()),
+                        tuple("Stage one", caseWithLongValue.getId()),
+                        tuple("Stage one", caseWithDoubleValue.getId())
+                );
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEquals("var", "test").list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .isEmpty();
+
+        assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().variableValueEqualsIgnoreCase("var", "test").list())
+                .extracting(PlanItemInstance::getName, PlanItemInstance::getCaseInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("Stage one", caseWithStringValue.getId())
+                );
+    }
+
     private List<String> startInstances(int numberOfInstances) {
         List<String> caseInstanceIds = new ArrayList<>();
         for (int i = 0; i < numberOfInstances; i++) {

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/Execution.xml
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/Execution.xml
@@ -922,17 +922,16 @@
                   <!-- Match-all variable-names when name is null -->
                   and A${index}.NAME_= #{queryVariableValue.name}
                 </if>
-                <if test="!queryVariableValue.type.equals('null')">
-                <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                <if test="queryVariableValue.needsTypeCheck()">
                   and A${index}.TYPE_ = #{queryVariableValue.type}
                 </if>
               	<if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                   <choose>
                     <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                      and lower(A${index}.TEXT_)
+                      and (lower(A${index}.TEXT_)
                     </when>
                     <otherwise>
-                      and A${index}.TEXT_
+                      and (A${index}.TEXT_
                     </otherwise>
                   </choose>
         	      <choose>
@@ -943,6 +942,10 @@
           	      <choose>
         			<when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
         		  </choose>
+                  <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.TEXT_ is null
+                  </if>
+                  )
               	</if>
               	<if test="queryVariableValue.textValue2 != null">
         	      and A${index}.TEXT2_
@@ -956,14 +959,22 @@
         		  </choose>
               	</if>
               	<if test="queryVariableValue.longValue != null">
-        	      and A${index}.LONG_
+        	      and (A${index}.LONG_
         	      <include refid="executionVariableOperator" />
         	      #{queryVariableValue.longValue}
+                  <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.LONG_ is null
+                  </if>
+                  )
               	</if>
               	<if test="queryVariableValue.doubleValue != null">
-        	      and A${index}.DOUBLE_
+        	      and (A${index}.DOUBLE_
         	      <include refid="executionVariableOperator" />
         	      #{queryVariableValue.doubleValue}
+                  <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.DOUBLE_ is null
+                  </if>
+                  )
               	</if>
               	<!-- Null variable type -->
               	<if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
@@ -1152,17 +1163,16 @@
                     <!-- Match-all variable-names when name is null -->
                     and A_OR${orIndex}.NAME_= #{queryVariableValue.name}
                   </if>
-                  <if test="!queryVariableValue.type.equals('null')">
-                  <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                  <if test="queryVariableValue.needsTypeCheck()">
                     and A_OR${orIndex}.TYPE_ = #{queryVariableValue.type}
                   </if>
                   <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                     <choose>
                       <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                        and lower(A_OR${orIndex}.TEXT_)
+                        and (lower(A_OR${orIndex}.TEXT_)
                       </when>
                       <otherwise>
-                        and A_OR${orIndex}.TEXT_
+                        and (A_OR${orIndex}.TEXT_
                       </otherwise>
                     </choose>
                   <choose>
@@ -1173,6 +1183,10 @@
                   <choose>
                     <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                   </choose>
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or A_OR${index}.TEXT_ is null
+                    </if>
+                    )
                   </if>
                   <if test="queryVariableValue.textValue2 != null">
                   and A_OR${orIndex}.TEXT2_
@@ -1186,14 +1200,22 @@
                     </choose>
                   </if>
                   <if test="queryVariableValue.longValue != null">
-                  and A_OR${orIndex}.LONG_
+                  and (A_OR${orIndex}.LONG_
                   <include refid="executionVariableOperator" />
                   #{queryVariableValue.longValue}
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or A_OR${index}.LONG_ is null
+                    </if>
+                    )
                   </if>
                   <if test="queryVariableValue.doubleValue != null">
-                  and A_OR${orIndex}.DOUBLE_
+                  and (A_OR${orIndex}.DOUBLE_
                   <include refid="executionVariableOperator" />
                   #{queryVariableValue.doubleValue}
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or A_OR${index}.DOUBLE_ is null
+                    </if>
+                    )
                   </if>
                   <!-- Null variable type -->
                   <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/HistoricProcessInstance.xml
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/HistoricProcessInstance.xml
@@ -516,17 +516,16 @@
                   <!-- Match-all variable-names when name is null -->
                   and A${index}.NAME_= #{queryVariableValue.name}
                 </if>
-                <if test="!queryVariableValue.type.equals('null')">
-                <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                <if test="queryVariableValue.needsTypeCheck()">
                   and A${index}.VAR_TYPE_ = #{queryVariableValue.type}
                 </if>
                 <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                   <choose>
                     <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                      and lower(A${index}.TEXT_)
+                      and (lower(A${index}.TEXT_)
                     </when>
                     <otherwise>
-                      and A${index}.TEXT_
+                      and (A${index}.TEXT_
                     </otherwise>
                   </choose>
                   <choose>
@@ -537,6 +536,10 @@
                   <choose>
                     <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                   </choose>
+                  <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.TEXT_ is null
+                  </if>
+                  )
                 </if>
                 <if test="queryVariableValue.textValue2 != null">
                 and A${index}.TEXT2_
@@ -550,14 +553,22 @@
                   </choose>
                 </if>
                 <if test="queryVariableValue.longValue != null">
-                    and A${index}.LONG_
+                    and (A${index}.LONG_
                     <include refid="executionVariableOperator" />
                     #{queryVariableValue.longValue}
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or A${index}.LONG_ is null
+                    </if>
+                    )
                 </if>
                 <if test="queryVariableValue.doubleValue != null">
-                    and A${index}.DOUBLE_
+                    and (A${index}.DOUBLE_
                     <include refid="executionVariableOperator" />
                     #{queryVariableValue.doubleValue}
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or A${index}.DOUBLE_ is null
+                    </if>
+                    )
                 </if>
                 <!-- Null variable type -->
                 <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
@@ -631,17 +642,16 @@
                     <!-- Match-all variable-names when name is null -->
                     and A_OR${orIndex}.NAME_= #{queryVariableValue.name}
                   </if>
-                  <if test="!queryVariableValue.type.equals('null')">
-                  <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                  <if test="queryVariableValue.needsTypeCheck()">
                     and A_OR${orIndex}.VAR_TYPE_ = #{queryVariableValue.type}
                   </if>
                   <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                     <choose>
                       <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                        and lower(A_OR${orIndex}.TEXT_)
+                        and (lower(A_OR${orIndex}.TEXT_)
                       </when>
                       <otherwise>
-                        and A_OR${orIndex}.TEXT_
+                        and (A_OR${orIndex}.TEXT_
                       </otherwise>
                     </choose>
                     <choose>
@@ -652,6 +662,10 @@
                     <choose>
                       <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                     </choose>
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or A_OR${index}.TEXT_ is null
+                    </if>
+                    )
                   </if>
                   <if test="queryVariableValue.textValue2 != null">
                     and A_OR${orIndex}.TEXT2_
@@ -665,14 +679,22 @@
                     </choose>
                   </if>
                   <if test="queryVariableValue.longValue != null">
-                    and A_OR${orIndex}.LONG_
+                    and (A_OR${orIndex}.LONG_
                     <include refid="executionVariableOperator" />
                     #{queryVariableValue.longValue}
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or A_OR${index}.LONG_ is null
+                    </if>
+                    )
                   </if>
                   <if test="queryVariableValue.doubleValue != null">
-                    and A_OR${orIndex}.DOUBLE_
+                    and (A_OR${orIndex}.DOUBLE_
                     <include refid="executionVariableOperator" />
                     #{queryVariableValue.doubleValue}
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or A_OR${index}.DOUBLE_ is null
+                    </if>
+                    )
                   </if>
                   <!-- Null variable type -->
                   <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoricProcessInstanceQueryTest.java
@@ -226,4 +226,96 @@ public class HistoricProcessInstanceQueryTest extends PluggableFlowableTestCase 
 
     }
 
+    @Test
+    public void testQueryVariableValueEqualsAndNotEquals() {
+        deployOneTaskTestProcess();
+        ProcessInstance processWithStringValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With string value")
+                .variable("var", "TEST")
+                .start();
+
+        ProcessInstance processWithNullValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With null value")
+                .variable("var", null)
+                .start();
+
+        ProcessInstance processWithLongValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With long value")
+                .variable("var", 100L)
+                .start();
+
+        ProcessInstance processWithDoubleValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With double value")
+                .variable("var", 45.55)
+                .start();
+
+        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("var", "TEST").list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .containsExactlyInAnyOrder(
+                            tuple("With null value", processWithNullValue.getId()),
+                            tuple("With long value", processWithLongValue.getId()),
+                            tuple("With double value", processWithDoubleValue.getId())
+                    );
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("var", "TEST").list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .containsExactlyInAnyOrder(
+                            tuple("With string value", processWithStringValue.getId())
+                    );
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("var", 100L).list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .containsExactlyInAnyOrder(
+                            tuple("With string value", processWithStringValue.getId()),
+                            tuple("With null value", processWithNullValue.getId()),
+                            tuple("With double value", processWithDoubleValue.getId())
+                    );
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("var", 100L).list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .containsExactlyInAnyOrder(
+                            tuple("With long value", processWithLongValue.getId())
+                    );
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("var", 45.55).list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .containsExactlyInAnyOrder(
+                            tuple("With string value", processWithStringValue.getId()),
+                            tuple("With null value", processWithNullValue.getId()),
+                            tuple("With long value", processWithLongValue.getId())
+                    );
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("var", 45.55).list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .containsExactlyInAnyOrder(
+                            tuple("With double value", processWithDoubleValue.getId())
+                    );
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("var", "test").list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .containsExactlyInAnyOrder(
+                            tuple("With string value", processWithStringValue.getId()),
+                            tuple("With null value", processWithNullValue.getId()),
+                            tuple("With long value", processWithLongValue.getId()),
+                            tuple("With double value", processWithDoubleValue.getId())
+                    );
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEquals("var", "test").list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .isEmpty();
+
+            assertThat(historyService.createHistoricProcessInstanceQuery().variableValueEqualsIgnoreCase("var", "test").list())
+                    .extracting(HistoricProcessInstance::getName, HistoricProcessInstance::getId)
+                    .containsExactlyInAnyOrder(
+                            tuple("With string value", processWithStringValue.getId())
+                    );
+        }
+    }
+
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
@@ -15,6 +15,7 @@ package org.flowable.engine.test.api.runtime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -1971,5 +1972,271 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
                 fail("Unknown 'getParentID()'");
             }
         }
+    }
+
+    @Test
+    public void testQueryVariableValueEqualsAndNotEquals() {
+        ProcessInstance processWithStringValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With string value")
+                .start();
+
+        ProcessInstance processWithNullValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With null value")
+                .start();
+
+        ProcessInstance processWithLongValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With long value")
+                .start();
+
+        ProcessInstance processWithDoubleValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With double value")
+                .start();
+
+        Execution executionWithStringValue = runtimeService.createExecutionQuery()
+                .processInstanceId(processWithStringValue.getId())
+                .activityId("theTask")
+                .singleResult();
+        assertThat(executionWithStringValue).isNotNull();
+        runtimeService.setVariableLocal(executionWithStringValue.getId(), "var", "TEST");
+
+        Execution executionWithNullValue = runtimeService.createExecutionQuery()
+                .processInstanceId(processWithNullValue.getId())
+                .activityId("theTask")
+                .singleResult();
+        assertThat(executionWithNullValue).isNotNull();
+        runtimeService.setVariableLocal(executionWithNullValue.getId(), "var", null);
+
+        Execution executionWithLongValue = runtimeService.createExecutionQuery()
+                .processInstanceId(processWithLongValue.getId())
+                .activityId("theTask")
+                .singleResult();
+        assertThat(executionWithLongValue).isNotNull();
+        runtimeService.setVariableLocal(executionWithLongValue.getId(), "var", 100L);
+
+        Execution executionWithDoubleValue = runtimeService.createExecutionQuery()
+                .processInstanceId(processWithDoubleValue.getId())
+                .activityId("theTask")
+                .singleResult();
+        assertThat(executionWithDoubleValue).isNotNull();
+        runtimeService.setVariableLocal(executionWithDoubleValue.getId(), "var", 45.55);
+
+        assertThat(runtimeService.createExecutionQuery().variableValueNotEquals("var", "TEST").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().variableValueEquals("var", "TEST").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithStringValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().variableValueNotEquals("var", 100L).list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithStringValue.getId()),
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().variableValueEquals("var", 100L).list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithLongValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().variableValueNotEquals("var", 45.55).list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithStringValue.getId()),
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().variableValueEquals("var", 45.55).list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().variableValueNotEquals("var", "test").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithStringValue.getId()),
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().variableValueNotEqualsIgnoreCase("var", "test").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().variableValueEquals("var", "test").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .isEmpty();
+
+        assertThat(runtimeService.createExecutionQuery().variableValueEqualsIgnoreCase("var", "test").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple(null, "theTask", executionWithStringValue.getId())
+                );
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    public void testQueryProcessVariableValueEqualsAndNotEquals() {
+        ProcessInstance processWithStringValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With string value")
+                .variable("var", "TEST")
+                .start();
+
+        ProcessInstance processWithNullValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With null value")
+                .variable("var", null)
+                .start();
+
+        ProcessInstance processWithLongValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With long value")
+                .variable("var", 100L)
+                .start();
+
+        ProcessInstance processWithDoubleValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With double value")
+                .variable("var", 45.55)
+                .start();
+
+        Execution executionWithStringValue = runtimeService.createExecutionQuery()
+                .processInstanceId(processWithStringValue.getId())
+                .activityId("theTask")
+                .singleResult();
+        assertThat(executionWithStringValue).isNotNull();
+
+        Execution executionWithNullValue = runtimeService.createExecutionQuery()
+                .processInstanceId(processWithNullValue.getId())
+                .activityId("theTask")
+                .singleResult();
+        assertThat(executionWithNullValue).isNotNull();
+
+        Execution executionWithLongValue = runtimeService.createExecutionQuery()
+                .processInstanceId(processWithLongValue.getId())
+                .activityId("theTask")
+                .singleResult();
+        assertThat(executionWithLongValue).isNotNull();
+
+        Execution executionWithDoubleValue = runtimeService.createExecutionQuery()
+                .processInstanceId(processWithDoubleValue.getId())
+                .activityId("theTask")
+                .singleResult();
+        assertThat(executionWithDoubleValue).isNotNull();
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueNotEquals("var", "TEST").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", null, processWithNullValue.getId()),
+                        tuple("With long value", null, processWithLongValue.getId()),
+                        tuple("With double value", null, processWithDoubleValue.getId()),
+
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueEquals("var", "TEST").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", null, processWithStringValue.getId()),
+                        tuple(null, "theTask", executionWithStringValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueNotEquals("var", 100L).list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", null, processWithStringValue.getId()),
+                        tuple("With null value", null, processWithNullValue.getId()),
+                        tuple("With double value", null, processWithDoubleValue.getId()),
+
+                        tuple(null, "theTask", executionWithStringValue.getId()),
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueEquals("var", 100L).list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With long value", null, processWithLongValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueNotEquals("var", 45.55).list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", null, processWithStringValue.getId()),
+                        tuple("With null value", null, processWithNullValue.getId()),
+                        tuple("With long value", null, processWithLongValue.getId()),
+
+                        tuple(null, "theTask", executionWithStringValue.getId()),
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueEquals("var", 45.55).list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With double value", null, processWithDoubleValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueNotEquals("var", "test").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", null, processWithStringValue.getId()),
+                        tuple("With null value", null, processWithNullValue.getId()),
+                        tuple("With long value", null, processWithLongValue.getId()),
+                        tuple("With double value", null, processWithDoubleValue.getId()),
+
+                        tuple(null, "theTask", executionWithStringValue.getId()),
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueNotEqualsIgnoreCase("var", "test").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", null, processWithNullValue.getId()),
+                        tuple("With long value", null, processWithLongValue.getId()),
+                        tuple("With double value", null, processWithDoubleValue.getId()),
+
+                        tuple(null, "theTask", executionWithNullValue.getId()),
+                        tuple(null, "theTask", executionWithLongValue.getId()),
+                        tuple(null, "theTask", executionWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueEquals("var", "test").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .isEmpty();
+
+        assertThat(runtimeService.createExecutionQuery().processVariableValueEqualsIgnoreCase("var", "test").list())
+                .extracting(Execution::getName, Execution::getActivityId, Execution::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", null, processWithStringValue.getId()),
+                        tuple(null, "theTask", executionWithStringValue.getId())
+                );
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -2148,4 +2148,101 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
                 .extracting(ProcessInstance::getId)
                 .containsExactly(processInstanceIds);
     }
+
+    @Test
+    @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    public void testQueryVariableValueEqualsAndNotEquals() {
+        ProcessInstance processWithStringValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With string value")
+                .variable("var", "TEST")
+                .start();
+
+        ProcessInstance processWithNullValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With null value")
+                .variable("var", null)
+                .start();
+
+        ProcessInstance processWithLongValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With long value")
+                .variable("var", 100L)
+                .start();
+
+        ProcessInstance processWithDoubleValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With double value")
+                .variable("var", 45.55)
+                .start();
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueNotEquals("var", "TEST").list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", processWithNullValue.getId()),
+                        tuple("With long value", processWithLongValue.getId()),
+                        tuple("With double value", processWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueEquals("var", "TEST").list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", processWithStringValue.getId())
+                );
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueNotEquals("var", 100L).list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", processWithStringValue.getId()),
+                        tuple("With null value", processWithNullValue.getId()),
+                        tuple("With double value", processWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueEquals("var", 100L).list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With long value", processWithLongValue.getId())
+                );
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueNotEquals("var", 45.55).list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", processWithStringValue.getId()),
+                        tuple("With null value", processWithNullValue.getId()),
+                        tuple("With long value", processWithLongValue.getId())
+                );
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueEquals("var", 45.55).list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With double value", processWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueNotEquals("var", "test").list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", processWithStringValue.getId()),
+                        tuple("With null value", processWithNullValue.getId()),
+                        tuple("With long value", processWithLongValue.getId()),
+                        tuple("With double value", processWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueNotEqualsIgnoreCase("var", "test").list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", processWithNullValue.getId()),
+                        tuple("With long value", processWithLongValue.getId()),
+                        tuple("With double value", processWithDoubleValue.getId())
+                );
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueEquals("var", "test").list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .isEmpty();
+
+        assertThat(runtimeService.createProcessInstanceQuery().variableValueEqualsIgnoreCase("var", "test").list())
+                .extracting(ProcessInstance::getName, ProcessInstance::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", processWithStringValue.getId())
+                );
+    }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -3627,6 +3627,199 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
+    public void testQueryVariableValueEqualsAndNotEquals() {
+        Task taskWithStringValue = taskService.createTaskBuilder()
+                .name("With string value")
+                .create();
+        taskIds.add(taskWithStringValue.getId());
+        taskService.setVariable(taskWithStringValue.getId(), "var", "TEST");
+
+        Task taskWithNullValue = taskService.createTaskBuilder()
+                .name("With null value")
+                .create();
+        taskIds.add(taskWithNullValue.getId());
+        taskService.setVariable(taskWithNullValue.getId(), "var", null);
+
+        Task taskWithLongValue = taskService.createTaskBuilder()
+                .name("With long value")
+                .create();
+        taskIds.add(taskWithLongValue.getId());
+        taskService.setVariable(taskWithLongValue.getId(), "var", 100L);
+
+        Task taskWithDoubleValue = taskService.createTaskBuilder()
+                .name("With double value")
+                .create();
+        taskIds.add(taskWithDoubleValue.getId());
+        taskService.setVariable(taskWithDoubleValue.getId(), "var", 45.55);
+
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("var", "TEST").list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", taskWithNullValue.getId()),
+                        tuple("With long value", taskWithLongValue.getId()),
+                        tuple("With double value", taskWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("var", "TEST").list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", taskWithStringValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("var", 100L).list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", taskWithStringValue.getId()),
+                        tuple("With null value", taskWithNullValue.getId()),
+                        tuple("With double value", taskWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("var", 100L).list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With long value", taskWithLongValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("var", 45.55).list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", taskWithStringValue.getId()),
+                        tuple("With null value", taskWithNullValue.getId()),
+                        tuple("With long value", taskWithLongValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("var", 45.55).list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With double value", taskWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEquals("var", "test").list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", taskWithStringValue.getId()),
+                        tuple("With null value", taskWithNullValue.getId()),
+                        tuple("With long value", taskWithLongValue.getId()),
+                        tuple("With double value", taskWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().taskVariableValueNotEqualsIgnoreCase("var", "test").list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With null value", taskWithNullValue.getId()),
+                        tuple("With long value", taskWithLongValue.getId()),
+                        tuple("With double value", taskWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().taskVariableValueEquals("var", "test").list())
+                .extracting(Task::getName, Task::getId)
+                .isEmpty();
+
+        assertThat(taskService.createTaskQuery().taskVariableValueEqualsIgnoreCase("var", "test").list())
+                .extracting(Task::getName, Task::getId)
+                .containsExactlyInAnyOrder(
+                        tuple("With string value", taskWithStringValue.getId())
+                );
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    public void testQueryProcessVariableValueEqualsAndNotEquals() {
+        ProcessInstance processWithStringValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With string value")
+                .variable("var", "TEST")
+                .start();
+
+        ProcessInstance processWithNullValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With null value")
+                .variable("var", null)
+                .start();
+
+        ProcessInstance processWithLongValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With long value")
+                .variable("var", 100L)
+                .start();
+
+        ProcessInstance processWithDoubleValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With double value")
+                .variable("var", 45.55)
+                .start();
+
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("var", "TEST").list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithNullValue.getId()),
+                        tuple("my task", processWithLongValue.getId()),
+                        tuple("my task", processWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("var", "TEST").list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithStringValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("var", 100L).list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithStringValue.getId()),
+                        tuple("my task", processWithNullValue.getId()),
+                        tuple("my task", processWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("var", 100L).list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithLongValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("var", 45.55).list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithStringValue.getId()),
+                        tuple("my task", processWithNullValue.getId()),
+                        tuple("my task", processWithLongValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("var", 45.55).list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().processVariableValueNotEquals("var", "test").list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithStringValue.getId()),
+                        tuple("my task", processWithNullValue.getId()),
+                        tuple("my task", processWithLongValue.getId()),
+                        tuple("my task", processWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().processVariableValueNotEqualsIgnoreCase("var", "test").list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithNullValue.getId()),
+                        tuple("my task", processWithLongValue.getId()),
+                        tuple("my task", processWithDoubleValue.getId())
+                );
+
+        assertThat(taskService.createTaskQuery().processVariableValueEquals("var", "test").list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .isEmpty();
+
+        assertThat(taskService.createTaskQuery().processVariableValueEqualsIgnoreCase("var", "test").list())
+                .extracting(Task::getName, Task::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        tuple("my task", processWithStringValue.getId())
+                );
+    }
+
     /**
      * Generates some test tasks. - 6 tasks where kermit is a candidate - 1 tasks where gonzo is assignee - 2 tasks assigned to management group - 2 tasks assigned to accountancy group - 1 task
      * assigned to both the management and accountancy group

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -731,4 +731,89 @@ public class HistoricVariableInstanceTest extends PluggableFlowableTestCase {
             assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(3);
         }
     }
+
+    @Test
+    @Deployment(resources = { "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    public void testQueryVariableValueEqualsAndNotEquals() {
+        ProcessInstance processWithStringValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With string value")
+                .variable("var", "TEST")
+                .start();
+
+        ProcessInstance processWithNullValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With null value")
+                .variable("var", null)
+                .start();
+
+        ProcessInstance processWithLongValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With long value")
+                .variable("var", 100L)
+                .start();
+
+        ProcessInstance processWithDoubleValue = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .name("With double value")
+                .variable("var", 45.55)
+                .start();
+
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().variableValueNotEquals("var", "TEST").list())
+                .extracting(HistoricVariableInstance::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        processWithNullValue.getId(),
+                        processWithLongValue.getId(),
+                        processWithDoubleValue.getId()
+                );
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("var", "TEST").list())
+                .extracting(HistoricVariableInstance::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        processWithStringValue.getId()
+                );
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().variableValueNotEquals("var", 100L).list())
+                .extracting(HistoricVariableInstance::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        processWithStringValue.getId(),
+                        processWithNullValue.getId(),
+                        processWithDoubleValue.getId()
+                );
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("var", 100L).list())
+                .extracting(HistoricVariableInstance::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        processWithLongValue.getId()
+                );
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().variableValueNotEquals("var", 45.55).list())
+                .extracting(HistoricVariableInstance::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        processWithStringValue.getId(),
+                        processWithNullValue.getId(),
+                        processWithLongValue.getId()
+                );
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("var", 45.55).list())
+                .extracting(HistoricVariableInstance::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        processWithDoubleValue.getId()
+                );
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().variableValueNotEquals("var", "test").list())
+                .extracting(HistoricVariableInstance::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                        processWithStringValue.getId(),
+                        processWithNullValue.getId(),
+                        processWithLongValue.getId(),
+                        processWithDoubleValue.getId()
+                );
+
+        assertThat(historyService.createHistoricVariableInstanceQuery().variableValueEquals("var", "test").list())
+                .extracting(HistoricVariableInstance::getProcessInstanceId)
+                .isEmpty();
+    }
 }

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
@@ -757,17 +757,17 @@
                   <!-- Match-all variable-names when name is null -->
                   and A${index}.NAME_= #{queryVar.name}
                 </if>
-                <if test="!queryVar.type.equals('null')">
+                <if test="queryVar.needsTypeCheck()">
                   and A${index}.VAR_TYPE_ = #{queryVar.type}
                 </if>
                 <!-- Variable value -->
                 <if test="queryVar.textValue != null &amp;&amp; queryVar.longValue == null &amp;&amp; queryVar.doubleValue == null">
                   <choose>
                     <when test="queryVar.operator.equals('EQUALS_IGNORE_CASE') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVar.operator.equals('LIKE_IGNORE_CASE')">
-                      and lower(A${index}.TEXT_)
+                      and (lower(A${index}.TEXT_)
                     </when>
                     <otherwise>
-                      and A${index}.TEXT_
+                      and (A${index}.TEXT_
                     </otherwise>
                   </choose>
                   <choose>
@@ -778,6 +778,10 @@
                   <choose>
         			<when test="queryVar.operator.equals('LIKE') || queryVar.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
         		  </choose>
+                  <if test="queryVar.operator.equals('NOT_EQUALS') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                    or A${index}.TEXT_ is null
+                  </if>
+                  )
                 </if>
                 <if test="queryVar.textValue2 != null">
                   and A${index}.TEXT2_
@@ -791,14 +795,22 @@
         		  </choose>
                 </if>
                 <if test="queryVar.longValue != null">
-                  and A${index}.LONG_
+                  and (A${index}.LONG_
                   <include refid="executionVariableOperator" />
                   #{queryVar.longValue}
+                  <if test="queryVar.operator.equals('NOT_EQUALS') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                    or A${index}.LONG_ is null
+                  </if>
+                  )
                 </if>
                 <if test="queryVar.doubleValue != null">
-                  and A${index}.DOUBLE_
+                  and (A${index}.DOUBLE_
                   <include refid="executionVariableOperator" />
                   #{queryVar.doubleValue}
+                  <if test="queryVar.operator.equals('NOT_EQUALS') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                    or A${index}.DOUBLE_ is null
+                  </if>
+                  )
                 </if>
                 <!-- Null variable type -->
                 <if test="queryVar.textValue == null &amp;&amp; queryVar.textValue2 == null &amp;&amp; queryVar.longValue == null &amp;&amp; queryVar.doubleValue == null">
@@ -946,17 +958,17 @@
                     <!-- Match-all variable-names when name is null -->
                     and A_${orLocal}OR${orIndex}.NAME_= #{queryVar.name}
                   </if>
-                  <if test="!queryVar.type.equals('null')">
+                  <if test="queryVar.needsTypeCheck()">
                     and A_${orLocal}OR${orIndex}.VAR_TYPE_ = #{queryVar.type}
                   </if>
                   <!-- Variable value -->
                   <if test="queryVar.textValue != null &amp;&amp; queryVar.longValue == null &amp;&amp; queryVar.doubleValue == null">
                     <choose>
                       <when test="queryVar.operator.equals('EQUALS_IGNORE_CASE') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVar.operator.equals('LIKE_IGNORE_CASE')">
-                        and lower(A_${orLocal}OR${orIndex}.TEXT_)
+                        and (lower(A_${orLocal}OR${orIndex}.TEXT_)
                       </when>
                       <otherwise>
-                        and A_${orLocal}OR${orIndex}.TEXT_
+                        and (A_${orLocal}OR${orIndex}.TEXT_
                       </otherwise>
                     </choose>
                     <choose>
@@ -967,6 +979,10 @@
                     <choose>
                       <when test="queryVar.operator.equals('LIKE') || queryVar.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                     </choose>
+                    <if test="queryVar.operator.equals('NOT_EQUALS') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A_${orLocal}OR${orIndex}.TEXT_ is null
+                    </if>
+                    )
                   </if>
                   <if test="queryVar.textValue2 != null">
                     and A_${orLocal}OR${orIndex}.TEXT2_
@@ -980,14 +996,22 @@
                     </choose>
                   </if>
                   <if test="queryVar.longValue != null">
-                    and A_${orLocal}OR${orIndex}.LONG_
+                    and (A_${orLocal}OR${orIndex}.LONG_
                     <include refid="executionVariableOperator" />
                     #{queryVar.longValue}
+                    <if test="queryVar.operator.equals('NOT_EQUALS') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A_${orLocal}OR${orIndex}.LONG_ is null
+                    </if>
+                    )
                   </if>
                   <if test="queryVar.doubleValue != null">
-                    and A_OR${orIndex}_${index}.DOUBLE_
+                    and (A_OR${orIndex}_${index}.DOUBLE_
                     <include refid="executionVariableOperator" />
                     #{queryVar.doubleValue}
+                    <if test="queryVar.operator.equals('NOT_EQUALS') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A_${orLocal}OR${orIndex}.DOUBLE_ is null
+                    </if>
+                    )
                   </if>
                   <!-- Null variable type -->
                   <if test="queryVar.textValue == null &amp;&amp; queryVar.textValue2 == null &amp;&amp; queryVar.longValue == null &amp;&amp; queryVar.doubleValue == null">

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -927,7 +927,7 @@
                 <if test="var.name == null">
                   and A${index}.NAME_ is not null
                 </if>
-                <if test="!var.type.equals('null')">
+                <if test="var.needsTypeCheck()">
                   and A${index}.TYPE_ = #{var.type}
                 </if>
 
@@ -935,10 +935,10 @@
                 <if test="var.textValue != null &amp;&amp; var.longValue == null &amp;&amp; var.doubleValue == null">
                   <choose>
                     <when test="var.operator.equals('EQUALS_IGNORE_CASE') || var.operator.equals('NOT_EQUALS_IGNORE_CASE') || var.operator.equals('LIKE_IGNORE_CASE')">
-                      and lower(A${index}.TEXT_)
+                      and (lower(A${index}.TEXT_)
                     </when>
                     <otherwise>
-                      and A${index}.TEXT_
+                      and (A${index}.TEXT_
                     </otherwise>
                   </choose>
                   <choose>
@@ -949,6 +949,10 @@
                   <choose>
         			<when test="var.operator.equals('LIKE') || var.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
         		  </choose>
+                  <if test="var.operator.equals('NOT_EQUALS') || var.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.TEXT_ is null
+                  </if>
+                  )
                 </if>
                 <if test="var.textValue2 != null">
                   and A${index}.TEXT2_
@@ -962,14 +966,22 @@
         		  </choose>
                 </if>
                 <if test="var.longValue != null">
-                  and A${index}.LONG_
+                  and (A${index}.LONG_
                   <include refid="executionVariableOperator" />
                   #{var.longValue}
+                  <if test="var.operator.equals('NOT_EQUALS') || var.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.LONG_ is null
+                  </if>
+                  )
                 </if>
                 <if test="var.doubleValue != null">
-                  and A${index}.DOUBLE_
+                  and (A${index}.DOUBLE_
                   <include refid="executionVariableOperator" />
                   #{var.doubleValue}
+                  <if test="var.operator.equals('NOT_EQUALS') || var.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                      or A${index}.DOUBLE_ is null
+                  </if>
+                  )
                 </if>
                 <!-- Null variable type -->
                 <if test="var.textValue == null &amp;&amp; var.textValue2 == null &amp;&amp; var.longValue == null &amp;&amp; var.doubleValue == null">
@@ -1371,17 +1383,17 @@
                       <if test="var.name == null">
                         and A_${orLocal}OR${orIndex}.NAME_ is not null
                       </if>
-                      <if test="!var.type.equals('null')">
+                      <if test="var.needsTypeCheck()">
                         and A_${orLocal}OR${orIndex}.TYPE_ = #{var.type}
                       </if>
                       <!-- Variable value -->
                       <if test="var.textValue != null &amp;&amp; var.longValue == null &amp;&amp; var.doubleValue == null">
                         <choose>
                           <when test="var.operator.equals('EQUALS_IGNORE_CASE') || var.operator.equals('NOT_EQUALS_IGNORE_CASE') || var.operator.equals('LIKE_IGNORE_CASE')">
-                            and lower(A_${orLocal}OR${orIndex}.TEXT_)
+                            and (lower(A_${orLocal}OR${orIndex}.TEXT_)
                           </when>
                           <otherwise>
-                            and A_${orLocal}OR${orIndex}.TEXT_
+                            and (A_${orLocal}OR${orIndex}.TEXT_
                           </otherwise>
                         </choose>
                         <choose>
@@ -1392,6 +1404,10 @@
                         <choose>
                             <when test="var.operator.equals('LIKE') || var.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                         </choose>
+                        <if test="var.operator.equals('NOT_EQUALS') || var.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                            or A_${orLocal}OR${orIndex}.TEXT_ is null
+                        </if>
+                        )
                       </if>
                       <if test="var.textValue2 != null">
                         and A_${orLocal}OR${orIndex}.TEXT2_
@@ -1405,14 +1421,22 @@
                         </choose>
                       </if>
                       <if test="var.longValue != null">
-                        and A_${orLocal}OR${orIndex}.LONG_
+                        and (A_${orLocal}OR${orIndex}.LONG_
                         <include refid="executionVariableOperator" />
                         #{var.longValue}
+                        <if test="var.operator.equals('NOT_EQUALS') || var.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                            or A_${orLocal}OR${orIndex}.LONG_ is null
+                        </if>
+                        )
                       </if>
                       <if test="var.doubleValue != null">
-                        and A_${orLocal}OR${orIndex}.DOUBLE_
+                        and (A_${orLocal}OR${orIndex}.DOUBLE_
                         <include refid="executionVariableOperator" />
                         #{var.doubleValue}
+                        <if test="var.operator.equals('NOT_EQUALS') || var.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                            or A_${orLocal}OR${orIndex}.DOUBLE_ is null
+                        </if>
+                        )
                       </if>
                       <!-- Null variable type -->
                       <if test="var.textValue == null &amp;&amp; var.textValue2 == null &amp;&amp; var.longValue == null &amp;&amp; var.doubleValue == null">

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/QueryVariableValue.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/QueryVariableValue.java
@@ -22,6 +22,7 @@ import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEnt
 import org.flowable.variable.service.impl.types.ByteArrayType;
 import org.flowable.variable.service.impl.types.JPAEntityListVariableType;
 import org.flowable.variable.service.impl.types.JPAEntityVariableType;
+import org.flowable.variable.service.impl.types.NullType;
 import org.flowable.variable.service.impl.util.CommandContextUtil;
 
 /**
@@ -105,6 +106,19 @@ public class QueryVariableValue implements Serializable {
             return variableInstanceEntity.getType().getTypeName();
         }
         return null;
+    }
+
+    public boolean needsTypeCheck() {
+        // When operator is not-equals or type of value is null, type doesn't matter!
+        if (operator == QueryOperator.NOT_EQUALS || operator == QueryOperator.NOT_EQUALS_IGNORE_CASE) {
+            return false;
+        }
+
+        if (variableInstanceEntity != null) {
+            return !NullType.TYPE_NAME.equals(variableInstanceEntity.getType().getTypeName());
+        }
+
+        return false;
     }
 
     public boolean isLocal() {

--- a/modules/flowable-variable-service/src/main/resources/org/flowable/variable/service/db/mapping/entity/HistoricVariableInstance.xml
+++ b/modules/flowable-variable-service/src/main/resources/org/flowable/variable/service/db/mapping/entity/HistoricVariableInstance.xml
@@ -263,12 +263,11 @@
 
             <!-- PLEASE NOTE: If you change anything have a look into the Execution, the same query object is used there! -->
             <if test="queryVariableValue != null">
-                <if test="!queryVariableValue.type.equals('null')">
-                    <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
+                <if test="queryVariableValue.needsTypeCheck()">
                     and RES.VAR_TYPE_ = #{queryVariableValue.type}
                 </if>
                 <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
-                    and RES.TEXT_
+                    and (RES.TEXT_
                     <choose>
                         <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">LIKE</when>
                         <otherwise>
@@ -279,6 +278,10 @@
                     <choose>
                         <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                     </choose>
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or RES.TEXT_ is null
+                    </if>
+                    )
                 </if>
                 <if test="queryVariableValue.textValue2 != null">
                     and RES.TEXT2_
@@ -294,14 +297,22 @@
                     </choose>
                 </if>
                 <if test="queryVariableValue.longValue != null">
-                    and RES.LONG_
+                    and (RES.LONG_
                     <include refid="executionVariableOperator" />
                     #{queryVariableValue.longValue}
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or RES.LONG_ is null
+                    </if>
+                    )
                 </if>
                 <if test="queryVariableValue.doubleValue != null">
-                    and RES.DOUBLE_
+                    and (RES.DOUBLE_
                     <include refid="executionVariableOperator" />
                     #{queryVariableValue.doubleValue}
+                    <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
+                        or RES.DOUBLE_ is null
+                    </if>
+                    )
                 </if>
                 <!-- Null variable type -->
                 <if


### PR DESCRIPTION
Do not merge yet.

This is an idea showing a possible way to implement notEquals for different types and null values in the DB.

This is done only for the `CaseInstanceQuery`. If the idea is accepted we should apply this logic to other queries as well