### PR TITLE
ProcessInstanceCollectionResource: Honor 'returnVariables' parameter …

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestResponseFactory.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestResponseFactory.java
@@ -571,41 +571,23 @@ public class RestResponseFactory {
     }
 
     public ProcessInstanceResponse createProcessInstanceResponse(ProcessInstance processInstance, RestUrlBuilder urlBuilder) {
-        ProcessInstanceResponse result = internalCreateProcessInstanceResponse(processInstance, urlBuilder);
-        if (processInstance.getProcessVariables() != null) {
-            Map<String, Object> variableMap = processInstance.getProcessVariables();
-            for (String name : variableMap.keySet()) {
-                result.addVariable(createRestVariable(name, variableMap.get(name), RestVariableScope.LOCAL, processInstance.getId(), VARIABLE_PROCESS, false, urlBuilder));
-            }
-        }
-
-        return result;
+        return createProcessInstanceResponse(processInstance, processInstance.getProcessVariables(), urlBuilder);
     }
 
-    public ProcessInstanceResponse createProcessInstanceResponse(ProcessInstance processInstance, boolean returnVariables,
-            Map<String, Object> runtimeVariableMap, List<HistoricVariableInstance> historicVariableList) {
+    public ProcessInstanceResponse createProcessInstanceResponse(ProcessInstance processInstance, Map<String, Object> variableMap) {
+        return createProcessInstanceResponse(processInstance, variableMap, createUrlBuilder());
+    }
 
-        RestUrlBuilder urlBuilder = createUrlBuilder();
+    public ProcessInstanceResponse createProcessInstanceResponse(ProcessInstance processInstance, Map<String, Object> variableMap, RestUrlBuilder urlBuilder) {
         ProcessInstanceResponse result = internalCreateProcessInstanceResponse(processInstance, urlBuilder);
 
-        if (returnVariables) {
-
-            if (processInstance.isEnded()) {
-                if (historicVariableList != null) {
-                    for (HistoricVariableInstance historicVariable : historicVariableList) {
-                        result.addVariable(createRestVariable(historicVariable.getVariableName(), historicVariable.getValue(), RestVariableScope.LOCAL, processInstance.getId(), VARIABLE_PROCESS, false,
-                                urlBuilder));
-                    }
-                }
-
-            } else {
-                if (runtimeVariableMap != null) {
-                    for (String name : runtimeVariableMap.keySet()) {
-                        result.addVariable(createRestVariable(name, runtimeVariableMap.get(name), RestVariableScope.LOCAL, processInstance.getId(), VARIABLE_PROCESS, false, urlBuilder));
-                    }
-                }
-            }
+        if (variableMap != null && !variableMap.isEmpty()) {
+            variableMap.entrySet().stream().map(
+                entry -> createRestVariable(
+                    entry.getKey(), entry.getValue(), RestVariableScope.LOCAL, processInstance.getId(), VARIABLE_PROCESS, false, urlBuilder))
+            .forEach(result::addVariable);
         }
+
         return result;
     }
 

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
@@ -436,7 +436,7 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
                         + "   ended: false"
                         + "}");
         JsonNode variablesArrayNode = responseNode.get("variables");
-        assertThat(variablesArrayNode).hasSize(7);
+        assertThat(variablesArrayNode).hasSize(0);
 
         ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().singleResult();
         assertThat(processInstance).isNotNull();


### PR DESCRIPTION
…instead of always returning them (default according to docs)

According to the documentation, a parameter `returnVariables` can be set to return variables when starting a process. The default is supposed to be `false`. At the moment the variables are always returned. There was a test which was "fixed" (?) with d9ebf1e5dcafcfae2e5c1f11c2ec6caf18159930.

As this behaviour is present for quite a while, maybe we should just set the default to true and change the documentation as well?