### PR TITLE
Update tests with more idiomatic AssertJ syntax

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/ActivityEventsTest.java
@@ -683,7 +683,6 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertThat(signalEvent.getActivityId()).isEqualTo("cloudformtask1");
         assertThat(signalEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
         assertThat(signalEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
-        assertThat(signalEvent.getCause()).isNotNull();
         assertThat(signalEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         BoundaryEvent cause = (BoundaryEvent) signalEvent.getCause();
         assertThat(((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef()).isEqualTo("message_1");
@@ -780,7 +779,6 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertThat(cancelEvent.getActivityId()).isEqualTo("cloudformtask1");
         assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
         assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
-        assertThat(cancelEvent.getCause()).isNotNull();
         assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         BoundaryEvent cause = (BoundaryEvent) cancelEvent.getCause();
         assertThat(((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef()).isEqualTo("message_1");
@@ -791,7 +789,6 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertThat(cancelEvent.getActivityId()).isEqualTo("subProcess");
         assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithMessage.getProcessInstanceId());
         assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
-        assertThat(cancelEvent.getCause()).isNotNull();
         assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         cause = (BoundaryEvent) cancelEvent.getCause();
         assertThat(((MessageEventDefinition) cause.getEventDefinitions().get(0)).getMessageRef()).isEqualTo("message_1");
@@ -875,7 +872,6 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertThat(cancelEvent.getExecutionId()).isEqualTo(executionWithSignal.getId());
         assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
         assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
-        assertThat(cancelEvent.getCause()).isNotNull();
         assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         BoundaryEvent cause = (BoundaryEvent) cancelEvent.getCause();
         assertThat(cause.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);
@@ -890,7 +886,6 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertThat(cancelEvent.getActivityId()).isEqualTo("subProcess");
         assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
         assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
-        assertThat(cancelEvent.getCause()).isNotNull();
         assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         cause = (BoundaryEvent) cancelEvent.getCause();
         assertThat(cause.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);
@@ -934,7 +929,6 @@ public class ActivityEventsTest extends PluggableFlowableTestCase {
         assertThat(cancelEvent.getActivityId()).isEqualTo("userTask");
         assertThat(cancelEvent.getProcessInstanceId()).isEqualTo(executionWithSignal.getProcessInstanceId());
         assertThat(cancelEvent.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
-        assertThat(cancelEvent.getCause()).isNotNull();
         assertThat(cancelEvent.getCause()).isInstanceOf(BoundaryEvent.class);
         BoundaryEvent cause = (BoundaryEvent) cancelEvent.getCause();
         assertThat(cause.getEventDefinitions().get(0)).isInstanceOf(SignalEventDefinition.class);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/AttachmentEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/AttachmentEventsTest.java
@@ -77,7 +77,6 @@ public class AttachmentEventsTest extends PluggableFlowableTestCase {
             Authentication.setAuthenticatedUserId("testuser");
             attachment = taskService.createAttachment("test", task.getId(), processInstance.getId(), "attachment name", "description",
                     new ByteArrayInputStream("test".getBytes()));
-            assertThat(attachment.getUserId()).isNotNull();
             assertThat(attachment.getUserId()).isEqualTo("testuser");
             assertThat(listener.getEventsReceived()).hasSize(2);
             event = (FlowableEngineEntityEvent) listener.getEventsReceived().get(0);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CallActivityTest.java
@@ -139,7 +139,6 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(1);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertThat(executionEntity.getParentId()).isNotNull();
         assertThat(executionEntity.getParentId()).isEqualTo(processExecutionId);
 
         FlowableEvent flowableEvent = mylistener.getEventsReceived().get(2);
@@ -307,7 +306,6 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(1);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertThat(executionEntity.getParentId()).isNotNull();
         assertThat(executionEntity.getParentId()).isEqualTo(processExecutionId);
 
         FlowableEvent flowableEvent = mylistener.getEventsReceived().get(2);
@@ -447,7 +445,6 @@ public class CallActivityTest extends PluggableFlowableTestCase {
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(idx++);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertThat(executionEntity.getParentId()).isNotNull();
         assertThat(executionEntity.getParentId()).isEqualTo(processExecutionId);
 
         FlowableEvent flowableEvent = mylistener.getEventsReceived().get(idx++);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/CancelCallActivityTest.java
@@ -104,7 +104,6 @@ public class CancelCallActivityTest extends PluggableFlowableTestCase {
         entityEvent = (FlowableEntityEvent) mylistener.getEventsReceived().get(1);
         assertThat(entityEvent.getType()).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         executionEntity = (ExecutionEntity) entityEvent.getEntity();
-        assertThat(executionEntity.getParentId()).isNotNull();
         assertThat(executionEntity.getParentId()).isEqualTo(processExecutionId);
 
         FlowableEvent activitiEvent = mylistener.getEventsReceived().get(2);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/DatabaseEventLoggerTest.java
@@ -100,7 +100,6 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
             if (i == 0) {
 
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_CREATED.name());
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -116,15 +115,13 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.PROCESS_INSTANCE_ID,
                                 Fields.VALUE_STRING,
                                 Fields.TENANT_ID
-                        );
-                assertThat(data)
+                        )
                         .containsEntry(Fields.TENANT_ID, testTenant);
             }
 
             // process instance start
             if (i == 1) {
 
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo("PROCESSINSTANCE_START");
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -140,21 +137,19 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.ID,
                                 Fields.PROCESS_DEFINITION_ID,
                                 Fields.TENANT_ID
-                        );
-                assertThat(data)
+                        )
                         .containsEntry(Fields.TENANT_ID, testTenant);
 
                 Map<String, Object> variableMap = (Map<String, Object>) data.get(Fields.VARIABLES);
                 assertThat(variableMap)
                         .containsOnly(entry("testVar", "helloWorld"));
 
-                assertThat(data).doesNotContainKey(Fields.NAME);
-                assertThat(data).doesNotContainKey(Fields.BUSINESS_KEY);
+                assertThat(data)
+                        .doesNotContainKeys(Fields.NAME, Fields.BUSINESS_KEY);
             }
 
             // Activity started
             if (i == 2 || i == 5 || i == 9 || i == 12) {
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_STARTED.name());
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -173,15 +168,13 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.EXECUTION_ID,
                                 Fields.ACTIVITY_TYPE,
                                 Fields.TENANT_ID
-                        );
-                assertThat(data)
+                        )
                         .containsEntry(Fields.TENANT_ID, testTenant);
             }
 
             // Leaving start
             if (i == 3) {
 
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED.name());
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -200,8 +193,7 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.EXECUTION_ID,
                                 Fields.ACTIVITY_TYPE,
                                 Fields.TENANT_ID
-                        );
-                assertThat(data)
+                        )
                         .contains(
                                 entry(Fields.ACTIVITY_ID, "startEvent1"),
                                 entry(Fields.TENANT_ID, "testTenant")
@@ -210,7 +202,6 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
             // Sequence flow taken
             if (i == 4 || i == 7 || i == 8) {
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.SEQUENCEFLOW_TAKEN.name());
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -228,15 +219,13 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.SOURCE_ACTIVITY_TYPE,
                                 Fields.SOURCE_ACTIVITY_TYPE,
                                 Fields.TENANT_ID
-                        );
-                assertThat(data)
+                        )
                         .containsEntry(Fields.TENANT_ID, testTenant);
             }
 
             // Leaving parallel gateway
             if (i == 6) {
 
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED.name());
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -261,7 +250,6 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
             // Tasks
             if (i == 11|| i == 14) {
 
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.TASK_CREATED.name());
                 assertThat(entry.getTimeStamp()).isNotNull();
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
@@ -282,8 +270,7 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.PROCESS_DEFINITION_ID,
                                 Fields.EXECUTION_ID,
                                 Fields.TENANT_ID
