### PR TITLE
Use primitive type instead of wrapper object

### DIFF
--- a/modules/flowable-app-engine-rest/src/main/java/org/flowable/app/rest/service/api/repository/AppDefinitionCollectionResource.java
+++ b/modules/flowable-app-engine-rest/src/main/java/org/flowable/app/rest/service/api/repository/AppDefinitionCollectionResource.java
@@ -152,13 +152,13 @@ public class AppDefinitionCollectionResource {
             appDefinitionQuery.appDefinitionTenantIdLike(allRequestParams.get("tenantIdLike"));
         }
         if (allRequestParams.containsKey("withoutTenantId")) {
-            Boolean withoutTenantId = Boolean.valueOf(allRequestParams.get("withoutTenantId"));
+            boolean withoutTenantId = Boolean.parseBoolean(allRequestParams.get("withoutTenantId"));
             if (withoutTenantId) {
                 appDefinitionQuery.appDefinitionWithoutTenantId();
             }
         }
         if (allRequestParams.containsKey("latest")) {
-            Boolean latest = Boolean.valueOf(allRequestParams.get("latest"));
+            boolean latest = Boolean.parseBoolean(allRequestParams.get("latest"));
             if (latest) {
                 appDefinitionQuery.latestVersion();
             }

--- a/modules/flowable-app-engine-rest/src/main/java/org/flowable/app/rest/service/api/repository/AppDeploymentCollectionResource.java
+++ b/modules/flowable-app-engine-rest/src/main/java/org/flowable/app/rest/service/api/repository/AppDeploymentCollectionResource.java
@@ -117,7 +117,7 @@ public class AppDeploymentCollectionResource {
             deploymentQuery.deploymentTenantIdLike(allRequestParams.get("tenantIdLike"));
         }
         if (allRequestParams.containsKey("withoutTenantId")) {
-            Boolean withoutTenantId = Boolean.valueOf(allRequestParams.get("withoutTenantId"));
+            boolean withoutTenantId = Boolean.parseBoolean(allRequestParams.get("withoutTenantId"));
             if (withoutTenantId) {
                 deploymentQuery.deploymentWithoutTenantId();
             }

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/repository/DeploymentCollectionResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/repository/DeploymentCollectionResource.java
@@ -127,7 +127,7 @@ public class DeploymentCollectionResource {
             deploymentQuery.deploymentTenantIdLike(allRequestParams.get("tenantIdLike"));
         }
         if (allRequestParams.containsKey("withoutTenantId")) {
-            Boolean withoutTenantId = Boolean.valueOf(allRequestParams.get("withoutTenantId"));
+            boolean withoutTenantId = Boolean.parseBoolean(allRequestParams.get("withoutTenantId"));
             if (withoutTenantId) {
                 deploymentQuery.deploymentWithoutTenantId();
             }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/ELExecutionContextBuilder.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/ELExecutionContextBuilder.java
@@ -125,7 +125,7 @@ public class ELExecutionContextBuilder {
                     BigDecimal transformedNumber = new BigDecimal((Double) inputVariable.getValue());
                     inputVariables.put(inputVariable.getKey(), transformedNumber);
                 } else if (inputVariable.getValue() instanceof Float) {
-                    Double doubleValue = Double.valueOf(inputVariable.getValue().toString());
+                    double doubleValue = Double.parseDouble(inputVariable.getValue().toString());
                     BigDecimal transformedNumber = new BigDecimal(doubleValue);
                     inputVariables.put(inputVariable.getKey(), transformedNumber);
                 }

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DmnDeploymentCollectionResource.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/repository/DmnDeploymentCollectionResource.java
@@ -122,7 +122,7 @@ public class DmnDeploymentCollectionResource {
             deploymentQuery.deploymentTenantIdLike(allRequestParams.get("tenantIdLike"));
         }
         if (allRequestParams.containsKey("withoutTenantId")) {
-            Boolean withoutTenantId = Boolean.valueOf(allRequestParams.get("withoutTenantId"));
+            boolean withoutTenantId = Boolean.parseBoolean(allRequestParams.get("withoutTenantId"));
             if (withoutTenantId) {
                 deploymentQuery.deploymentWithoutTenantId();
             }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/calendar/DefaultBusinessCalendar.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/calendar/DefaultBusinessCalendar.java
@@ -79,7 +79,7 @@ public class DefaultBusinessCalendar implements BusinessCalendar {
         }
 
         String quantityText = singleUnitQuantity.substring(0, spaceIndex);
-        Integer quantity = Integer.valueOf(quantityText);
+        int quantity = Integer.parseInt(quantityText);
 
         String unitText = singleUnitQuantity.substring(spaceIndex + 1).trim().toLowerCase();
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
@@ -155,8 +155,8 @@ public class ProcessDiagramLayoutFactory {
         NodeList waypoints = bpmnModel.getElementsByTagNameNS(BpmnParser.OMG_DI_NS, "waypoint");
         for (int i = 0; i < waypoints.getLength(); i++) {
             Element waypoint = (Element) waypoints.item(i);
-            Double x = Double.valueOf(waypoint.getAttribute("x"));
-            Double y = Double.valueOf(waypoint.getAttribute("y"));
+            double x = Double.parseDouble(waypoint.getAttribute("x"));
+            double y = Double.parseDouble(waypoint.getAttribute("y"));
 
             if (minX == null || x < minX) {
                 minX = x;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/EventInstanceBpmnUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/EventInstanceBpmnUtil.java
@@ -62,7 +62,7 @@ public class EventInstanceBpmnUtil {
                 for (ExtensionElement outParameter : outParameters) {
                     String payloadSourceName = outParameter.getAttributeValue(null, BpmnXMLConstants.ATTRIBUTE_IOPARAMETER_SOURCE);
                     String variableName = outParameter.getAttributeValue(null, BpmnXMLConstants.ATTRIBUTE_IOPARAMETER_TARGET);
-                    Boolean isTransient = Boolean.valueOf(outParameter.getAttributeValue(null, "transient"));
+                    boolean isTransient = Boolean.parseBoolean(outParameter.getAttributeValue(null, "transient"));
                     setEventParameterVariable(payloadSourceName, variableName, isTransient, payloadInstances, variableScope);
                 }
             }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -1840,8 +1840,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .containsExactly("taskKey1");
 
         // No task should be found with unexisting key
-        Long count = taskService.createTaskQuery().taskDefinitionKey("unexistingKey").count();
-        assertThat(count.longValue()).isZero();
+        long count = taskService.createTaskQuery().taskDefinitionKey("unexistingKey").count();
+        assertThat(count).isZero();
     }
 
     @Test
@@ -1859,8 +1859,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .containsExactly("taskKey1");
 
         // No task should be found with unexisting key
-        Long count = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKey("unexistingKey").count();
-        assertThat(count.longValue()).isZero();
+        long count = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKey("unexistingKey").count();
+        assertThat(count).isZero();
     }
 
     @Test
@@ -1939,8 +1939,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .containsExactly("taskKey123");
 
         // No task should be found with unexisting key
-        Long count = taskService.createTaskQuery().taskDefinitionKeyLike("%unexistingKey%").count();
-        assertThat(count.longValue()).isZero();
+        long count = taskService.createTaskQuery().taskDefinitionKeyLike("%unexistingKey%").count();
+        assertThat(count).isZero();
     }
 
     @Test
@@ -1973,8 +1973,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .containsExactly("taskKey123");
 
         // No task should be found with unexisting key
-        Long count = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeyLike("%unexistingKey%").count();
-        assertThat(count.longValue()).isZero();
+        long count = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeyLike("%unexistingKey%").count();
+        assertThat(count).isZero();
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/cfg/CustomMybatisMapperTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/cfg/CustomMybatisMapperTest.java
@@ -98,9 +98,9 @@ public class CustomMybatisMapperTest extends ResourceFlowableTestCase {
         assertThat(results).hasSize(5);
         for (int i = 0; i < 5; i++) {
             Map<String, Object> result = results.get(i);
-            Long id = Long.valueOf((String) getValue(result, "taskId"));
-            Long variableValue = ((Number) getValue(result, "variableValue")).longValue();
-            assertThat(variableValue.longValue()).isEqualTo(id * 2);
+            long id = Long.parseLong((String) getValue(result, "taskId"));
+            long variableValue = ((Number) getValue(result, "variableValue")).longValue();
+            assertThat(variableValue).isEqualTo(id * 2);
         }
 
         // Cleanup

--- a/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/repository/DeploymentCollectionResource.java
+++ b/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/repository/DeploymentCollectionResource.java
@@ -127,7 +127,7 @@ public class DeploymentCollectionResource {
             deploymentQuery.deploymentTenantIdLike(allRequestParams.get("tenantIdLike"));
         }
         if (allRequestParams.containsKey("withoutTenantId")) {
-            Boolean withoutTenantId = Boolean.valueOf(allRequestParams.get("withoutTenantId"));
+            boolean withoutTenantId = Boolean.parseBoolean(allRequestParams.get("withoutTenantId"));
             if (withoutTenantId) {
                 deploymentQuery.deploymentWithoutTenantId();
             }

--- a/modules/flowable-form-rest/src/main/java/org/flowable/form/rest/service/api/repository/FormDefinitionCollectionResource.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/form/rest/service/api/repository/FormDefinitionCollectionResource.java
@@ -151,13 +151,13 @@ public class FormDefinitionCollectionResource {
             formDefinitionQuery.formTenantIdLike(allRequestParams.get("tenantIdLike"));
         }
         if (allRequestParams.containsKey("withoutTenantId")) {
-            Boolean withoutTenantId = Boolean.valueOf(allRequestParams.get("withoutTenantId"));
+            boolean withoutTenantId = Boolean.parseBoolean(allRequestParams.get("withoutTenantId"));
             if (withoutTenantId) {
                 formDefinitionQuery.formWithoutTenantId();
             }
         }
         if (allRequestParams.containsKey("latest")) {
-            Boolean latest = Boolean.valueOf(allRequestParams.get("latest"));
+            boolean latest = Boolean.parseBoolean(allRequestParams.get("latest"));
             if (latest) {
                 formDefinitionQuery.latestVersion();
             }

--- a/modules/flowable-form-rest/src/main/java/org/flowable/form/rest/service/api/repository/FormDeploymentCollectionResource.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/form/rest/service/api/repository/FormDeploymentCollectionResource.java
@@ -121,7 +121,7 @@ public class FormDeploymentCollectionResource {
             deploymentQuery.deploymentTenantIdLike(allRequestParams.get("tenantIdLike"));
         }
         if (allRequestParams.containsKey("withoutTenantId")) {
-            Boolean withoutTenantId = Boolean.valueOf(allRequestParams.get("withoutTenantId"));
+            boolean withoutTenantId = Boolean.parseBoolean(allRequestParams.get("withoutTenantId"));
             if (withoutTenantId) {
                 deploymentQuery.deploymentWithoutTenantId();
             }

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/util/JsonConverterUtil.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/util/JsonConverterUtil.java
@@ -173,7 +173,7 @@ public class JsonConverterUtil implements EditorJsonConstants, StencilConstants 
         Set<Long> result = new HashSet<>(); // Using a Set to filter out doubles
         for (JsonNode node : jsonNodes) {
             if (node.has(propertyName)) {
-                Long propertyValue = node.get(propertyName).asLong();
+                long propertyValue = node.get(propertyName).asLong();
                 if (propertyValue > 0) { // Just to be safe
                     result.add(propertyValue);
                 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentCollectionResource.java
@@ -129,7 +129,7 @@ public class DeploymentCollectionResource {
             deploymentQuery.deploymentTenantIdLike(allRequestParams.get("tenantIdLike"));
         }
         if (allRequestParams.containsKey("withoutTenantId")) {
-            Boolean withoutTenantId = Boolean.valueOf(allRequestParams.get("withoutTenantId"));
+            boolean withoutTenantId = Boolean.parseBoolean(allRequestParams.get("withoutTenantId"));
             if (withoutTenantId) {
                 deploymentQuery.deploymentWithoutTenantId();
             }


### PR DESCRIPTION
When most (if not all) of a variable is using primitive operations there is no need to wrap them in an Object type.
