### PR TITLE
Use newly created variable in place of null value

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/async/json/transformer/TaskEndedHistoryJsonTransformer.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/async/json/transformer/TaskEndedHistoryJsonTransformer.java
@@ -61,7 +61,7 @@ public class TaskEndedHistoryJsonTransformer extends AbstractTaskHistoryJsonTran
             HistoricTaskService historicTaskService = cmmnEngineConfiguration.getTaskServiceConfiguration().getHistoricTaskService();
             HistoricTaskInstanceEntity historicTaskInstanceEntity = historicTaskService.createHistoricTask();
             copyCommonHistoricTaskInstanceFields(historicalData, historicTaskInstanceEntity);
-            setEndProperties(historicalData, historicTaskInstance);
+            setEndProperties(historicalData, historicTaskInstanceEntity);
             historicTaskService.insertHistoricTask(historicTaskInstanceEntity, false);
         }
     }


### PR DESCRIPTION
The variable, `historicTaskInstance` is null that is being sent to `setEndProperties`.  Use the newly created `historicTaskInstanceEntity` instead.