### PR TITLE
Introduce flag to control error messages being sent back with 500

### DIFF
--- a/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/exception/BaseExceptionHandlerAdvice.java
+++ b/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/exception/BaseExceptionHandlerAdvice.java
@@ -19,6 +19,7 @@ import org.flowable.common.engine.api.FlowableObjectNotFoundException;
 import org.flowable.common.engine.api.FlowableTaskAlreadyClaimedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -35,6 +36,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public class BaseExceptionHandlerAdvice {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseExceptionHandlerAdvice.class);
+    @Value("${flowable.common.rest.exception.return-messages-for-500-errors:false}")
+    protected boolean returnErrorMessagesFor500Errors;
 
     @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE) // 415
     @ExceptionHandler(FlowableContentNotSupportedException.class)
@@ -99,7 +102,7 @@ public class BaseExceptionHandlerAdvice {
     @ResponseBody
     public ErrorInfo handleOtherException(Exception e) {
         LOGGER.error("Unhandled exception", e);
-        return new ErrorInfo("Internal server error", e);
+        return new ErrorInfo("Internal server error", returnErrorMessagesFor500Errors ? e : null);
     }
 
 }


### PR DESCRIPTION
Today Flowable by default returns detailed error messages for all errors
For errors 500, however, responses contain information about software
exceptions with detailed error description if an error occurs. Such
information is revealed at multiple endpoints in case of invalid input
parameters.
Technical information is not supposed to be visible to clients as it
does not provide any added value. To an attacker however, this
information might give valuable hints as to which frameworks and
libraries are used by the web application. Apart from that, technical
details can help in the analysis of errors and simplify the search for
security issues.

So to avoid this, the default behavior was changed not to return
detailed messages for all 500 errors. That default can also be
overridden by the newly introduced flag:
`flowable.common.rest.exception.return-messages-for-500-errors`

#### Check List:
* Unit tests: NA
* Documentation: NO