### PR TITLE
Initialize ProcessInstanceMigrationDocument correctly

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ProcessInstanceMigrationValidationCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/ProcessInstanceMigrationValidationCmd.java
@@ -67,6 +67,7 @@ public class ProcessInstanceMigrationValidationCmd implements Command<ProcessIns
 
         this.processDefinitionKey = processDefinitionKey;
         this.processDefinitionVersion = processDefinitionVersion;
+        this.processInstanceMigrationDocument = processInstanceMigrationDocument;
         this.processDefinitionTenantId = processDefinitionTenantId;
     }
 


### PR DESCRIPTION
I was getting a NullPointerExecption on migrations when upgrading to 6.6.0.
I found that the ProcessInstanceMigrationDocument was not getting initialized - simple fix!
#### Check List:
* Unit tests: YES
* Documentation: NA
