### PR TITLE
Update Spring Boot to version 2.3.4, Spring Framework to version 5.2.…

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -137,22 +137,22 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.30          MIT License
 org.slf4j                       slf4j-api                   1.7.30          MIT License
 org.slf4j                       slf4j-log4j12               1.7.30          MIT License
-org.springframework             spring-beans                5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-context              5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.2.8.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.3.3.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.3.3.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.3.3.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.3.3.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-context              5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.2.9.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.3.4.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.3.4.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.3.4.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.3.4.RELEASE   The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.0          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.3.1.RELEASE</spring.boot.version>
-		<spring.framework.version>5.2.8.RELEASE</spring.framework.version>
-		<spring.security.version>5.3.3.RELEASE</spring.security.version>
-		<spring.amqp.version>2.2.7.RELEASE</spring.amqp.version>
-		<spring.kafka.version>2.5.2.RELEASE</spring.kafka.version>
-		<reactor-netty.version>0.9.10.RELEASE</reactor-netty.version>
+		<spring.boot.version>2.3.4.RELEASE</spring.boot.version>
+		<spring.framework.version>5.2.9.RELEASE</spring.framework.version>
+		<spring.security.version>5.3.4.RELEASE</spring.security.version>
+		<spring.amqp.version>2.2.11.RELEASE</spring.amqp.version>
+		<spring.kafka.version>2.5.6.RELEASE</spring.kafka.version>
+		<reactor-netty.version>0.9.12.RELEASE</reactor-netty.version>
 		<jackson.version>2.11.0</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>


### PR DESCRIPTION
…9 and Spring Security to version 5.3.4.

These are the exact Spring dependency versions used by Spring Boot 2.3.4 (see: https://github.com/spring-projects/spring-boot/blob/v2.3.4.RELEASE/spring-boot-project/spring-boot-dependencies/build.gradle).