### PR TITLE
Import a process model as a new version

### DIFF
--- a/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/i18n/en.json
+++ b/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/i18n/en.json
@@ -2163,7 +2163,8 @@
               "DROPZONE": "Drop a .bpmn or .bpmn20.xml BPMN XML file",
               "CANCEL-UPLOAD": "Cancel the upload",
               "ERROR": "Error while processing the BPMN XML file",
-              "NO-DROP": "Drag and drop not supported"
+              "NO-DROP": "Drag and drop not supported",
+              "NEW-VERSION": "Import into existing process model as new version if keys are matching."
           }
         },
         "ALERT": {

--- a/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/scripts/controllers/processes.js
+++ b/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/scripts/controllers/processes.js
@@ -246,7 +246,8 @@ angular.module('flowableModeler')
 .controller('ImportProcessModelCtrl', ['$rootScope', '$scope', '$http', 'Upload', '$location', function ($rootScope, $scope, $http, Upload, $location) {
 
   $scope.model = {
-       loading: false
+       loading: false,
+       importNewVersionIndicator: false
   };
 
   $scope.onFileSelect = function($files, isIE) {
@@ -264,7 +265,8 @@ angular.module('flowableModeler')
           Upload.upload({
               url: url,
               method: 'POST',
-              file: file
+              file: file,
+              fields: { importNewVersionIndicator: $scope.model.importNewVersionIndicator }
           }).progress(function(evt) {
 	      $scope.model.loading = true;
               $scope.model.uploadProgress = parseInt(100.0 * evt.loaded / evt.total);

--- a/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/views/popup/process-import.html
+++ b/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/views/popup/process-import.html
@@ -16,6 +16,13 @@
                     <i class="glyphicon glyphicon-info-sign"></i>
                     {{'PROCESS.POPUP.IMPORT-DESCRIPTION' | translate}}
                 </p>
+
+                <div ng-if="model.error && model.errorMessage && model.errorMessage.length > 0" class="alert error" style="font-size: 14px; margin-top:20px">
+                    <div class="popup-error" style="font-size: 14px">
+                        <span class="glyphicon glyphicon-remove-circle"></span>
+                        <span>{{'PROCESS.POPUP.IMPORT.ERROR' | translate}} <span ng-if="model.errorMessage"> : </span>{{model.errorMessage}}</span>
+                    </div>
+                </div>
                 <!--[if IE 9]>
 
                 <div class="import-process-form">
@@ -65,14 +72,18 @@
                 </div>
 
                 <!-- <![endif]-->
+
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" ng-model="model.importNewVersionIndicator" id="importNewVersionIndicator">
+                    <label class="form-check-label" for="importNewVersionIndicator">
+                        Import into existing process model as new version if keys are matching.
+                    </label>
+                </div>
             </div>
 
             <div class="modal-footer-wrapper">
                 <div class="modal-footer">
                     <loading></loading>
-                    <div class="pull-right modeler-processes-error" ng-if="model.error">
-                        <span>{{'PROCESS.POPUP.IMPORT.ERROR' | translate}} <span ng-if="model.errorMessage"> : </span>{{model.errorMessage}}</span>
-                    </div>
                 </div>
             </div>
         </div>

--- a/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/views/popup/process-import.html
+++ b/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/views/popup/process-import.html
@@ -76,7 +76,7 @@
                 <div class="form-check">
                     <input class="form-check-input" type="checkbox" ng-model="model.importNewVersionIndicator" id="importNewVersionIndicator">
                     <label class="form-check-label" for="importNewVersionIndicator">
-                        Import into existing process model as new version if keys are matching.
+                        {{'PROCESS.POPUP.IMPORT.NEW-VERSION' | translate}}
                     </label>
                 </div>
             </div>

--- a/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/ModelsResource.java
+++ b/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/ModelsResource.java
@@ -75,8 +75,12 @@ public class ModelsResource {
     }
 
     @PostMapping(value = "/rest/import-process-model", produces = "application/json")
-    public ModelRepresentation importProcessModel(HttpServletRequest request, @RequestParam("file") MultipartFile file) {
-        return modelQueryService.importProcessModel(request, file);
+    public ModelRepresentation importProcessModel(
+            HttpServletRequest request,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("importNewVersionIndicator") Boolean importNewVersionIndicator) {
+
+        return modelQueryService.importProcessModel(request, file, importNewVersionIndicator);
     }
 
     /*


### PR DESCRIPTION
This PR is going to improve three topics (refer to https://forum.flowable.org/t/import-a-process-model-as-a-new-version/7522) regarding the "Import Process" behavior of the "Modeler App":

1. AS IS: It is currently possible to import a new workflow with key "X" even if there is already a workflow existing with that key "X" resulting in a duplicate. Subsequent save operations will then fail. TO BE: Importing a workflow with existing key will no longer be possible.

2. AS IS: Error Messages on Import Process are showing as part of the footer, right aligned without proper layout. TO BE: Align error message handling with the "Create Process" dialog.

3. AS IS: It is currently not possible to import a new version into an existing process. TO BE: Provide a new Option "Create new version if the key of that workflow already exists." as part of the import dialog. If importing a workflow with an already existing key and the option is checked then continue to import the workflow as a new version into the existing one.

Out of Scope
- Change of documentation
- Change of CMMN, DMN and Form