### PR TITLE
Use equalsIgnoreCase()

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/history/HistoryLevel.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/history/HistoryLevel.java
@@ -40,7 +40,7 @@ public enum HistoryLevel {
      */
     public static HistoryLevel getHistoryLevelForKey(String key) {
         for (HistoryLevel level : values()) {
-            if (level.key.equals(key)) {
+            if (level.key.equalsIgnoreCase(key)) {
                 return level;
             }
         }


### PR DESCRIPTION
When investigating a forum post on history level it appears that in Spring Boot both `flowable.history-level=NONE` and `flowable.history-level=none` have the same effect.

In a Flowable cfg.xml file the same isn't true; `<property name="history" value="none" />` is OK but `<property name="history" value="NONE" />` generates a `FlowableIllegalArgumentException: Illegal value for history-level: NONE` message.

This PR just changes the equals to ignore the case so both function the same.
