### PR TITLE
Use uppercase l for long literal values

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncCmmnHistoryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncCmmnHistoryTest.java
@@ -736,11 +736,11 @@ public class AsyncCmmnHistoryTest extends CustomCmmnConfigurationFlowableTestCas
         cmmnTaskService.complete(task.getId());
 
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().count()).isZero();
-        assertThat(cmmnManagementService.createHistoryJobQuery().count()).isEqualTo(10l);
+        assertThat(cmmnManagementService.createHistoryJobQuery().count()).isEqualTo(10);
 
         waitForAsyncHistoryExecutorToProcessAllJobs();
 
-        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(11l);
+        assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(11);
         assertThat(cmmnHistoryService.createHistoricTaskLogEntryQuery().taskId(task.getId()).type(HistoricTaskLogEntryType.USER_TASK_CREATED.name()).count())
                 .isEqualTo(1);
         assertThat(

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTaskLogTest.java
@@ -827,7 +827,7 @@ public class HistoryServiceTaskLogTest {
                 assertThat(logEntries).hasSize(1);
                 assertThat(logEntries.get(0)).extracting(HistoricTaskLogEntry::getTaskId).isEqualTo(task.getId());
 
-                assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(1l);
+                assertThat(historyService.createHistoricTaskLogEntryQuery().taskId(task.getId()).count()).isEqualTo(1);
             }
 
         } finally {
@@ -1031,7 +1031,7 @@ public class HistoryServiceTaskLogTest {
                         allLogEntries.get(1).getLogNumber(), allLogEntries.get(2).getLogNumber(), allLogEntries.get(3).getLogNumber()
                 );
 
-                assertThat(historicTaskLogEntryQuery.count()).isEqualTo(3l);
+                assertThat(historicTaskLogEntryQuery.count()).isEqualTo(3);
 
                 List<HistoricTaskLogEntry> pagedLogEntries = historicTaskLogEntryQuery.listPage(1, 1);
                 assertThat(pagedLogEntries).hasSize(1);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RecordRuntimeActivitiesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RecordRuntimeActivitiesTest.java
@@ -36,7 +36,7 @@ public class RecordRuntimeActivitiesTest extends AbstractTestCase {
         try {
             processEngine.getRuntimeService().startProcessInstanceByKey("oneTaskProcess");
 
-            assertThat(processEngine.getRuntimeService().createActivityInstanceQuery().count() > 0L).isTrue();
+            assertThat(processEngine.getRuntimeService().createActivityInstanceQuery().count()).isGreaterThan(0);
         } finally {
             processEngine.getRepositoryService().deleteDeployment(deployment.getId(), true);
             processEngine.close();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -827,8 +827,8 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // via expressions
         Task taskInSecondSubProcess = taskQuery.singleResult();
         assertThat(taskInSecondSubProcess.getName()).isEqualTo("Task in subprocess");
-        assertThat(runtimeService.getVariable(taskInSecondSubProcess.getProcessInstanceId(), "y")).isEqualTo(10);
-        assertThat(taskService.getVariable(taskInSecondSubProcess.getId(), "y")).isEqualTo(10);
+        assertThat(runtimeService.getVariable(taskInSecondSubProcess.getProcessInstanceId(), "y")).isEqualTo(10L);
+        assertThat(taskService.getVariable(taskInSecondSubProcess.getId(), "y")).isEqualTo(10L);
 
         // Completing this task ends the subprocess which leads to a task in the super process
         taskService.complete(taskInSecondSubProcess.getId());
@@ -836,8 +836,8 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // one task in the subprocess should be active after starting the process instance
         Task taskAfterSecondSubProcess = taskQuery.singleResult();
         assertThat(taskAfterSecondSubProcess.getName()).isEqualTo("Task in super process");
-        assertThat(runtimeService.getVariable(taskAfterSecondSubProcess.getProcessInstanceId(), "z")).isEqualTo(15);
-        assertThat(taskService.getVariable(taskAfterSecondSubProcess.getId(), "z")).isEqualTo(15);
+        assertThat(runtimeService.getVariable(taskAfterSecondSubProcess.getProcessInstanceId(), "z")).isEqualTo(15L);
+        assertThat(taskService.getVariable(taskAfterSecondSubProcess.getId(), "z")).isEqualTo(15L);
 
         // and end last task in Super process
         taskService.complete(taskAfterSecondSubProcess.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -817,7 +817,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertThat(taskService.getVariable(taskAfterSubProcess.getId(), "superVariable")).isEqualTo("Hello from sub process.");
 
         vars.clear();
-        vars.put("x", 5l);
+        vars.put("x", 5L);
 
         // Completing this task ends the super process which leads to a task in
         // the super process
@@ -827,8 +827,8 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // via expressions
         Task taskInSecondSubProcess = taskQuery.singleResult();
         assertThat(taskInSecondSubProcess.getName()).isEqualTo("Task in subprocess");
-        assertThat(runtimeService.getVariable(taskInSecondSubProcess.getProcessInstanceId(), "y")).isEqualTo(10l);
-        assertThat(taskService.getVariable(taskInSecondSubProcess.getId(), "y")).isEqualTo(10l);
+        assertThat(runtimeService.getVariable(taskInSecondSubProcess.getProcessInstanceId(), "y")).isEqualTo(10);
+        assertThat(taskService.getVariable(taskInSecondSubProcess.getId(), "y")).isEqualTo(10);
 
         // Completing this task ends the subprocess which leads to a task in the super process
         taskService.complete(taskInSecondSubProcess.getId());
@@ -836,8 +836,8 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // one task in the subprocess should be active after starting the process instance
         Task taskAfterSecondSubProcess = taskQuery.singleResult();
         assertThat(taskAfterSecondSubProcess.getName()).isEqualTo("Task in super process");
-        assertThat(runtimeService.getVariable(taskAfterSecondSubProcess.getProcessInstanceId(), "z")).isEqualTo(15l);
-        assertThat(taskService.getVariable(taskAfterSecondSubProcess.getId(), "z")).isEqualTo(15l);
+        assertThat(runtimeService.getVariable(taskAfterSecondSubProcess.getProcessInstanceId(), "z")).isEqualTo(15);
+        assertThat(taskService.getVariable(taskAfterSecondSubProcess.getId(), "z")).isEqualTo(15);
 
         // and end last task in Super process
         taskService.complete(taskAfterSecondSubProcess.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/signal/SignalEventTest.java
@@ -185,7 +185,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         assertThat(variableMap)
                 .containsOnly(
                         entry("myNewTextVar", "John Doe"),
-                        entry("myNewNumberVar", 2l));
+                        entry("myNewNumberVar", 2L));
     }
 
     @Test
@@ -208,7 +208,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
 
         try {
             processEngineConfiguration.getClock().setCurrentTime(new Date(System.currentTimeMillis() + 1000));
-            waitForJobExecutorToProcessAllJobs(10000, 100l);
+            waitForJobExecutorToProcessAllJobs(10000, 100L);
 
             assertThat(createEventSubscriptionQuery().count()).isZero();
             assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
@@ -239,7 +239,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         
         try {
             processEngineConfiguration.getClock().setCurrentTime(new Date(System.currentTimeMillis() + 1000));
-            waitForJobExecutorToProcessAllJobs(10000, 100l);
+            waitForJobExecutorToProcessAllJobs(10000, 100L);
 
             Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
             assertThat(task).isNotNull();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
@@ -516,7 +516,7 @@ public class VerifyDatabaseOperationsTest extends PluggableFlowableTestCase {
                 "HistoricTaskLogEntryEntityImpl", 2L,
                     "CommentEntityImpl", 2L,
                     "HistoricIdentityLinkEntityImpl-bulk-with-2", 2L, 
-                    "IdentityLinkEntityImpl-bulk-with-2", 2l);
+                    "IdentityLinkEntityImpl-bulk-with-2", 2L);
             assertDatabaseSelects("AddIdentityLinkCmd", 
                     "selectById org.flowable.task.service.impl.persistence.entity.TaskEntityImpl", 2L, 
                     "selectById org.flowable.engine.impl.persistence.entity.ExecutionEntityImpl", 2L,

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceSuspensionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/ProcessInstanceSuspensionTest.java
@@ -104,7 +104,7 @@ public class ProcessInstanceSuspensionTest extends PluggableFlowableTestCase {
 
         // the acquire jobs command sees the job:
         List<TimerJobEntity> acquiredJobs = executeAcquireJobsCommand();
-        assertThat(acquiredJobs).hasSize(1);;
+        assertThat(acquiredJobs).hasSize(1);
 
         // suspend the process instance:
         repositoryService.suspendProcessDefinitionById(pd.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/async/AsyncHistoryTest.java
@@ -602,7 +602,7 @@ public class AsyncHistoryTest extends CustomConfigurationFlowableTestCase {
         taskService.complete(task.getId());
 
         assertThat(historyService.createHistoricTaskLogEntryQuery().count()).isZero();
-        assertThat(managementService.createHistoryJobQuery().count()).isEqualTo(12l);
+        assertThat(managementService.createHistoryJobQuery().count()).isEqualTo(12);
 
         waitForHistoryJobExecutorToProcessAllJobs(7000, 200);
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/form/FormServiceTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/api/form/FormServiceTest.java
@@ -175,7 +175,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         Map<String, Object> expectedVariables = new HashMap<String, Object>();
         expectedVariables.put("room", "5b");
         expectedVariables.put("SpeakerName", "Mike");
-        expectedVariables.put("duration", 45l);
+        expectedVariables.put("duration", 45L);
         expectedVariables.put("free", Boolean.TRUE);
         expectedVariables.put("double", 45.5d);
 
@@ -241,7 +241,7 @@ public class FormServiceTest extends PluggableFlowableTestCase {
         expectedVariables = new HashMap<String, Object>();
         expectedVariables.put("room", "5b");
         expectedVariables.put("SpeakerName", "Mike");
-        expectedVariables.put("duration", 45l);
+        expectedVariables.put("duration", 45L);
         expectedVariables.put("free", Boolean.TRUE);
         expectedVariables.put("double", 45.5d);
 

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -284,7 +284,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         assertEquals("Hello from sub process.", taskService.getVariable(taskAfterSubProcess.getId(), "superVariable"));
 
         vars.clear();
-        vars.put("x", 5l);
+        vars.put("x", 5L);
 
         // Completing this task ends the super process which leads to a task in the super process
         taskService.complete(taskAfterSubProcess.getId(), vars);
@@ -292,8 +292,8 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // now we are the second time in the sub process but passed variables via expressions
         org.flowable.task.api.Task taskInSecondSubProcess = taskQuery.singleResult();
         assertEquals("Task in subprocess", taskInSecondSubProcess.getName());
-        assertEquals(10l, runtimeService.getVariable(taskInSecondSubProcess.getProcessInstanceId(), "y"));
-        assertEquals(10l, taskService.getVariable(taskInSecondSubProcess.getId(), "y"));
+        assertEquals(10L, runtimeService.getVariable(taskInSecondSubProcess.getProcessInstanceId(), "y"));
+        assertEquals(10L, taskService.getVariable(taskInSecondSubProcess.getId(), "y"));
 
         // Completing this task ends the subprocess which leads to a task in the super process
         taskService.complete(taskInSecondSubProcess.getId());
@@ -301,8 +301,8 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         // one task in the subprocess should be active after starting the process instance
         org.flowable.task.api.Task taskAfterSecondSubProcess = taskQuery.singleResult();
         assertEquals("Task in super process", taskAfterSecondSubProcess.getName());
-        assertEquals(15l, runtimeService.getVariable(taskAfterSecondSubProcess.getProcessInstanceId(), "z"));
-        assertEquals(15l, taskService.getVariable(taskAfterSecondSubProcess.getId(), "z"));
+        assertEquals(15L, runtimeService.getVariable(taskAfterSecondSubProcess.getProcessInstanceId(), "z"));
+        assertEquals(15L, taskService.getVariable(taskAfterSecondSubProcess.getId(), "z"));
 
         // and end last task in Super process
         taskService.complete(taskAfterSecondSubProcess.getId());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventTest.java
@@ -105,7 +105,7 @@ public class SignalEventTest extends PluggableFlowableTestCase {
         try {
             clock.setCurrentTime(new Date(System.currentTimeMillis() + 1000));
             processEngineConfiguration.setClock(clock);
-            waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000, 200l);
+            waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(10000, 200L);
 
             assertEquals(0, createEventSubscriptionQuery().count());
             assertEquals(0, runtimeService.createProcessInstanceQuery().count());

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -137,7 +137,7 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         org.flowable.task.api.Task lastTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         taskService.complete(lastTask.getId());
 
-        assertEquals(0l, runtimeService.createProcessInstanceQuery().active().count());
+        assertEquals(0L, runtimeService.createProcessInstanceQuery().active().count());
     }
 
     /**

--- a/modules/flowable5-test/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
@@ -305,13 +305,13 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertEquals("one", historicProcessVariable.getValue());
 
         Map<String, Object> variables3 = new HashMap<String, Object>();
-        variables3.put("long", 1000l);
+        variables3.put("long", 1000L);
         variables3.put("double", 25.43d);
         ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("receiveTask", variables3);
         runtimeService.trigger(processInstance3.getProcessInstanceId());
 
         assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableName("long").count());
-        assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("long", 1000l).count());
+        assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("long", 1000L).count());
         assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableName("double").count());
         assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("double", 25.43d).count());
 


### PR DESCRIPTION
Instead of doing pieces here and there I grepped the source and changed all lower case `l` literal to uppercase `L` literal as needed.

In some cases it isn't even needed and as side benefit I improved one of the `assertThat()` tests.

As an added bonus I removed a single occurrence of a duplicated semi-colon.
