### PR TITLE
Feature/start process instance definition caching

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceAsyncCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceAsyncCmd.java
@@ -39,7 +39,7 @@ public class StartProcessInstanceAsyncCmd extends StartProcessInstanceCmd {
     @Override
     public ProcessInstance execute(CommandContext commandContext) {
         ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration(commandContext);
-        ProcessDefinition processDefinition = getProcessDefinition(processEngineConfiguration);
+        ProcessDefinition processDefinition = getProcessDefinition(processEngineConfiguration, commandContext);
         processInstanceHelper = CommandContextUtil.getProcessEngineConfiguration(commandContext).getProcessInstanceHelper();
         ExecutionEntity processInstance = (ExecutionEntity) processInstanceHelper.createProcessInstance(processDefinition, businessKey, processInstanceName,
             overrideDefinitionTenantId, predefinedProcessInstanceId, variables, transientVariables,

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceCmd.java
@@ -256,20 +256,14 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
         if (processDefinitionId != null) {
             processDefinition = deploymentCache.findDeployedProcessDefinitionById(processDefinitionId);
             if (processDefinition == null) {
-                processDefinition = processDefinitionEntityManager.findById(processDefinitionId);
-            }
-            if (processDefinition == null) {
                 throw new FlowableObjectNotFoundException("No process definition found for id = '" + processDefinitionId + "'", ProcessDefinition.class);
             }
 
         } else if (processDefinitionKey != null && (tenantId == null || ProcessEngineConfiguration.NO_TENANT_ID.equals(tenantId))) {
 
             if (processDefinitionParentDeploymentId != null) {
-                processDefinition = deploymentCache.findDeployedLatestProcessDefinitionByKey(processDefinitionKey);
-                if (processDefinition == null) {
-                    processDefinition = processDefinitionEntityManager
-                            .findProcessDefinitionByParentDeploymentAndKey(processDefinitionParentDeploymentId, processDefinitionKey);
-                }
+                processDefinition = processDefinitionEntityManager
+                        .findProcessDefinitionByParentDeploymentAndKey(processDefinitionParentDeploymentId, processDefinitionKey);
             }
 
             if (processDefinition == null) {
@@ -283,11 +277,8 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
         } else if (processDefinitionKey != null && tenantId != null && !ProcessEngineConfiguration.NO_TENANT_ID.equals(tenantId)) {
 
             if (processDefinitionParentDeploymentId != null) {
-                processDefinition = deploymentCache.findDeployedLatestProcessDefinitionByKeyAndTenantId(processDefinitionKey, tenantId);
-                if (processDefinition == null) {
-                    processDefinition = processDefinitionEntityManager
-                            .findProcessDefinitionByParentDeploymentAndKeyAndTenantId(processDefinitionParentDeploymentId, processDefinitionKey, tenantId);
-                }
+                processDefinition = processDefinitionEntityManager
+                        .findProcessDefinitionByParentDeploymentAndKeyAndTenantId(processDefinitionParentDeploymentId, processDefinitionKey, tenantId);
             }
 
             if (processDefinition == null) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
@@ -102,7 +102,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
     public void testStartProcessInstanceByIdUnexistingId() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceById("unexistingId"))
                 .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
-                .hasMessageContaining("No process definition found for id = 'unexistingId'");
+                .hasMessageContaining("no deployed process definition found with id 'unexistingId'");
     }
 
     @Test
@@ -254,7 +254,7 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
 
         assertThatThrownBy(() -> processInstanceBuilder.processDefinitionId("nonExistingDefinitionId").startAsync())
             .isExactlyInstanceOf(FlowableObjectNotFoundException.class)
-            .hasMessage("No process definition found for id = 'nonExistingDefinitionId'");
+            .hasMessage("no deployed process definition found with id 'nonExistingDefinitionId'");
     }
 
     @Test


### PR DESCRIPTION
Change process instance start for starting by process definition id to a cache based implementation. This is how it was before commit 6188d61eec3e190ae26245989398fa8d9f41c364.
Behavior for process definition key is not changed, since the `DeploymentManager` is not using the cache for key lookup.

#### Check List:
* Unit tests: NO
* Documentation: NO
