### PR TITLE
Fix MultiInstanceActivityBehavior wrt renamed variable names

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -287,9 +287,9 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
         FlowElement flowNode = execution.getCurrentFlowElement();
 
         return FlowableEventBuilder.createMultiInstanceActivityCompletedEvent(eventType,
-                (int) execution.getVariable(NUMBER_OF_INSTANCES),
-                (int) execution.getVariable(NUMBER_OF_ACTIVE_INSTANCES),
-                (int) execution.getVariable(NUMBER_OF_COMPLETED_INSTANCES),
+                getLoopVariable(execution, NUMBER_OF_INSTANCES),
+                getLoopVariable(execution, NUMBER_OF_ACTIVE_INSTANCES),
+                getLoopVariable(execution, NUMBER_OF_COMPLETED_INSTANCES),
                 flowNode.getId(),
                 flowNode.getName(), execution.getId(), execution.getProcessInstanceId(), execution.getProcessDefinitionId(), flowNode);
     }


### PR DESCRIPTION
We were trying to rename default loop variable names by an own extended implementation of MultiInstanceActivityBehavior which overwrites the methods setLoopVariable(), getLoopVariable() and getLocalLoopVariable(), renaming the variables and delegating to their overwritten implementations.

This works well except in case of MultiInstanceActivityBehavior.buildCompletedEvent() because it invokes directly DelegateExecution.getVariable() utilizing final constant values. There is no chance to intercept there smoothly.

This Pull Request changes this part of code to also use (as already all other places) getLoopVariable() which can be easily overwritten by extending classes.

The added test verifies that the created events carry the expected variable values.

#### Check List:
* Unit tests: YES
* Documentation: NA
