### PR TITLE
Fixed bug where the async-history-executor was not started when using…

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2322,7 +2322,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                 if (asyncHistoryExecutor.getJobServiceConfiguration() == null) {
                     asyncHistoryExecutor.setJobServiceConfiguration(jobServiceConfiguration);
                 }
-                asyncHistoryExecutor.setAutoActivate(asyncHistoryExecutorActivate);
 
             } else {
                 // In case an async history executor was injected, only the job handlers are set. 
@@ -2349,6 +2348,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
             jobServiceConfiguration.setAsyncHistoryExecutor(asyncHistoryExecutor);
             jobServiceConfiguration.setAsyncHistoryExecutorNumberOfRetries(asyncHistoryExecutorNumberOfRetries);
+
+            asyncHistoryExecutor.setAutoActivate(asyncHistoryExecutorActivate);
         }
     }
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/process/ProcessAsyncHistoryExecutorTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/process/ProcessAsyncHistoryExecutorTest.java
@@ -72,6 +72,33 @@ public class ProcessAsyncHistoryExecutorTest {
 
             assertThat(((ProcessEngineConfigurationImpl) context.getBean(ProcessEngine.class).getProcessEngineConfiguration()).isAsyncHistoryEnabled()).isTrue();
 
+            assertThat(processAsyncExecutor.isAutoActivate()).isTrue();
+            assertThat(processAsyncHistoryExecutor.isAutoActivate()).isTrue();
+
+        }));
+    }
+
+    @Test
+    public void asyncHistoryExecutorBeanAvailableAndNotAutoActivate() {
+        contextRunner.withPropertyValues(
+            "flowable.process.async-history.enable=true",
+            "flowable.async-history-executor-activate=false").run((context -> {
+            assertThat(context)
+                .hasSingleBean(ProcessEngine.class)
+                .hasBean("taskExecutor")
+                .hasBean("processAsyncExecutor")
+                .hasBean("asyncHistoryExecutor");
+
+            AsyncExecutor processAsyncExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncExecutor();
+            assertThat(processAsyncExecutor).isNotNull();
+            AsyncExecutor processAsyncHistoryExecutor = context.getBean(ProcessEngine.class).getProcessEngineConfiguration().getAsyncHistoryExecutor();
+            assertThat(processAsyncHistoryExecutor).isNotNull();
+
+            assertThat(((ProcessEngineConfigurationImpl) context.getBean(ProcessEngine.class).getProcessEngineConfiguration()).isAsyncHistoryEnabled()).isTrue();
+
+            assertThat(processAsyncExecutor.isAutoActivate()).isTrue();
+            assertThat(processAsyncHistoryExecutor.isAutoActivate()).isFalse();
+
         }));
     }
 


### PR DESCRIPTION
… Spring-boot and the property flowable.async-history-executor-activate was ignored

#### Check List:
* Unit tests: YES
* Documentation: NA

I have fixed a bug where when using spring-boot the async-history-executor was not started automatically. There is also a setting `flowable.async-history-executor-activate` which looks like it should be able to toggle whether it has started, but has no effect.

I made the async history executor configuration to work in the same way as the normal async job executor. I also added a unit test to verify this behaviour. This means the above property now works as expected.