### PR TITLE
Added new filter to HistoricTaskInstanceQuery

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -1279,8 +1279,8 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
     @Test
     public void testQueryByAssignedOr() {
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssigned();
-        assertThat(query.count()).isEqualTo(0);
-        assertThat(query.list()).hasSize(0);
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -1268,6 +1268,20 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(query.count()).isEqualTo(11);
         assertThat(query.list()).hasSize(11);
     }
+    
+    @Test
+    public void testQueryByAssigned() {
+        TaskQuery query = taskService.createTaskQuery().taskAssigned();
+        assertThat(query.count()).isEqualTo(1);
+        assertThat(query.list()).hasSize(1);
+    }
+
+    @Test
+    public void testQueryByAssignedOr() {
+        TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssigned();
+        assertThat(query.count()).isEqualTo(0);
+        assertThat(query.list()).hasSize(0);
+    }
 
     @Test
     public void testQueryByCandidateUser() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricTaskInstanceTest.java
@@ -223,6 +223,8 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("kermi%").count()).isEqualTo(1);
         assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("%ermi%").count()).isEqualTo(1);
         assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("%johndoe%").count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigned().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().taskUnassigned().count()).isZero();
 
         // Delete reason
         assertThat(historyService.createHistoricTaskInstanceQuery().taskDeleteReason("deleted").count()).isZero();
@@ -633,6 +635,8 @@ public class HistoricTaskInstanceTest extends PluggableFlowableTestCase {
         assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssignee("johndoe").endOr().count()).isZero();
         assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssigneeLike("%ermit").endOr().count()).isEqualTo(1);
         assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssigneeLike("%johndoe%").endOr().count()).isZero();
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssigned().endOr().count()).isEqualTo(1);
+        assertThat(historyService.createHistoricTaskInstanceQuery().or().taskUnassigned().endOr().count()).isZero();
 
         assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().or().taskAssigneeLike("%ermit").endOr().count()).isEqualTo(1);
         assertThat(historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().or().taskAssigneeLike("%johndoe%").endOr().count()).isZero();

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
@@ -107,6 +107,12 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
      * executed.
      */
     T taskAssigneeLikeIgnoreCase(String assigneeLikeIgnoreCase);
