### PR TITLE
initialize bulk insert entities for multi-engine usage

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1433,7 +1433,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                 addSessionFactory(sessionFactory);
             }
         }
-
+        if (isUsingRelationalDatabase()) {
+            initDbSqlSessionFactoryEntitySettings();
+        }
     }
 
     @Override


### PR DESCRIPTION
Behavior before: in a multi-engine setup the bulk settings for the process engine
  was never configured since sessionFactories was not null and the
  initDbSqlSessionFactory() was never called during the ProcessEngine setup.

Behavior after: initDbSqlSessionFactoryEntitySettings() is always executed, as long
  as the process engine is configured with a relational database. With this it's
  ensured that the bulk insert is also happening for a multi-engine setup with
  pre-configured sessionFactories. This behavior is consistent with the behavior of
  other engines

#### Check List:
* Unit tests: NO
* Documentation: NA
