### PR TITLE
More typos

### DIFF
--- a/docs/docusaurus/docs/cmmn/ch08-REST.md
+++ b/docs/docusaurus/docs/cmmn/ch08-REST.md
@@ -1408,7 +1408,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 | - | - | - | - |
 |caseInstanceId|No|String|The case instance id for which the stage overview is retrieved.|    
 
-*Success reponse body* {
+*Success response body* {
 
 ```
 [

--- a/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/properties/BackwardsCompatiblePropertiesLoader.java
+++ b/modules/flowable-app-rest/src/main/java/org/flowable/rest/app/properties/BackwardsCompatiblePropertiesLoader.java
@@ -77,7 +77,7 @@ public class BackwardsCompatiblePropertiesLoader implements EnvironmentPostProce
                     logger.info("Properties location [{}] not resolvable: {}", location, ex.getMessage());
                 }
             } catch (IOException ex) {
-                throw new UncheckedIOException("Failed to creaty property source", ex);
+                throw new UncheckedIOException("Failed to create property source", ex);
             }
         }
     }

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ExtensionElementsXMLConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ExtensionElementsXMLConverter.java
@@ -231,7 +231,7 @@ public class ExtensionElementsXMLConverter extends CaseElementXmlConverter {
             ((FlowableListener) currentCmmnElement).getFieldExtensions().add(extension);
 
         } else {
-            throw new FlowableException("Programmatic error: field added to unkown element '" + currentCmmnElement + "'");
+            throw new FlowableException("Programmatic error: field added to unknown element '" + currentCmmnElement + "'");
 
         }
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/CreateInjectedPlanItemInstanceCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/CreateInjectedPlanItemInstanceCmd.java
@@ -117,7 +117,7 @@ public class CreateInjectedPlanItemInstanceCmd implements Command<PlanItemInstan
         CaseInstanceEntity caseInstanceEntity = cmmnEngineConfiguration.getCaseInstanceEntityManager().findById(planItemInstanceBuilder.getCaseInstanceId());
         if (caseInstanceEntity == null) {
             throw new FlowableIllegalArgumentException(
-                "The case instance with id " + planItemInstanceBuilder.getCaseInstanceId() + " could not be found or is no longer an ative case instance.");
+                "The case instance with id " + planItemInstanceBuilder.getCaseInstanceId() + " could not be found or is no longer an active case instance.");
         }
         return caseInstanceEntity;
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/ChangePlanItemStateBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/ChangePlanItemStateBuilderImpl.java
@@ -144,7 +144,7 @@ public class ChangePlanItemStateBuilderImpl implements ChangePlanItemStateBuilde
     @Override
     public void changeState() {
         if (runtimeService == null) {
-            throw new FlowableException("CmmnRuntimeService cannot be null, Obtain your builder instance from the CmmnRuntimService to access this feature");
+            throw new FlowableException("CmmnRuntimeService cannot be null, Obtain your builder instance from the CmmnRuntimeService to access this feature");
         }
         runtimeService.changePlanItemState(this);
     }

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverter.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverter.java
@@ -341,7 +341,7 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
         CmmnModel cmmnModel = new CmmnModel();
         CmmnModelIdHelper cmmnModelIdHelper = new CmmnModelIdHelper();
 
-        cmmnModel.setTargetNamespace("http://flowable.org/cmmn"); // will be overriden later with actual value
+        cmmnModel.setTargetNamespace("http://flowable.org/cmmn"); // will be overridden later with actual value
         Map<String, JsonNode> shapeMap = new HashMap<>();
         Map<String, JsonNode> sourceRefMap = new HashMap<>();
         Map<String, JsonNode> edgeMap = new HashMap<>();

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/management/HistoryJobCollectionResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/management/HistoryJobCollectionResource.java
@@ -59,7 +59,7 @@ public class HistoryJobCollectionResource {
             @ApiImplicitParam(name = "id", dataType = "string", value = "Only return the job with the given id", paramType = "query"),
             @ApiImplicitParam(name = "withException", dataType = "boolean", value = "If true, only return jobs for which an exception occurred while executing it. If false, this parameter is ignored.", paramType = "query"),
             @ApiImplicitParam(name = "exceptionMessage", dataType = "string", value = "Only return jobs with the given exception message", paramType = "query"),
-            @ApiImplicitParam(name = "scopeTyoe", dataType = "string", value = "Only return jobs with the given scope type", paramType = "query"),
+            @ApiImplicitParam(name = "scopeType", dataType = "string", value = "Only return jobs with the given scope type", paramType = "query"),
             @ApiImplicitParam(name = "tenantId", dataType = "string", value = "Only return jobs with the given tenantId.", paramType = "query"),
             @ApiImplicitParam(name = "tenantIdLike", dataType = "string", value = "Only return jobs with a tenantId like the given value.", paramType = "query"),
             @ApiImplicitParam(name = "withoutTenantId", dataType = "boolean", value = "If true, only returns jobs without a tenantId set. If false, the withoutTenantId parameter is ignored.", paramType = "query"),

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/repository/CaseDefinitionIdentityLinkCollectionResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/repository/CaseDefinitionIdentityLinkCollectionResource.java
@@ -59,7 +59,7 @@ public class CaseDefinitionIdentityLinkCollectionResource extends BaseCaseDefini
     @ApiResponses(value = {
             @ApiResponse(code = 201, message = "Indicates the case definition was found and the identity link was created."),
             @ApiResponse(code = 400, message = "Indicates the body does not contain the correct information."),
-            @ApiResponse(code = 404, message = "Indicates the requested ccase definition was not found.")
+            @ApiResponse(code = 404, message = "Indicates the requested case definition was not found.")
     })
     @PostMapping(value = "/cmmn-repository/case-definitions/{caseDefinitionId}/identitylinks", produces = "application/json")
     public RestIdentityLink createIdentityLink(@ApiParam(name = "caseDefinitionId") @PathVariable String caseDefinitionId, @RequestBody RestIdentityLink identityLink, HttpServletRequest request, HttpServletResponse response) {

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceMock.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WebServiceMock.java
@@ -73,7 +73,7 @@ public interface WebServiceMock {
     void setTo(@WebParam(name = "value") int value);
 
     /**
-     * Returns a formated string composed of prefix + current count + suffix
+     * Returns a formatted string composed of prefix + current count + suffix
      *
      * @param prefix
      *            the prefix

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -248,8 +248,8 @@ public abstract class AbstractEngineConfiguration {
     protected boolean usingRelationalDatabase = true;
     
     /**
-     * Flag that can be set to configure whether or not a schema is used. This is usefil for custom implementations that do not use relational databases at all.
-     * Setting {@link #usingRelationalDatabase} to true will automotically imply using a schema.
+     * Flag that can be set to configure whether or not a schema is used. This is useful for custom implementations that do not use relational databases at all.
+     * Setting {@link #usingRelationalDatabase} to true will automatically imply using a schema.
      */
     protected boolean usingSchemaMgmt = true;
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/javax/el/Expression.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/javax/el/Expression.java
@@ -20,7 +20,7 @@ import java.util.Hashtable;
 
 /**
  * Base class for the expression subclasses {@link ValueExpression} and {@link MethodExpression},
- * implementing characterstics common to both. All expressions must implement the equals() and
+ * implementing characteristics common to both. All expressions must implement the equals() and
  * hashCode() methods so that two expressions can be compared for equality. They are redefined
  * abstract in this class to force their implementation in subclasses. All expressions must also be
  * Serializable so that they can be saved and restored. Expressions are also designed to be
@@ -76,7 +76,7 @@ public abstract class Expression implements Serializable {
 	/**
 	 * Returns whether this expression was created from only literal text. This method must return
 	 * true if and only if the expression string this expression was created from contained no
-	 * unescaped EL delimeters (${...} or #{...}).
+	 * unescaped EL delimiters (${...} or #{...}).
 	 * 
 	 * @return true if this expression was created from only literal text; false otherwise.
 	 */

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/runtime/ChangeActivityStateBuilderImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/runtime/ChangeActivityStateBuilderImpl.java
@@ -220,7 +220,7 @@ public class ChangeActivityStateBuilderImpl implements ChangeActivityStateBuilde
     @Override
     public void changeState() {
         if (runtimeService == null) {
-            throw new FlowableException("RuntimeService cannot be null, Obtain your builder instance from the RuntimService to access this feature");
+            throw new FlowableException("RuntimeService cannot be null, Obtain your builder instance from the RuntimeService to access this feature");
         }
         runtimeService.changeActivityState(this);
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -247,7 +247,7 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         TimerJobQuery jobQuery = managementService.createTimerJobQuery().processInstanceId(pi.getId());
         assertThat(jobQuery.count()).isEqualTo(2);
 
-        // After setting the clock to time '50minutes and 5 seconds', the bouth timers should fire in parralel
+        // After setting the clock to time '50minutes and 5 seconds', the both timers should fire in parallel
         processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + ((50 * 60 * 1000) + 5000)));
         try {
             JobTestHelper.waitForJobExecutorToProcessAllJobsAndExecutableTimerJobs(

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAVariableTest.java
@@ -382,7 +382,7 @@ public class JPAVariableTest extends ResourceFlowableTestCase {
     public void testStoreJPAEntityListAsVariableEdgeCases() {
 
         // Test using mixed JPA-entities which are not serializable, should not
-        // be picked up by JPA list type en therefor fail due to serialization error
+        // be picked up by JPA list type and therefore fail due to serialization error
         assertThatThrownBy(() ->
         {
             Map<String, Object> variables = new HashMap<>();

--- a/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/repository/ChannelDefinitionModelResource.java
+++ b/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/repository/ChannelDefinitionModelResource.java
@@ -33,7 +33,7 @@ import io.swagger.annotations.Authorization;
 @Api(tags = { "Channel Definitions" }, description = "Manage Channel Definitions", authorizations = { @Authorization(value = "basicAuth") })
 public class ChannelDefinitionModelResource extends BaseEventDefinitionResource {
 
-    @ApiOperation(value = "Get a channel definition JSPN model", tags = { "Channel Definitions" }, nickname = "getChannelModelResource")
+    @ApiOperation(value = "Get a channel definition JSON model", tags = { "Channel Definitions" }, nickname = "getChannelModelResource")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Indicates the event definition was found and the model is returned. The response contains the full event definition model."),
             @ApiResponse(code = 404, message = "Indicates the requested event definition was not found.")

--- a/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/repository/EventDefinitionModelResource.java
+++ b/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/repository/EventDefinitionModelResource.java
@@ -33,7 +33,7 @@ import io.swagger.annotations.Authorization;
 @Api(tags = { "Event Definitions" }, description = "Manage Event Definitions", authorizations = { @Authorization(value = "basicAuth") })
 public class EventDefinitionModelResource extends BaseEventDefinitionResource {
 
-    @ApiOperation(value = "Get an event definition JSPN model", tags = { "Event Definitions" }, nickname = "getEventModelResource")
+    @ApiOperation(value = "Get an event definition JSON model", tags = { "Event Definitions" }, nickname = "getEventModelResource")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Indicates the event definition was found and the model is returned. The response contains the full event definition model."),
             @ApiResponse(code = 404, message = "Indicates the requested event definition was not found.")

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/cmd/SetChannelDefinitionCategoryCmd.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/cmd/SetChannelDefinitionCategoryCmd.java
@@ -51,7 +51,7 @@ public class SetChannelDefinitionCategoryCmd implements Command<Void> {
         // Update category
         channelDefinition.setCategory(category);
 
-        // Remove channel from cache, it will be refetched later
+        // Remove channel from cache, it will be refetch later
         DeploymentCache<ChannelDefinitionCacheEntry> channelDefinitionCache = CommandContextUtil.getEventRegistryConfiguration().getChannelDefinitionCache();
         if (channelDefinitionCache != null) {
             channelDefinitionCache.remove(channelDefinitionId);

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/cmd/SetEventDefinitionCategoryCmd.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/cmd/SetEventDefinitionCategoryCmd.java
@@ -51,7 +51,7 @@ public class SetEventDefinitionCategoryCmd implements Command<Void> {
         // Update category
         eventDefinition.setCategory(category);
 
-        // Remove form from cache, it will be refetched later
+        // Remove form from cache, it will be refetch later
         DeploymentCache<EventDefinitionCacheEntry> eventDefinitionCache = CommandContextUtil.getEventRegistryConfiguration().getEventDefinitionCache();
         if (eventDefinitionCache != null) {
             eventDefinitionCache.remove(eventDefinitionId);

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/persistence/entity/ChannelDefinitionEntityImpl.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/persistence/entity/ChannelDefinitionEntityImpl.java
@@ -139,7 +139,7 @@ public class ChannelDefinitionEntityImpl extends AbstractEventRegistryNoRevision
 
     @Override
     public String toString() {
-        return "ChannelDefitionEntity[" + id + "]";
+        return "ChannelDefinitionEntity[" + id + "]";
     }
 
 }

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/persistence/entity/EventDefinitionEntityImpl.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/persistence/entity/EventDefinitionEntityImpl.java
@@ -127,7 +127,7 @@ public class EventDefinitionEntityImpl extends AbstractEventRegistryNoRevisionEn
 
     @Override
     public String toString() {
-        return "EventDefitionEntity[" + id + "]";
+        return "EventDefinitionEntity[" + id + "]";
     }
 
 }

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/SetFormDefinitionCategoryCmd.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/impl/cmd/SetFormDefinitionCategoryCmd.java
@@ -51,7 +51,7 @@ public class SetFormDefinitionCategoryCmd implements Command<Void> {
         // Update category
         formDefinition.setCategory(category);
 
-        // Remove form from cache, it will be refetched later
+        // Remove form from cache, it will be refetch later
         DeploymentCache<FormDefinitionCacheEntry> formDefinitionCache = CommandContextUtil.getFormEngineConfiguration().getFormDefinitionCache();
         if (formDefinitionCache != null) {
             formDefinitionCache.remove(formDefinitionId);

--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/ExpressionUtils.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/ExpressionUtils.java
@@ -54,7 +54,7 @@ public abstract class ExpressionUtils {
                 if (stringValue.equalsIgnoreCase("true") || stringValue.equalsIgnoreCase("false")) {
                     return Boolean.parseBoolean(value.toString());
                 }
-                throw new FlowableException("String value \"" + value + "\" is not alloved in boolean expression");
+                throw new FlowableException("String value \"" + value + "\" is not allowed in boolean expression");
             }
             if (value instanceof Boolean) {
                 return (Boolean) value;

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/validation/HttpServiceTaskValidationTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/validation/HttpServiceTaskValidationTest.java
@@ -51,7 +51,7 @@ public class HttpServiceTaskValidationTest extends HttpServiceTaskTestCase {
     public void testInvalidFlags() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("invalidFlags"))
                 .isExactlyInstanceOf(FlowableException.class)
-                .hasMessage("String value \"Accept application/json\" is not alloved in boolean expression");
+                .hasMessage("String value \"Accept application/json\" is not allowed in boolean expression");
     }
 
     @Test

--- a/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/DefaultManagementAgent.java
+++ b/modules/flowable-jmx/src/main/java/org/flowable/management/jmx/DefaultManagementAgent.java
@@ -194,7 +194,7 @@ public class DefaultManagementAgent implements ManagementAgent {
             return;
         }
         if (registryPort == null) {
-            LOGGER.warn("Registery port is null. JMX connector creation skipped.");
+            LOGGER.warn("Registry port is null. JMX connector creation skipped.");
             return;
         }
 

--- a/modules/flowable-job-service-api/src/main/java/org/flowable/job/api/Job.java
+++ b/modules/flowable-job-service-api/src/main/java/org/flowable/job/api/Job.java
@@ -31,7 +31,7 @@ public interface Job extends JobInfo {
 
     /**
      * Returns the correlation id of a job.
-     * The same job can be moved around and have its techinical id changed.
+     * The same job can be moved around and have its technical id changed.
      * This id allows tracking that job.
      */
     String getCorrelationId();

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/DeadLetterJobQueryImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/DeadLetterJobQueryImpl.java
@@ -317,7 +317,7 @@ public class DeadLetterJobQueryImpl extends AbstractQuery<DeadLetterJobQuery, Jo
     @Override
     public DeadLetterJobQueryImpl jobTenantId(String tenantId) {
         if (tenantId == null) {
-            throw new FlowableIllegalArgumentException("Provided tentant id is null");
+            throw new FlowableIllegalArgumentException("Provided tenant id is null");
         }
         this.tenantId = tenantId;
         return this;
@@ -326,7 +326,7 @@ public class DeadLetterJobQueryImpl extends AbstractQuery<DeadLetterJobQuery, Jo
     @Override
     public DeadLetterJobQueryImpl jobTenantIdLike(String tenantIdLike) {
         if (tenantIdLike == null) {
-            throw new FlowableIllegalArgumentException("Provided tentant id is null");
+            throw new FlowableIllegalArgumentException("Provided tenant id is null");
         }
         this.tenantIdLike = tenantIdLike;
         return this;

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/TimerJobQueryImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/TimerJobQueryImpl.java
@@ -292,7 +292,7 @@ public class TimerJobQueryImpl extends AbstractQuery<TimerJobQuery, Job> impleme
     @Override
     public TimerJobQueryImpl jobTenantId(String tenantId) {
         if (tenantId == null) {
-            throw new FlowableIllegalArgumentException("Provided tentant id is null");
+            throw new FlowableIllegalArgumentException("Provided tenant id is null");
         }
         this.tenantId = tenantId;
         return this;
@@ -301,7 +301,7 @@ public class TimerJobQueryImpl extends AbstractQuery<TimerJobQuery, Job> impleme
     @Override
     public TimerJobQueryImpl jobTenantIdLike(String tenantIdLike) {
         if (tenantIdLike == null) {
-            throw new FlowableIllegalArgumentException("Provided tentant id is null");
+            throw new FlowableIllegalArgumentException("Provided tenant id is null");
         }
         this.tenantIdLike = tenantIdLike;
         return this;

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -148,7 +148,7 @@ public class DefaultAsyncJobExecutor extends AbstractAsyncExecutor {
     protected void initAsyncJobExecutionThreadPool() {
         if (taskExecutor == null) {
             // This is for backwards compatibility
-            // If there is no task executor then use the Default one and start it immediatelly.
+            // If there is no task executor then use the Default one and start it immediately.
             DefaultAsyncTaskExecutor defaultAsyncTaskExecutor = new DefaultAsyncTaskExecutor();
             defaultAsyncTaskExecutor.start();
             this.taskExecutor = defaultAsyncTaskExecutor;

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/ManagedAsyncJobExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/ManagedAsyncJobExecutor.java
@@ -50,7 +50,7 @@ public class ManagedAsyncJobExecutor extends DefaultAsyncJobExecutor {
             super.initAsyncJobExecutionThreadPool();
         } else if (taskExecutor != null) {
             // This is for backwards compatibility
-            // If there is no task executor then use the Default one and start it immediatelly.
+            // If there is no task executor then use the Default one and start it immediately.
             DefaultAsyncTaskExecutor defaultAsyncTaskExecutor = new DefaultAsyncTaskExecutor();
             defaultAsyncTaskExecutor.setThreadFactory(threadFactory);
             defaultAsyncTaskExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/message/AsyncJobMessageReceiver.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/message/AsyncJobMessageReceiver.java
@@ -29,11 +29,11 @@ import org.flowable.job.service.impl.persistence.entity.JobEntityManager;
  * Helper class to be used in a setup of async jobs handling where the job is 
  * inserted in the same database transaction as the runtime data in combination with sending message to a message queue.
  * 
- * Use a sublass of {@link AbstractMessageBasedJobManager} to send the message, this
+ * Use a subclass of {@link AbstractMessageBasedJobManager} to send the message, this
  * class, with the proper handler instance set, will take care of handling it on the receiving side.
  * 
  * This class contains the boilerplate logic that is needed to fetch the job data 
- * and delete the job in case of a succesful processing.
+ * and delete the job in case of a successful processing.
  * 
  * @author Joram Barrez
  */

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/history/async/DefaultAsyncHistoryJobProducer.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/history/async/DefaultAsyncHistoryJobProducer.java
@@ -119,7 +119,7 @@ public class DefaultAsyncHistoryJobProducer implements AsyncHistoryListener {
     
     protected void processHistoryJobEntities(CommandContext commandContext, JobServiceConfiguration jobServiceConfiguration,
             List<ObjectNode> historyObjectNodes, List<HistoryJobEntity> historyJobEntities) {
-        // Meant to be overidden in case something extra needs to happen with the created history job entities. 
+        // Meant to be overridden in case something extra needs to happen with the created history job entities.
     }
 
 }

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/SubProcessJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/SubProcessJsonConverter.java
@@ -110,7 +110,7 @@ public class SubProcessJsonConverter extends BaseBpmnJsonConverter {
             subProcess.getFlowElements().addAll(dataObjects);
         }
         
-        //store correct convertion info...
+        //store correct conversion info...
         if (STENCIL_COLLAPSED_SUB_PROCESS.equals(BpmnJsonConverterUtil.getStencilId(elementNode))) {
             GraphicInfo graphicInfo = model.getGraphicInfo(BpmnJsonConverterUtil.getElementId(elementNode));
             graphicInfo.setExpanded(false); //default is null!

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/HistoryJobCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/HistoryJobCollectionResource.java
@@ -59,7 +59,7 @@ public class HistoryJobCollectionResource {
             @ApiImplicitParam(name = "id", dataType = "string", value = "Only return the job with the given id", paramType = "query"),
             @ApiImplicitParam(name = "withException", dataType = "boolean", value = "If true, only return jobs for which an exception occurred while executing it. If false, this parameter is ignored.", paramType = "query"),
             @ApiImplicitParam(name = "exceptionMessage", dataType = "string", value = "Only return jobs with the given exception message", paramType = "query"),
-            @ApiImplicitParam(name = "scopeTyoe", dataType = "string", value = "Only return jobs with the given scope type", paramType = "query"),
+            @ApiImplicitParam(name = "scopeType", dataType = "string", value = "Only return jobs with the given scope type", paramType = "query"),
             @ApiImplicitParam(name = "tenantId", dataType = "string", value = "Only return jobs with the given tenantId.", paramType = "query"),
             @ApiImplicitParam(name = "tenantIdLike", dataType = "string", value = "Only return jobs with a tenantId like the given value.", paramType = "query"),
             @ApiImplicitParam(name = "withoutTenantId", dataType = "boolean", value = "If true, only returns jobs without a tenantId set. If false, the withoutTenantId parameter is ignored.", paramType = "query"),

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
@@ -79,7 +79,7 @@ public class ProcessInstanceCollectionResource extends BaseProcessInstanceResour
             @ApiImplicitParam(name = "processDefinitionVersion", dataType = "integer", value = "Only return process instances with the given process definition version.", paramType = "query"),
             @ApiImplicitParam(name = "processDefinitionEngineVersion", dataType = "string", value = "Only return process instances with the given process definition engine version.", paramType = "query"),
             @ApiImplicitParam(name = "businessKey", dataType = "string", value = "Only return process instances with the given businessKey.", paramType = "query"),
-            @ApiImplicitParam(name = "businessKeyLike", dataType = "string", value = "Only return process instancess with the businessKey like the given key.", paramType = "query"),
+            @ApiImplicitParam(name = "businessKeyLike", dataType = "string", value = "Only return process instances with the businessKey like the given key.", paramType = "query"),
             @ApiImplicitParam(name = "startedBy", dataType = "string", value = "Only return process instances started by the given user.", paramType = "query"),
             @ApiImplicitParam(name = "startedBefore", dataType = "string", format = "date-time", value = "Only return process instances started before the given date.", paramType = "query"),
             @ApiImplicitParam(name = "startedAfter", dataType = "string", format = "date-time", value = "Only return process instances started after the given date.", paramType = "query"),

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCollectionResourceTest.java
@@ -193,7 +193,7 @@ public class TaskCollectionResourceTest extends BaseSpringRestTestCase {
             url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?priority=100";
             assertResultsPresentInDataResponse(url, adhocTask.getId());
 
-            // Mininmum Priority filtering
+            // Minimum Priority filtering
             url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?minimumPriority=70";
             assertResultsPresentInDataResponse(url, adhocTask.getId());
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskQueryResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskQueryResourceTest.java
@@ -118,7 +118,7 @@ public class TaskQueryResourceTest extends BaseSpringRestTestCase {
             requestNode.put("priority", 100);
             assertResultsPresentInPostDataResponse(url, requestNode, adhocTask.getId());
 
-            // Mininmum Priority filtering
+            // Minimum Priority filtering
             requestNode.removeAll();
             requestNode.put("minimumPriority", 70);
             assertResultsPresentInPostDataResponse(url, requestNode, adhocTask.getId());

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/form/FormEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/form/FormEngineAutoConfiguration.java
@@ -115,7 +115,7 @@ public class FormEngineAutoConfiguration extends AbstractSpringEngineAutoConfigu
         }
 
         CommonAutoDeploymentProperties deploymentProperties = this.autoDeploymentProperties.deploymentPropertiesForEngine(ScopeTypes.FORM);
-        // Always add the out of the box auto deyment strategies as last
+        // Always add the out of the box auto deployment strategies as last
         deploymentStrategies.add(new DefaultAutoDeploymentStrategy(deploymentProperties));
         deploymentStrategies.add(new SingleResourceAutoDeploymentStrategy(deploymentProperties));
         deploymentStrategies.add(new ResourceParentFolderAutoDeploymentStrategy(deploymentProperties));

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/transaction/SpringTransactionAndExceptionsTest.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/transaction/SpringTransactionAndExceptionsTest.java
@@ -244,7 +244,7 @@ public class SpringTransactionAndExceptionsTest extends SpringFlowableTestCase {
             @Override
             public void execute(DelegateExecution execution) {
 
-                // Exception gets catched, so shouldn't lead to rolling back the whole transaction
+                // Exception gets caught, so shouldn't lead to rolling back the whole transaction
                 try {
                     managementService.executeCommand(new Command<Void>() {
 

--- a/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/CmmnJobClientResource.java
+++ b/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/CmmnJobClientResource.java
@@ -111,7 +111,7 @@ public class CmmnJobClientResource extends AbstractClientResource {
     }
 
     /**
-     * GET /rest/admin/cmmn-jobs/{jobId}/exception-stracktrace -> return job stacktrace
+     * GET /rest/admin/cmmn-jobs/{jobId}/exception-stacktrace -> return job stacktrace
      */
     @GetMapping(value = "/rest/admin/cmmn-jobs/{jobId}/stacktrace", produces = "text/plain")
     public String getCmmnJobStacktrace(@PathVariable String jobId, HttpServletRequest request) throws BadRequestException {

--- a/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/JobClientResource.java
+++ b/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/JobClientResource.java
@@ -111,7 +111,7 @@ public class JobClientResource extends AbstractClientResource {
     }
 
     /**
-     * GET /rest/admin/jobs/{jobId}/exception-stracktrace -> return job stacktrace
+     * GET /rest/admin/jobs/{jobId}/exception-stacktrace -> return job stacktrace
      */
     @GetMapping(value = "/rest/admin/jobs/{jobId}/stacktrace", produces = "text/plain")
     public String getJobStacktrace(@PathVariable String jobId, HttpServletRequest request) throws BadRequestException {

--- a/modules/flowable-ui/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/properties/FlowableIdmAppProperties.java
+++ b/modules/flowable-ui/flowable-ui-idm-logic/src/main/java/org/flowable/ui/idm/properties/FlowableIdmAppProperties.java
@@ -238,7 +238,7 @@ public class FlowableIdmAppProperties {
     public static class Keycloak {
 
         /**
-         * Whether the keyloak idm service should be enabled
+         * Whether the keycloak idm service should be enabled
          */
         private boolean enabled = false;
 

--- a/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/ConverterContext.java
+++ b/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/ConverterContext.java
@@ -395,7 +395,7 @@ public class ConverterContext implements BpmnJsonConverterContext, CmmnJsonConve
     }
 
     /*
-     * Model JSON String retieval
+     * Model JSON String retrieval
      */
 
     public Map<String, String> getProcessKeyToJsonStringMap() {

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/VariableService.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/VariableService.java
@@ -46,7 +46,7 @@ public interface VariableService {
      * <b>IMPORTANT:</b> If you use this method you would have to call {@link VariableInstanceEntity#setValue(Object)}
      * for setting the value
      * @param name the name of the variable to create
-     * @param type the type of the creted variable
+     * @param type the type of the created variable
      *
      * @return the {@link VariableInstanceEntity} to be used
      */

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/VariableInstanceEntityManager.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/VariableInstanceEntityManager.java
@@ -30,7 +30,7 @@ public interface VariableInstanceEntityManager extends EntityManager<VariableIns
      * <b>IMPORTANT:</b> If you use this method you would have to call {@link VariableInstanceEntity#setValue(Object)}
      * for setting the value
      * @param name the name of the variable to create
-     * @param type the type of the creted variable
+     * @param type the type of the created variable
      *
      * @return the {@link VariableInstanceEntity} to be used
      */

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/VariableScopeImpl.java
@@ -1060,7 +1060,7 @@ public abstract class VariableScopeImpl extends AbstractEntity implements Serial
     }
 
     /**
-     * Return whether changes to the variables are progagated to the history storage.
+     * Return whether changes to the variables are propagated to the history storage.
      */
     protected abstract boolean isPropagateToHistoricVariable();
     


### PR DESCRIPTION
Fixed more typos.   There are many remaining issues but they are used either too often, are in model code, method names, or are file names.   There was even one case where I couldn't figure out what was meant; the word **cuby** in `org.flowable.engine.RuntimeService` where it reads (line 1061):
<pre>
.....  which are included in the cuby SQL directly.
</pre>

Anytime a correction was made to a message (e.g., exception message) I checked that it wasn't used anywhere else or if it was for example in a test I made the corresponding change.

The most **risky** changes were in the files `HistoryJobCollectionResource` which can be found in both the `flowable-rest` and `flowable-cmmn-rest` modules where the code reads (line 62):
<pre>
 @ApiImplicitParam(name = "scopeTyoe", dataType = "string", value = ...
</pre>
and I changed the **name** from **scopeTyoe** to **scopeType**
<pre>
 @ApiImplicitParam(name = "scopeType", dataType = "string", value = ...
</pre>