### PR TITLE
Convert JUnit4 tests to JUnit5

### DIFF
--- a/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -36,8 +36,8 @@ import org.flowable.app.spring.SpringAppEngineConfiguration;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.util.IoUtil;
 import org.flowable.common.spring.CommonAutoDeploymentStrategy;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -105,7 +105,7 @@ public class SpringAutoDeployTest {
         this.repositoryService = applicationContext.getBean(AppRepositoryService.class);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         removeAllDeployments();
         if (this.applicationContext != null) {

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -18,7 +18,7 @@ import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.flowable.app.engine.AppEngine;
 import org.flowable.app.engine.impl.cfg.StandaloneInMemAppEngineConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji

--- a/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/persistence/EntitiesTest.java
+++ b/modules/flowable-app-engine/src/test/java/org/flowable/app/engine/test/persistence/EntitiesTest.java
@@ -13,7 +13,7 @@
 package org.flowable.app.engine.test.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.List;
@@ -27,7 +27,7 @@ import org.apache.commons.io.IOUtils;
 import org.flowable.app.engine.AppEngineConfiguration;
 import org.flowable.app.engine.impl.db.EntityDependencyOrder;
 import org.flowable.app.engine.impl.db.EntityToTableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -18,7 +18,7 @@ import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.flowable.cmmn.engine.CmmnEngine;
 import org.flowable.cmmn.engine.impl.cfg.StandaloneInMemCmmnEngineConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/persistence/EntitiesTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/persistence/EntitiesTest.java
@@ -13,7 +13,7 @@
 package org.flowable.cmmn.test.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.List;
@@ -27,7 +27,7 @@ import org.apache.commons.io.IOUtils;
 import org.flowable.cmmn.engine.CmmnEngineConfiguration;
 import org.flowable.cmmn.engine.impl.db.EntityDependencyOrder;
 import org.flowable.cmmn.engine.impl.db.EntityToTableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -36,8 +36,8 @@ import org.flowable.cmmn.spring.CmmnEngineFactoryBean;
 import org.flowable.cmmn.spring.SpringCmmnEngineConfiguration;
 import org.flowable.common.engine.impl.util.IoUtil;
 import org.flowable.common.spring.CommonAutoDeploymentStrategy;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -67,7 +67,7 @@ public class SpringAutoDeployTest {
     protected ConfigurableApplicationContext applicationContext;
     protected CmmnRepositoryService repositoryService;
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         removeAllDeployments();
         if (this.applicationContext != null) {

--- a/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/ForceCloseMybatisConnectionPoolTest.java
@@ -18,7 +18,7 @@ import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.flowable.content.engine.ContentEngine;
 import org.flowable.content.engine.impl.cfg.StandaloneInMemContentEngineConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji

--- a/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/persistence/EntitiesTest.java
+++ b/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/persistence/EntitiesTest.java
@@ -13,7 +13,7 @@
 package org.flowable.content.engine.test.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.List;
@@ -27,7 +27,7 @@ import org.apache.commons.io.IOUtils;
 import org.flowable.content.engine.ContentEngineConfiguration;
 import org.flowable.content.engine.impl.db.EntityDependencyOrder;
 import org.flowable.content.engine.impl.db.EntityToTableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WSDLImporterTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WSDLImporterTest.java
@@ -27,8 +27,8 @@ import java.util.stream.Collectors;
 import org.flowable.common.engine.impl.util.ReflectUtil;
 import org.flowable.engine.impl.bpmn.data.SimpleStructureDefinition;
 import org.flowable.engine.impl.bpmn.data.StructureDefinition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Esteban Robles Luna
@@ -37,7 +37,7 @@ public class WSDLImporterTest {
 
     private CxfWSDLImporter importer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         importer = new CxfWSDLImporter();
     }

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/impl/el/util/CollectionUtilTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/impl/el/util/CollectionUtilTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -18,7 +18,7 @@ import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.flowable.dmn.engine.DmnEngine;
 import org.flowable.dmn.engine.impl.cfg.StandaloneInMemDmnEngineConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/persistence/EntitiesTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/persistence/EntitiesTest.java
@@ -13,7 +13,7 @@
 package org.flowable.dmn.engine.test.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.List;
@@ -27,7 +27,7 @@ import org.apache.commons.io.IOUtils;
 import org.flowable.dmn.engine.DmnEngineConfiguration;
 import org.flowable.dmn.engine.impl.db.EntityDependencyOrder;
 import org.flowable.dmn.engine.impl.db.EntityToTableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -18,7 +18,7 @@ import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji

--- a/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/db/EntitiesTest.java
+++ b/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/db/EntitiesTest.java
@@ -13,7 +13,7 @@
 package org.flowable.eventregistry.test.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.List;
@@ -25,7 +25,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.io.IOUtils;
 import org.flowable.eventregistry.impl.EventRegistryEngineConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/ForceCloseMybatisConnectionPoolTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/ForceCloseMybatisConnectionPoolTest.java
@@ -18,7 +18,7 @@ import org.apache.ibatis.datasource.pooled.PoolState;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.flowable.form.engine.FormEngine;
 import org.flowable.form.engine.impl.cfg.StandaloneInMemFormEngineConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Zheng Ji

--- a/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/persistence/EntitiesTest.java
+++ b/modules/flowable-form-engine/src/test/java/org/flowable/form/engine/test/persistence/EntitiesTest.java
@@ -13,7 +13,7 @@
 package org.flowable.form.engine.test.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.List;
@@ -27,7 +27,7 @@ import org.apache.commons.io.IOUtils;
 import org.flowable.form.engine.FormEngineConfiguration;
 import org.flowable.form.engine.impl.db.EntityDependencyOrder;
 import org.flowable.form.engine.impl.db.EntityToTableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api-security/src/test/java/org/flowable/test/spring/boot/SecurityAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-samples/flowable-spring-boot-sample-rest-api-security/src/test/java/org/flowable/test/spring/boot/SecurityAutoConfigurationTest.java
@@ -22,8 +22,8 @@ import org.flowable.spring.boot.FlowableSecurityAutoConfiguration;
 import org.flowable.spring.boot.ProcessEngineAutoConfiguration;
 import org.flowable.spring.boot.idm.IdmEngineAutoConfiguration;
 import org.flowable.spring.boot.idm.IdmEngineServicesAutoConfiguration;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -42,7 +42,7 @@ public class SecurityAutoConfigurationTest {
 
     private AnnotationConfigApplicationContext applicationContext;
 
-    @After
+    @AfterEach
     public void close() {
         this.applicationContext.close();
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/spring/boot/environment/FlowableDefaultPropertiesEnvironmentPostProcessorTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/spring/boot/environment/FlowableDefaultPropertiesEnvironmentPostProcessorTest.java
@@ -17,8 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -33,7 +33,7 @@ public class FlowableDefaultPropertiesEnvironmentPostProcessorTest {
 
     private ConfigurableApplicationContext context;
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (context != null) {
             context.close();

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/spring/boot/ldap/FlowableLdapPropertiesTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/spring/boot/ldap/FlowableLdapPropertiesTest.java
@@ -1,4 +1,4 @@
-package org.flowable.spring.boot.ldap;/* Licensed under the Apache License, Version 2.0 (the "License");
+/* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -10,6 +10,7 @@ package org.flowable.spring.boot.ldap;/* Licensed under the Apache License, Vers
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.flowable.spring.boot.ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.flowable.ldap.LDAPConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Filip Hrisafov

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/app/AppEngineAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/app/AppEngineAutoConfigurationTest.java
@@ -49,7 +49,7 @@ import org.flowable.spring.boot.idm.IdmEngineAutoConfiguration;
 import org.flowable.spring.boot.idm.IdmEngineServicesAutoConfiguration;
 import org.flowable.task.api.Task;
 import org.flowable.test.spring.boot.util.CustomUserEngineConfigurerConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;

--- a/modules/flowable-spring-security/src/test/java/org/flowable/spring/security/SpringSecurityAuthenticationContextTest.java
+++ b/modules/flowable-spring-security/src/test/java/org/flowable/spring/security/SpringSecurityAuthenticationContextTest.java
@@ -16,9 +16,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.security.Principal;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -34,13 +34,13 @@ public class SpringSecurityAuthenticationContextTest {
 
     private Authentication initial;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         initial = SecurityContextHolder.getContext().getAuthentication();
         SecurityContextHolder.getContext().setAuthentication(null);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         SecurityContextHolder.getContext().setAuthentication(initial);
     }


### PR DESCRIPTION
Convert JUnit4 tests to JUnit5.  If this type of PR is acceptable there are a little more than 100 other files that can be converted easily.

In the process of converting moved a `package` statement that was before the license header to its proper place after the header.