### PR TITLE
Chore: remove unused imports

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/event/TaskAssignedEventTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/event/TaskAssignedEventTest.java
@@ -19,7 +19,6 @@ import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
 import org.flowable.common.engine.api.delegate.event.AbstractFlowableEventListener;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
-import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.common.engine.impl.event.FlowableEntityEventImpl;
 import org.flowable.task.api.Task;

--- a/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
+++ b/modules/flowable-content-rest/src/test/java/org/flowable/content/rest/service/api/BaseSpringContentRestTestCase.java
@@ -33,7 +33,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/BaseSpringDmnRestTestCase.java
+++ b/modules/flowable-dmn-rest/src/test/java/org/flowable/dmn/rest/service/api/BaseSpringDmnRestTestCase.java
@@ -31,7 +31,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/SerializableVariablesDiabledTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/SerializableVariablesDiabledTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;


### PR DESCRIPTION
This is embarrassing as I'm the reason for the unused imports because of push removing duplicated catch clauses.