### PR TITLE
Use isAutoComplete variable

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/TerminateCaseInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/TerminateCaseInstanceOperation.java
@@ -66,7 +66,7 @@ public class TerminateCaseInstanceOperation extends AbstractDeleteCaseInstanceOp
         // we don't use the completion flag directly on the entity as it gets evaluated only at the end of an evaluation cycle which we didn't hit yet
         // at this point, so we need a proper evaluation of the completion
         CompletionEvaluationResult completionEvaluationResult = PlanItemInstanceContainerUtil
-            .shouldPlanItemContainerComplete(commandContext, caseInstance, true);
+            .shouldPlanItemContainerComplete(commandContext, caseInstance, isAutoComplete);
 
         if (!completionEvaluationResult.isCompletable()) {
             // we can't complete the case as it is currently not completable, so we need to throw an exception


### PR DESCRIPTION
The code reads:
```
CompletionEvaluationResult completionEvaluationResult = PlanItemInstanceContainerUtil
            .shouldPlanItemContainerComplete(commandContext, caseInstance, true);
```

where the last parameter to the method is whether the container is autocomplete or not.

Note that the previous line of code reads:
```
boolean isAutoComplete = getPlanModel(caseInstance).isAutoComplete();
```
but the variable `isAutoComplete` is never used and thus a dead store.  I assumed that instead of always passing `true` the variable should be used in its place.

I didn't find a test that exercised the code directly.
