### PR TITLE
Chore: remove unused import from recent push

### DIFF
--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/cfg/HttpServiceTaskCfgSpringWebClientTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/cfg/HttpServiceTaskCfgSpringWebClientTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import javax.net.ssl.SSLHandshakeException;
 
-import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.test.Deployment;
 import org.flowable.http.common.impl.spring.reactive.SpringWebClientFlowableHttpClient;


### PR DESCRIPTION
Remove unused import that is new as a result of today's merge to master.