### PR TITLE
Update Spring Security to 5.3.6

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.2.11.RELEASE  The 
 org.springframework             spring-core                 5.2.11.RELEASE  The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.2.11.RELEASE  The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.3.5.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.3.5.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.3.5.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.3.5.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.3.6.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.3.6.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.3.6.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.3.6.RELEASE   The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.0          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.3.6.RELEASE</spring.boot.version>
 		<spring.framework.version>5.2.11.RELEASE</spring.framework.version>
-		<spring.security.version>5.3.5.RELEASE</spring.security.version>
+		<spring.security.version>5.3.6.RELEASE</spring.security.version>
 		<spring.amqp.version>2.2.11.RELEASE</spring.amqp.version>
 		<spring.kafka.version>2.5.8.RELEASE</spring.kafka.version>
 		<reactor-netty.version>0.9.12.RELEASE</reactor-netty.version>


### PR DESCRIPTION
The only dependency changes for 5.3.6 are given in the Release Notes as:

Dependency Upgrades

- Update to Google App Engine 1.9.83
- Update to Spring Boot 2.2.11

Flowable already uses a later version of Spring Boot.