### PR TITLE
Change test for cut-n-paste issue

### DIFF
--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/deployment/DeploymentTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/deployment/DeploymentTest.java
@@ -500,7 +500,7 @@ public class DeploymentTest extends AbstractFlowableDmnTest {
         assertThat(decisionServices2).hasSize(2);
 
         List<DmnDecision> decisionTables = repositoryService.createDecisionQuery().decisionType(DecisionTypes.DECISION_TABLE).list();
-        assertThat(decisionServices2).hasSize(2);
+        assertThat(decisionTables).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
I noticed the following code:
````
        List<DmnDecision> decisionServices2 = repositoryService.createDecisionQuery().decisionType(DecisionTypes.DECISION_SERVICE).list();
        assertThat(decisionServices2).hasSize(2);

        List<DmnDecision> decisionTables = repositoryService.createDecisionQuery().decisionType(DecisionTypes.DECISION_TABLE).list();
        assertThat(decisionServices2).hasSize(2);
````
It seemed strange that the last `assertThat()` statement was testing a variable (`decisionServices2`) from the previous section of code and not the most recent call to `createDecisionQuery()`.

I changed the last `assertThat()` to test the variable `decisionTables` but the condition needed to change also to `isEmpty()`.