### PR TITLE
Fixed : Validation error is thrown when "to" is not given but "bcc" or "cc" is given in email task

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
@@ -187,7 +187,7 @@ public class MailActivityBehavior extends CoreCmmnActivityBehavior {
     
     protected void validateToCcBcc(CommandContext commandContext, String to, String cc, String bcc, String tenantId) {
         
-        if(to == null && cc == null && bcc == null) {
+        if (to == null && cc == null && bcc == null) {
             throw new FlowableException("No recipient could be found for sending email");
         }
         
@@ -208,7 +208,7 @@ public class MailActivityBehavior extends CoreCmmnActivityBehavior {
         }
         
         String[] bccs = splitAndTrim(newBcc);
-        if(tos == null && ccs == null && bccs == null) {
+        if (tos == null && ccs == null && bccs == null) {
             throw new FlowableException("No recipient could be found for sending email");
         }
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
@@ -97,7 +97,7 @@ public class MailActivityBehavior extends CoreCmmnActivityBehavior {
 
             email = createEmail(textStr, htmlStr, attachmentsExist(files, dataSources));
             addHeader(email, headersStr);
-            validateToCcBcc(commandContext, toStr, ccStr, bccStr, planItemInstanceEntity.getTenantId());
+            validateToCcBcc(toStr, ccStr, bccStr);
             addTo(commandContext, email, toStr, planItemInstanceEntity.getTenantId());
             setFrom(commandContext, email, fromStr, planItemInstanceEntity.getTenantId());
             addCc(commandContext, email, ccStr, planItemInstanceEntity.getTenantId());
@@ -185,41 +185,17 @@ public class MailActivityBehavior extends CoreCmmnActivityBehavior {
         }
     }
     
-    protected void validateToCcBcc(CommandContext commandContext, String to, String cc, String bcc, String tenantId) {
-        
+    protected void validateToCcBcc(String to, String cc, String bcc) {
         if (to == null && cc == null && bcc == null) {
-            throw new FlowableException("No recipient could be found for sending email");
-        }
-        
-        String newTo, newCc, newBcc;
-        newTo = newCc = newBcc = getForceTo(commandContext, tenantId);
-        if (newTo == null) {
-            newTo = to;
-        }
-        
-        String[] tos = splitAndTrim(newTo);
-        if (newCc == null) {
-            newCc = cc;
-        }
-        
-        String[] ccs = splitAndTrim(newCc);
-        if (newBcc == null) {
-            newBcc = bcc;
-        }
-        
-        String[] bccs = splitAndTrim(newBcc);
-        if (tos == null && ccs == null && bccs == null) {
             throw new FlowableException("No recipient could be found for sending email");
         }
     }
 
     protected void addTo(CommandContext commandContext, Email email, String to, String tenantId) {
-        if (to == null) {
-           return;
-        }
-        String newTo = getForceTo(commandContext, tenantId);
+        String forceTo = getForceTo(commandContext, tenantId);
+        String newTo = forceTo == null ? to : forceTo;
         if (newTo == null) {
-            newTo = to;
+            return;
         }
         String[] tos = splitAndTrim(newTo);
         if (tos != null) {

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/task/CmmnMailTaskTest.testCcBccWithoutTo.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/task/CmmnMailTaskTest.testCcBccWithoutTo.cmmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+    <case id="testCcBccWithoutToMail" name="testCcBccWithoutToMail" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+            <extensionElements>
+                <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+                <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+            </extensionElements>
+            <planItem id="planItem1" name="Email task" definitionRef="emailTask1"></planItem>
+            <planItem id="planItem2" name="Email task2" definitionRef="emailTask2"></planItem>
+            <task id="emailTask1" name="Email task" flowable:type="mail">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[EmailTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                    <flowable:field name="from">
+                        <flowable:string><![CDATA[flowable@localhost]]></flowable:string>
+                    </flowable:field>
+                    <flowable:field name="subject">
+                        <flowable:string><![CDATA[Hello!]]></flowable:string>
+                    </flowable:field>
+                    <flowable:field name="text">
+                        <flowable:string><![CDATA[This is a test]]></flowable:string>
+                    </flowable:field>
+                    <flowable:field name="cc">
+                        <flowable:string><![CDATA[cc@flowable.org]]></flowable:string>
+                    </flowable:field>
+                </extensionElements>
+            </task>
+            <task id="emailTask2" name="Email task2" flowable:type="mail">
+                <extensionElements>
+                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
+                    <design:stencilid><![CDATA[EmailTask]]></design:stencilid>
+                    <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                    <flowable:field name="from">
+                        <flowable:string><![CDATA[flowable@localhost]]></flowable:string>
+                    </flowable:field>
+                    <flowable:field name="subject">
+                        <flowable:string><![CDATA[Hello!]]></flowable:string>
+                    </flowable:field>
+                    <flowable:field name="text">
+                        <flowable:string><![CDATA[This is a test]]></flowable:string>
+                    </flowable:field>
+                    <flowable:field name="bcc">
+                        <flowable:string><![CDATA[bcc@flowable.org]]></flowable:string>
+                    </flowable:field>
+                </extensionElements>
+            </task>
+        </casePlanModel>
+    </case>
+</definitions>

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -197,7 +197,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     
     protected void validateToCcBcc(String to, String cc, String bcc, String tenantId) {
         
-        if(to == null && cc == null && bcc == null) {
+        if (to == null && cc == null && bcc == null) {
             throw new FlowableException("No recipient could be found for sending email");
         }
         
@@ -218,7 +218,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
         }
         
         String[] bccs = splitAndTrim(newBcc);
-        if(tos == null && ccs == null && bccs == null) {
+        if (tos == null && ccs == null && bccs == null) {
             throw new FlowableException("No recipient could be found for sending email");
         }
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -107,7 +107,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
     
                 email = createEmail(textStr, htmlStr, attachmentsExist(files, dataSources));
                 addHeader(email, headersStr);
-                validateToCcBcc(toStr, ccStr, bccStr, execution.getTenantId());
+                validateToCcBcc(toStr, ccStr, bccStr);
                 addTo(email, toStr, execution.getTenantId());
                 setFrom(email, fromStr, execution.getTenantId());
                 addCc(email, ccStr, execution.getTenantId());
@@ -195,42 +195,20 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
         }
     }
     
-    protected void validateToCcBcc(String to, String cc, String bcc, String tenantId) {
-        
+    protected void validateToCcBcc(String to, String cc, String bcc) {
         if (to == null && cc == null && bcc == null) {
-            throw new FlowableException("No recipient could be found for sending email");
-        }
-        
-        String newTo, newCc, newBcc;
-        newTo = newCc = newBcc = getForceTo(tenantId);
-        if (newTo == null) {
-            newTo = to;
-        }
-        
-        String[] tos = splitAndTrim(newTo);
-        if (newCc == null) {
-            newCc = cc;
-        }
-        
-        String[] ccs = splitAndTrim(newCc);
-        if (newBcc == null) {
-            newBcc = bcc;
-        }
-        
-        String[] bccs = splitAndTrim(newBcc);
-        if (tos == null && ccs == null && bccs == null) {
             throw new FlowableException("No recipient could be found for sending email");
         }
     }
     
     protected void addTo(Email email, String to, String tenantId) {
-        if (to == null) {
+        String forceTo = getForceTo(tenantId);
+        String newTo = forceTo == null ? to : forceTo;
+
+        if (newTo == null) {
             return;
         }
-        String newTo = getForceTo(tenantId);
-        if (newTo == null) {
-            newTo = to;
-        }
+        
         String[] tos = splitAndTrim(newTo);
         if (tos != null) {
             for (String t : tos) {

--- a/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DefaultProcessValidatorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/standalone/validation/DefaultProcessValidatorTest.java
@@ -354,6 +354,19 @@ public class DefaultProcessValidatorTest {
                 );
     }
 
+    @Test
+    void testMailTask() {
+        BpmnModel bpmnModel = readBpmnModelFromXml("org/flowable/standalone/validation/processWithMailTask.bpmn20.xml");
+
+        List<ValidationError> errors = processValidator.validate(bpmnModel);
+
+        assertThat(errors)
+                .extracting(ValidationError::getProblem, ValidationError::getDefaultDescription, ValidationError::getActivityId, ValidationError::isWarning)
+                .containsExactlyInAnyOrder(
+                        tuple(Problems.MAIL_TASK_NO_RECIPIENT, "No recipient is defined on the mail activity", "sendMailWithoutanything", false)
+                );
+    }
+
     protected void assertCommonProblemFieldForActivity(ValidationError error) {
         assertProcessElementError(error);
 

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testCcAndBccWithoutTo.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/mail/EmailSendTaskTest.testCcAndBccWithoutTo.bpmn20.xml
@@ -1,0 +1,47 @@
+<definitions 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="ccAndBccWithoutTo" >
+
+    <startEvent id="theStart" />
+    
+    <sequenceFlow sourceRef="theStart" targetRef="sendMailWithCc" />
+    
+    <sendTask id="sendMailWithCc" activiti:type="mail">
+      <extensionElements>
+        <activiti:field name="subject">
+          <activiti:string>Hello world</activiti:string>
+        </activiti:field>
+        <activiti:field name="text">
+          <activiti:string>This is the content</activiti:string>
+        </activiti:field>
+        <activiti:field name="cc">
+          <activiti:string>fozzie@activiti.org</activiti:string>
+        </activiti:field>
+      </extensionElements>
+    </sendTask>
+    
+    <sequenceFlow sourceRef="sendMailWithCc" targetRef="sendMailWithBcc" />
+    
+    <sendTask id="sendMailWithBcc" activiti:type="mail">
+      <extensionElements>
+        <activiti:field name="subject">
+          <activiti:string>Hello world</activiti:string>
+        </activiti:field>
+        <activiti:field name="text">
+          <activiti:string>This is the content</activiti:string>
+        </activiti:field>
+        <activiti:field name="bcc">
+          <activiti:string>mispiggy@activiti.org</activiti:string>
+        </activiti:field>
+      </extensionElements>
+    </sendTask>
+    <sequenceFlow sourceRef="sendMailWithBcc" targetRef="theEnd" />
+    
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/standalone/validation/processWithMailTask.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/standalone/validation/processWithMailTask.bpmn20.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="toCcAndBcc" >
+
+    <startEvent id="theStart" />
+    <sequenceFlow sourceRef="theStart" targetRef="sendMailWithoutanything" />
+    
+    <serviceTask id="sendMailWithoutanything" activiti:type="mail">
+      <extensionElements>
+        <activiti:field name="subject">
+          <activiti:string>Hello world</activiti:string>
+        </activiti:field>
+        <activiti:field name="text">
+          <activiti:string>This is the content</activiti:string>
+        </activiti:field>
+      </extensionElements>
+    </serviceTask>
+    
+    <sequenceFlow sourceRef="sendMailWithoutanything" targetRef="sendMailWithTo" />
+    <serviceTask id="sendMailWithTo" activiti:type="mail">
+      <extensionElements>
+        <activiti:field name="to">
+          <activiti:string>kermit@activiti.org</activiti:string>
+        </activiti:field>
+        <activiti:field name="subject">
+          <activiti:string>Hello world</activiti:string>
+        </activiti:field>
+        <activiti:field name="text">
+          <activiti:string>This is the content</activiti:string>
+        </activiti:field>
+      </extensionElements>
+    </serviceTask>
+    
+    <sequenceFlow sourceRef="sendMailWithTo" targetRef="sendMailWithCC" />
+    <serviceTask id="sendMailWithCC" activiti:type="mail">
+      <extensionElements>
+        <activiti:field name="subject">
+          <activiti:string>Hello world</activiti:string>
+        </activiti:field>
+        <activiti:field name="text">
+          <activiti:string>This is the content</activiti:string>
+        </activiti:field>
+        <activiti:field name="cc">
+          <activiti:string>fozzie@activiti.org</activiti:string>
+        </activiti:field>
+      </extensionElements>
+    </serviceTask>
+    
+    <sequenceFlow sourceRef="sendMailWithCC" targetRef="sendMailWithBCC" />
+    <serviceTask id="sendMailWithBCC" activiti:type="mail">
+      <extensionElements>
+        <activiti:field name="subject">
+          <activiti:string>Hello world</activiti:string>
+        </activiti:field>
+        <activiti:field name="text">
+          <activiti:string>This is the content</activiti:string>
+        </activiti:field>
+        <activiti:field name="bcc">
+          <activiti:string>mispiggy@activiti.org</activiti:string>
+        </activiti:field>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow sourceRef="sendMailWithBCC" targetRef="theEnd" />
+    
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ExternalInvocationTaskValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ExternalInvocationTaskValidator.java
@@ -32,7 +32,7 @@ public abstract class ExternalInvocationTaskValidator extends ProcessLevelValida
         boolean textOrHtmlDefined = false;
 
         for (FieldExtension fieldExtension : fieldExtensions) {
-            if ("to".equals(fieldExtension.getFieldName())) {
+            if ("to".equals(fieldExtension.getFieldName()) || "cc".equals(fieldExtension.getFieldName()) || "bcc".equals(fieldExtension.getFieldName())) {
                 toDefined = true;
             }
             if ("html".equals(fieldExtension.getFieldName())) {

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ExternalInvocationTaskValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ExternalInvocationTaskValidator.java
@@ -32,20 +32,20 @@ public abstract class ExternalInvocationTaskValidator extends ProcessLevelValida
         boolean textOrHtmlDefined = false;
 
         for (FieldExtension fieldExtension : fieldExtensions) {
-            if ("to".equals(fieldExtension.getFieldName()) || "cc".equals(fieldExtension.getFieldName()) || "bcc".equals(fieldExtension.getFieldName())) {
-                toDefined = true;
-            }
-            if ("html".equals(fieldExtension.getFieldName())) {
-                textOrHtmlDefined = true;
-            }
-            if ("htmlVar".equals(fieldExtension.getFieldName())) {
-                textOrHtmlDefined = true;
-            }
-            if ("text".equals(fieldExtension.getFieldName())) {
-                textOrHtmlDefined = true;
-            }
-            if ("textVar".equals(fieldExtension.getFieldName())) {
-                textOrHtmlDefined = true;
+            switch (fieldExtension.getFieldName()) {
+                case "to":
+                case "cc":
+                case "bcc": {
+                    toDefined = true;
+                    break;
+                }
+                case "html":
+                case "htmlVar":
+                case "text":
+                case "textVar": {
+                    textOrHtmlDefined = true;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixed below issue : 
"No recipient is defined on the mail activity" validation message is shown when "to" field is not provided and "cc" or "bcc" is provided in email task.

Normally, user can send email by just providing value in "cc" and "bcc".

so i have changed validation code for email task and now validation error won't be given if any one of them is provided.