### PR TITLE
Update to SpringBoot 2.3.8 (and dependencies)

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -96,10 +96,10 @@ Quartz
 This software includes unchanged copies of the following libraries:
 
 aopalliance                     aopalliance                 1.0             Public Domain
-com.fasterxml.jackson.core      jackson-annotations         2.11.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-core                2.11.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-databind            2.11.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-joda       2.11.2          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-annotations         2.11.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-core                2.11.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-databind            2.11.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.datatype  jackson-datatype-joda       2.11.4          The Apache Software License, Version 2.0
 com.google.guava                guava                       29.0-jre        The Apache Software License, Version 2.0
 com.h2database                  h2                          1.4.200         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,13 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.3.7.RELEASE</spring.boot.version>
+		<spring.boot.version>2.3.8.RELEASE</spring.boot.version>
 		<spring.framework.version>5.2.12.RELEASE</spring.framework.version>
 		<spring.security.version>5.3.6.RELEASE</spring.security.version>
-		<spring.amqp.version>2.2.13.RELEASE</spring.amqp.version>
-		<spring.kafka.version>2.5.10.RELEASE</spring.kafka.version>
+		<spring.amqp.version>2.2.14.RELEASE</spring.amqp.version>
+		<spring.kafka.version>2.5.11.RELEASE</spring.kafka.version>
 		<reactor-netty.version>0.9.12.RELEASE</reactor-netty.version>
-		<jackson.version>2.11.2</jackson.version>
+		<jackson.version>2.11.4</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
 		<camel.version>2.25.0</camel.version>


### PR DESCRIPTION
Release notes at: https://github.com/spring-projects/spring-boot/releases/tag/v2.3.8.RELEASE

Updated associated dependencies as listed in the release notes.