-                        );
-                assertThat(data)
+                        )
                         .doesNotContainKeys(
                                 Fields.DESCRIPTION,
                                 Fields.CATEGORY,
@@ -291,16 +278,14 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.DUE_DATE,
                                 Fields.FORM_KEY,
                                 Fields.USER_ID
-                        );
+                        )
 
-                assertThat(data)
                         .containsEntry(Fields.TENANT_ID, testTenant);
 
             }
 
             if (i == 10 || i == 13) {
 
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.TASK_ASSIGNED.name());
                 assertThat(entry.getTimeStamp()).isNotNull();
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
@@ -321,8 +306,7 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.PROCESS_DEFINITION_ID,
                                 Fields.EXECUTION_ID,
                                 Fields.TENANT_ID
-                        );
-                assertThat(data)
+                        )
                         .doesNotContainKeys(
                                 Fields.DESCRIPTION,
                                 Fields.CATEGORY,
@@ -330,9 +314,8 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.DUE_DATE,
                                 Fields.FORM_KEY,
                                 Fields.USER_ID
-                        );
+                        )
 
-                assertThat(data)
                         .containsEntry(Fields.TENANT_ID, testTenant);
             }
 
@@ -358,7 +341,6 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
 
             // org.flowable.task.service.Task completion
             if (i == 1 || i == 6) {
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.TASK_COMPLETED.name());
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -392,15 +374,12 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.OWNER,
                                 Fields.DUE_DATE,
                                 Fields.FORM_KEY
-                        );
-
-                assertThat(data)
+                        )
                         .containsEntry(Fields.TENANT_ID, testTenant);
             }
 
             // Activity Completed
             if (i == 2 || i == 7 || i == 10 || i == 13) {
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo(FlowableEngineEventType.ACTIVITY_COMPLETED.name());
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -420,9 +399,7 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.ACTIVITY_TYPE,
                                 Fields.TENANT_ID,
                                 Fields.BEHAVIOR_CLASS
-                        );
-
-                assertThat(data)
+                        )
                         .containsEntry(Fields.TENANT_ID, testTenant);
 
                 if (i == 2) {
@@ -463,14 +440,11 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.TARGET_ACTIVITY_ID,
                                 Fields.TARGET_ACTIVITY_TYPE,
                                 Fields.TARGET_ACTIVITY_BEHAVIOR_CLASS
-                        );
-
-                assertThat(data)
+                        )
                         .containsEntry(Fields.TENANT_ID, testTenant);
             }
 
             if (i == 14 || i == 15) {
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo("VARIABLE_DELETED");
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -480,7 +454,6 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
             }
 
             if (i == 16) {
-                assertThat(entry.getType()).isNotNull();
                 assertThat(entry.getType()).isEqualTo("PROCESSINSTANCE_END");
                 assertThat(entry.getProcessDefinitionId()).isNotNull();
                 assertThat(entry.getProcessInstanceId()).isNotNull();
@@ -496,14 +469,11 @@ public class DatabaseEventLoggerTest extends PluggableFlowableTestCase {
                                 Fields.ID,
                                 Fields.PROCESS_DEFINITION_ID,
                                 Fields.TENANT_ID
-                        );
-                assertThat(data)
+                        )
                         .doesNotContainKeys(
                                 Fields.NAME,
                                 Fields.BUSINESS_KEY
-                        );
-
-                assertThat(data)
+                        )
                         .containsEntry(Fields.TENANT_ID, testTenant);
             }
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/FlowableEventDispatcherTest.java
@@ -260,30 +260,25 @@ public class FlowableEventDispatcherTest extends PluggableFlowableTestCase {
     public void testActivitiEventTypeParsing() throws Exception {
         // Check with empty null
         FlowableEngineEventType[] types = FlowableEngineEventType.getTypesFromString(null);
-        assertThat(types).isNotNull();
         assertThat(types).isEmpty();
 
         // Check with empty string
         types = FlowableEngineEventType.getTypesFromString("");
-        assertThat(types).isNotNull();
         assertThat(types).isEmpty();
 
         // Single value
         types = FlowableEngineEventType.getTypesFromString("ENTITY_CREATED");
-        assertThat(types).isNotNull();
         assertThat(types).hasSize(1);
         assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
 
         // Multiple value
         types = FlowableEngineEventType.getTypesFromString("ENTITY_CREATED,ENTITY_DELETED");
-        assertThat(types).isNotNull();
         assertThat(types).hasSize(2);
         assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         assertThat(types[1]).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);
 
         // Additional separators should be ignored
         types = FlowableEngineEventType.getTypesFromString(",ENTITY_CREATED,,ENTITY_DELETED,,,");
-        assertThat(types).isNotNull();
         assertThat(types).hasSize(2);
         assertThat(types[0]).isEqualTo(FlowableEngineEventType.ENTITY_CREATED);
         assertThat(types[1]).isEqualTo(FlowableEngineEventType.ENTITY_DELETED);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/TransactionEventListenerTest.java
@@ -95,8 +95,11 @@ public class TransactionEventListenerTest extends PluggableFlowableTestCase {
             // During the async history execution it is possible that some historic jobs are inserted again (to be retried) therefore using hasSizeGreaterThan
             assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_CREATED.name())).hasSizeGreaterThanOrEqualTo(historyCreatedEvents);
             assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_INITIALIZED.name())).hasSizeGreaterThanOrEqualTo(historyCreatedEvents);
