### PR TITLE
Fix infinite recursion

### DIFF
--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/JobInfoEntityManagerImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/JobInfoEntityManagerImpl.java
@@ -70,7 +70,7 @@ public abstract class JobInfoEntityManagerImpl<T extends JobInfoEntity, DM exten
 
     @Override
     public JobServiceConfiguration getJobServiceConfiguration() {
-        return getJobServiceConfiguration();
+        return getServiceConfiguration();
     }
 
 }


### PR DESCRIPTION
As the code currently is written a call to `getJobServiceConfiguration()` results in infinite recursion.  I think the intent was to call `getServiceConfiguration` which is part of `AbstractServiceEngineEntityManager`.

FWIW, `JobInfoEntityManagerImpl` extends `AbstractJobServiceEngineEntityManager` which extends `AbstractServiceEngineEntityManager`.