### PR TITLE
Replace Collections.sort() with List.sort()

### DIFF
--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WSDLImporterTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WSDLImporterTest.java
@@ -125,7 +125,8 @@ public class WSDLImporterTest {
 
     private List<WSOperation> sortOperations() {
         List<WSOperation> operations = new ArrayList<>(importer.getOperations().values());
-        Collections.sort(operations, new Comparator<WSOperation>() {
+        operations.sort(new Comparator<WSOperation>() {
+
             @Override
             public int compare(WSOperation o1, WSOperation o2) {
                 return o1.getName().compareTo(o2.getName());
@@ -136,7 +137,8 @@ public class WSDLImporterTest {
 
     private List<StructureDefinition> sortStructures() {
         List<StructureDefinition> structures = new ArrayList<>(importer.getStructures().values());
-        Collections.sort(structures, new Comparator<StructureDefinition>() {
+        structures.sort(new Comparator<StructureDefinition>() {
+
             @Override
             public int compare(StructureDefinition o1, StructureDefinition o2) {
                 return o1.getId().compareTo(o2.getId());

--- a/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WSDLImporterTest.java
+++ b/modules/flowable-cxf/src/test/java/org/flowable/engine/impl/webservice/WSDLImporterTest.java
@@ -19,7 +19,6 @@ import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyOutputOrder.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyOutputOrder.java
@@ -13,7 +13,6 @@
 package org.flowable.dmn.engine.impl.hitpolicy;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyOutputOrder.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyOutputOrder.java
@@ -62,7 +62,7 @@ public class HitPolicyOutputOrder extends AbstractHitPolicy implements ComposeDe
         }
 
         // sort on predefined list(s) of output values
-        Collections.sort(ruleResults, new Comparator<Map<String, Object>>() {
+        ruleResults.sort(new Comparator<Map<String, Object>>() {
 
             @Override
             public int compare(Map<String, Object> o1, Map<String, Object> o2) {
@@ -70,8 +70,8 @@ public class HitPolicyOutputOrder extends AbstractHitPolicy implements ComposeDe
                 for (Map.Entry<String, List<Object>> entry : executionContext.getOutputValues().entrySet()) {
                     List<Object> outputValues = entry.getValue();
                     if (outputValues != null && !outputValues.isEmpty()) {
-                        compareToBuilder.append(o1.get(entry.getKey()), o2.get(entry.getKey()), 
-                                        new OutputOrderComparator<>(outputValues.toArray(new Comparable[outputValues.size()])));
+                        compareToBuilder.append(o1.get(entry.getKey()), o2.get(entry.getKey()),
+                                new OutputOrderComparator<>(outputValues.toArray(new Comparable[outputValues.size()])));
                         compareToBuilder.toComparison();
                     }
                 }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyPriority.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyPriority.java
@@ -40,7 +40,8 @@ public class HitPolicyPriority extends AbstractHitPolicy implements ComposeDecis
         List<Map<String, Object>> ruleResults = new ArrayList<>(executionContext.getRuleResults().values());
 
         // sort on predefined list(s) of output values
-        Collections.sort(ruleResults, new Comparator<Object>() {
+        ruleResults.sort(new Comparator<Object>() {
+
             boolean noOutputValuesPresent = true;
 
             @SuppressWarnings("unchecked")
@@ -51,9 +52,9 @@ public class HitPolicyPriority extends AbstractHitPolicy implements ComposeDecis
                     List<Object> outputValues = entry.getValue();
                     if (outputValues != null && !outputValues.isEmpty()) {
                         noOutputValuesPresent = false;
-                        compareToBuilder.append(((Map<String, Object>) o1).get(entry.getKey()), 
-                                        ((Map<String, Object>) o2).get(entry.getKey()), 
-                                        new OutputOrderComparator<>(outputValues.toArray(new Comparable[outputValues.size()])));
+                        compareToBuilder.append(((Map<String, Object>) o1).get(entry.getKey()),
+                                ((Map<String, Object>) o2).get(entry.getKey()),
+                                new OutputOrderComparator<>(outputValues.toArray(new Comparable[outputValues.size()])));
                     }
                 }
 
@@ -63,9 +64,11 @@ public class HitPolicyPriority extends AbstractHitPolicy implements ComposeDecis
                     if (CommandContextUtil.getDmnEngineConfiguration().isStrictMode()) {
                         throw new FlowableException(String.format("HitPolicy %s violated; no output values present.", getHitPolicyName()));
                     } else {
-                        executionContext.getAuditContainer().setValidationMessage(String.format("HitPolicy %s violated; no output values present. Setting first valid result as final result.", getHitPolicyName()));
+                        executionContext.getAuditContainer().setValidationMessage(
+                                String.format("HitPolicy %s violated; no output values present. Setting first valid result as final result.",
+                                        getHitPolicyName()));
                     }
-                    
+
                     return 0;
                 }
             }

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyPriority.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/hitpolicy/HitPolicyPriority.java
@@ -13,7 +13,6 @@
 package org.flowable.dmn.engine.impl.hitpolicy;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -981,7 +981,8 @@ public abstract class AbstractEngineConfiguration {
 
                 // Order them according to the priorities (useful for dependent
                 // configurator)
-                Collections.sort(allConfigurators, new Comparator<EngineConfigurator>() {
+                allConfigurators.sort(new Comparator<EngineConfigurator>() {
+
                     @Override
                     public int compare(EngineConfigurator configurator1, EngineConfigurator configurator2) {
                         int priority1 = configurator1.getPriority();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessInstanceHistoryLogImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessInstanceHistoryLogImpl.java
@@ -105,7 +105,8 @@ public class ProcessInstanceHistoryLogImpl implements ProcessInstanceHistoryLog 
     }
 
     public void orderHistoricData() {
-        Collections.sort(historicData, new Comparator<HistoricData>() {
+        historicData.sort(new Comparator<HistoricData>() {
+
             @Override
             public int compare(HistoricData data1, HistoricData data2) {
                 return data1.getTime().compareTo(data2.getTime());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessInstanceHistoryLogImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/ProcessInstanceHistoryLogImpl.java
@@ -14,7 +14,6 @@ package org.flowable.engine.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ScopeUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ScopeUtil.java
@@ -63,7 +63,8 @@ public class ScopeUtil {
         }
 
         // signal compensation events in reverse order of their 'created' timestamp
-        Collections.sort(eventSubscriptions, new Comparator<EventSubscriptionEntity>() {
+        eventSubscriptions.sort(new Comparator<EventSubscriptionEntity>() {
+
             @Override
             public int compare(EventSubscriptionEntity o1, EventSubscriptionEntity o2) {
                 return o2.getCreated().compareTo(o1.getCreated());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ScopeUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ScopeUtil.java
@@ -14,7 +14,6 @@
 package org.flowable.engine.impl.bpmn.helper;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -678,7 +678,7 @@ public class ExecutionEntityManagerImpl
         if (childExecutions != null && childExecutions.size() > 0) {
 
             // Have a fixed ordering of child executions (important for the order in which events are sent)
-            Collections.sort(childExecutions, ExecutionEntity.EXECUTION_ENTITY_START_TIME_ASC_COMPARATOR);
+            childExecutions.sort(ExecutionEntity.EXECUTION_ENTITY_START_TIME_ASC_COMPARATOR);
 
             for (ExecutionEntity childExecution : childExecutions) {
                 if (!executionIdsToExclude.contains(childExecution.getId())) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/MybatisActivityInstanceDataManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/MybatisActivityInstanceDataManager.java
@@ -12,7 +12,6 @@
  */
 package org.flowable.engine.impl.persistence.entity.data.impl;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/MybatisActivityInstanceDataManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/MybatisActivityInstanceDataManager.java
@@ -75,7 +75,7 @@ public class MybatisActivityInstanceDataManager extends AbstractProcessDataManag
     public List<ActivityInstanceEntity> findActivityInstancesByProcessInstanceId(String processInstanceId, boolean includeDeleted) {
         List<ActivityInstanceEntity> activityInstances = getList(getDbSqlSession(), "selectActivityInstancesByProcessInstanceId", processInstanceId, 
                 activitiesByProcessInstanceIdMatcher, true, includeDeleted);
-        Collections.sort(activityInstances, Comparator.comparing(ActivityInstanceEntity::getStartTime)
+        activityInstances.sort(Comparator.comparing(ActivityInstanceEntity::getStartTime)
                 .thenComparing(Comparator.nullsFirst(Comparator.comparing(ActivityInstanceEntity::getTransactionOrder))));
         return activityInstances;
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationTest.java
@@ -3082,7 +3082,7 @@ public class ProcessInstanceMigrationTest extends AbstractProcessInstanceMigrati
         List<HistoricDetail> updateList = historyService.createHistoricDetailQuery().processInstanceId(processInstanceToMigrate.getId()).variableUpdates()
                 .list();
 
-        Collections.sort(updateList, Comparator.comparingInt(histDetail -> Integer.parseInt(histDetail.getId())));
+        updateList.sort(Comparator.comparingInt(histDetail -> Integer.parseInt(histDetail.getId())));
         assertThat(updateList)
                 .extracting(historicDetail -> ((HistoricDetailVariableInstanceUpdateEntity) historicDetail).getVariableType().getTypeName())
                 .containsExactly(values);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -13,7 +13,6 @@
 
 package org.flowable.engine.test.bpmn.event.message;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.HashMap;

--- a/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/FormsResource.java
+++ b/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/FormsResource.java
@@ -84,7 +84,7 @@ public class FormsResource {
             reps.add(new FormRepresentation(model));
         }
 
-        Collections.sort(reps, new NameComparator());
+        reps.sort(new NameComparator());
 
         ResultListDataRepresentation result = new ResultListDataRepresentation(reps);
         result.setTotal(Long.valueOf(models.size()));

--- a/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/FormsResource.java
+++ b/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/FormsResource.java
@@ -14,7 +14,6 @@ package org.flowable.ui.modeler.rest.app;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 


### PR DESCRIPTION
JDK 8 introduced the faster `List.sort()` method.  In more recent versions of the JDK, `Collections.sort()` now just calls `List.sort()` so changing the method reduces on indirect method call in the chain.
