### PR TITLE
Remove null check before instanceOf

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/DefaultCmmnHistoryManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/DefaultCmmnHistoryManager.java
@@ -429,12 +429,12 @@ public class DefaultCmmnHistoryManager implements CmmnHistoryManager {
         PlanItemDefinition planItemDefinition = planItemInstanceEntity.getPlanItem().getPlanItemDefinition();
         String includeInStageOverviewValue = null;
         if (planItemInstanceEntity.isStage()) {
-            if (planItemDefinition != null && planItemDefinition instanceof Stage) {
+            if (planItemDefinition instanceof Stage) {
                 Stage stage = (Stage) planItemDefinition;
                 includeInStageOverviewValue = stage.getIncludeInStageOverview();
             }
             
-        } else if (planItemDefinition != null && planItemDefinition instanceof Milestone) {
+        } else if (planItemDefinition instanceof Milestone) {
             Milestone milestone = (Milestone) planItemDefinition;
             includeInStageOverviewValue = milestone.getIncludeInStageOverview();
         }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/async/AbstractAsyncCmmnHistoryManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/async/AbstractAsyncCmmnHistoryManager.java
@@ -299,12 +299,12 @@ public abstract class AbstractAsyncCmmnHistoryManager implements CmmnHistoryMana
         PlanItemDefinition planItemDefinition = planItemInstanceEntity.getPlanItem().getPlanItemDefinition();
         String includeInStageOverviewValue = null;
         if (planItemInstanceEntity.isStage()) {
-            if (planItemDefinition != null && planItemDefinition instanceof Stage) {
+            if (planItemDefinition instanceof Stage) {
                 Stage stage = (Stage) planItemDefinition;
                 includeInStageOverviewValue = stage.getIncludeInStageOverview();
             }
             
-        } else if (planItemDefinition != null && planItemDefinition instanceof Milestone) {
+        } else if (planItemDefinition instanceof Milestone) {
             Milestone milestone = (Milestone) planItemDefinition;
             includeInStageOverviewValue = milestone.getIncludeInStageOverview();
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/EvaluateConditionalEventsOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/EvaluateConditionalEventsOperation.java
@@ -58,7 +58,7 @@ public class EvaluateConditionalEventsOperation extends AbstractOperation {
         for (ExecutionEntity childExecutionEntity : allExecutions) {
             String activityId = childExecutionEntity.getCurrentActivityId();
             FlowElement currentFlowElement = process.getFlowElement(activityId, true);
-            if (currentFlowElement != null && currentFlowElement instanceof Event) {
+            if (currentFlowElement instanceof Event) {
                 Event event = (Event) currentFlowElement;
                 if (!event.getEventDefinitions().isEmpty() && event.getEventDefinitions().get(0) instanceof ConditionalEventDefinition) {
                 
@@ -68,7 +68,7 @@ public class EvaluateConditionalEventsOperation extends AbstractOperation {
                     }
                 }
             
-            } else if (currentFlowElement != null && currentFlowElement instanceof SubProcess) {
+            } else if (currentFlowElement instanceof SubProcess) {
                 SubProcess subProcess = (SubProcess) currentFlowElement;
                 List<EventSubProcess> childEventSubProcesses = subProcess.findAllSubFlowElementInFlowMapOfType(EventSubProcess.class);
                 evaluateEventSubProcesses(childEventSubProcesses, childExecutionEntity);
@@ -94,7 +94,7 @@ public class EvaluateConditionalEventsOperation extends AbstractOperation {
                             if (StringUtils.isNotEmpty(conditionExpression)) {
                                 Expression expression = CommandContextUtil.getProcessEngineConfiguration(commandContext).getExpressionManager().createExpression(conditionExpression);
                                 Object result = expression.getValue(parentExecution);
-                                if (result != null && result instanceof Boolean && (Boolean) result) {
+                                if (result instanceof Boolean && (Boolean) result) {
                                     conditionIsTrue = true;
                                 }
                             

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/BoundaryConditionalEventActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/BoundaryConditionalEventActivityBehavior.java
@@ -61,7 +61,7 @@ public class BoundaryConditionalEventActivityBehavior extends BoundaryEventActiv
         ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration(commandContext);
         Expression expression = processEngineConfiguration.getExpressionManager().createExpression(conditionExpression);
         Object result = expression.getValue(execution);
-        if (result != null && result instanceof Boolean && (Boolean) result) {
+        if (result instanceof Boolean && (Boolean) result) {
             processEngineConfiguration.getActivityInstanceEntityManager().recordActivityStart(executionEntity);
             
             FlowableEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/EventSubProcessConditionalStartEventActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/EventSubProcessConditionalStartEventActivityBehavior.java
@@ -44,7 +44,7 @@ public class EventSubProcessConditionalStartEventActivityBehavior extends FlowNo
         
         Expression expression = CommandContextUtil.getProcessEngineConfiguration(commandContext).getExpressionManager().createExpression(conditionExpression);
         Object result = expression.getValue(execution);
-        if (result != null && result instanceof Boolean && (Boolean) result) {
+        if (result instanceof Boolean && (Boolean) result) {
             CommandContextUtil.getActivityInstanceEntityManager(commandContext).recordActivityStart((ExecutionEntity) execution);
             super.trigger(execution, signalName, signalData);
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/IntermediateCatchConditionalEventActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/IntermediateCatchConditionalEventActivityBehavior.java
@@ -54,7 +54,7 @@ public class IntermediateCatchConditionalEventActivityBehavior extends Intermedi
         Expression expression = processEngineConfiguration.getExpressionManager().createExpression(conditionExpression);
         Object result = expression.getValue(execution);
         
-        if (result != null && result instanceof Boolean && (Boolean) result) {
+        if (result instanceof Boolean && (Boolean) result) {
             ExecutionEntity executionEntity = (ExecutionEntity) execution;
             FlowableEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();
             if (eventDispatcher != null && eventDispatcher.isEnabled()) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -81,7 +81,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
         boolean isSkipExpressionEnabled = false;
         String skipExpressionText = null;
         CommandContext commandContext = CommandContextUtil.getCommandContext();
-        if (flowElement != null && flowElement instanceof ServiceTask) {
+        if (flowElement instanceof ServiceTask) {
             ServiceTask serviceTask = (ServiceTask) flowElement;
             skipExpressionText = serviceTask.getSkipExpression();
             isSkipExpressionEnabled = SkipExpressionUtil.isSkipExpressionEnabled(skipExpressionText, flowElement.getId(), execution, commandContext);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/BpmnLoggingSessionUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/BpmnLoggingSessionUtil.java
@@ -120,7 +120,7 @@ public class BpmnLoggingSessionUtil {
         String message = null;
         FlowElement flowElement = execution.getCurrentFlowElement();
         SequenceFlow sequenceFlow = null;
-        if (flowElement != null && flowElement instanceof SequenceFlow) {
+        if (flowElement instanceof SequenceFlow) {
             sequenceFlow = (SequenceFlow) flowElement;
             String sequenceFlowId = "";
             if (sequenceFlow.getId() != null) {


### PR DESCRIPTION
The null-check is redundant as `instanceof` operator implies non-nullity.
