### PR TITLE
Fix wrong engine name

### DIFF
--- a/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-app-engine-spring/src/test/java/org/flowable/app/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -145,7 +145,7 @@ public class SpringAutoDeployTest {
         assertThat(appDefinitionQuery.count()).isEqualTo(1);
     }
 
-    // Updating the form file should lead to a new deployment when restarting the Spring container
+    // Updating the app file should lead to a new deployment when restarting the Spring container
     @Test
     public void testResourceRedeploymentAfterAppDefinitionChange() throws Exception {
         createAppContextWithoutDeploymentMode();
@@ -170,7 +170,7 @@ public class SpringAutoDeployTest {
             IoUtil.writeStringToFile(originalAppFileContent, filePath);
         }
 
-        // Assertions come AFTER the file write! Otherwise the form file is
+        // Assertions come AFTER the file write! Otherwise the app file is
         // messed up if the assertions fail.
         assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
         assertThat(repositoryService.createAppDefinitionQuery().count()).isEqualTo(2);

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngine.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngine.java
@@ -24,7 +24,7 @@ import org.flowable.common.engine.impl.FlowableVersions;
  */
 public interface AppEngine extends Engine {
     
-    /** the version of the flowable CMMN library */
+    /** the version of the flowable App Engine */
     String VERSION = FlowableVersions.CURRENT_VERSION;
 
     AppManagementService getAppManagementService();

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngines.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngines.java
@@ -51,7 +51,7 @@ public abstract class AppEngines {
     public static synchronized void init() {
         if (!isInitialized()) {
             if (appEngines == null) {
-                // Create new map to store CMMN engines if current map is null
+                // Create new map to store App engines if current map is null
                 appEngines = new HashMap<>();
             }
             ClassLoader classLoader = AppEngines.class.getClassLoader();
@@ -59,7 +59,7 @@ public abstract class AppEngines {
             try {
                 resources = classLoader.getResources("flowable.app.cfg.xml");
             } catch (IOException e) {
-                throw new FlowableException("problem retrieving flowable.cmmn.cfg.xml resources on the classpath: " + System.getProperty("java.class.path"), e);
+                throw new FlowableException("problem retrieving flowable.app.cfg.xml resources on the classpath: " + System.getProperty("java.class.path"), e);
             }
 
             // Remove duplicated configuration URL's using set. Some

--- a/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-cmmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -144,7 +144,7 @@ public class SpringAutoDeployTest {
         assertThat(caseDefinitionQuery.count()).isEqualTo(1);
     }
 
-    // Updating the form file should lead to a new deployment when restarting the Spring container
+    // Updating the CMMN file should lead to a new deployment when restarting the Spring container
     @Test
     public void testResourceRedeploymentAfterCaseDefinitionChange() throws Exception {
         createAppContextWithoutDeploymentMode();
@@ -169,7 +169,7 @@ public class SpringAutoDeployTest {
             IoUtil.writeStringToFile(originalCaseFileContent, filePath);
         }
 
-        // Assertions come AFTER the file write! Otherwise the form file is
+        // Assertions come AFTER the file write! Otherwise the CMMN file is
         // messed up if the assertions fail.
         assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
         assertThat(repositoryService.createCaseDefinitionQuery().count()).isEqualTo(2);

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngineConfiguration.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngineConfiguration.java
@@ -186,7 +186,7 @@ public class DmnEngineConfiguration extends AbstractEngineConfiguration
 
 
     /**
-     * Set this to true if you want to have extra checks on the BPMN xml that is parsed. See http://www.jorambarrez.be/blog/2013/02/19/uploading-a-funny-xml -can-bring-down-your-server/
+     * Set this to true if you want to have extra checks on the DMN xml that is parsed. See http://www.jorambarrez.be/blog/2013/02/19/uploading-a-funny-xml -can-bring-down-your-server/
      *
      * Unfortunately, this feature is not available on some platforms (JDK 6, JBoss), hence the reason why it is disabled by default. If your platform allows the use of StaxSource during XML parsing,
      * do enable it.

--- a/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/flowable-dmn-spring/src/test/java/org/flowable/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -143,7 +143,7 @@ public class SpringAutoDeployTest extends AbstractDmnTestCase {
         assertThat(decisionQuery.count()).isEqualTo(2);
     }
 
-    // Updating the form file should lead to a new deployment when restarting the Spring container
+    // Updating the DMN file should lead to a new deployment when restarting the Spring container
     public void testResourceRedeploymentAfterDecisionTableChange() throws Exception {
         createAppContextWithoutDeploymentMode();
         assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(1);
@@ -167,7 +167,7 @@ public class SpringAutoDeployTest extends AbstractDmnTestCase {
             IoUtil.writeStringToFile(originalFormFileContent, filePath);
         }
 
-        // Assertions come AFTER the file write! Otherwise the form file is
+        // Assertions come AFTER the file write! Otherwise the DMN file is
         // messed up if the assertions fail.
         assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(2);
         assertThat(repositoryService.createDecisionQuery().count()).isEqualTo(4);

--- a/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/management/EventRegistryEngineResource.java
+++ b/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/management/EventRegistryEngineResource.java
@@ -37,7 +37,7 @@ public class EventRegistryEngineResource {
     @Autowired(required=false)
     protected EventRegistryRestApiInterceptor restApiInterceptor;
 
-    @ApiOperation(value = "Get engine info", tags = { "Cmmn Engine" })
+    @ApiOperation(value = "Get engine info", tags = { "Event Registry Engine" })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Indicates the engine info is returned."),
     })

--- a/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FlowableFormRule.java
+++ b/modules/flowable-form-engine/src/main/java/org/flowable/form/engine/test/FlowableFormRule.java
@@ -27,7 +27,7 @@ import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 /**
- * Convenience for DmnEngine and services initialization in the form of a JUnit rule.
+ * Convenience for FormEngine and services initialization in the form of a JUnit rule.
  * 
  * <p>
  * Usage:

--- a/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/AppDeploymentsClientResource.java
+++ b/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/AppDeploymentsClientResource.java
@@ -48,11 +48,11 @@ public class AppDeploymentsClientResource extends AbstractClientResource {
     protected AppDeploymentService clientService;
 
     /**
-     * GET /rest/admin/app-deployments -> get a list of form deployments.
+     * GET /rest/admin/app-deployments -> get a list of app deployments.
      */
     @GetMapping(produces = "application/json")
     public JsonNode listAppDeployments(HttpServletRequest request) {
-        LOGGER.debug("REST request to get a list of form deployments");
+        LOGGER.debug("REST request to get a list of app deployments");
 
         JsonNode resultNode = null;
         ServerConfig serverConfig = retrieveServerConfig(EndpointType.APP);
@@ -62,7 +62,7 @@ public class AppDeploymentsClientResource extends AbstractClientResource {
             resultNode = clientService.listDeployments(serverConfig, parameterMap);
 
         } catch (FlowableServiceException e) {
-            LOGGER.error("Error getting form deployments", e);
+            LOGGER.error("Error getting app deployments", e);
             throw new BadRequestException(e.getMessage());
         }
 
@@ -70,7 +70,7 @@ public class AppDeploymentsClientResource extends AbstractClientResource {
     }
 
     /**
-     * POST /rest/admin/app-deployments: upload a form deployment
+     * POST /rest/admin/app-deployments: upload a app deployment
      */
     @PostMapping(produces = "application/json")
     public JsonNode handleAppFileUpload(HttpServletRequest request, @RequestParam("file") MultipartFile file) {

--- a/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/CmmnDeploymentsClientResource.java
+++ b/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/CmmnDeploymentsClientResource.java
@@ -48,11 +48,11 @@ public class CmmnDeploymentsClientResource extends AbstractClientResource {
     protected CmmnDeploymentService clientService;
 
     /**
-     * GET /rest/admin/cmmn-deployments -> get a list of form deployments.
+     * GET /rest/admin/cmmn-deployments -> get a list of CMMN deployments.
      */
     @GetMapping(produces = "application/json")
     public JsonNode listCmmnDeployments(HttpServletRequest request) {
-        LOGGER.debug("REST request to get a list of form deployments");
+        LOGGER.debug("REST request to get a list of CMMN deployments");
 
         JsonNode resultNode = null;
         ServerConfig serverConfig = retrieveServerConfig(EndpointType.CMMN);
@@ -62,7 +62,7 @@ public class CmmnDeploymentsClientResource extends AbstractClientResource {
             resultNode = clientService.listDeployments(serverConfig, parameterMap);
 
         } catch (FlowableServiceException e) {
-            LOGGER.error("Error getting form deployments", e);
+            LOGGER.error("Error getting CMMN deployments", e);
             throw new BadRequestException(e.getMessage());
         }
 
@@ -70,7 +70,7 @@ public class CmmnDeploymentsClientResource extends AbstractClientResource {
     }
 
     /**
-     * POST /rest/admin/cmmn-deployments: upload a form deployment
+     * POST /rest/admin/cmmn-deployments: upload a CMMN deployment
      */
     @PostMapping(produces = "application/json")
     public JsonNode handleCmmnFileUpload(HttpServletRequest request, @RequestParam("file") MultipartFile file) {
@@ -88,7 +88,7 @@ public class CmmnDeploymentsClientResource extends AbstractClientResource {
                 }
 
             } catch (IOException e) {
-                LOGGER.error("Error deploying form upload", e);
+                LOGGER.error("Error deploying CMMN upload", e);
                 throw new InternalServerErrorException("Could not deploy file: " + e.getMessage());
             }
 

--- a/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/DecisionTableDeploymentsClientResource.java
+++ b/modules/flowable-ui/flowable-ui-admin-rest/src/main/java/org/flowable/ui/admin/rest/client/DecisionTableDeploymentsClientResource.java
@@ -70,7 +70,7 @@ public class DecisionTableDeploymentsClientResource extends AbstractClientResour
     }
 
     /**
-     * POST /rest/admin/decision-table-deployments: upload a form deployment
+     * POST /rest/admin/decision-table-deployments: upload a DMN deployment
      */
     @PostMapping(produces = "application/json")
     public JsonNode handleDmnFileUpload(HttpServletRequest request, @RequestParam("file") MultipartFile file) {


### PR DESCRIPTION
Inspired by the recent [PR ](https://github.com/flowable/flowable-engine/pull/2726) by @vzickner, fix occurrences where the wrong (engine) name was used in exceptions, logging, comments, etc.
