### PR TITLE
fixed: Export or download of file names with non-English characters is abnormal

### DIFF
--- a/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionExportService.java
+++ b/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionExportService.java
@@ -84,7 +84,8 @@ public class AppDefinitionExportService extends BaseAppDefinitionService {
 
     protected void createAppDefinitionZip(HttpServletResponse response, Model appModel, AppDefinitionRepresentation appDefinition) {
         try {
-            response.setHeader("Content-Disposition", "attachment; filename=\"" + appDefinition.getName() + ".zip\"; filename*=utf-8''" + UriUtils.encode(appDefinition.getName() + ".zip", "utf-8"));
+            String encodedFileName = UriUtils.encode(appDefinition.getName() + ".zip", "utf-8");
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + encodedFileName + "\"; filename*=utf-8''" + encodedFileName);
 
             ServletOutputStream servletOutputStream = response.getOutputStream();
             response.setContentType("application/zip");
@@ -184,7 +185,8 @@ public class AppDefinitionExportService extends BaseAppDefinitionService {
     public void createAppDefinitionBar(HttpServletResponse response, Model appModel, AppDefinitionRepresentation appDefinition) {
 
         try {
-            response.setHeader("Content-Disposition", "attachment; filename=\"" + appDefinition.getName() + ".bar\"; filename*=utf-8''" + UriUtils.encode(appDefinition.getName() + ".bar", "utf-8"));
+            String encodedFileName = UriUtils.encode(appDefinition.getName() + ".bar", "utf-8");
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + encodedFileName + "\"; filename*=utf-8''" + encodedFileName);
 
             byte[] deployZipArtifact = createDeployableZipArtifact(appModel, appDefinition.getDefinition());
 

--- a/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/AbstractModelBpmnResource.java
+++ b/modules/flowable-ui/flowable-ui-modeler-rest/src/main/java/org/flowable/ui/modeler/rest/app/AbstractModelBpmnResource.java
@@ -71,7 +71,7 @@ public class AbstractModelBpmnResource {
             LOGGER.warn("Failed to encode name {}", name);
         }
 
-        String contentDispositionValue = "attachment; filename=" + name;
+        String contentDispositionValue = "attachment; filename=" + encodedName;
         if (encodedName != null) {
             contentDispositionValue += "; filename*=" + encodedName;
         }


### PR DESCRIPTION
fixed: When the file name has Simplified Chinese or other non-English characters, the file name does not use UriUtils.encode() encoding, which causes the download or export of the file to fail.

#### Check List:
* Unit tests: Found in our project
* Error info as follow:
a header value contains a prohibited character '\u0000': attachment; filename=\"\u0000.;Ñ4öãÆAPP.zip\"; filename*=utf-8''%E9%94%80%E5%94%AE%E6%80%BB%E7%9B%91%E4%B8%B4%E6%97%B6%E8%A7%A3%E5%AF%86APP.zip