### PR TITLE
Remove no longer necessary jackson-datatype-json-org dependency.

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -100,7 +100,6 @@ com.fasterxml.jackson.core      jackson-annotations         2.11.2          The 
 com.fasterxml.jackson.core      jackson-core                2.11.2          The Apache Software License, Version 2.0
 com.fasterxml.jackson.core      jackson-databind            2.11.2          The Apache Software License, Version 2.0
 com.fasterxml.jackson.datatype  jackson-datatype-joda       2.11.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-json-org   2.11.2          The Apache Software License, Version 2.0
 com.google.guava                guava                       29.0-jre        The Apache Software License, Version 2.0
 com.h2database                  h2                          1.4.200         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0

--- a/modules/flowable-ui/flowable-ui-admin-logic/pom.xml
+++ b/modules/flowable-ui/flowable-ui-admin-logic/pom.xml
@@ -94,10 +94,6 @@
 		<!-- JSON -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-json-org</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui/flowable-ui-admin-rest/pom.xml
+++ b/modules/flowable-ui/flowable-ui-admin-rest/pom.xml
@@ -73,10 +73,6 @@
         </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-json-org</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui/flowable-ui-common/pom.xml
+++ b/modules/flowable-ui/flowable-ui-common/pom.xml
@@ -153,10 +153,6 @@
     <!-- Json -->
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-json-org</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
     </dependency>
     

--- a/modules/flowable-ui/flowable-ui-idm-conf/pom.xml
+++ b/modules/flowable-ui/flowable-ui-idm-conf/pom.xml
@@ -65,12 +65,6 @@
             <artifactId>mysql-connector-java</artifactId>
             <scope>test</scope>
         </dependency>
-        
-		<!-- JSON -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-json-org</artifactId>
-        </dependency>
 
         <!-- COMMON dependencies -->
         <dependency>

--- a/modules/flowable-ui/flowable-ui-idm-logic/pom.xml
+++ b/modules/flowable-ui/flowable-ui-idm-logic/pom.xml
@@ -34,12 +34,6 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
-        
-		<!-- JSON -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-json-org</artifactId>
-		</dependency>
 
 		<!-- COMMON dependencies -->
 		<dependency>

--- a/modules/flowable-ui/flowable-ui-idm-rest/pom.xml
+++ b/modules/flowable-ui/flowable-ui-idm-rest/pom.xml
@@ -45,10 +45,6 @@
         </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-json-org</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui/flowable-ui-modeler-logic/pom.xml
+++ b/modules/flowable-ui/flowable-ui-modeler-logic/pom.xml
@@ -106,10 +106,6 @@
 		<!-- JSON -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-json-org</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui/flowable-ui-modeler-rest/pom.xml
+++ b/modules/flowable-ui/flowable-ui-modeler-rest/pom.xml
@@ -73,10 +73,6 @@
         </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-json-org</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui/flowable-ui-task-conf/pom.xml
+++ b/modules/flowable-ui/flowable-ui-task-conf/pom.xml
@@ -170,10 +170,6 @@
 		<!-- JSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-json-org</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
 

--- a/modules/flowable-ui/flowable-ui-task-logic/pom.xml
+++ b/modules/flowable-ui/flowable-ui-task-logic/pom.xml
@@ -110,10 +110,6 @@
         </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-json-org</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/modules/flowable-ui/flowable-ui-task-rest/pom.xml
+++ b/modules/flowable-ui/flowable-ui-task-rest/pom.xml
@@ -81,10 +81,6 @@
         </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-json-org</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-joda</artifactId>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1023,11 +1023,6 @@
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.datatype</groupId>
-				<artifactId>jackson-datatype-json-org</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.datatype</groupId>
 				<artifactId>jackson-datatype-joda</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>


### PR DESCRIPTION
The `json.org` classed were removed from flowable in f301804b5de89bd9fc434440b737f6b7a6b7dae9 and de6f97c1d648605e695ded4d70871856729723f9

I could not find any usage of `json.org`.

`jackson-datatype-json-org` uses the `org.json:json` artifact whose license it not compatible with the Apache license (see: https://www.apache.org/legal/resolved.html#category-x).