### PR TITLE
Upgrade to Spring 5.2.12.RELEASE

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.30          MIT License
 org.slf4j                       slf4j-api                   1.7.30          MIT License
 org.slf4j                       slf4j-log4j12               1.7.30          MIT License
-org.springframework             spring-beans                5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-context              5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.2.11.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-context              5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.2.12.RELEASE  The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.3.5.RELEASE   The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.3.5.RELEASE   The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.3.5.RELEASE   The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.3.6.RELEASE</spring.boot.version>
-		<spring.framework.version>5.2.11.RELEASE</spring.framework.version>
+		<spring.framework.version>5.2.12.RELEASE</spring.framework.version>
 		<spring.security.version>5.3.5.RELEASE</spring.security.version>
 		<spring.amqp.version>2.2.11.RELEASE</spring.amqp.version>
 		<spring.kafka.version>2.5.8.RELEASE</spring.kafka.version>
@@ -23,7 +23,7 @@
 		<jackson.version>2.11.2</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
-    <camel.version>2.25.0</camel.version>
+		<camel.version>2.25.0</camel.version>
 		<cxf.version>3.4.0</cxf.version>
 		<slf4j.version>1.7.30</slf4j.version>
 		<groovy.version>3.0.6</groovy.version>


### PR DESCRIPTION
Release notes: https://github.com/spring-projects/spring-framework/releases/tag/v5.2.12.RELEASE

Not dependency updates that are part Flowable.