-            assertThat(TestTransactionEventListener.eventsReceived).doesNotContainKey(FlowableEngineEventType.PROCESS_STARTED.name());
-            assertThat(TestTransactionEventListener.eventsReceived).doesNotContainKey(FlowableEngineEventType.TASK_CREATED.name());
+            assertThat(TestTransactionEventListener.eventsReceived)
+                    .doesNotContainKeys(
+                            FlowableEngineEventType.PROCESS_STARTED.name(),
+                            FlowableEngineEventType.TASK_CREATED.name()
+            );
 
         } else {
             assertThat(TestTransactionEventListener.eventsReceived.get(FlowableEngineEventType.ENTITY_CREATED.name())).hasSize(expectedCreatedEvents);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/history/HistoryServiceTest.java
@@ -218,7 +218,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(processInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricProcessInstance> processInstances = processInstanceQuery.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(5);
 
         for (HistoricProcessInstance historicProcessInstance : processInstances) {
@@ -307,7 +306,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(processInstanceQuery.list().get(0).getDeploymentId()).isEqualTo(deployment.getId());
 
         List<HistoricProcessInstance> processInstances = processInstanceQuery.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(5);
 
         processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentId("invalid");
@@ -332,7 +330,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(processInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricProcessInstance> processInstances = processInstanceQuery.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(5);
 
         deploymentIds = new ArrayList<>();
@@ -356,7 +353,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricTaskInstance> taskInstances = taskInstanceQuery.list();
-        assertThat(taskInstances).isNotNull();
         assertThat(taskInstances).hasSize(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().deploymentId("invalid");
@@ -380,7 +376,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricTaskInstance> taskInstances = taskInstanceQuery.list();
-        assertThat(taskInstances).isNotNull();
         assertThat(taskInstances).hasSize(5);
 
         deploymentIds.add("invalid");
@@ -408,7 +403,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricTaskInstance> taskInstances = taskInstanceQuery.list();
-        assertThat(taskInstances).isNotNull();
         assertThat(taskInstances).hasSize(5);
 
         taskInstanceQuery = historyService.createHistoricTaskInstanceQuery().or().deploymentId("invalid").endOr();
@@ -497,7 +491,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         assertThat(taskInstanceQuery.count()).isEqualTo(5);
 
         List<HistoricTaskInstance> taskInstances = taskInstanceQuery.list();
-        assertThat(taskInstances).isNotNull();
         assertThat(taskInstances).hasSize(5);
 
         deploymentIds.add("invalid");
@@ -621,7 +614,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         // Test EQUAL on single string variable, should result in 2 matches
         HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().variableValueEquals("stringVar", "abcdef");
         List<HistoricProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Test EQUAL on two string variables, should result in single match
@@ -782,7 +774,6 @@ public class HistoryServiceTest extends PluggableFlowableTestCase {
         // Query on single short variable, should result in 2 matches
         HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().variableValueEquals("dateVar", date1);
         List<HistoricProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Query on two short variables, should result in single value

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/identity/IdentityServiceTest.java
@@ -244,7 +244,6 @@ public class IdentityServiceTest extends PluggableFlowableTestCase {
     @Test
     public void testFindUsersByGroupUnexistingGroup() {
         List<User> users = identityService.createUserQuery().memberOfGroup("unexistinggroup").list();
-        assertThat(users).isNotNull();
         assertThat(users).isEmpty();
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/JobQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/JobQueryTest.java
@@ -521,7 +521,6 @@ public class JobQueryTest extends PluggableFlowableTestCase {
         Job failedJob = query.singleResult();
         assertThat(failedJob).isNotNull();
         assertThat(failedJob.getProcessInstanceId()).isEqualTo(processInstance.getId());
-        assertThat(failedJob.getExceptionMessage()).isNotNull();
         assertThat(failedJob.getExceptionMessage()).containsSequence(EXCEPTION_MESSAGE);
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ManagementServiceTest.java
@@ -103,13 +103,11 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         Job timerJob2 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
         assertThat(timerJob2).isNotNull();
-        assertThat(timerJob2.getExceptionMessage()).isNotNull();
         assertThat(timerJob2.getExceptionMessage())
                 .contains("This is an exception thrown from scriptTask");
 
         // Get the full stacktrace using the managementService
         String exceptionStack = managementService.getTimerJobExceptionStacktrace(timerJob2.getId());
-        assertThat(exceptionStack).isNotNull();
         assertThat(exceptionStack)
                 .contains("This is an exception thrown from scriptTask");
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ExecutionQueryTest.java
@@ -303,7 +303,6 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         // Test EQUAL on single string variable, should result in 2 matches
         ExecutionQuery query = runtimeService.createExecutionQuery().variableValueEquals("stringVar", "abcdef");
         List<Execution> executions = query.list();
-        assertThat(executions).isNotNull();
         assertThat(executions).hasSize(2);
 
         // Test EQUAL on two string variables, should result in single match
@@ -524,7 +523,6 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         // Query on single long variable, should result in 2 matches
         ExecutionQuery query = runtimeService.createExecutionQuery().variableValueEquals("longVar", 12345L);
         List<Execution> executions = query.list();
-        assertThat(executions).isNotNull();
         assertThat(executions).hasSize(2);
 
         // Query on two long variables, should result in single match
@@ -613,7 +611,6 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         // Query on single double variable, should result in 2 matches
         ExecutionQuery query = runtimeService.createExecutionQuery().variableValueEquals("doubleVar", 12345.6789);
         List<Execution> executions = query.list();
-        assertThat(executions).isNotNull();
         assertThat(executions).hasSize(2);
 
         // Query on two double variables, should result in single value
@@ -702,7 +699,6 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         // Query on single integer variable, should result in 2 matches
         ExecutionQuery query = runtimeService.createExecutionQuery().variableValueEquals("integerVar", 12345);
         List<Execution> executions = query.list();
-        assertThat(executions).isNotNull();
         assertThat(executions).hasSize(2);
 
         // Query on two integer variables, should result in single value
@@ -793,7 +789,6 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         // Query on single short variable, should result in 2 matches
         ExecutionQuery query = runtimeService.createExecutionQuery().variableValueEquals("shortVar", shortVar);
         List<Execution> executions = query.list();
-        assertThat(executions).isNotNull();
         assertThat(executions).hasSize(2);
 
         // Query on two short variables, should result in single value
@@ -899,7 +894,6 @@ public class ExecutionQueryTest extends PluggableFlowableTestCase {
         // Query on single short variable, should result in 2 matches
         ExecutionQuery query = runtimeService.createExecutionQuery().variableValueEquals("dateVar", date1);
         List<Execution> executions = query.list();
-        assertThat(executions).isNotNull();
         assertThat(executions).hasSize(2);
 
         // Query on two short variables, should result in single value

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -748,7 +748,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         // Test EQUAL on single string variable, should result in 2 matches
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().variableValueEquals("stringVar", "abcdef");
         List<ProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Test EQUAL on two string variables, should result in single match
@@ -845,7 +844,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         // Query on single long variable, should result in 2 matches
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().variableValueEquals("longVar", 12345L);
         List<ProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Query on two long variables, should result in single match
@@ -934,7 +932,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         // Query on single double variable, should result in 2 matches
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().variableValueEquals("doubleVar", 12345.6789);
         List<ProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Query on two double variables, should result in single value
@@ -1025,7 +1022,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         // Query on single integer variable, should result in 2 matches
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().variableValueEquals("integerVar", 12345);
         List<ProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Query on two integer variables, should result in single value
@@ -1115,7 +1111,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().or().variableValueEquals("integerVar", 12345).processDefinitionId("undefined")
                 .endOr();
         List<ProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         query = runtimeService.createProcessInstanceQuery()
@@ -1128,7 +1123,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
                 .processDefinitionId("undefined")
                 .endOr();
         processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Query on two integer variables, should result in single value
@@ -1247,7 +1241,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         // Query on single short variable, should result in 2 matches
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().variableValueEquals("shortVar", shortVar);
         List<ProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Query on two short variables, should result in single value
@@ -1354,7 +1347,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         // Query on single short variable, should result in 2 matches
         ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().variableValueEquals("dateVar", date1);
         List<ProcessInstance> processInstances = query.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(2);
 
         // Query on two short variables, should result in single value
@@ -1492,7 +1484,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
 
         // Test value-only matching, no results present
         instances = runtimeService.createProcessInstanceQuery().variableValueEquals(true).list();
-        assertThat(instances).isNotNull();
         assertThat(instances).isEmpty();
     }
 
@@ -1843,7 +1834,6 @@ public class ProcessInstanceQueryTest extends PluggableFlowableTestCase {
         assertThat(processInstanceQuery.count()).isEqualTo(5);
 
         List<ProcessInstance> processInstances = processInstanceQuery.list();
-        assertThat(processInstances).isNotNull();
         assertThat(processInstances).hasSize(5);
 
         for (ProcessInstance processInstance : processInstances) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeActivityInstanceTest.java
@@ -397,8 +397,6 @@ public class RuntimeActivityInstanceTest extends PluggableFlowableTestCase {
         List<ActivityInstance> activityInstance = runtimeService.createActivityInstanceQuery().activityId("join").processInstanceId(processInstance.getId())
                 .list();
 
-        assertThat(activityInstance).isNotNull();
-
         // History contains 2 entries for parallel join (one for each path
         // arriving in the join), should contain end-time
         assertThat(activityInstance).hasSize(2);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeServiceTest.java
@@ -75,7 +75,6 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         vars.put("longString", longString.toString());
         runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
         org.flowable.task.api.Task task = taskService.createTaskQuery().includeProcessVariables().singleResult();
-        assertThat(task.getProcessVariables()).isNotNull();
         assertThat(task.getProcessVariables())
                 .containsEntry("longString", longString.toString());
     }
@@ -471,7 +470,6 @@ public class RuntimeServiceTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
         List<String> activities = runtimeService.getActiveActivityIds(processInstance.getId());
-        assertThat(activities).isNotNull();
         assertThat(activities).hasSize(1);
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
@@ -81,8 +81,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task1", "task2");
-        assertThat(executionsByActivity).doesNotContainKey("parallelJoin");
+        assertThat(executionsByActivity)
+                .containsKeys("task1", "task2")
+                .doesNotContainKey("parallelJoin");
 
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
@@ -116,8 +117,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).doesNotContainKey("task1");
-        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
+        assertThat(executionsByActivity)
+                .doesNotContainKey("task1")
+                .containsKeys("task2", "parallelJoin");
 
         assertThat(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive()).isFalse();
 
@@ -295,8 +297,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).doesNotContainKey("task1");
-        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
+        assertThat(executionsByActivity)
+                .doesNotContainKey("task1")
+                .containsKeys("task2", "parallelJoin");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
@@ -339,8 +342,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).doesNotContainKey("task1");
-        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
+        assertThat(executionsByActivity)
+                .doesNotContainKey("task1")
+                .containsKeys("task2", "parallelJoin");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
@@ -387,8 +391,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task1", "task2");
-        assertThat(executionsByActivity).doesNotContainKey("parallelJoin");
+        assertThat(executionsByActivity)
+                .containsKeys("task1", "task2")
+                .doesNotContainKey("parallelJoin");
 
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
@@ -402,8 +407,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "parallelJoin")
+                .doesNotContainKey("task1");
 
         assertThat(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive()).isFalse();
 
@@ -559,8 +565,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "parallelJoin")
+                .doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
@@ -603,8 +610,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "parallelJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "parallelJoin")
+                .doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
@@ -649,8 +657,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         assertThat(executions).hasSize(2);
 
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task1", "task2");
-        assertThat(executionsByActivity).doesNotContainKey("gwJoin");
+        assertThat(executionsByActivity).
+                containsKeys("task1", "task2")
+                .doesNotContainKey("gwJoin");
 
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
@@ -664,8 +673,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
 
         assertThat(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive()).isFalse();
 
@@ -822,8 +832,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -867,8 +878,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
@@ -912,8 +924,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task1", "task2");
-        assertThat(executionsByActivity).doesNotContainKey("gwJoin");
+        assertThat(executionsByActivity)
+                .containsKeys("task1", "task2")
+                .doesNotContainKey("gwJoin");
 
         //Complete one task1
         Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
@@ -927,8 +940,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
 
         assertThat(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive()).isFalse();
 
@@ -1084,8 +1098,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
@@ -1128,8 +1143,9 @@ public class ChangeStateForGatewaysTest extends PluggableFlowableTestCase {
         executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
         assertThat(executions).hasSize(2);
         Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
-        assertThat(executionsByActivity).containsKeys("task2", "gwJoin");
-        assertThat(executionsByActivity).doesNotContainKey("task1");
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/changestate/ChangeStateTest.java
@@ -2329,8 +2329,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
                 .contains(
                         entry("processVar1", "test"),
                         entry("processVar2", 10)
-                );
-        assertThat(processVariables)
+                )
                 .doesNotContainKeys("localVar1", "localVar2");
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("taskBefore").singleResult();
@@ -2420,8 +2419,7 @@ public class ChangeStateTest extends PluggableFlowableTestCase {
                 .contains(
                         entry("processVar1", "test"),
                         entry("processVar2", 10)
-                );
-        assertThat(processVariables)
+                )
                 .doesNotContainKeys("localVar1", "localVar2");
 
         Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("taskBefore").singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationDocumentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationDocumentTest.java
@@ -408,10 +408,8 @@ public class ProcessInstanceMigrationDocumentTest extends AbstractTestCase {
         assertThat(migrationDocument.getMigrateToProcessDefinitionTenantId()).isEqualTo(definitionTenantId);
         assertThat(migrationDocument.getActivityMigrationMappings()).usingFieldByFieldElementComparator().containsExactly(oneToOne1, oneToOne2);
         assertThat(migrationDocument.getActivitiesLocalVariables())
-                .containsKeys("newActivity1", "newActivity2");
-        assertThat(migrationDocument.getActivitiesLocalVariables())
-                .containsEntry("newActivity1", (Collections.singletonMap("variableString", "variableValue")));
-        assertThat(migrationDocument.getActivitiesLocalVariables())
+                .containsKeys("newActivity1", "newActivity2")
+                .containsEntry("newActivity1", (Collections.singletonMap("variableString", "variableValue")))
                 .containsEntry("newActivity2", (Collections.singletonMap("variableDouble", 12345.6789)));
         assertThat(migrationDocument.getProcessInstanceVariables()).isEqualTo(processInstanceVars);
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskAndVariablesQueryTest.java
@@ -75,18 +75,18 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testQuery() {
-        org.flowable.task.api.Task task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("gonzo").singleResult();
+        Task task = taskService.createTaskQuery().includeTaskLocalVariables().taskAssignee("gonzo").singleResult();
         assertThat(task.getProcessVariables()).isEmpty();
         Map<String, Object> variableMap = task.getTaskLocalVariables();
-        assertThat(variableMap).hasSize(3);
         assertThat(variableMap)
+                .hasSize(3)
                 .contains(
                         entry("testVar", "someVariable"),
                         entry("testVar2", 123)
                 );
         assertThat(new String((byte[]) variableMap.get("testVarBinary"))).isEqualTo("This is a binary variable");
 
-        List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
+        List<Task> tasks = taskService.createTaskQuery().list();
         assertThat(tasks).hasSize(3);
 
         task = taskService.createTaskQuery().includeProcessVariables().taskAssignee("gonzo").singleResult();
@@ -121,8 +121,8 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
 
         task = taskService.createTaskQuery().includeProcessVariables().taskAssignee("kermit").singleResult();
         assertThat(task.getTaskLocalVariables()).isEmpty();
-        assertThat(task.getProcessVariables()).hasSize(3);
         assertThat(task.getProcessVariables())
+                .hasSize(3)
                 .contains(
                         entry("processVar", true),
                         entry("anotherProcessVar", 123)
@@ -131,8 +131,9 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
 
         tasks = taskService.createTaskQuery().includeTaskLocalVariables().taskCandidateUser("kermit").list();
         assertThat(tasks).hasSize(2);
-        assertThat(tasks.get(0).getTaskLocalVariables()).hasSize(2);
-        assertThat(tasks.get(0).getTaskLocalVariables()).containsEntry("test", "test");
+        assertThat(tasks.get(0).getTaskLocalVariables())
+                .hasSize(2)
+                .containsEntry("test", "test");
         assertThat(tasks.get(0).getProcessVariables()).isEmpty();
 
         tasks = taskService.createTaskQuery().includeProcessVariables().taskCandidateUser("kermit").list();
@@ -264,19 +265,16 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
     public void testQueryWithIncludeTaskVariableAndTaskCategory() {
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskAssignee("gonzo").list();
         for (org.flowable.task.api.Task task : tasks) {
-            assertThat(task.getCategory()).isNotNull();
             assertThat(task.getCategory()).isEqualTo("testCategory");
         }
 
         tasks = taskService.createTaskQuery().taskAssignee("gonzo").includeTaskLocalVariables().list();
         for (org.flowable.task.api.Task task : tasks) {
-            assertThat(task.getCategory()).isNotNull();
             assertThat(task.getCategory()).isEqualTo("testCategory");
         }
 
         tasks = taskService.createTaskQuery().taskAssignee("gonzo").includeProcessVariables().list();
         for (org.flowable.task.api.Task task : tasks) {
-            assertThat(task.getCategory()).isNotNull();
             assertThat(task.getCategory()).isEqualTo("testCategory");
         }
     }
@@ -377,9 +375,10 @@ public class TaskAndVariablesQueryTest extends PluggableFlowableTestCase {
             query1 = query1.processVariableValueEquals("anotherProcessVar", i);
         }
         query1 = query1.endOr();
-        org.flowable.task.api.Task task = query1.singleResult();
-        assertThat(task.getProcessVariables()).hasSize(2);
-        assertThat(task.getProcessVariables()).containsEntry("anotherProcessVar", 123);
+        Task task = query1.singleResult();
+        assertThat(task.getProcessVariables())
+                .hasSize(2)
+                .containsEntry("anotherProcessVar", 123);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -3085,13 +3085,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         // Query task, including identity links
         task = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().singleResult();
         assertThat(task).isNotNull();
-        assertThat(task.getIdentityLinks()).isNotNull();
         assertThat(task.getIdentityLinks()).hasSize(1);
 
         // Query task, including identity links, process variables, and task variables
         task = taskService.createTaskQuery().taskId(task.getId()).includeIdentityLinks().includeProcessVariables().includeTaskLocalVariables().singleResult();
         assertThat(task).isNotNull();
-        assertThat(task.getIdentityLinks()).isNotNull();
         assertThat(task.getIdentityLinks()).hasSize(1);
         IdentityLinkInfo identityLink = task.getIdentityLinks().get(0);
         assertThat(identityLink.getProcessInstanceId()).isNull();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/tenant/TenancyTest.java
@@ -361,7 +361,6 @@ public class TenancyTest extends PluggableFlowableTestCase {
         assertThat(repositoryService.createProcessDefinitionQuery().list()).hasSize(2);
         assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(TEST_TENANT_ID).list()).isEmpty();
         assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(newTenantId).list()).hasSize(1);
-        assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionTenantId(newTenantId).list()).hasSize(1);
 
         // Verify process instances
         assertThat(runtimeService.createProcessInstanceQuery().list()).hasSize(nrOfProcessInstancesNoTenant + nrOfProcessInstancesWithTenant);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/variables/VariablesTest.java
@@ -30,6 +30,7 @@ import org.flowable.engine.delegate.JavaDelegate;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.repository.Deployment;
 import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.task.api.Task;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.jupiter.api.AfterEach;
@@ -257,7 +258,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
     public void testGetVariablesLocal2() {
 
         // Trying the same after moving the process
-        org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
+        Task task = taskService.createTaskQuery().singleResult();
         taskService.complete(task.getId());
 
         task = taskService.createTaskQuery().taskName("Task 3").singleResult();
@@ -308,8 +309,8 @@ public class VariablesTest extends PluggableFlowableTestCase {
                 .contains(
                         entry("stringVar1", "stringVarValue-1"),
                         entry("stringVar2", "stringVarValue-2")
-                );
-        assertThat(vars).doesNotContainKey("myVar");
+                )
+                .doesNotContainKey("myVar");
 
         // Execution local
 
@@ -351,9 +352,9 @@ public class VariablesTest extends PluggableFlowableTestCase {
 
         assertThat(vars)
                 .contains(
-                    entry("stringVar1", "hello"),
-                    entry("stringVar2", "world"),
-                    entry("myVar", "test123")
+                        entry("stringVar1", "hello"),
+                        entry("stringVar2", "world"),
+                        entry("myVar", "test123")
                 );
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/cache/CacheTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/cache/CacheTaskTest.java
@@ -45,10 +45,8 @@ public class CacheTaskTest extends PluggableFlowableTestCase {
     public void testProcessInstanceAndExecutionIdInCache() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
 
-        assertThat(ServiceCacheTask.processInstanceId).isNotNull();
         assertThat(ServiceCacheTask.processInstanceId).isEqualTo(processInstance.getId());
         assertThat(ServiceCacheTask.executionId).isNotNull();
-        assertThat(ServiceCacheTask.historicProcessInstanceId).isNotNull();
         assertThat(ServiceCacheTask.historicProcessInstanceId).isEqualTo(processInstance.getId());
     }
 
@@ -59,9 +57,7 @@ public class CacheTaskTest extends PluggableFlowableTestCase {
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
 
-        assertThat(TestCacheTaskListener.TASK_ID).isNotNull();
         assertThat(TestCacheTaskListener.TASK_ID).isEqualTo(task.getId());
-        assertThat(TestCacheTaskListener.HISTORIC_TASK_ID).isNotNull();
         assertThat(TestCacheTaskListener.HISTORIC_TASK_ID).isEqualTo(task.getId());
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -855,21 +855,17 @@ public class CallActivityAdvancedTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callTwoSubProcesses");
 
         List<ProcessInstance> instanceList = runtimeService.createProcessInstanceQuery().list();
-        assertThat(instanceList).isNotNull();
         assertThat(instanceList).hasSize(3);
 
         List<Task> taskList = taskService.createTaskQuery().list();
-        assertThat(taskList).isNotNull();
         assertThat(taskList).hasSize(2);
 
         runtimeService.deleteProcessInstance(processInstance.getId(), "Test cascading");
 
         instanceList = runtimeService.createProcessInstanceQuery().list();
-        assertThat(instanceList).isNotNull();
         assertThat(instanceList).isEmpty();
 
         taskList = taskService.createTaskQuery().list();
-        assertThat(taskList).isNotNull();
         assertThat(taskList).isEmpty();
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -66,7 +66,6 @@ public class BpmnDeploymentTest extends PluggableFlowableTestCase {
         // verify content
         InputStream deploymentInputStream = repositoryService.getResourceAsStream(deploymentId, bpmnResourceName);
         String contentFromDeployment = readInputStreamToString(deploymentInputStream);
-        assertThat(contentFromDeployment).isNotEmpty();
         assertThat(contentFromDeployment).contains("process id=\"emptyProcess\"");
 
         InputStream fileInputStream = ReflectUtil.getResourceAsStream(

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/deployment/ParsedDeploymentTest.java
@@ -88,15 +88,16 @@ public class ParsedDeploymentTest extends PluggableFlowableTestCase {
         ProcessDefinitionEntity id2 = getProcessDefinitionEntityFromList(processDefinitions, ID2_ID);
         assertThat(parsedDeployment.getBpmnParseForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id2));
         assertThat(parsedDeployment.getBpmnModelForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel());
-        assertThat(parsedDeployment.getProcessModelForProcessDefinition(id1)).isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey()));
+        assertThat(parsedDeployment.getProcessModelForProcessDefinition(id1))
+                .isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey()));
         assertThat(parsedDeployment.getResourceForProcessDefinition(id1).getName()).isEqualTo(IDR_XML_NAME);
         assertThat(parsedDeployment.getResourceForProcessDefinition(id2).getName()).isEqualTo(IDR_XML_NAME);
 
         ProcessDefinitionEntity en1 = getProcessDefinitionEntityFromList(processDefinitions, EN1_ID);
         ProcessDefinitionEntity en2 = getProcessDefinitionEntityFromList(processDefinitions, EN2_ID);
         assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1))
-                .isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(en2));
-        assertThat(parsedDeployment.getBpmnParseForProcessDefinition(en1)).isNotEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id2));
+                .isSameAs(parsedDeployment.getBpmnParseForProcessDefinition(en2))
+                .isNotEqualTo(parsedDeployment.getBpmnParseForProcessDefinition(id2));
         assertThat(parsedDeployment.getResourceForProcessDefinition(en1).getName()).isEqualTo(EN_XML_NAME);
         assertThat(parsedDeployment.getResourceForProcessDefinition(en2).getName()).isEqualTo(EN_XML_NAME);
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -207,11 +207,9 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
         task = taskService.createTaskQuery().singleResult();
 
         Object testVariable2 = runtimeService.getVariable(processInstance.getId(), "test2");
-        assertThat(testVariable2).isNotNull();
         assertThat(testVariable2).hasToString("compensated2");
 
         Object testVariable1 = runtimeService.getVariable(processInstance.getId(), "test1");
-        assertThat(testVariable1).isNotNull();
         assertThat(testVariable1).hasToString("compensated1");
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -491,7 +491,6 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         calendar.add(Calendar.HOUR, 2);
         Job rescheduledTimerJob = managementService.rescheduleTimeDateJob(timerJob.getId(), sdf.format(calendar.getTime()));
         assertThat(rescheduledTimerJob).isNotNull();
-        assertThat(rescheduledTimerJob.getId()).isNotNull();
         assertThat(rescheduledTimerJob.getId()).isNotSameAs(timerJob.getId());
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -691,7 +690,6 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         String timeCycle = "R/PT2H";
         Job rescheduledTimerJob = managementService.rescheduleTimerJob(timerJob.getId(), null, null, timeCycle, null, null);
         assertThat(rescheduledTimerJob).isNotNull();
-        assertThat(rescheduledTimerJob.getId()).isNotNull();
         assertThat(rescheduledTimerJob.getId()).isNotSameAs(timerJob.getId());
 
         timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -200,7 +200,6 @@ public class IntermediateTimerEventTest extends PluggableFlowableTestCase {
         calendar.add(Calendar.HOUR, 2);
         Job rescheduledJob = managementService.rescheduleTimeDateJob(timerJob.getId(), sdf.format(calendar.getTime()));
         assertThat(rescheduledJob).isNotNull();
-        assertThat(rescheduledJob.getId()).isNotNull();
         assertThat(rescheduledJob.getId()).isNotSameAs(timerJob.getId());
 
         Job timer = managementService.createTimerJobQuery().singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -775,8 +775,8 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         assertThat(childExecutions).hasSize(5);
         classifiedExecutions = childExecutions.stream().collect(Collectors.groupingBy(Execution::getActivityId));
         assertThat(classifiedExecutions)
-                .containsKeys("multiInstanceSubProcess", "taskInclusive1", "taskInclusive2", "inclusiveJoin");
-        assertThat(classifiedExecutions).doesNotContainKey("taskInclusive3");
+                .containsKeys("multiInstanceSubProcess", "taskInclusive1", "taskInclusive2", "inclusiveJoin")
+                .doesNotContainKey("taskInclusive3");
         assertThat(classifiedExecutions.get("multiInstanceSubProcess")).hasSize(2);
         assertThat(classifiedExecutions.get("taskInclusive1")).hasSize(1);
         assertThat(classifiedExecutions.get("taskInclusive2")).hasSize(1);
@@ -786,8 +786,8 @@ public class InclusiveGatewayTest extends PluggableFlowableTestCase {
         tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
         classifiedTasks = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
         assertThat(classifiedTasks)
-                .containsOnlyKeys("taskInclusive1", "taskInclusive2");
-        assertThat(classifiedTasks).doesNotContainKeys("taskInclusive3");
+                .containsOnlyKeys("taskInclusive1", "taskInclusive2")
+                .doesNotContainKeys("taskInclusive3");
 
         //Finish the rest of the tasks
         Stream.concat(classifiedTasks.get("taskInclusive1").stream(), classifiedTasks.get("taskInclusive2").stream())

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -51,7 +51,6 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertThat(task.getDueDate()).isNotNull();
         assertThat(task.getDueDate()).isEqualTo(date);
     }
 
@@ -106,7 +105,6 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
-        assertThat(task.getDueDate()).isNotNull();
         assertThat(task.getDueDate()).isEqualTo(new Date(0));
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
@@ -109,7 +109,6 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         // start the process
         runtimeService.startProcessInstanceByKey("ForkProcess");
         List<org.flowable.task.api.Task> taskList = taskService.createTaskQuery().list();
-        assertThat(taskList).isNotNull();
         assertThat(taskList).hasSize(2);
 
         // make sure user task exists

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/VariableScopeTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/db/VariableScopeTest.java
@@ -142,18 +142,16 @@ public class VariableScopeTest extends PluggableFlowableTestCase {
         // subProcessTask execution contains local the variablenames "test",
         // "subProcessLocalVariable" but not "helloWorld" and
         // "mainProcessLocalVariable"
-        assertThat(result).contains("test"); // the variable "test" was set
-        // locally by SetLocalVariableTask
-        assertThat(result).contains("subProcessLocalVariable");
+        assertThat(result).contains("test"); // the variable "test" was set locally by SetLocalVariableTask
         assertThat(result)
+                .contains("subProcessLocalVariable")
                 .doesNotContain("mainProcessLocalVariable", "helloWorld");
 
         // Returns a set of global variablenames of subProcessTask execution
         result = processEngineConfiguration.getCommandExecutor().execute(new GetVariableNamesCommand(subProcessTask.getExecutionId(), false));
 
         // subProcessTask execution contains global all defined variablenames
-        assertThat(result).contains("test"); // the variable "test" was set
-        // locally by SetLocalVariableTask
+        assertThat(result).contains("test"); // the variable "test" was set locally by SetLocalVariableTask
         assertThat(result)
                 .contains("subProcessLocalVariable", "helloWorld", "mainProcessLocalVariable");
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/ExpressionManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/ExpressionManagerTest.java
@@ -117,7 +117,6 @@ public class ExpressionManagerTest extends PluggableFlowableTestCase {
 
         // Check of the testMethod has been called with the current execution
         String value = (String) runtimeService.getVariable(processInstance.getId(), "testVar");
-        assertThat(value).isNotNull();
         assertThat(value).isEqualTo("myValue");
     }
 
@@ -132,7 +131,6 @@ public class ExpressionManagerTest extends PluggableFlowableTestCase {
             // Check if the variable that has been set in service-task is the
             // authenticated user
             String value = (String) runtimeService.getVariable(processInstance.getId(), "theUser");
-            assertThat(value).isNotNull();
             assertThat(value).isEqualTo("frederik");
         } finally {
             // Cleanup

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/externalworker/ExternalWorkerServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/externalworker/ExternalWorkerServiceTaskTest.java
@@ -846,7 +846,6 @@ public class ExternalWorkerServiceTaskTest extends PluggableFlowableTestCase {
 
         Job movedJob = managementService.moveDeadLetterJobToExecutableJob(deadLetterJob.getId(), 4);
 
-        assertThat(movedJob).isNotNull();
         assertThat(movedJob).isInstanceOf(ExternalWorkerJob.class);
         assertThat(movedJob.getJobType()).isEqualTo(Job.JOB_TYPE_EXTERNAL_WORKER);
         assertThat(movedJob.getRetries()).isEqualTo(4);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricActivityInstanceTest.java
@@ -442,8 +442,6 @@ public class HistoricActivityInstanceTest extends PluggableFlowableTestCase {
 
         List<HistoricActivityInstance> historicActivityInstance = historyService.createHistoricActivityInstanceQuery().activityId("join").processInstanceId(processInstance.getId()).list();
 
-        assertThat(historicActivityInstance).isNotNull();
-
         // History contains 2 entries for parallel join (one for each path
         // arriving in the join), should contain end-time
         assertThat(historicActivityInstance).hasSize(2);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/ClearProcessInstanceLocksTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/ClearProcessInstanceLocksTest.java
@@ -97,7 +97,6 @@ public class ClearProcessInstanceLocksTest extends PluggableFlowableTestCase {
             processEngineConfiguration.getCommandExecutor().execute(new LockExclusiveJobCmd((Job) acquiredJob, processEngineConfiguration.getJobServiceConfiguration()));
 
             // After locking, the lockowner should be shared by the job and the process instance
-            assertThat(acquiredJob.getLockOwner()).isNotNull();
             assertThat(acquiredJob.getLockOwner()).isEqualTo(processEngineConfiguration.getAsyncExecutor().getLockOwner());
             assertThat(acquiredJob.getLockExpirationTime()).isNotNull();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/json/JsonTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/json/JsonTest.java
@@ -513,7 +513,6 @@ public class JsonTest extends PluggableFlowableTestCase {
                         + "}");
 
         value = (ObjectNode) runtimeService.getVariable(processInstance.getId(), BIG_JSON_OBJ);
-        assertThat(value).isNotNull();
         assertThat(value).hasToString(createBigJsonObject().toString());
 
         VariableInstance variableInstance = runtimeService.getVariableInstance(processInstance.getId(), BIG_JSON_OBJ);
@@ -531,7 +530,6 @@ public class JsonTest extends PluggableFlowableTestCase {
 
             assertThat(historicVariableInstances.get(0).getVariableName()).isEqualTo(BIG_JSON_OBJ);
             value = (ObjectNode) historicVariableInstances.get(0).getValue();
-            assertThat(value).isNotNull();
             assertThat(value).hasToString(createBigJsonObject().toString());
 
             assertThat(historicVariableInstances.get(1).getVariableName()).isEqualTo(MY_JSON_OBJ);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/mdc/MDCLoggingTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/logging/mdc/MDCLoggingTest.java
@@ -80,10 +80,13 @@ public class MDCLoggingTest extends PluggableFlowableTestCase {
                 .isInstanceOf(Exception.class);
         String messages = console.toString();
 
-        assertThat(messages).contains("ProcessDefinitionId=" + TestService.processDefinitionId);
-        assertThat(messages).contains("executionId=" + TestService.executionId);
-        assertThat(messages).contains("mdcProcessInstanceID=" + TestService.processInstanceId);
-        assertThat(messages).contains("mdcBusinessKey=" + (TestService.businessKey == null ? "" : TestService.businessKey));
+        assertThat(messages)
+                .contains(
+                        "ProcessDefinitionId=" + TestService.processDefinitionId,
+                        "executionId=" + TestService.executionId,
+                        "mdcProcessInstanceID=" + TestService.processInstanceId,
+                        "mdcBusinessKey=" + (TestService.businessKey == null ? "" : TestService.businessKey)
+                );
         console.clear();
         restoreLoggers();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
@@ -43,12 +43,10 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersProcess", "businessKey123");
 
         String varSetInExecutionListener = (String) runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
-        assertThat(varSetInExecutionListener).isNotNull();
         assertThat(varSetInExecutionListener).isEqualTo("firstValue");
 
         // Check if business key was available in execution listener
         String businessKey = (String) runtimeService.getVariable(processInstance.getId(), "businessKeyInExecution");
-        assertThat(businessKey).isNotNull();
         assertThat(businessKey).isEqualTo("businessKey123");
 
         // Transition take executionListener will set 2 variables
@@ -58,7 +56,6 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
 
         varSetInExecutionListener = (String) runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
 
-        assertThat(varSetInExecutionListener).isNotNull();
         assertThat(varSetInExecutionListener).isEqualTo("secondValue");
 
         ExampleExecutionListenerPojo myPojo = new ExampleExecutionListenerPojo();
@@ -71,7 +68,6 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         // First usertask uses a method-expression as executionListener:
         // ${myPojo.myMethod(execution.eventName)}
         ExampleExecutionListenerPojo pojoVariable = (ExampleExecutionListenerPojo) runtimeService.getVariable(processInstance.getId(), "myPojo");
-        assertThat(pojoVariable.getReceivedEventName()).isNotNull();
         assertThat(pojoVariable.getReceivedEventName()).isEqualTo("end");
 
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
@@ -114,7 +110,6 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersProcess", variables);
 
         Object varSetByListener = runtimeService.getVariable(processInstance.getId(), "var");
-        assertThat(varSetByListener).isNotNull();
         assertThat(varSetByListener).isInstanceOf(String.class);
 
         // Result is a concatenation of fixed injected field and injected expression
@@ -181,12 +176,10 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
         // Process start executionListener will have executionListener class
         // that sets 2 variables
         varSetInExecutionListener = (String) runtimeService.getVariable(processInstance.getId(), "variableSetInExecutionListener");
-        assertThat(varSetInExecutionListener).isNotNull();
         assertThat(varSetInExecutionListener).isEqualTo("firstValue");
 
         // Check if business key was available in execution listener
         String businessKey = (String) runtimeService.getVariable(processInstance.getId(), "businessKeyInExecution");
-        assertThat(businessKey).isNotNull();
         assertThat(businessKey).isEqualTo("businessKey123");
 
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/servicetask/JavaServiceTaskTest.java
@@ -188,7 +188,6 @@ public class JavaServiceTaskTest extends PluggableFlowableTestCase {
 
         // Check if business-key was available from the process
         String key = (String) runtimeService.getVariable(processInstance.getId(), "businessKeySetOnExecution");
-        assertThat(key).isNotNull();
         assertThat(key).isEqualTo("1234567890");
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/shell/ShellTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/shell/ShellTaskTest.java
@@ -63,7 +63,6 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("echoShellWindows");
 
             String st = (String) runtimeService.getVariable(pi.getId(), "resultVar");
-            assertThat(st).isNotNull();
             assertThat(st).startsWith("EchoTest");
         }
     }
@@ -77,7 +76,6 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("echoShellLinux");
 
             String st = (String) runtimeService.getVariable(pi.getId(), "resultVar");
-            assertThat(st).isNotNull();
             assertThat(st).startsWith("EchoTest");
         }
     }
@@ -91,7 +89,6 @@ public class ShellTaskTest extends PluggableFlowableTestCase {
             ProcessInstance pi = runtimeService.startProcessInstanceByKey("echoShellMac");
 
             String st = (String) runtimeService.getVariable(pi.getId(), "resultVar");
-            assertThat(st).isNotNull();
             assertThat(st).startsWith("EchoTest");
         }
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
@@ -206,7 +206,6 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         runtimeService.startProcessInstanceByKey("executionListenersOnDelete");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(1);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("User Task 1").singleResult();
@@ -219,7 +218,6 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         tasks = taskService.createTaskQuery().list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).isEmpty();
 
         assertThat(TaskDeleteListener.getCurrentMessages())
@@ -237,7 +235,6 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersOnDelete");
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().list();
-        assertThat(tasks).isNotNull();
         assertThat(tasks).hasSize(1);
 
         org.flowable.task.api.Task task = taskService.createTaskQuery().taskName("User Task 1").singleResult();
@@ -250,7 +247,6 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         tasks = taskService.createTaskQuery().list();
 
-        assertThat(tasks).isNotNull();
         assertThat(tasks).isEmpty();
 
         assertThat(TaskDeleteListener.getCurrentMessages())

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/processdefinitions/ProcessDefinitionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/processdefinitions/ProcessDefinitionsTest.java
@@ -48,8 +48,6 @@ public class ProcessDefinitionsTest extends PluggableFlowableTestCase {
 
         List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().orderByProcessDefinitionKey().asc().orderByProcessDefinitionVersion().desc().list();
 
-        assertThat(processDefinitions).isNotNull();
-
         assertThat(processDefinitions).hasSize(5);
 
         ProcessDefinition processDefinition = processDefinitions.get(0);

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -987,7 +987,6 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertThat(dataObject.getName()).isEqualTo("stringVar");
         assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(dataObject.getType()).isEqualTo("string");
-        assertThat(dataObject.getType()).isEqualTo("string");
         assertThat(dataObject.getValue()).isEqualTo("coca-cola");
 
         // getDataObjects via names (from subprocess)
@@ -1503,7 +1502,6 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertThat(dataObject.getDescription()).isEqualTo("intVar 'default' description");
         assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
         assertThat(dataObject.getId()).isNotNull();
-        assertThat(dataObject.getId()).isNotNull();
         assertThat(dataObject.getLocalizedName()).isEqualTo("intVar");
         assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(dataObject.getType()).isEqualTo("int");
@@ -1587,7 +1585,6 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("intVarId");
         assertThat(dataObject.getDescription()).isEqualTo("intVar 'en-AU' Description");
         assertThat(dataObject.getExecutionId()).isEqualTo(subprocess.getId());
-        assertThat(dataObject.getId()).isNotNull();
         assertThat(dataObject.getId()).isNotNull();
         assertThat(dataObject.getLocalizedName()).isEqualTo("intVar 'en-AU' Name");
         assertThat(dataObject.getName()).isEqualTo("intVar");
@@ -1737,7 +1734,6 @@ public class VariablesTest extends PluggableFlowableTestCase {
         assertThat(dataObject.getValue()).isEqualTo("coca-cola");
         assertThat(dataObject.getLocalizedName()).isEqualTo("stringVar");
         assertThat(dataObject.getDescription()).isEqualTo("stringVar 'default' description");
-        assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
         assertThat(dataObject.getDataObjectDefinitionKey()).isEqualTo("stringVarId");
         assertThat(dataObject.getType()).isEqualTo("string");
         assertThat(dataObject.getProcessInstanceId()).isEqualTo(processInstance.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/history/FullHistoryTest.java
@@ -202,7 +202,6 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertThat(historicVariable.getVariableName()).isEqualTo("number");
         assertThat(historicVariable.getValue()).isEqualTo("two");
         assertThat(historicVariable.getCreateTime()).isNotNull();
-        assertThat(historicVariable.getLastUpdatedTime()).isNotNull();
         assertThat(historicVariable.getLastUpdatedTime()).isNotSameAs(historicVariable.getCreateTime());
 
         historicVariable = historicVariables.get(3);
@@ -481,7 +480,6 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
 
         // Out execution only has a single activity waiting, the task
         List<String> activityIds = runtimeService.getActiveActivityIds(task.getExecutionId());
-        assertThat(activityIds).isNotNull();
         assertThat(activityIds).hasSize(1);
 
         String taskActivityId = activityIds.get(0);
@@ -879,7 +877,6 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
 
         // Historic property should be available
         List<HistoricDetail> details = historyService.createHistoricDetailQuery().formProperties().processInstanceId(processInstance.getId()).list();
-        assertThat(details).isNotNull();
         assertThat(details).hasSize(1);
 
         // org.flowable.task.service.Task should be active in the same activity as the previous one
@@ -887,7 +884,6 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         formService.submitTaskFormData(task.getId(), data);
 
         details = historyService.createHistoricDetailQuery().formProperties().processInstanceId(processInstance.getId()).list();
-        assertThat(details).isNotNull();
         assertThat(details).hasSize(2);
 
         // Should have 2 different historic activity instance ID's, with the
@@ -1135,7 +1131,6 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("booleanVar", true).count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("dateVar", date).count()).isZero();
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("nullVar", null).count()).isZero();
-        assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("nullVar", null).count()).isZero();
 
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("longVar", 67890L).count()).isEqualTo(1);
         assertThat(historyService.createHistoricProcessInstanceQuery().variableValueNotEquals("shortVar", (short) 456).count()).isEqualTo(1);
@@ -1292,7 +1287,6 @@ public class FullHistoryTest extends ResourceFlowableTestCase {
 
         assertThat(variableUpdates).hasSize(1);
         HistoricVariableUpdate update = (HistoricVariableUpdate) variableUpdates.get(0);
-        assertThat(update.getValue()).isNotNull();
         assertThat(update.getValue()).isInstanceOf(FieldAccessJPAEntity.class);
 
         assertThat(((FieldAccessJPAEntity) update.getValue()).getId()).isEqualTo(entity.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAVariableTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/jpa/JPAVariableTest.java
@@ -254,7 +254,6 @@ public class JPAVariableTest extends ResourceFlowableTestCase {
         // Set to JPA-entity again
         runtimeService.setVariable(processInstance.getId(), "simpleEntityFieldAccess", simpleEntityFieldAccess);
         currentValue = runtimeService.getVariable(processInstance.getId(), "simpleEntityFieldAccess");
-        assertThat(currentValue).isNotNull();
         assertThat(currentValue).isInstanceOf(FieldAccessJPAEntity.class);
         assertThat(((FieldAccessJPAEntity) currentValue).getId().longValue()).isEqualTo(1L);
 

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/rules/RulesDeployerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/rules/RulesDeployerTest.java
@@ -50,7 +50,6 @@ public class RulesDeployerTest extends ResourceFlowableTestCase {
         assertThat(order.isValid()).isTrue();
 
         Collection<Object> ruleOutputList = (Collection<Object>) runtimeService.getVariable(processInstance.getId(), "rulesOutput");
-        assertThat(ruleOutputList).isNotNull();
         assertThat(ruleOutputList).hasSize(1);
         order = (Order) ruleOutputList.iterator().next();
         assertThat(order.isValid()).isTrue();


### PR DESCRIPTION
This is a follow up PR based on a [discussion ](https://github.com/flowable/flowable-engine/pull/2632#discussion_r500496040) with Pascal on the first  [PR ](https://github.com/flowable/flowable-engine/pull/2632).

Basically the changes are removing `isNotNull` type checks that are covered by the subsequent `isEqual`, `hasSize`, `contains`, `isInstanceOf` tests.

There are also some merging of conditions when the variable under test is repeated.
