### PR TITLE
The 'or' should be 'and'

### DIFF
--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyPriority.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyPriority.java
@@ -49,7 +49,7 @@ public class HitPolicyPriority extends AbstractHitPolicy implements ComposeDecis
                 CompareToBuilder compareToBuilder = new CompareToBuilder();
                 for (Map.Entry<String, List<Object>> entry : executionContext.getOutputValues().entrySet()) {
                     List<Object> outputValues = entry.getValue();
-                    if (outputValues != null || !outputValues.isEmpty()) {
+                    if (outputValues != null && !outputValues.isEmpty()) {
                         noOutputValuesPresent = false;
                         compareToBuilder.append(((Map<String, Object>) o1).get(entry.getKey()), 
                                         ((Map<String, Object>) o2).get(entry.getKey()), 


### PR DESCRIPTION
In the line of code:
```
if (outputValues != null || !outputValues.isEmpty())
```
the `||` should be `&&` because of `outputValues` is `null` then the next clause will generate a NPE.
