### PR TITLE
Add the groovy artifact to dependency management.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <camel.version>2.25.0</camel.version>
 		<cxf.version>3.4.0</cxf.version>
 		<slf4j.version>1.7.30</slf4j.version>
+		<groovy.version>3.0.6</groovy.version>
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 
 		<junit.version>4.13</junit.version>
@@ -779,7 +780,12 @@
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-jsr223</artifactId>
-				<version>3.0.6</version>
+				<version>${groovy.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.groovy</groupId>
+				<artifactId>groovy</artifactId>
+				<version>${groovy.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.drools</groupId>


### PR DESCRIPTION
This ensures that the same versions of the groovy-jsr223 and the groovy artifact are used by flowable-spring-boot components.

Spring Boot 2.3 dependency management manages the groovy artifact to 2.5. Therefore Flowable `6.6.0` Spring Boot components use version `3.0.6` of the `groovy-jsr223` artifact and version `2.5.13` of the `groovy` artifact .