### PR TITLE
Fix case of LOGGER and typos

### DIFF
--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/cmd/SetAppDefinitionCategoryCmd.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/cmd/SetAppDefinitionCategoryCmd.java
@@ -51,7 +51,7 @@ public class SetAppDefinitionCategoryCmd implements Command<Void> {
         // Update category
         appDefinition.setCategory(category);
 
-        // Remove app definition from cache, it will be refetched later
+        // Remove app definition from cache, it will be refetch later
         DeploymentCache<AppDefinitionCacheEntry> appDefinitionCache = CommandContextUtil.getAppEngineConfiguration(commandContext).getAppDefinitionCache();
         if (appDefinitionCache != null) {
             appDefinitionCache.remove(appDefinitionId);

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/interceptor/AppCommandInvoker.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/interceptor/AppCommandInvoker.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AppCommandInvoker extends AbstractCommandInterceptor {
 
-    private static final Logger logger = LoggerFactory.getLogger(AppCommandInvoker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppCommandInvoker.class);
 
     @SuppressWarnings("unchecked")
     @Override

--- a/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
+++ b/modules/flowable-camel/src/test/java/org/flowable/camel/exception/CamelExceptionTest.java
@@ -77,7 +77,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
         }
     }
 
-    // check happy path in synchronouse camel call
+    // check happy path in synchronous camel call
     @Test
     @Deployment(resources = { "org/flowable/camel/exception/bpmnExceptionInRouteSynchronous.bpmn20.xml" })
     public void testHappyPathSynchronous() {
@@ -89,7 +89,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
         assertThat(NoExceptionServiceMock.isCalled()).isTrue();
     }
 
-    // Check Non BPMN error in synchronouse camel call
+    // Check Non BPMN error in synchronous camel call
     @Test
     @Deployment(resources = { "org/flowable/camel/exception/bpmnExceptionInRouteSynchronous.bpmn20.xml" })
     public void testNonBpmnExceptionInCamel() {
@@ -138,7 +138,7 @@ public class CamelExceptionTest extends SpringFlowableTestCase {
         assertThat(NoExceptionServiceMock.isCalled()).isTrue();
     }
 
-    // check non bpmn exception in asynchronouse camel call
+    // check non bpmn exception in asynchronous camel call
     @Test
     @Deployment(resources = { "org/flowable/camel/exception/bpmnExceptionInRouteAsynchronous.bpmn20.xml" })
     public void testNonBpmnPathAsynchronous() {

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnManagementService.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnManagementService.java
@@ -130,7 +130,7 @@ public interface CmmnManagementService {
     HistoryJob moveDeadLetterJobToHistoryJob(String jobId, int retries);
 
     /**
-     * Moves a suspendend job from the suspended letter job table back to be an executable job. The retries are untouched.
+     * Moves a suspended job from the suspended letter job table back to be an executable job. The retries are untouched.
      *
      * @param jobId
      *            id of the job to move, cannot be null.

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/InjectedPlanItemInstanceBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/InjectedPlanItemInstanceBuilder.java
@@ -22,7 +22,7 @@ public interface InjectedPlanItemInstanceBuilder {
     /**
      * The explicit name for the new plan item to be created, if this is not set, the name of the referenced element is taken instead.
      *
-     * @param name the explicit name to be used for the new plan item, which superseeds the one from the referenced plan item model
+     * @param name the explicit name to be used for the new plan item, which supersedes the one from the referenced plan item model
      * @return the builder reference for method chaining
      */
     InjectedPlanItemInstanceBuilder name(String name);

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/AbstractPlanItemDefinitionExport.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/AbstractPlanItemDefinitionExport.java
@@ -23,7 +23,7 @@ import org.flowable.cmmn.model.PlanItemDefinition;
 public abstract class AbstractPlanItemDefinitionExport<T extends PlanItemDefinition> implements CmmnXmlConstants {
 
     /**
-     * The class for which exporter subclasess works for
+     * The class for which exporter subclasses works for
      * @return a Class that extends PlanItemDefinition
      */
     protected abstract Class<? extends T> getExportablePlanItemDefinitionClass();
@@ -57,7 +57,7 @@ public abstract class AbstractPlanItemDefinitionExport<T extends PlanItemDefinit
     }
 
     /**
-     * Subclasses must override this method to provide the xml element tag value of this planItemDefintion
+     * Subclasses must override this method to provide the xml element tag value of this planItemDefinition
      *
      * @param planItemDefinition the plan item definition to write
      * @return the value of the xml element tag to write

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/CmmnXmlConverterTest.java
@@ -179,7 +179,7 @@ public class CmmnXmlConverterTest extends AbstractConverterTest {
         assertThat(nestedStage).isNotNull();
         assertThat(nestedStage.getName()).isEqualTo("Nested Stage");
 
-        // Nested stage has 3 plan items, and one of them refereces the rootTook from the plan model
+        // Nested stage has 3 plan items, and one of them references the rootTook from the plan model
         assertThat(nestedStage.getPlanItems()).hasSize(3);
         Stage nestedNestedStage = null;
         for (PlanItem planItem : nestedStage.getPlanItems()) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngine.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngine.java
@@ -33,7 +33,7 @@ public interface CmmnEngine extends Engine {
     String VERSION = FlowableVersions.CURRENT_VERSION;
 
     /**
-     * Starts the execuctors (async and async history), if they are configured to be auto-actived.
+     * Starts the execuctors (async and async history), if they are configured to be auto-activated.
      */
     void startExecutors();
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/CmmnEngineImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/CmmnEngineImpl.java
@@ -87,7 +87,7 @@ public class CmmnEngineImpl implements CmmnEngine {
 
         // When running together with the bpmn engine, the asyncHistoryExecutor is shared by default.
         // However, calling multiple times .start() won't do anything (the method returns if already running),
-        // so no need to check this case specically here.
+        // so no need to check this case specifically here.
         if (asyncHistoryExecutor != null && asyncHistoryExecutor.isAutoActivate()) {
             asyncHistoryExecutor.start();
         }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractEvaluationCriteriaOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractEvaluationCriteriaOperation.java
@@ -120,7 +120,7 @@ public abstract class AbstractEvaluationCriteriaOperation extends AbstractCaseIn
      *
      * @param planItemInstanceEntity the plan item instance to test for a repetition rule
      * @param satisfiedEntryCriterion the optional, satisfied entry criterion activating the plan item, might be null
-     * @param planItemInstanceContainer the parent container of the gievn plan item
+     * @param planItemInstanceContainer the parent container of the given plan item
      * @param evaluationResult the evaluation result used to collect information during the evaluation of a list of plan items, will be modified inside this
      *          method to reflect gained information about further evaluation as well as any newly created plan item instances for repetition
      * @return true, if the plan item must be activated, false otherwise

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CreatePlanItemInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CreatePlanItemInstanceOperation.java
@@ -33,7 +33,7 @@ public class CreatePlanItemInstanceOperation extends AbstractChangePlanItemInsta
     protected void internalExecute() {
         if (ExpressionUtil.hasRepetitionRule(planItemInstanceEntity)) {
             //Increase repetition counter, value is kept from the previous instance of the repetition
-            //@see CmmOpertion.copyAndInsertPlanItemInstance used by @see EvaluateCriteriaOperation and @see AbstractDeletePlanItemInstanceOperation
+            //@see CmmOperation.copyAndInsertPlanItemInstance used by @see EvaluateCriteriaOperation and @see AbstractDeletePlanItemInstanceOperation
             //Or if its the first instance of the repetition, this call sets the counter to 1
             setRepetitionCounter(planItemInstanceEntity, getRepetitionCounter(planItemInstanceEntity) + 1);
         }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/CompleteStagePlanItemInstanceCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/CompleteStagePlanItemInstanceCmd.java
@@ -50,7 +50,7 @@ public class CompleteStagePlanItemInstanceCmd extends AbstractNeedsPlanItemInsta
         if (!PlanItemDefinitionType.STAGE.equals(planItemInstanceEntity.getPlanItemDefinitionType())) {
             throw new FlowableIllegalArgumentException("Can only complete plan item instances of type stage. Type is " + planItemInstanceEntity.getPlanItemDefinitionType());
         }
-        if (!force && !planItemInstanceEntity.isCompletable()) { // if force is true, ignore the completeable flag
+        if (!force && !planItemInstanceEntity.isCompletable()) { // if force is true, ignore the completable flag
             throw new FlowableIllegalArgumentException("Can only complete a stage plan item instance that is marked as completable (there might still be active plan item instance).");
         }
         CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation(planItemInstanceEntity);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseDefinitionCategoryCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseDefinitionCategoryCmd.java
@@ -51,7 +51,7 @@ public class SetCaseDefinitionCategoryCmd implements Command<Void> {
         // Update category
         caseDefinition.setCategory(category);
 
-        // Remove case definition from cache, it will be refetched later
+        // Remove case definition from cache, it will be refetch later
         DeploymentCache<CaseDefinitionCacheEntry> caseDefinitionCache = CommandContextUtil.getCmmnEngineConfiguration(commandContext).getCaseDefinitionCache();
         if (caseDefinitionCache != null) {
             caseDefinitionCache.remove(caseDefinitionId);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/interceptor/CmmnCommandInvoker.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/interceptor/CmmnCommandInvoker.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CmmnCommandInvoker extends AbstractCommandInterceptor {
 
-    private static final Logger logger = LoggerFactory.getLogger(CmmnCommandInvoker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CmmnCommandInvoker.class);
 
     protected AgendaOperationRunner agendaOperationRunner;
 
@@ -76,9 +76,7 @@ public class CmmnCommandInvoker extends AbstractCommandInterceptor {
         if (runnable instanceof CmmnOperation) {
             CmmnOperation operation = (CmmnOperation) runnable;
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Executing agenda operation {}", runnable);
-            }
+            LOGGER.debug("Executing agenda operation {}", runnable);
 
             agendaOperationRunner.executeOperation(commandContext, runnable);
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/interceptor/CmmnCommandInvoker.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/interceptor/CmmnCommandInvoker.java
@@ -76,7 +76,9 @@ public class CmmnCommandInvoker extends AbstractCommandInterceptor {
         if (runnable instanceof CmmnOperation) {
             CmmnOperation operation = (CmmnOperation) runnable;
 
-            LOGGER.debug("Executing agenda operation {}", runnable);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Executing agenda operation {}", runnable);
+            }
 
             agendaOperationRunner.executeOperation(commandContext, runnable);
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/parser/CmmnParserImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/parser/CmmnParserImpl.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CmmnParserImpl implements CmmnParser {
 
-    private final Logger LOGGER = LoggerFactory.getLogger(CmmnParserImpl.class);
+    private final Logger logger = LoggerFactory.getLogger(CmmnParserImpl.class);
 
     protected CmmnParseHandlers cmmnParseHandlers;
     protected CmmnActivityBehaviorFactory activityBehaviorFactory;
@@ -51,7 +51,7 @@ public class CmmnParserImpl implements CmmnParser {
             return cmmnParseResult;
 
         } catch (IOException e) {
-            LOGGER.error("Could not read bytes from CMMN resource", e);
+            logger.error("Could not read bytes from CMMN resource", e);
             return new CmmnParseResult();
         }
     }
@@ -119,7 +119,7 @@ public class CmmnParserImpl implements CmmnParser {
                 }
 
                 if (cmmnModel.findPlanItem(cmmnReference) == null && cmmnModel.getCriterion(cmmnReference) == null) {
-                    LOGGER.warn("Invalid reference in diagram interchange definition: could not find {}", cmmnReference);
+                    logger.warn("Invalid reference in diagram interchange definition: could not find {}", cmmnReference);
                 }
             }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/parser/CmmnParserImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/parser/CmmnParserImpl.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CmmnParserImpl implements CmmnParser {
 
-    private final Logger logger = LoggerFactory.getLogger(CmmnParserImpl.class);
+    private final Logger LOGGER = LoggerFactory.getLogger(CmmnParserImpl.class);
 
     protected CmmnParseHandlers cmmnParseHandlers;
     protected CmmnActivityBehaviorFactory activityBehaviorFactory;
@@ -51,7 +51,7 @@ public class CmmnParserImpl implements CmmnParser {
             return cmmnParseResult;
 
         } catch (IOException e) {
-            logger.error("Could not read bytes from CMMN resource", e);
+            LOGGER.error("Could not read bytes from CMMN resource", e);
             return new CmmnParseResult();
         }
     }
@@ -119,7 +119,7 @@ public class CmmnParserImpl implements CmmnParser {
                 }
 
                 if (cmmnModel.findPlanItem(cmmnReference) == null && cmmnModel.getCriterion(cmmnReference) == null) {
-                    logger.warn("Invalid reference in diagram interchange definition: could not find {}", cmmnReference);
+                    LOGGER.warn("Invalid reference in diagram interchange definition: could not find {}", cmmnReference);
                 }
             }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/CaseInstanceEntityImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/CaseInstanceEntityImpl.java
@@ -269,7 +269,7 @@ public class CaseInstanceEntityImpl extends AbstractCmmnEngineVariableScopeEntit
     @Override
     protected VariableScopeImpl getParentVariableScope() {
         // A case instance is the root of variables.
-        // In case of parent-child case instances, the variables needs to be defined explictely in input/outpur vars 
+        // In case of parent-child case instances, the variables needs to be defined explicitly in input/output vars
         return null;
     }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceEntityBuilder.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/persistence/entity/PlanItemInstanceEntityBuilder.java
@@ -65,7 +65,7 @@ public interface PlanItemInstanceEntityBuilder {
     PlanItemInstanceEntityBuilder caseInstanceId(String caseInstanceId);
 
     /**
-     * Set the id of the stage plan item instace the new plan item instance is a direct child of.
+     * Set the id of the stage plan item instance the new plan item instance is a direct child of.
      * @param stagePlanItemInstance the parent stage instance for the new plan item instance
      * @return the builder instance for method chaining
      */

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/process/ProcessInstanceService.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/process/ProcessInstanceService.java
@@ -25,7 +25,7 @@ public interface ProcessInstanceService {
 
     /**
      * @return A new id that will be used when starting a process instance.
-     *         This is for example needed to set the bidrectional relation
+     *         This is for example needed to set the bidirectional relation
      *         when a case instance starts a process instance through a process task.
      */
     String generateNewProcessInstanceId();
@@ -65,7 +65,7 @@ public interface ProcessInstanceService {
     Object resolveExpression(String executionId, String expression);
 
     /**
-     * Triggeres a case instance that was started by a process instance.
+     * Triggers a case instance that was started by a process instance.
      */
     void triggerCaseTask(String executionId, Map<String, Object> variables);
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/FlowableCmmnExtension.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/FlowableCmmnExtension.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The CmmnEngine and the services will be made available to the test class through the parameter resolution (BeforeEach, AfterEach, test methods).
  * The CmmnEngine will be initialized by default with the flowable.cmmn.cfg.xml resource on the classpath.
- * To specify a different configuration file, annotate your class witn {@link CmmnConfigurationResource}.
+ * To specify a different configuration file, annotate your class with {@link CmmnConfigurationResource}.
  * Cmmn engines will be cached as part of the JUnit Jupiter Extension context.
  * Right before the first time the setUp is called for a given configuration resource, the cmmn engine will be constructed.
  * </p>

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/FlowableCmmnTest.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/FlowableCmmnTest.java
@@ -49,9 +49,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </pre>
  *
  * <p>
- * The CmmnEngine and the services will be made available to the test class through the parameter resolution (BeforeEach, AfterEach, test moethds).
+ * The CmmnEngine and the services will be made available to the test class through the parameter resolution (BeforeEach, AfterEach, test methods).
  * The CmmnEngine will be initialized by default with the flowable.cmmn.cfg.xml resource on the classpath.
- * To specify a different configuration file, annotate your class witn {@link CmmnConfigurationResource}.
+ * To specify a different configuration file, annotate your class with {@link CmmnConfigurationResource}.
  * Cmmn engines will be cached as part of the JUnit Jupiter Extension context.
  * Right before the first time the setUp is called for a given configuration resource, the cmmn engine will be constructed.
  * </p>

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/authorization/StartAuthorizationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/authorization/StartAuthorizationTest.java
@@ -138,7 +138,7 @@ public class StartAuthorizationTest extends FlowableCmmnTestCase {
             assertThat(extractProperty("getUserId").from(links))
                     .contains("user1");
 
-            // Case instance identity links should not have an impcat on the identityLinks query
+            // Case instance identity links should not have an impact on the identityLinks query
             Authentication.setAuthenticatedUserId("user1");
             CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionId(latestCaseDef.getId()).start();
             List<IdentityLink> identityLinksForCaseInstance = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/MultiTenantCmmnEventRegistryConsumerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/MultiTenantCmmnEventRegistryConsumerTest.java
@@ -290,7 +290,7 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         assertThat(cmmnRuntimeService.createEventSubscriptionQuery().singleResult().getTenantId()).isNullOrEmpty();
 
         InboundChannelModel defaultSharedInboundChannelModel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("sharedDefaultChannel");
-        // The chanel has a tenant detector that will use the correct tenant to start the case instance
+        // The channel has a tenant detector that will use the correct tenant to start the case instance
 
         ((TestInboundChannelAdapter) defaultSharedInboundChannelModel.getInboundEventChannelAdapter()).triggerEventForTenantId("customerA", TENANT_A);
         assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceTenantId(TENANT_A).count()).isEqualTo(1);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/RepetitionRuleTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/RepetitionRuleTest.java
@@ -168,7 +168,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         cmmnManagementService.executeJob(job.getId());
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
-        // A plan item in state 'waiting for repetition' should exist for the yask
+        // A plan item in state 'waiting for repetition' should exist for the task
         planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
                 .planItemInstanceStateWaitingForRepetition()
@@ -227,7 +227,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         cmmnManagementService.executeJob(job.getId());
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
-        // A plan item in state 'waiting for repetition' should exist for the yask
+        // A plan item in state 'waiting for repetition' should exist for the task
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
                 .planItemInstanceStateWaitingForRepetition()
@@ -290,7 +290,7 @@ public class RepetitionRuleTest extends FlowableCmmnTestCase {
         cmmnManagementService.executeJob(job.getId());
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(1);
 
-        // A plan item in state 'waiting for repetition' should exist for the yask
+        // A plan item in state 'waiting for repetition' should exist for the task
         PlanItemInstance planItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .planItemDefinitionType(PlanItemDefinitionType.HUMAN_TASK)
                 .planItemInstanceStateWaitingForRepetition()

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/listener/AvailableConditionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/listener/AvailableConditionTest.java
@@ -36,7 +36,7 @@ public class AvailableConditionTest extends FlowableCmmnTestCase {
     public void testAvailableConditionInPlanModelPlanItemInstance() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testAvailableConditionInPlanModelPlanItemInstance").start();
 
-        // The plan item instance for the event listener should have been created in the unavailabe state, as the condition is not true.
+        // The plan item instance for the event listener should have been created in the unavailable state, as the condition is not true.
         PlanItemInstance eventListenerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
             .planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
             .singleResult();
@@ -87,7 +87,7 @@ public class AvailableConditionTest extends FlowableCmmnTestCase {
     public void testAvailableConditionWithEventListenerInStage() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testAvailableCondition").start();
 
-        // The plan item instance for the event listener should have been created in the unavailabe state, as the condition is not true.
+        // The plan item instance for the event listener should have been created in the unavailable state, as the condition is not true.
         PlanItemInstance eventListenerPlanItemInstance = cmmnRuntimeService.createPlanItemInstanceQuery()
             .planItemDefinitionType(PlanItemDefinitionType.USER_EVENT_LISTENER)
             .singleResult();

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemExitSentryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/PlanItemExitSentryTest.java
@@ -221,7 +221,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, WAITING_FOR_REPETITION);
 
-        // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in witing for repetition state
+        // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in waiting for repetition state
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", WAITING_FOR_REPETITION);
@@ -324,7 +324,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, WAITING_FOR_REPETITION);
 
-        // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in witing for repetition state
+        // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in waiting for repetition state
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active and enabled tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", WAITING_FOR_REPETITION);
@@ -388,7 +388,7 @@ public class PlanItemExitSentryTest extends FlowableCmmnTestCase {
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, WAITING_FOR_REPETITION);
 
-        // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in witing for repetition state
+        // trigger exit sentry with Task B still in active state -> must terminate the active task B, but leave it in waiting for repetition state
         cmmnRuntimeService.completeUserEventListenerInstance(getPlanItemInstanceIdByName(planItemInstances, "Kill active and enabled tasks B"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
         assertPlanItemInstanceState(planItemInstances, "Task B", WAITING_FOR_REPETITION);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StageTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StageTest.java
@@ -152,7 +152,7 @@ public class StageTest extends FlowableCmmnTestCase {
                 .extracting(PlanItemInstance::getName)
                 .containsExactly(expectedNames);
 
-        // Commplete inner nested stage (2nd stage)
+        // Complete inner nested stage (2nd stage)
         cmmnRuntimeService.triggerPlanItemInstance(planItemInstances.get(2).getId());
         planItemInstances = cmmnRuntimeService.createPlanItemInstanceQuery().caseInstanceId(caseInstance.getId())
                 .planItemInstanceState(PlanItemInstanceState.ACTIVE)

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/CaseInstanceQueryResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/CaseInstanceQueryResourceTest.java
@@ -124,7 +124,7 @@ public class CaseInstanceQueryResourceTest extends BaseSpringRestTestCase {
         variableNode.put("operation", "like");
         assertResultsPresentInPostDataResponse(url, requestNode, caseInstance.getId());
 
-        // String liek ignore case
+        // String like ignore case
         variableNode.put("name", "stringVar");
         variableNode.put("value", "AzEr%");
         variableNode.put("operation", "likeIgnoreCase");

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/TaskCollectionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/TaskCollectionResourceTest.java
@@ -196,7 +196,7 @@ public class TaskCollectionResourceTest extends BaseSpringRestTestCase {
             url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_TASK_COLLECTION) + "?priority=100";
             assertResultsPresentInDataResponse(url, adhocTask.getId());
 
-            // Mininmum Priority filtering
+            // Minimum Priority filtering
             url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_TASK_COLLECTION) + "?minimumPriority=70";
             assertResultsPresentInDataResponse(url, adhocTask.getId());
 

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/TaskQueryResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/TaskQueryResourceTest.java
@@ -109,7 +109,7 @@ public class TaskQueryResourceTest extends BaseSpringRestTestCase {
             requestNode.put("priority", 100);
             assertResultsPresentInPostDataResponse(url, requestNode, adhocTask.getId());
 
-            // Mininmum Priority filtering
+            // Minimum Priority filtering
             requestNode.removeAll();
             requestNode.put("minimumPriority", 70);
             assertResultsPresentInPostDataResponse(url, requestNode, adhocTask.getId());

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceMock.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceMock.java
@@ -79,7 +79,7 @@ public interface WebServiceMock {
      *            the prefix
      * @param suffix
      *            the suffix
-     * @return the formated string
+     * @return the formatted string
      */
     @WebResult(name = "prettyPrint")
     String prettyPrintCount(@WebParam(name = "prefix") String prefix, @WebParam(name = "suffix") String suffix);

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/cmd/SetDecisionTableCategoryCmd.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/cmd/SetDecisionTableCategoryCmd.java
@@ -50,7 +50,7 @@ public class SetDecisionTableCategoryCmd implements Command<Void> {
         // Update category
         decisionTable.setCategory(category);
 
-        // Remove process definition from cache, it will be refetched later
+        // Remove process definition from cache, it will be refetch later
         DeploymentCache<DecisionCacheEntry> decisionTableCache = CommandContextUtil.getDmnEngineConfiguration().getDefinitionCache();
         if (decisionTableCache != null) {
             decisionTableCache.remove(decisionTableId);

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/DmnCommandInvoker.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/DmnCommandInvoker.java
@@ -56,7 +56,9 @@ public class DmnCommandInvoker extends AbstractCommandInterceptor {
         DmnEngineAgenda agenda = CommandContextUtil.getAgenda(commandContext);
         while (!agenda.isEmpty()) {
             Runnable runnable = agenda.getNextOperation();
-            LOGGER.debug("Executing agenda operation {}", runnable);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Executing agenda operation {}", runnable);
+            }
             runnable.run();
         }
     }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/DmnCommandInvoker.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/interceptor/DmnCommandInvoker.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DmnCommandInvoker extends AbstractCommandInterceptor {
 
-    private static final Logger logger = LoggerFactory.getLogger(DmnCommandInvoker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DmnCommandInvoker.class);
 
     @SuppressWarnings("unchecked")
     @Override
@@ -56,9 +56,7 @@ public class DmnCommandInvoker extends AbstractCommandInterceptor {
         DmnEngineAgenda agenda = CommandContextUtil.getAgenda(commandContext);
         while (!agenda.isEmpty()) {
             Runnable runnable = agenda.getNextOperation();
-            if (logger.isDebugEnabled()) {
-                logger.debug("Executing agenda operation {}", runnable);
-            }
+            LOGGER.debug("Executing agenda operation {}", runnable);
             runnable.run();
         }
     }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/VariableContainsExpressionFunction.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/VariableContainsExpressionFunction.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
  * - {@link ArrayNode}: supports checking if the arraynode contains a JsonNode for the types that are supported as variable type
  * 
  * When the variable value is null, false is returned in all cases.
- * When the variale value is not null, and the instance type is not one of the cases above, false will be returned.
+ * When the variable value is not null, and the instance type is not one of the cases above, false will be returned.
  * 
  * @author Joram Barrez
  */

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/VariableIsEmptyExpressionFunction.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/VariableIsEmptyExpressionFunction.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
  * - {@link ArrayNode}: if the json array has no elements.
  * 
  * When the variable value is null, true is returned in all cases.
- * When the variale value is not null, and the instance type is not one of the cases above, false will be returned.
+ * When the variable value is not null, and the instance type is not one of the cases above, false will be returned.
  * 
  * @author Joram Barrez
  */

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/ManagementService.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/ManagementService.java
@@ -199,7 +199,7 @@ public interface ManagementService {
     HistoryJob moveDeadLetterJobToHistoryJob(String jobId, int retries);
 
     /**
-     * Moves a suspendend job from the suspended letter job table back to be an executable job. The retries are untouched.
+     * Moves a suspended job from the suspended letter job table back to be an executable job. The retries are untouched.
      * 
      * @param jobId
      *            id of the job to move, cannot be null.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngine.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/ProcessEngine.java
@@ -40,7 +40,7 @@ public interface ProcessEngine extends Engine {
     String VERSION = FlowableVersions.CURRENT_VERSION;
 
     /**
-     * Starts the execuctors (async and async history), if they are configured to be auto-actived.
+     * Starts the execuctors (async and async history), if they are configured to be auto-activated.
      */
     void startExecutors();
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessEngineEvent.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/FlowableProcessEngineEvent.java
@@ -27,7 +27,7 @@ public interface FlowableProcessEngineEvent extends FlowableEngineEvent {
     /**
      * Return the execution this event is associated with. Returns null, if the event was not related to an active execution.
      * 
-     * Note that this will only retun a {@link DelegateExecution} instance when a command context is active.
+     * Note that this will only return a {@link DelegateExecution} instance when a command context is active.
      */
     DelegateExecution getExecution();
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessDefinitionCategoryCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessDefinitionCategoryCmd.java
@@ -64,7 +64,7 @@ public class SetProcessDefinitionCategoryCmd implements Command<Void> {
         // Update category
         processDefinition.setCategory(category);
 
-        // Remove process definition from cache, it will be refetched later
+        // Remove process definition from cache, it will be refetch later
         DeploymentCache<ProcessDefinitionCacheEntry> processDefinitionCache = processEngineConfiguration.getProcessDefinitionCache();
         if (processDefinitionCache != null) {
             processDefinitionCache.remove(processDefinitionId);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/context/Context.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/context/Context.java
@@ -22,7 +22,7 @@ import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.util.CommandContextUtil;
 
 /**
- * Quick access methods (only useable when within a command execution) to the current 
+ * Quick access methods (only usable when within a command execution) to the current
  * 
  * - {@link org.flowable.common.engine.impl.interceptor.CommandContext},
  * - {@link ProcessEngineConfigurationImpl}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ActivityInstanceEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ActivityInstanceEntityManager.java
@@ -59,7 +59,7 @@ public interface ActivityInstanceEntityManager extends EntityManager<ActivityIns
      * Record the start of an activity, if activity event logging is enabled.
      *
      * @param executionEntity
-     *     execution which is starting activityz
+     *     execution which is starting activity
      */
     void recordActivityStart(ExecutionEntity executionEntity);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/MybatisExecutionDataManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/MybatisExecutionDataManager.java
@@ -123,7 +123,7 @@ public class MybatisExecutionDataManager extends AbstractProcessDataManager<Exec
             return true;
         }
         
-        // Fetches execution tree. This will store them in the cache and thus avoind extra database calls.
+        // Fetches execution tree. This will store them in the cache and thus avoids extra database calls.
         getList("selectExecutionsWithSameRootProcessInstanceId", executionId,
                 executionsWithSameRootProcessInstanceIdMatcher, true);
         

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/migration/ProcessInstanceMigrationBuilder.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/migration/ProcessInstanceMigrationBuilder.java
@@ -85,7 +85,7 @@ public interface ProcessInstanceMigrationBuilder {
     /**
      * The java delegate expression executed before process instance migration
      *
-     * @param expressionString string which resolves into java delagate instance
+     * @param expressionString string which resolves into java delegate instance
      * @return process instance migration builder
      */
     ProcessInstanceMigrationBuilder preUpgradeJavaDelegateExpression(String expressionString);
@@ -109,7 +109,7 @@ public interface ProcessInstanceMigrationBuilder {
     /**
      * The java delegate expression executed after process instance migration
      *
-     * @param expressionString string which resolves into java delagate instance
+     * @param expressionString string which resolves into java delegate instance
      * @return process instance migration builder
      */
     ProcessInstanceMigrationBuilder postUpgradeJavaDelegateExpression(String expressionString);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/ProcessInstanceBuilder.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/ProcessInstanceBuilder.java
@@ -88,7 +88,7 @@ public interface ProcessInstanceBuilder {
     ProcessInstanceBuilder referenceType(String referenceType);
 
     /**
-     * Set the optional instance id of the stage this process instance belongs to, if it runns in the context of a CMMN case.
+     * Set the optional instance id of the stage this process instance belongs to, if it runs in the context of a CMMN case.
      */
     ProcessInstanceBuilder stageInstanceId(String stageInstanceId);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableExtension.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableExtension.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The ProcessEngine and the services will be made available to the test class through the parameter resolution (BeforeEach, AfterEach, test methods).
  * The ProcessEngine will be initialized by default with the flowable.cfg.xml resource on the classpath.
- * To specify a different configuration file, annotate your class witn {@link ConfigurationResource}.
+ * To specify a different configuration file, annotate your class with {@link ConfigurationResource}.
  * Process engines will be cached as part of the JUnit Jupiter Extension context.
  * Right before the first time the setUp is called for a given configuration resource, the process engine will be constructed.
  * </p>

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableTest.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/FlowableTest.java
@@ -50,9 +50,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </pre>
  *
  * <p>
- * The ProcessEngine and the services will be made available to the test class through the parameter resolution (BeforeEach, AfterEach, test moethds).
+ * The ProcessEngine and the services will be made available to the test class through the parameter resolution (BeforeEach, AfterEach, test methods).
  * The processEngine will be initialized by default with the flowable.cfg.xml resource on the classpath.
- * To specify a different configuration file, annotate your class witn {@link ConfigurationResource}.
+ * To specify a different configuration file, annotate your class with {@link ConfigurationResource}.
  * Process engines will be cached as part of the JUnit Jupiter Extension context.
  * Right before the first time the setUp is called for a given configuration resource, the process engine will be constructed.
  * </p>

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
@@ -742,7 +742,7 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("One");
 
-        // Completing the task should trigger the event subprocess. This interupts the main flow.
+        // Completing the task should trigger the event subprocess. This interrupts the main flow.
         taskService.complete(task.getId());
         Task subOneTask = taskService.createTaskQuery().taskName("sub one").singleResult();
         assertThat(subOneTask).isNotNull();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
@@ -2971,7 +2971,7 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
                 .extracting(Task::getProcessDefinitionId)
                 .containsOnly(procWithSignal.getId());
 
-        //Behaves like interrupting since theres no execution in the parentScop
+        //Behaves like interrupting since theres no execution in the parentScope
         job = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(job).isNull();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
@@ -3011,7 +3011,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
             // serializable - when starting the process instance
             // serializable - when triggering the received task (the value is updated so new detail is created)
             // json - when doing the migration new variable is set
-            // json - when triggering the received task (the value is udpated so new details is created
+            // json - when triggering the received task (the value is updated so new details is created
             assertThatVariablesTypeHistoryIs(processInstanceToMigrate, "serializable", "serializable", "json", "json");
         }
     }
@@ -3041,7 +3041,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
             // serializable - when starting the process instance
             // serializable - when triggering the received task (the value is updated so new detail is created)
             // json - when doing the migration new variable is set
-            // json - when triggering the received task (the value is udpated so new details is created
+            // json - when triggering the received task (the value is updated so new details is created
             assertThatVariablesTypeHistoryIs(processInstanceToMigrate, "serializable", "serializable", "json", "json");
         }
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -469,7 +469,7 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         Task taskAfterSubProcessInSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterSubProcessInSubProcess.getName()).isEqualTo("Task after subprocess");
 
-        // Completing this task finishes the first subproces
+        // Completing this task finishes the first subprocess
         taskService.complete(taskAfterSubProcessInSubProcess.getId());
         Task taskAfterSubProcess = taskService.createTaskQuery().singleResult();
         assertThat(taskAfterSubProcess.getName()).isEqualTo("Task after subprocess");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ThrowingDelegate.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/error/ThrowingDelegate.java
@@ -19,15 +19,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ThrowingDelegate implements JavaDelegate {
-	private static final Logger logger = LoggerFactory.getLogger(ThrowingDelegate.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(ThrowingDelegate.class);
 	
 	@Override
 	public void execute(DelegateExecution execution) {
-		logger.info("Entered throwing delegate");
+		LOGGER.info("Entered throwing delegate");
 		Boolean localError = (Boolean) execution.getVariable("localError");
 		
 		if (localError) {
-			logger.info("Throwing local error");
+			LOGGER.info("Throwing local error");
 			throw new BpmnError("localError");			
 		}
 	}

--- a/modules/flowable-jms-spring-executor/src/main/java/org/flowable/spring/executor/jms/HistoryJobMessageListener.java
+++ b/modules/flowable-jms-spring-executor/src/main/java/org/flowable/spring/executor/jms/HistoryJobMessageListener.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 public class HistoryJobMessageListener implements javax.jms.MessageListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(HistoryJobMessageListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HistoryJobMessageListener.class);
 
     protected JobServiceConfiguration jobServiceConfiguration;
     protected AsyncRunnableExecutionExceptionHandler exceptionHandler;
@@ -44,7 +44,7 @@ public class HistoryJobMessageListener implements javax.jms.MessageListener {
                 executeAsyncRunnable.run();
             }
         } catch (Exception e) {
-            logger.error("Exception when handling message from job queue", e);
+            LOGGER.error("Exception when handling message from job queue", e);
         }
     }
 

--- a/modules/flowable-ui/flowable-ui-common/src/main/java/org/flowable/ui/common/properties/BackwardsCompatiblePropertiesLoader.java
+++ b/modules/flowable-ui/flowable-ui-common/src/main/java/org/flowable/ui/common/properties/BackwardsCompatiblePropertiesLoader.java
@@ -77,7 +77,7 @@ public class BackwardsCompatiblePropertiesLoader implements EnvironmentPostProce
                     logger.info("Properties location [{}] not resolvable: {}", location, ex.getMessage());
                 }
             } catch (IOException ex) {
-                throw new UncheckedIOException("Failed to creaty property source", ex);
+                throw new UncheckedIOException("Failed to create property source", ex);
             }
         }
     }


### PR DESCRIPTION
Changed the case of the `logger` variable in  `private static final Logger logger` to all upper case to match all other uses. 

Also stumbled upon a few spelling/grammar mistakes and took the occasion to fix them.
