### PR TITLE
Minor cleanup of CallActivityBehavior

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -127,10 +127,8 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
             businessKey = processInstance.getBusinessKey();
         }
         
-        Map<String, Object> variables = new HashMap<>();
-        
         StartSubProcessInstanceBeforeContext instanceBeforeContext = new StartSubProcessInstanceBeforeContext(businessKey, callActivity.getProcessInstanceName(), 
-                        variables, executionEntity, callActivity.getInParameters(), callActivity.isInheritVariables(), 
+                        new HashMap<>(), executionEntity, callActivity.getInParameters(), callActivity.isInheritVariables(),
                         initialFlowElement.getId(), initialFlowElement, subProcess, processDefinition);
         
         if (processEngineConfiguration.getStartProcessInstanceInterceptor() != null) {
@@ -143,7 +141,7 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
 
         FlowableEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();
         if (eventDispatcher != null && eventDispatcher.isEnabled()) {
-            processEngineConfiguration.getEventDispatcher().dispatchEvent(
+            eventDispatcher.dispatchEvent(
                     FlowableEventBuilder.createEntityEvent(FlowableEngineEventType.PROCESS_CREATED, subProcessInstance),
                     processEngineConfiguration.getEngineCfgKey());
         }


### PR DESCRIPTION
* Declare "variables" HashMap inline to avoid it being accidentally used further down
* Use already retrieved eventDispatcher instead of fetching it again from process engine configuration

#### Check List:
* Unit tests: NA
* Documentation: NA
