### PR TITLE
Fixed bug in Flowable admin app where terminating a case failed with …

### DIFF
--- a/modules/flowable-ui/flowable-ui-admin-frontend/src/main/resources/static/admin/scripts/case-instance-controllers.js
+++ b/modules/flowable-ui/flowable-ui-admin-frontend/src/main/resources/static/admin/scripts/case-instance-controllers.js
@@ -415,7 +415,7 @@ flowableAdminApp.controller('CaseInstanceController', ['$scope', '$rootScope', '
                 templateUrl: 'views/case-instance-delete-popup.html',
                 controller: 'DeleteCaseModalInstanceCtrl',
                 resolve: {
-                    process: function () {
+                    caseInstance: function () {
                         return $scope.caseInstance;
                     },
                     action: function () {
@@ -425,7 +425,7 @@ flowableAdminApp.controller('CaseInstanceController', ['$scope', '$rootScope', '
             });
 
             modalInstance.result.then(function (deleteCaseInstance) {
-                if (deleteProcessInstance) {
+                if (deleteCaseInstance) {
                     if (action == 'delete') {
                         $scope.addAlert($translate.instant('ALERT.CASE-INSTANCE.DELETED', $scope.caseInstance), 'info');
                         $scope.returnToList();


### PR DESCRIPTION
…d with an error in the frontend

#### Check List:
* Unit tests: NO
* Documentation: NO

I found a bug in the Flowable UI admin app. When trying to terminate a case instance from the case instance view (e.g. http://localhost:8080/flowable-ui/admin/#/case-instance/e2ed07e2-09fe-11eb-bc9f-080027d168e9) then an javascript error would occur when pressing the terminate button and the case instance would fail to be terminated.

![bild](https://user-images.githubusercontent.com/592501/95554043-d0467e00-0a0f-11eb-80d9-5139352b563a.png)

Gives the following stacktrace.

```
Error: [$injector:unpr] http://errors.angularjs.org/1.3.13/$injector/unpr?p0=caseInstanceProvider%20%3C-%20caseInstance%20%3C-%20DeleteCaseModalInstanceCtrl
S/<@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:6:417
ab/n.$injector<@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:38:7
d@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:36:13
ab/u.$injector<@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:38:81
d@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:36:13
e@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:36:283
instantiate@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:36:432
Fe/this.$get</<@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:76:5
a.$get</k.open/<@http://localhost:8080/flowable-ui/admin/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js:8:29473
f/<@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:112:20
$eval@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:125:305
$digest@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:122:398
$apply@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:126:58
l@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:81:171
P@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:85:301
vf/</w.onload@http://localhost:8080/flowable-ui/admin/bower_components/angular/angular.min.js:86:315
```

In the code there are references to variables called `process` and `deleteProcessInstance` rather than `caseInstance` and `deleteCaseInstance`. I would guess this was a copy and paste error when creating the controller, and the names have now been corrected.