### PR TITLE
Remove boxing of already boxed value

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricProcessInstanceBaseResource.java
@@ -101,7 +101,7 @@ public class HistoricProcessInstanceBaseResource {
             query.processDefinitionName(queryRequest.getProcessDefinitionName());
         }
         if (queryRequest.getProcessDefinitionVersion() != null) {
-            query.processDefinitionVersion(Integer.valueOf(queryRequest.getProcessDefinitionVersion()));
+            query.processDefinitionVersion(queryRequest.getProcessDefinitionVersion());
         }
         if (queryRequest.getProcessDefinitionCategory() != null) {
             query.processDefinitionCategory(queryRequest.getProcessDefinitionCategory());


### PR DESCRIPTION
This is a redundant operation since any boxed value will first be auto-unboxed before boxing the value again.
The method `queryRequest.getProcessDefinitionVersion()` returns an `Integer`.