### PR TITLE
Fixing a modeler problem: property checkboxes are invisible

### DIFF
--- a/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/editor-app/configuration/properties.js
+++ b/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/editor-app/configuration/properties.js
@@ -21,7 +21,8 @@ FLOWABLE.PROPERTY_CONFIG =
         "writeModeTemplateUrl": "editor-app/configuration/properties/string-property-write-mode-template.html"
     },
     "boolean": {
-        "templateUrl": "editor-app/configuration/properties/boolean-property-template.html"
+        "readModeTemplateUrl": "editor-app/configuration/properties/boolean-property-template.html",
+        "writeModeTemplateUrl": "editor-app/configuration/properties/boolean-property-template.html"
     },
     "text" : {
         "readModeTemplateUrl": "editor-app/configuration/properties/default-value-display-template.html",


### PR DESCRIPTION
Due to a wrong configuration boolean properties couldn't be modified in modeler because the checkbox component couldn't be rendered

#### Check List:
* Unit tests: NA
* Documentation: NA
