### PR TITLE
Update Jackson to version 2.12.3.

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -96,10 +96,10 @@ Quartz
 This software includes unchanged copies of the following libraries:
 
 aopalliance                     aopalliance                 1.0             Public Domain
-com.fasterxml.jackson.core      jackson-annotations         2.11.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-core                2.11.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-databind            2.11.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-joda       2.11.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-annotations         2.12.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-core                2.12.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-databind            2.12.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.datatype  jackson-datatype-joda       2.12.3          The Apache Software License, Version 2.0
 com.google.guava                guava                       30.1-jre        The Apache Software License, Version 2.0
 com.h2database                  h2                          1.4.200         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <name>Flowable - CMNMN Rest - Classes</name>
+  <name>Flowable - CMMN Rest - Classes</name>
   <artifactId>flowable-cmmn-rest</artifactId>
   <packaging>jar</packaging>
 
@@ -228,6 +228,11 @@
     <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit-assertj</artifactId>
+      <scope>test</scope>
+    </dependency>
+      <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/JavaTimeObjectMapperProvider.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/JavaTimeObjectMapperProvider.java
@@ -1,0 +1,40 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.rest;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import net.javacrumbs.jsonunit.providers.Jackson2ObjectMapperProvider;
+
+public class JavaTimeObjectMapperProvider implements Jackson2ObjectMapperProvider {
+
+    private final ObjectMapper objectMapper;
+    private final ObjectMapper lenientObjectMapper;
+
+    public JavaTimeObjectMapperProvider() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+        lenientObjectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        lenientObjectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        lenientObjectMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+        lenientObjectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+    }
+
+    @Override
+    public ObjectMapper getObjectMapper(boolean lenient) {
+        return lenient ? lenientObjectMapper : objectMapper;
+    }
+
+}

--- a/modules/flowable-cmmn-rest/src/test/resources/META-INF/services/net.javacrumbs.jsonunit.providers.Jackson2ObjectMapperProvider
+++ b/modules/flowable-cmmn-rest/src/test/resources/META-INF/services/net.javacrumbs.jsonunit.providers.Jackson2ObjectMapperProvider
@@ -1,0 +1,1 @@
+org.flowable.cmmn.rest.JavaTimeObjectMapperProvider

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -157,6 +157,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+       </dependency>
+        <dependency>
             <groupId>org.flowable</groupId>
             <artifactId>flowable-spring</artifactId>
             <scope>test</scope>

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/JavaTimeObjectMapperProvider.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/JavaTimeObjectMapperProvider.java
@@ -1,0 +1,40 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.rest;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import net.javacrumbs.jsonunit.providers.Jackson2ObjectMapperProvider;
+
+public class JavaTimeObjectMapperProvider implements Jackson2ObjectMapperProvider {
+
+    private final ObjectMapper objectMapper;
+    private final ObjectMapper lenientObjectMapper;
+
+    public JavaTimeObjectMapperProvider() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+        lenientObjectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        lenientObjectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        lenientObjectMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+        lenientObjectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+    }
+
+    @Override
+    public ObjectMapper getObjectMapper(boolean lenient) {
+        return lenient ? lenientObjectMapper : objectMapper;
+    }
+
+}

--- a/modules/flowable-rest/src/test/resources/META-INF/services/net.javacrumbs.jsonunit.providers.Jackson2ObjectMapperProvider
+++ b/modules/flowable-rest/src/test/resources/META-INF/services/net.javacrumbs.jsonunit.providers.Jackson2ObjectMapperProvider
@@ -1,0 +1,1 @@
+org.flowable.rest.JavaTimeObjectMapperProvider

--- a/modules/flowable-spring-boot/pom.xml
+++ b/modules/flowable-spring-boot/pom.xml
@@ -33,6 +33,13 @@
                 <version>1.4.01</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring.boot.version}</version>
@@ -43,13 +50,6 @@
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-bom</artifactId>
                 <version>${spring.security.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<spring.amqp.version>2.3.6</spring.amqp.version>
 		<spring.kafka.version>2.6.7</spring.kafka.version>
 		<reactor-netty.version>1.0.6</reactor-netty.version>
-		<jackson.version>2.11.4</jackson.version>
+		<jackson.version>2.12.3</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
 		<camel.version>2.25.0</camel.version>
@@ -1013,24 +1013,11 @@
 				<version>30.1-jre</version>
 			</dependency>
 			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
 				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.datatype</groupId>
-				<artifactId>jackson-datatype-joda</artifactId>
-				<version>${jackson.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
New version of https://github.com/flowable/flowable-engine/pull/2812 as I can not reopen the pull request because of force pushing.

Not sure if this should be merged or if you like to wait until Spring Boot uses Jackson 2.12.