### PR TITLE
Fixed bug where requests from the admin app backend were sent using I…

### DIFF
--- a/modules/flowable-ui/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/FlowableClientService.java
+++ b/modules/flowable-ui/flowable-ui-admin-logic/src/main/java/org/flowable/ui/admin/service/engine/FlowableClientService.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AUTH;
 import org.apache.http.auth.AuthScope;
@@ -40,6 +41,7 @@ import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -503,36 +505,31 @@ public class FlowableClientService {
 
     public HttpPost createPost(String uri, ServerConfig serverConfig) {
         HttpPost post = new HttpPost(getServerUrl(serverConfig, uri));
-        post.setHeader("Content-Type", "application/json");
-        post.setHeader("Accept", "application/json");
+        post.setHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
         return post;
     }
 
     public HttpPost createPost(URIBuilder builder, ServerConfig serverConfig) {
         HttpPost post = new HttpPost(getServerUrl(serverConfig, builder));
-        post.setHeader("Content-Type", "application/json");
-        post.setHeader("Accept", "application/json");
+        post.setHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
         return post;
     }
 
     public HttpPut createPut(String uri, ServerConfig serverConfig) {
         HttpPut put = new HttpPut(getServerUrl(serverConfig, uri));
-        put.setHeader("Content-Type", "application/json");
-        put.setHeader("Accept", "application/json");
+        put.setHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
         return put;
     }
 
     public HttpPut createPut(URIBuilder builder, ServerConfig serverConfig) {
         HttpPut put = new HttpPut(getServerUrl(serverConfig, builder));
-        put.setHeader("Content-Type", "application/json");
-        put.setHeader("Accept", "application/json");
+        put.setHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
         return put;
     }
 
     public HttpDelete createDelete(URIBuilder builder, ServerConfig serverConfig) {
         HttpDelete delete = new HttpDelete(getServerUrl(serverConfig, builder));
-        delete.setHeader("Content-Type", "application/json");
-        delete.setHeader("Accept", "application/json");
+        delete.setHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
         return delete;
     }
 
@@ -541,7 +538,7 @@ public class FlowableClientService {
         // add
 
         try {
-            return new StringEntity(json.toString());
+            return new StringEntity(json.toString(), ContentType.APPLICATION_JSON);
         } catch (Exception e) {
             LOGGER.warn("Error translation json to http client entity {}", json, e);
         }
@@ -550,7 +547,7 @@ public class FlowableClientService {
 
     public StringEntity createStringEntity(String json) {
         try {
-            return new StringEntity(json);
+            return new StringEntity(json, ContentType.APPLICATION_JSON);
         } catch (Exception e) {
             LOGGER.warn("Error translation json to http client entity {}", json, e);
         }


### PR DESCRIPTION
…SO-8859-1 encoding instead of UTF-8

#### Check List:
* Unit tests: NO
* Documentation: NO

When using the Flowable admin-app I was unable to update process variables containing the Swedish characters åäö.

After investigation I saw that the problem was in the Flowable admin-app and when I sent a request body like:

```
POST http://localhost:8080/flowable-ui/admin-app/rest/admin/process-instances/8f9b37b6-03b5-11eb-89e2-080027d168e9/variables/myvar
{"name":"myvar","type":"string","value":"öäå"}
```

would result in the following exception:

```
org.flowable.ui.admin.service.engine.exception.FlowableServiceException: request body could not be transformed to a RestVariable instance.
	at org.flowable.ui.admin.service.engine.FlowableClientService.executeRequest(FlowableClientService.java:165) ~[classes/:na]
	at org.flowable.ui.admin.service.engine.FlowableClientService.executeRequest(FlowableClientService.java:133) ~[classes/:na]
	at org.flowable.ui.admin.service.engine.FlowableClientService.executeRequest(FlowableClientService.java:129) ~[classes/:na]
	at org.flowable.ui.admin.service.engine.ProcessInstanceService.updateVariable(ProcessInstanceService.java:150) ~[classes/:na]
	at org.flowable.ui.admin.rest.client.ProcessInstanceClientResource.updateVariable(ProcessInstanceClientResource.java:87) ~[classes/:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_262]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_262]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_262]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_262]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:190) [spring-web-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:138) [spring-web-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:105) [spring-webmvc-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:878) [spring-webmvc-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:792) [spring-webmvc-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) [spring-webmvc-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1040) [spring-webmvc-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:943) [spring-webmvc-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) [spring-webmvc-5.2.9.RELEASE.jar:5.2.9.RELEASE]
	at org.springframework.web.servlet.FrameworkServlet.doPut(FrameworkServlet.java:920) [spring-webmvc-5.2.9.RELEASE.jar:5.2.9.RELEASE]
```

The request would be correctly received by the admin-app but would then send a request to the Flowable Rest-API with the request body encoded as text/plain with a charset of ISO-8859-1. In `FlowableClientService` a `org.apache.http.entity.StringEntity` is created without a specified content-type. The content-type for `StringEntity` is then set as `org.apache.http.entity.ContentType.DEFAULT_TEXT` by default which is `text/plain; charset=ISO-8859-1`.

Unfortunately also in the `FlowableClientService` the "Content-type" is overwritten to become `application/json` without a specified charset. This means in the Flowable Rest API the charset UTF-8 is assumed (as this is the normal charset for JSON).

This results in the request body to the Flowable Rest API to be encoded as ISO-8859-1 but the header to only specify `application/json` and assume the charset `UTF-8`.

The fix is to explicitly set the `StringEntity` to use `application/json; charset=UTF-8` and to not overwrite the `Content-type` header.
Additionally I have modified the `Accept` header to use constants from the Apache HTTP client library instead of String literals-