### PR TITLE
Upgrade to Spring Boot 2.4.4 and Spring Framework 5.3.5

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.30          MIT License
 org.slf4j                       slf4j-api                   1.7.30          MIT License
 org.slf4j                       slf4j-log4j12               1.7.30          MIT License
-org.springframework             spring-beans                5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.4           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.4           The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.5           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.4.5           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.4.5           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.4.5           The Apache Software License, Version 2.0

--- a/modules/flowable-app-engine-rest/pom.xml
+++ b/modules/flowable-app-engine-rest/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <flowable.artifact>
             org.flowable.app.rest
         </flowable.artifact>
@@ -198,37 +199,37 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jetty.version>9.4.38.v20210224</jetty.version>
     <flowable.artifact>
       org.flowable.cmmn.rest
     </flowable.artifact>
@@ -186,37 +187,37 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.35.v20201120</version>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.35.v20201120</version>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
-      <version>9.4.35.v20201120</version>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
-      <version>9.4.35.v20201120</version>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-io</artifactId>
-      <version>9.4.35.v20201120</version>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>9.4.35.v20201120</version>
+      <version>${jetty.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -17,6 +17,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<jetty.version>9.4.38.v20210224</jetty.version>
 		<flowable.artifact>
 			org.flowable.content.rest
 		</flowable.artifact>
@@ -199,37 +200,37 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>9.4.35.v20201120</version>
+			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>9.4.35.v20201120</version>
+			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-http</artifactId>
-			<version>9.4.35.v20201120</version>
+			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<version>9.4.35.v20201120</version>
+			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-io</artifactId>
-			<version>9.4.35.v20201120</version>
+			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-util</artifactId>
-			<version>9.4.35.v20201120</version>
+			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <flowable.artifact>
             org.flowable.dmn.rest.service
         </flowable.artifact>
@@ -213,37 +214,37 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/modules/flowable-event-registry-rest/pom.xml
+++ b/modules/flowable-event-registry-rest/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <flowable.artifact>
             org.flowable.eventregistry.rest
         </flowable.artifact>
@@ -202,37 +203,37 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <flowable.artifact>
             org.flowable.form.rest
         </flowable.artifact>
@@ -198,37 +199,37 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.2.14.v20151106</jetty.version>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <flowable.osgi.import.pkg>*</flowable.osgi.import.pkg>
         <flowable.artifact>
             org.flowable.http

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.38.v20210224</jetty.version>
+        <jetty.version>9.2.14.v20151106</jetty.version>
         <flowable.osgi.import.pkg>*</flowable.osgi.import.pkg>
         <flowable.artifact>
             org.flowable.http

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <flowable.artifact>
             org.flowable.rest
         </flowable.artifact>
@@ -212,37 +213,37 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.4.3</spring.boot.version>
-		<spring.framework.version>5.3.4</spring.framework.version>
+		<spring.boot.version>2.4.4</spring.boot.version>
+		<spring.framework.version>5.3.5</spring.framework.version>
 		<spring.security.version>5.4.5</spring.security.version>
-		<spring.amqp.version>2.3.5</spring.amqp.version>
-		<spring.kafka.version>2.6.6</spring.kafka.version>
+		<spring.amqp.version>2.3.6</spring.amqp.version>
+		<spring.kafka.version>2.6.7</spring.kafka.version>
 		<reactor-netty.version>1.0.3</reactor-netty.version>
 		<jackson.version>2.11.4</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
@@ -995,7 +995,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.2.6</version>
+				<version>42.2.19</version>
 			</dependency>
 			<dependency>
 				<groupId>xerces</groupId>


### PR DESCRIPTION
See Spring Boot release notes at: https://github.com/spring-projects/spring-boot/releases/tag/v2.4.4
See Spring Framework release notes at: https://github.com/spring-projects/spring-framework/releases/tag/v5.3.5

Updated dependencies and added `jetty.version` property to simplify future changes.

