### PR TITLE
Upgrade to Spring Security 5.4.5

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.4           The 
 org.springframework             spring-core                 5.3.4           The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.4           The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.4.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.4.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.4.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.4.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.4.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.4.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.4.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.4.5           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.4.2</spring.boot.version>
 		<spring.framework.version>5.3.4</spring.framework.version>
-		<spring.security.version>5.4.4</spring.security.version>
+		<spring.security.version>5.4.5</spring.security.version>
 		<spring.amqp.version>2.3.4</spring.amqp.version>
 		<spring.kafka.version>2.6.5</spring.kafka.version>
 		<reactor-netty.version>1.0.3</reactor-netty.version>


### PR DESCRIPTION
See release notes: https://github.com/spring-projects/spring-security/releases/tag/5.4.5

Simple downgrade of dependent jar.