### PR TITLE
Chore: remove duplicated catch clauses

### DIFF
--- a/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
@@ -193,8 +193,6 @@ public abstract class BaseSpringContentRestTestCase extends AbstractContentTestC
             httpResponses.add(response);
             return response;
 
-        } catch (ClientProtocolException e) {
-            fail(e.getMessage());
         } catch (IOException e) {
             fail(e.getMessage());
         }

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/BaseSpringDmnRestTestCase.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/BaseSpringDmnRestTestCase.java
@@ -193,8 +193,6 @@ public abstract class BaseSpringDmnRestTestCase extends AbstractDmnTestCase {
             httpResponses.add(response);
             return response;
 
-        } catch (ClientProtocolException e) {
-            fail(e.getMessage());
         } catch (IOException e) {
             fail(e.getMessage());
         }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/SerializableVariablesDiabledTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/SerializableVariablesDiabledTest.java
@@ -193,8 +193,6 @@ public class SerializableVariablesDiabledTest {
 
             response.close();
 
-        } catch (ClientProtocolException e) {
-            fail(e.getMessage());
         } catch (IOException e) {
             fail(e.getMessage());
         }


### PR DESCRIPTION
Remove duplicated `catch` clauses;  `ClientProtocolException` extends `IOException` so the additional `catch` is redundant. 
