### PR TITLE
Use processDefinitionId to avoid NPE

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityImpl.java
@@ -1389,7 +1389,7 @@ public class ExecutionEntityImpl extends AbstractBpmnEngineVariableScopeEntity i
     protected void resolveProcessDefinitionInfo() {
         ProcessDefinition processDefinition = ProcessDefinitionUtil.getProcessDefinition(processDefinitionId);
         if (processDefinition == null) {
-            throw new FlowableException("Cannot get process definition for id " + processDefinition.getId());
+            throw new FlowableException("Cannot get process definition for id " + processDefinitionId);
         }
         
         this.processDefinitionKey = processDefinition.getKey();


### PR DESCRIPTION
See [comment in commit](https://github.com/flowable/flowable-engine/commit/e43101f1aaa2b463d6a71a21419c8ada69b70663#r44002698) which reads in part:

       This is going to throw a NPE as processDefinition is null (line 1391); I believe instead of processDefinition.getId() it should just be processDefinitionId
