### PR TITLE
Execute shutdown() to stop taskExecutor instead of start() in DefaultAsyncJobExecutor

### DIFF
--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -159,8 +159,7 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
 
     protected void stopExecutingAsyncJobs() {
         if (taskExecutor != null && shutdownTaskExecutor) {
-            // The cast is safe because shutdownTaskExecutor can only be true if we created it
-            ((DefaultAsyncTaskExecutor) taskExecutor).start();
+            taskExecutor.shutdown();
             taskExecutor = null;
         }
     }


### PR DESCRIPTION
#### Check List:
* Unit tests: NO
* Documentation: NA
