### PR TITLE
Adding new functional delegate VariableGetOrDefaultIfNotExistExpressionFunctio…

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -233,6 +233,7 @@ import org.flowable.common.engine.impl.el.function.VariableContainsExpressionFun
 import org.flowable.common.engine.impl.el.function.VariableEqualsExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableExistsExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableGetExpressionFunction;
+import org.flowable.common.engine.impl.el.function.VariableGetOrDefaultIfNotExistExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableGetOrDefaultExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableGreaterThanExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableGreaterThanOrEqualsExpressionFunction;
@@ -1008,6 +1009,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
             flowableFunctionDelegates.add(new VariableGetExpressionFunction());
             flowableFunctionDelegates.add(new VariableGetOrDefaultExpressionFunction());
+            flowableFunctionDelegates.add(new VariableGetOrDefaultIfNotExistExpressionFunction());
 
             flowableFunctionDelegates.add(new VariableContainsAnyExpressionFunction());
             flowableFunctionDelegates.add(new VariableContainsExpressionFunction());

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/VariableGetOrDefaultIfNotExistExpressionFunction.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/el/function/VariableGetOrDefaultIfNotExistExpressionFunction.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.common.engine.impl.el.function;
+
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.common.engine.impl.javax.el.PropertyNotFoundException;
+
+/**
+ * Returns the value of a variable (even if it's null), or a default if the variable is not found.
+ * This avoids the {@link PropertyNotFoundException} that otherwise gets thrown when referencing a variable in JUEL.
+ *
+ * @author Balavivek Bala Naga Sethuraja
+ */
+public class VariableGetOrDefaultIfNotExistExpressionFunction extends AbstractFlowableVariableExpressionFunction {
+
+    public VariableGetOrDefaultIfNotExistExpressionFunction() {
+        super("getOrDefaultIfNotExist");
+    }
+
+    public static Object getOrDefaultIfNotExist(VariableContainer variableContainer, String variableName, Object value) {
+        if (variableContainer.hasVariable(variableName)) {
+            return getVariableValue(variableContainer, variableName);
+        } else {
+            return value;
+        }
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -69,6 +69,7 @@ import org.flowable.common.engine.impl.el.function.VariableContainsExpressionFun
 import org.flowable.common.engine.impl.el.function.VariableEqualsExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableExistsExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableGetExpressionFunction;
+import org.flowable.common.engine.impl.el.function.VariableGetOrDefaultIfNotExistExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableGetOrDefaultExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableGreaterThanExpressionFunction;
 import org.flowable.common.engine.impl.el.function.VariableGreaterThanOrEqualsExpressionFunction;
@@ -2608,6 +2609,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
             flowableFunctionDelegates.add(new VariableGetExpressionFunction());
             flowableFunctionDelegates.add(new VariableGetOrDefaultExpressionFunction());
+            flowableFunctionDelegates.add(new VariableGetOrDefaultIfNotExistExpressionFunction());
 
             flowableFunctionDelegates.add(new VariableContainsAnyExpressionFunction());
             flowableFunctionDelegates.add(new VariableContainsExpressionFunction());


### PR DESCRIPTION
Adding new functional delegate VariableGetOrDefaultIfNotExistExpressionFunction: to get the value from container irrespective of null or default

Existing function delegate `VariableGetOrDefaultExpressionFunction` will return the default value even when the variable is found in variable container. This delegate function will return same value from variable container as such. Users can use with their use case specifications.

#### Check List:
* Unit tests:  NA
* Documentation: YES: As Java docs. 
