### PR TITLE
Update Spring Framework, Security, Boot and friends

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -124,7 +124,7 @@ log4j                           log4j                       1.2.17          The 
 org.apache.commons              commons-email               1.5             Apache License, Version 2.0
 org.apache.commons              commons-lang3               3.11            The Apache Software License, Version 2.0
 org.apache.httpcomponents       httpclient                  4.5.12          Apache License, Version 2.0
-org.apache.httpcomponents       httpcore                    4.4.13          Apache License, Version 2.0
+org.apache.httpcomponents       httpcore                    4.4.14          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.12          Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
 org.codehaus.groovy             groovy                      3.0.6           The Apache Software License, Version 2.0
@@ -136,22 +136,22 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.30          MIT License
 org.slf4j                       slf4j-api                   1.7.30          MIT License
 org.slf4j                       slf4j-log4j12               1.7.30          MIT License
-org.springframework             spring-beans                5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-context              5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.2.11.RELEASE  The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.3.5.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.3.5.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.3.5.RELEASE   The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.3.5.RELEASE   The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-context              5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.2.12.RELEASE  The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.3.6.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.3.6.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.3.6.RELEASE   The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.3.6.RELEASE   The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.0          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<name>Flowable</name>
@@ -14,16 +14,16 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.3.6.RELEASE</spring.boot.version>
-		<spring.framework.version>5.2.11.RELEASE</spring.framework.version>
-		<spring.security.version>5.3.5.RELEASE</spring.security.version>
-		<spring.amqp.version>2.2.11.RELEASE</spring.amqp.version>
-		<spring.kafka.version>2.5.8.RELEASE</spring.kafka.version>
+		<spring.boot.version>2.3.7.RELEASE</spring.boot.version>
+		<spring.framework.version>5.2.12.RELEASE</spring.framework.version>
+		<spring.security.version>5.3.6.RELEASE</spring.security.version>
+		<spring.amqp.version>2.2.13.RELEASE</spring.amqp.version>
+		<spring.kafka.version>2.5.10.RELEASE</spring.kafka.version>
 		<reactor-netty.version>0.9.12.RELEASE</reactor-netty.version>
 		<jackson.version>2.11.2</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
-    <camel.version>2.25.0</camel.version>
+		<camel.version>2.25.0</camel.version>
 		<cxf.version>3.4.0</cxf.version>
 		<slf4j.version>1.7.30</slf4j.version>
 		<groovy.version>3.0.6</groovy.version>
@@ -129,11 +129,11 @@
 				<artifactId>httpclient</artifactId>
 				<version>4.5.12</version>
 			</dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-                <version>4.4.13</version>
-            </dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore</artifactId>
+				<version>4.4.14</version>
+			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpmime</artifactId>
@@ -227,7 +227,7 @@
 			<dependency>
 				<groupId>com.ibm.db2</groupId>
 				<artifactId>jcc</artifactId>
-				<version>11.5.0.0</version>
+				<version>11.5.5.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.flowable</groupId>
@@ -348,7 +348,7 @@
                 <groupId>org.flowable</groupId>
                 <artifactId>flowable-idm-rest</artifactId>
                 <version>${project.version}</version>
-            </dependency>    
+            </dependency>
 			<dependency>
 				<groupId>org.flowable</groupId>
 				<artifactId>flowable-dmn-api</artifactId>
@@ -775,7 +775,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.3.5.Final</version>
+				<version>5.4.25.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
Spring Framework 5.2.12 notes: https://github.com/spring-projects/spring-framework/releases/tag/v5.2.12.RELEASE
Spring Security 5.3.6 notes: https://github.com/spring-projects/spring-security/releases/tag/5.3.6.RELEASE
Spring Boot 2.37 notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.3.7.RELEASE

Spring Boot has the most dependency updates and those that Flowable uses have been updated to match.

This PR supersedes the individual update PRs: PR #2738 and PR #2732  
