### PR TITLE
Use the EventRegistryEngineConfigurator produced by a method in ProcessEngineConfiguration

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2749,7 +2749,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                 if (eventRegistryConfigurator != null) {
                     specificConfigurators.add(eventRegistryConfigurator);
                 } else {
-                    specificConfigurators.add(new EventRegistryEngineConfigurator());
+                    specificConfigurators.add(createDefaultEventRegistryEngineConfigurator());
                 }
             }
             


### PR DESCRIPTION
Currently ProcessEngineConfiguration always creates EventRegistryEngineConfigurator as the default event registry, even when using the SpringProcessEngineConfiguration, which overrides the createDefaultEventRegistryEngineConfigurator() method.

#### Check List:
* Unit tests: NA
* Documentation: NA
