### PR TITLE
所有的包装类对象之间值的比较，全部使用equals方法比较。

### DIFF
--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/GraphicInfo.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/GraphicInfo.java
@@ -128,7 +128,7 @@ public class GraphicInfo {
     	}
 
     	// only check for elements that support this value
-    	if (null != this.getExpanded() && null != ginfo.getExpanded() && this.getExpanded() != ginfo.getExpanded()) {
+    	if (null != this.getExpanded() && null != ginfo.getExpanded() && !this.getExpanded().equals(ginfo.getExpanded())) {
     		return false;
     	}
     	return true;

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/GraphicInfo.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/GraphicInfo.java
@@ -118,7 +118,7 @@ public class GraphicInfo extends BaseElement {
     	}
 
     	// only check for elements that support this value
-    	if (null != this.getExpanded() && null != ginfo.getExpanded() && this.getExpanded() != ginfo.getExpanded()) {
+    	if (null != this.getExpanded() && null != ginfo.getExpanded() && !this.getExpanded().equals(ginfo.getExpanded())) {
     		return false;
     	}
     	return true;

--- a/modules/flowable-dmn-model/src/main/java/org/flowable/dmn/model/GraphicInfo.java
+++ b/modules/flowable-dmn-model/src/main/java/org/flowable/dmn/model/GraphicInfo.java
@@ -114,7 +114,7 @@ public class GraphicInfo extends DmnElement {
         }
 
         // only check for elements that support this value
-        if (null != this.getExpanded() && null != ginfo.getExpanded() && this.getExpanded() != ginfo.getExpanded()) {
+        if (null != this.getExpanded() && null != ginfo.getExpanded() && !this.getExpanded().equals(ginfo.getExpanded())) {
             return false;
         }
         return true;


### PR DESCRIPTION
所有的包装类对象之间值的比较，全部使用equals方法比较。 说明：对于Integer var=?在-128至127之间的赋值，Integer对象是在IntegerCache.cache产生，会复用已有对象，这个区间内的Integer值可以直接使用==进行判断，但是这个区间之外的所有数据，都会在堆上产生，并不会复用已有对象，这是一个大坑，推荐使用equals方法进行判断。
            
    Integer a = 235;
    Integer b = 235;
    if (a.equals(b)) {
        // code
    }