+    
+    /** Only select tasks which don't have an assignee. */
+    T taskUnassigned();
+    
+    /** Only select historic task instances which are assigned to any user */
+    T taskAssigned();
 
     /**
      * Only select tasks with an assignee that is in the given list

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskQuery.java
@@ -23,9 +23,6 @@ import java.util.Collection;
  */
 public interface TaskQuery extends TaskInfoQuery<TaskQuery, Task> {
 
-    /** Only select tasks which don't have an assignee. */
-    TaskQuery taskUnassigned();
-
     /** Only select tasks with the given {@link DelegationState}. */
     TaskQuery taskDelegationState(DelegationState delegationState);
 

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/history/HistoricTaskInstanceQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/history/HistoricTaskInstanceQuery.java
@@ -103,15 +103,5 @@ public interface HistoricTaskInstanceQuery extends TaskInfoQuery<HistoricTaskIns
      * Order by task delete reason (needs to be followed by {@link #asc()} or {@link #desc()}).
      */
     HistoricTaskInstanceQuery orderByDeleteReason();
-    
-    /**
-     * Only select historic task instances which are not assigned to any users
-     */
-    HistoricTaskInstanceQuery taskUnassigned();
-    
-    /**
-     * Only select historic task instances which are assigned to any user
-     */
-    HistoricTaskInstanceQuery taskAssigned();
 
 }

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/history/HistoricTaskInstanceQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/history/HistoricTaskInstanceQuery.java
@@ -103,5 +103,15 @@ public interface HistoricTaskInstanceQuery extends TaskInfoQuery<HistoricTaskIns
      * Order by task delete reason (needs to be followed by {@link #asc()} or {@link #desc()}).
      */
     HistoricTaskInstanceQuery orderByDeleteReason();
+    
+    /**
+     * Only select historic task instances which are not assigned to any users
+     */
+    HistoricTaskInstanceQuery taskUnassigned();
+    
+    /**
+     * Only select historic task instances which are assigned to any user
+     */
+    HistoricTaskInstanceQuery taskAssigned();
 
 }

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
@@ -98,6 +98,8 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     protected String taskAssignee;
     protected String taskAssigneeLike;
     protected String taskAssigneeLikeIgnoreCase;
+    protected boolean withAssignee;
+    protected boolean withoutAssignee;
     protected Collection<String> taskAssigneeIds;
     protected String taskDefinitionKey;
     protected String taskDefinitionKeyLike;
@@ -2041,6 +2043,14 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     public String getTaskAssigneeLike() {
         return taskAssigneeLike;
     }
+    
+    public boolean isWithAssignee() {
+        return withAssignee;
+    }
+    
+    public boolean isWithoutAssignee() {
+        return withoutAssignee;
+    }
 
     public Collection<String> getTaskAssigneeIds() {
         return taskAssigneeIds;
@@ -2133,5 +2143,27 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
 
     public List<HistoricTaskInstanceQueryImpl> getOrQueryObjects() {
         return orQueryObjects;
+    }
+    
+    @Override
+    public HistoricTaskInstanceQuery taskUnassigned() {
+        if (inOrStatement) {
+            this.currentOrQueryObject.withoutAssignee = true;
+        }
+        else {
+            this.withoutAssignee = true;
+        }
+        return this;
+    }
+    
+    @Override
+    public HistoricTaskInstanceQuery taskAssigned() {
+        if (inOrStatement) {
+            this.currentOrQueryObject.withAssignee = true;
+        }
+        else {
+            this.withAssignee = true;
+        }
+        return this;
     }
 }

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
@@ -73,6 +73,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     protected String ownerLike;
     protected String ownerLikeIgnoreCase;
     protected boolean unassigned;
+    protected boolean withAssignee;
     protected boolean noDelegationState;
     protected DelegationState delegationState;
     protected String candidateUser;
@@ -1808,6 +1809,10 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     public boolean getUnassigned() {
         return unassigned;
     }
+    
+    public boolean isWithAssignee() {
+        return withAssignee;
+    }
 
     public DelegationState getDelegationState() {
         return delegationState;
@@ -2134,6 +2139,16 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     public long count() {
         cachedCandidateGroups = null;
         return super.count();
+    }
+
+    @Override
+    public TaskQuery taskAssigned() {
+        if (orActive) {
+            currentOrQueryObject.withAssignee = true;
+        } else {
+            this.withAssignee = true;
+        }
+        return this;
     }
 
 }

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
@@ -1159,6 +1159,12 @@
           #{assigneeId}
         </foreach>
       </if>
+      <if test="withAssignee">
+        and ${queryTablePrefix}ASSIGNEE_ IS NOT NULL
+      </if>
+      <if test="withoutAssignee">
+        and ${queryTablePrefix}ASSIGNEE_ IS NULL
+      </if>
       <if test="taskPriority != null">
         and ${queryTablePrefix}PRIORITY_ = #{taskPriority}
       </if>
@@ -1383,6 +1389,12 @@
       </if>
        <if test="orQueryObject.taskAssigneeLikeIgnoreCase != null">
         or ${queryTablePrefix}ASSIGNEE_ like #{orQueryObject.taskAssigneeLikeIgnoreCase}${wildcardEscapeClause}
+      </if>
+      <if test="orQueryObject.withAssignee">
+        or ${queryTablePrefix}ASSIGNEE_ IS NOT NULL
+      </if>
+      <if test="orQueryObject.withoutAssignee">
+        or ${queryTablePrefix}ASSIGNEE_ IS NULL
       </if>
       <if test="orQueryObject.taskAssigneeIds != null &amp;&amp; orQueryObject.taskAssigneeIds.size() &gt; 0">
         or ${queryTablePrefix}ASSIGNEE_ IN

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -660,6 +660,9 @@
       <if test="unassigned">
         and RES.ASSIGNEE_ IS NULL
       </if>
+      <if test="withAssignee">
+        and RES.ASSIGNEE_ IS NOT NULL
+      </if>
       <if test="noDelegationState">
         and RES.DELEGATION_ IS NULL
       </if>
@@ -1123,6 +1126,9 @@
             <if test="orQueryObject.unassigned">
               or RES.ASSIGNEE_ IS NULL
             </if>
+            <if test="orQueryObject.withAssignee">
+              and RES.ASSIGNEE_ IS NOT NULL
+      		</if>
             <if test="orQueryObject.noDelegationState">
               or RES.DELEGATION_ IS NULL
             </if>

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -1127,7 +1127,7 @@
               or RES.ASSIGNEE_ IS NULL
             </if>
             <if test="orQueryObject.withAssignee">
-              and RES.ASSIGNEE_ IS NOT NULL
+              or RES.ASSIGNEE_ IS NOT NULL
       		</if>
             <if test="orQueryObject.noDelegationState">
               or RES.DELEGATION_ IS NULL


### PR DESCRIPTION
Added new filter taskAssigned(filtering task where assignee is not null) and taskUnassigned(filtering task where assignee is null) for HistoricTaskInstanceQuery
