### PR TITLE
Update Groovy to version 3.0.6.

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -128,8 +128,8 @@ org.apache.httpcomponents       httpclient                  4.5.12          Apac
 org.apache.httpcomponents       httpcore                    4.4.13          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.12          Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy                      3.0.5           The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy-jsr223               3.0.5           The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy                      3.0.6           The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy-jsr223               3.0.6           The Apache Software License, Version 2.0
 org.liquibase                   liquibase-core              3.8.0           Apache License, Version 2.0
 org.mybatis                     mybatis                     3.5.5           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              2.0.5           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -777,7 +777,7 @@
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-jsr223</artifactId>
-				<version>3.0.5</version>
+				<version>3.0.6</version>
 			</dependency>
 			<dependency>
 				<groupId>org.drools</groupId>


### PR DESCRIPTION
This version of Groovy supports Java 16.