### PR TITLE
Fixed ContentManagementServiceImpl and DmnManagementServiceImpl to ha…

### DIFF
--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngineConfiguration.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/ContentEngineConfiguration.java
@@ -60,7 +60,7 @@ public class ContentEngineConfiguration extends AbstractEngineConfiguration impl
     // SERVICES
     // /////////////////////////////////////////////////////////////////
 
-    protected ContentManagementService contentManagementService = new ContentManagementServiceImpl();
+    protected ContentManagementService contentManagementService = new ContentManagementServiceImpl(this);
     protected ContentService contentService = new ContentServiceImpl();
 
     // DATA MANAGERS ///////////////////////////////////////////////////

--- a/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/ContentManagementServiceImpl.java
+++ b/modules/flowable-content-engine/src/main/java/org/flowable/content/engine/impl/ContentManagementServiceImpl.java
@@ -31,6 +31,10 @@ import org.flowable.content.engine.impl.cmd.GetTableNameCmd;
  */
 public class ContentManagementServiceImpl extends CommonEngineServiceImpl<ContentEngineConfiguration> implements ContentManagementService {
 
+    public ContentManagementServiceImpl(ContentEngineConfiguration contentEngineConfiguration) {
+        super(contentEngineConfiguration);
+    }
+
     @Override
     public Map<String, Long> getTableCount() {
         return commandExecutor.execute(new GetTableCountCmd(configuration.getEngineCfgKey()));

--- a/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/AbstractFlowableContentTest.java
+++ b/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/AbstractFlowableContentTest.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.content.engine.test;
 
+import org.flowable.content.api.ContentManagementService;
 import org.flowable.content.api.ContentService;
 import org.flowable.content.engine.ContentEngine;
 import org.flowable.content.engine.ContentEngineConfiguration;
@@ -38,6 +39,7 @@ public class AbstractFlowableContentTest {
     protected static ContentEngine cachedContentEngine;
     protected ContentEngineConfiguration contentEngineConfiguration;
     protected ContentService contentService;
+    protected ContentManagementService contentManagementService;
 
     @Before
     public void initContentEngine() {
@@ -47,6 +49,7 @@ public class AbstractFlowableContentTest {
 
         this.contentEngineConfiguration = cachedContentEngine.getContentEngineConfiguration();
         this.contentService = cachedContentEngine.getContentService();
+        this.contentManagementService = cachedContentEngine.getContentManagementService();
     }
 
 }

--- a/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/mgmt/ContentManagementServiceTest.java
+++ b/modules/flowable-content-engine/src/test/java/org/flowable/content/engine/test/mgmt/ContentManagementServiceTest.java
@@ -1,0 +1,87 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.content.engine.test.mgmt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.management.TableMetaData;
+import org.flowable.content.engine.impl.persistence.entity.ContentItemEntity;
+import org.flowable.content.engine.test.AbstractFlowableContentTest;
+import org.junit.Test;
+
+public class ContentManagementServiceTest extends AbstractFlowableContentTest {
+
+    @Test
+    public void testGetMetaDataForUnexistingTable() {
+        TableMetaData metaData = contentManagementService.getTableMetaData("unexistingtable");
+        assertThat(metaData).isNull();
+    }
+
+    @Test
+    public void testGetMetaDataNullTableName() {
+        assertThatThrownBy(() -> contentManagementService.getTableMetaData(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("tableName is null");
+    }
+
+    @Test
+    public void testGetTableName() {
+        String table = contentManagementService.getTableName(ContentItemEntity.class);
+        assertThat(table).isEqualTo("ACT_CO_CONTENT_ITEM");
+    }
+
+    @Test
+    public void testTableCount() {
+        Map<String, Long> tableCount = contentManagementService.getTableCount();
+
+        String tablePrefix = contentEngineConfiguration.getDatabaseTablePrefix();
+
+        assertThat(tableCount.get(tablePrefix + "ACT_CO_CONTENT_ITEM")).isZero();
+    }
+
+    @Test
+    public void testGetTableMetaData() {
+
+        String tablePrefix = contentEngineConfiguration.getDatabaseTablePrefix();
+
+        TableMetaData tableMetaData = contentManagementService.getTableMetaData(tablePrefix + "ACT_CO_CONTENT_ITEM");
+        assertThat(tableMetaData.getColumnTypes()).hasSameSizeAs(tableMetaData.getColumnNames());
+        assertThat(tableMetaData.getColumnNames()).hasSize(17);
+
+        int createdByIndex = tableMetaData.getColumnNames().indexOf("CREATED_BY_");
+        int createdIndex = tableMetaData.getColumnNames().indexOf("CREATED_");
+
+        assertThat(createdByIndex).isGreaterThanOrEqualTo(0);
+        assertThat(createdIndex).isGreaterThanOrEqualTo(0);
+
+        assertOneOf(new String[] { "VARCHAR", "NVARCHAR2", "nvarchar", "NVARCHAR" }, tableMetaData.getColumnTypes().get(createdByIndex));
+        assertOneOf(new String[] { "TIMESTAMP", "TIMESTAMP(6)", "datetime", "DATETIME" }, tableMetaData.getColumnTypes().get(createdIndex));
+    }
+
+    private void assertOneOf(String[] possibleValues, String currentValue) {
+        for (String value : possibleValues) {
+            if (currentValue.equals(value)) {
+                return;
+            }
+        }
+        fail("Value '" + currentValue + "' should be one of: " + Arrays.deepToString(possibleValues));
+    }
+
+}

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngineConfiguration.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngineConfiguration.java
@@ -125,7 +125,7 @@ public class DmnEngineConfiguration extends AbstractEngineConfiguration
     // SERVICES
     // /////////////////////////////////////////////////////////////////
 
-    protected DmnManagementService dmnManagementService = new DmnManagementServiceImpl();
+    protected DmnManagementService dmnManagementService = new DmnManagementServiceImpl(this);
     protected DmnRepositoryService dmnRepositoryService = new DmnRepositoryServiceImpl();
     protected DmnDecisionService ruleService = new DmnDecisionServiceImpl(this);
     protected DmnHistoryService dmnHistoryService = new DmnHistoryServiceImpl();

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/DmnManagementServiceImpl.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/DmnManagementServiceImpl.java
@@ -31,6 +31,10 @@ import org.flowable.dmn.engine.impl.cmd.GetTableNameCmd;
  */
 public class DmnManagementServiceImpl extends CommonEngineServiceImpl<DmnEngineConfiguration> implements DmnManagementService {
 
+    public DmnManagementServiceImpl(DmnEngineConfiguration dmnEngineConfiguration) {
+        super(dmnEngineConfiguration);
+    }
+
     @Override
     public Map<String, Long> getTableCount() {
         return commandExecutor.execute(new GetTableCountCmd(configuration.getEngineCfgKey()));

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/mgmt/DmnManagementServiceTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/mgmt/DmnManagementServiceTest.java
@@ -1,0 +1,92 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.flowable.dmn.engine.test.mgmt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.management.TableMetaData;
+import org.flowable.dmn.engine.impl.persistence.entity.HistoricDecisionExecutionEntity;
+import org.flowable.dmn.engine.test.AbstractFlowableDmnTest;
+import org.junit.Test;
+
+public class DmnManagementServiceTest extends AbstractFlowableDmnTest {
+
+    @Test
+    public void testGetMetaDataForUnexistingTable() {
+        TableMetaData metaData = managementService.getTableMetaData("unexistingtable");
+        assertThat(metaData).isNull();
+    }
+
+    @Test
+    public void testGetMetaDataNullTableName() {
+        assertThatThrownBy(() -> managementService.getTableMetaData(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining("tableName is null");
+    }
+
+    @Test
+    public void testGetTableName() {
+        String table = managementService.getTableName(HistoricDecisionExecutionEntity.class);
+        assertThat(table).isEqualTo("ACT_DMN_HI_DECISION_EXECUTION");
+    }
+
+    @Test
+    public void testTableCount() {
+        Map<String, Long> tableCount = managementService.getTableCount();
+
+        String tablePrefix = dmnEngineConfiguration.getDatabaseTablePrefix();
+
+        assertThat(tableCount).containsEntry(tablePrefix + "ACT_GE_PROPERTY", 2L);
+        assertThat(tableCount.get(tablePrefix + "ACT_DMN_DECISION")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_DMN_DEPLOYMENT")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_DMN_DEPLOYMENT_RESOURCE")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_DMN_HI_DECISION_EXECUTION")).isZero();
+        assertThat(tableCount.get(tablePrefix + "ACT_GE_BYTEARRAY")).isZero();
+    }
+
+    @Test
+    public void testGetTableMetaData() {
+
+        String tablePrefix = dmnEngineConfiguration.getDatabaseTablePrefix();
+
+        TableMetaData tableMetaData = managementService.getTableMetaData(tablePrefix + "ACT_DMN_HI_DECISION_EXECUTION");
+        assertThat(tableMetaData.getColumnTypes()).hasSameSizeAs(tableMetaData.getColumnNames());
+        assertThat(tableMetaData.getColumnNames()).hasSize(12);
+
+        int instanceIdIndex = tableMetaData.getColumnNames().indexOf("INSTANCE_ID_");
+        int startTimeIndex = tableMetaData.getColumnNames().indexOf("START_TIME_");
+
+        assertThat(instanceIdIndex).isGreaterThanOrEqualTo(0);
+        assertThat(startTimeIndex).isGreaterThanOrEqualTo(0);
+
+        assertOneOf(new String[] { "VARCHAR", "NVARCHAR2", "nvarchar", "NVARCHAR" }, tableMetaData.getColumnTypes().get(instanceIdIndex));
+        assertOneOf(new String[] { "TIMESTAMP", "TIMESTAMP(6)", "datetime", "DATETIME" }, tableMetaData.getColumnTypes().get(startTimeIndex));
+    }
+
+    private void assertOneOf(String[] possibleValues, String currentValue) {
+        for (String value : possibleValues) {
+            if (currentValue.equals(value)) {
+                return;
+            }
+        }
+        fail("Value '" + currentValue + "' should be one of: " + Arrays.deepToString(possibleValues));
+    }
+
+}


### PR DESCRIPTION
…ve the engine configuration correctly set

The change in https://github.com/flowable/flowable-engine/commit/08913533c2e1a8728f38b4196749f67c39ae057f#diff-56721dd6cb9a32d25c7b088032016bd9c511a828bce4b162ddfb916b107a072b which was shipped in Flowable 6.6.0 has caused a regression in the `ContentManagementServiceImpl` and `DmnManagementServiceImpl` classes.

When performing some of the methods in these classes like `getTableCount()` and `getTableMetaData(String tablename)` it requires a non-null `configuration` on the object. (`ContentEngineConfiguration` or `DmnEngineConfiguration`).

This value however can not be set for these classes. There is no constructor taking in an engine configuration or any setter methods. When compared to the process or form management services then these provide an engine configuration in the constructor.

This fix adds a constructor taking a `ContentEngineConfiguration` or `DmnEngineConfiguration` and adds unit testing. 

#### Check List:
* Unit tests: YES
* Documentation: NA
