### PR TITLE
Handle candiate groups and users user task activity

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -314,7 +314,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Ac
                     Expression idExpression = expressionManager.createExpression(userIdentityLink);
                     Object value = idExpression.getValue(execution);
 
-                    Collection<String> userIds = extractCandidates(value);
+                    Collection<String> userIds = extractCandidates(value, idExpression.getExpressionText());
                     for (String userId : userIds) {
                         IdentityLinkEntity identityLinkEntity = processEngineConfiguration.getIdentityLinkServiceConfiguration()
                                 .getIdentityLinkService().createTaskIdentityLink(task.getId(), userId, null, customUserIdentityLinkType);
@@ -341,7 +341,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Ac
 
                     Expression idExpression = expressionManager.createExpression(groupIdentityLink);
                     Object value = idExpression.getValue(execution);
-                    Collection<String> groupIds = extractCandidates(value);
+                    Collection<String> groupIds = extractCandidates(value, idExpression.getExpressionText());
                     for (String groupId : groupIds) {
                         IdentityLinkEntity identityLinkEntity = processEngineConfiguration.getIdentityLinkServiceConfiguration()
                                 .getIdentityLinkService().createTaskIdentityLink(
@@ -414,7 +414,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Ac
                 Expression groupIdExpr = expressionManager.createExpression(candidateGroup);
                 Object value = groupIdExpr.getValue(execution);
                 if (value != null) {
-                    Collection<String> candidates = extractCandidates(value);
+                    Collection<String> candidates = extractCandidates(value, groupIdExpr.getExpressionText());
                     List<IdentityLinkEntity> identityLinkEntities = processEngineConfiguration.getIdentityLinkServiceConfiguration()
                             .getIdentityLinkService().addCandidateGroups(task.getId(), candidates);
 
@@ -444,7 +444,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Ac
                 Expression userIdExpr = expressionManager.createExpression(candidateUser);
                 Object value = userIdExpr.getValue(execution);
                 if (value != null) {
-                    Collection<String> candidates = extractCandidates(value);
+                    Collection<String> candidates = extractCandidates(value, userIdExpr.getExpressionText());
                     List<IdentityLinkEntity> identityLinkEntities = processEngineConfiguration.getIdentityLinkServiceConfiguration()
                             .getIdentityLinkService().addCandidateUsers(task.getId(), candidates);
 
@@ -465,7 +465,8 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Ac
         }
     }
 
-    protected Collection<String> extractCandidates(Object value) {
+    public Collection<String> extractCandidates(Object value, String expressionText) {
+        handleUnsupportedType(value, expressionText);
         if (value instanceof Collection) {
             return (Collection<String>) value;
         } else if (value instanceof ArrayNode) {
@@ -485,6 +486,21 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Ac
 
         return Collections.emptyList();
 
+    }
+
+    protected void handleUnsupportedType(Object value, String expressionText) {
+        if (value instanceof Boolean) {
+            throw new FlowableIllegalArgumentException("Value of type boolean is not supported for expression '" + expressionText +  "'.");
+        }
+        if (value instanceof Double) {
+            throw new FlowableIllegalArgumentException("Value of type double is not supported for expression '" + expressionText +  "'.");
+        }
+        if (value instanceof Float) {
+            throw new FlowableIllegalArgumentException("Value of type float is not supported for expression '" + expressionText +  "'.");
+        }
+        if (value instanceof ObjectNode) {
+            throw new FlowableIllegalArgumentException("Value of type objectNode is not supported for expression '" + expressionText +  "'.");
+        }
     }
 
     protected String getAssigneeValue(UserTask userTask, MigrationContext migrationContext, ObjectNode taskElementProperties) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -883,6 +883,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected boolean isExpressionCacheEnabled = true;
     protected int expressionCacheSize = 4096;
     protected int expressionTextLengthCacheLimit = -1; // negative value to have no max length
+    protected int userTaskCandidateGroupsLimit = -1; // By default, no limit
+    protected int userTaskCandidateUsersLimit = -1; // By default, no limit
 
     protected BusinessCalendarManager businessCalendarManager;
 
@@ -3423,6 +3425,22 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     public ProcessEngineConfigurationImpl setExpressionTextLengthCacheLimit(int expressionTextLengthCacheLimit) {
         this.expressionTextLengthCacheLimit = expressionTextLengthCacheLimit;
         return this;
+    }
+
+    public int getUserTaskCandidateGroupsLimit() {
+        return userTaskCandidateGroupsLimit;
+    }
+
+    public void setUserTaskCandidateGroupsLimit(int userTaskCandidateGroupsLimit) {
+        this.userTaskCandidateGroupsLimit = userTaskCandidateGroupsLimit;
+    }
+
+    public int getUserTaskCandidateUsersLimit() {
+        return userTaskCandidateUsersLimit;
+    }
+
+    public void setUserTaskCandidateUsersLimit(int userTaskCandidateUsersLimit) {
+        this.userTaskCandidateUsersLimit = userTaskCandidateUsersLimit;
     }
 
     public BusinessCalendarManager getBusinessCalendarManager() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/UserTaskTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,11 +14,13 @@
 package org.flowable.engine.test.bpmn.usertask;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.common.engine.impl.interceptor.CommandExecutor;
@@ -38,6 +40,10 @@ import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Joram Barrez
@@ -59,7 +65,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         assertThat(task.getProcessDefinitionId()).isNotNull();
         assertThat(task.getTaskDefinitionKey()).isNotNull();
         assertThat(task.getCreateTime()).isNotNull();
-        
+
         // the next test verifies that if an execution creates a task, that no events are created during creation of the task.
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY, processEngineConfiguration)) {
             assertThat(taskService.getTaskEvents(task.getId())).isEmpty();
@@ -154,7 +160,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
 
         // Complete task and verify history
         taskService.complete(task.getId());
-            
+
         if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
             HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
             assertThat(historicTaskInstance.getCategory()).isEqualTo(newCategory);
@@ -189,7 +195,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
 
         assertThat(task.getFormKey()).isEqualTo("test123");
     }
-    
+
     @Test
     @Deployment
     public void testEmptyAssignmentExpression() {
@@ -199,27 +205,27 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         variableMap.put("candidateGroups", null);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variableMap);
         assertThat(processInstance).isNotNull();
-        
+
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
         assertThat(task.getAssignee()).isNull();
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(task.getId());
         assertThat(identityLinks).isEmpty();
-        
+
         variableMap = new HashMap<>();
         variableMap.put("assignee", "");
         variableMap.put("candidateUsers", "");
         variableMap.put("candidateGroups", "");
         processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variableMap);
         assertThat(processInstance).isNotNull();
-        
+
         task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task).isNotNull();
         assertThat(task.getAssignee()).isNull();
         identityLinks = taskService.getIdentityLinksForTask(task.getId());
         assertThat(identityLinks).isEmpty();
     }
-    
+
     @Test
     @Deployment
     public void testNonStringProperties() {
@@ -233,7 +239,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         vars.put("taskCandidateGroups", 7);
         vars.put("taskCandidateUsers", 8);
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("nonStringProperties", vars);
-        
+
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
         assertThat(task.getName()).isEqualTo("1");
         assertThat(task.getDescription()).isEqualTo("2");
@@ -241,7 +247,7 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         assertThat(task.getFormKey()).isEqualTo("4");
         assertThat(task.getAssignee()).isEqualTo("5");
         assertThat(task.getOwner()).isEqualTo("6");
-        
+
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(task.getId());
         assertThat(identityLinks).hasSize(4);
         int candidateIdentityLinkCount = 0;
@@ -257,13 +263,46 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         }
         assertThat(candidateIdentityLinkCount).isEqualTo(2);
     }
-    
+
+    @Test
+    @Deployment
+    public void testUnsupportedPropertyType() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode objectNode = objectMapper.createObjectNode();
+        objectNode.set("integer", objectMapper.convertValue(1, JsonNode.class));
+        objectNode.set("string", objectMapper.convertValue("string", JsonNode.class));
+
+        assertErrorForProperty("unsupportedPropertyType", false, "user1",
+                "Value of type boolean is not supported for expression '${taskCandidateGroups}'.");
+
+        assertErrorForProperty("unsupportedPropertyType", 5.21f, "user1",
+                "Value of type float is not supported for expression '${taskCandidateGroups}'.");
+
+        assertErrorForProperty("unsupportedPropertyType", 0.55d, "user1",
+                "Value of type double is not supported for expression '${taskCandidateGroups}'.");
+
+        assertErrorForProperty("unsupportedPropertyType", objectNode, "user1",
+                "Value of type objectNode is not supported for expression '${taskCandidateGroups}'.");
+
+        assertErrorForProperty("unsupportedPropertyType", "group1", false,
+                "Value of type boolean is not supported for expression '${taskCandidateUsers}'.");
+
+        assertErrorForProperty("unsupportedPropertyType", "group1", 5.21f,
+                "Value of type float is not supported for expression '${taskCandidateUsers}'.");
+
+        assertErrorForProperty("unsupportedPropertyType", "group1", 0.55d,
+                "Value of type double is not supported for expression '${taskCandidateUsers}'.");
+
+        assertErrorForProperty("unsupportedPropertyType", "group1", objectNode,
+                "Value of type objectNode is not supported for expression '${taskCandidateUsers}'.");
+    }
+
     @Test
     @Deployment(resources="org/flowable/engine/test/bpmn/usertask/UserTaskTest.testTaskPropertiesNotNull.bpmn20.xml")
     public void testCreateUserTaskInterceptor() throws Exception {
         TestCreateUserTaskInterceptor testCreateUserTaskInterceptor = new TestCreateUserTaskInterceptor();
         processEngineConfiguration.setCreateUserTaskInterceptor(testCreateUserTaskInterceptor);
-        
+
         try {
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
@@ -272,10 +311,10 @@ public class UserTaskTest extends PluggableFlowableTestCase {
             assertThat(task.getName()).isEqualTo("my task");
             assertThat(task.getDescription()).isEqualTo("Very important");
             assertThat(task.getCategory()).isEqualTo("testCategory");
-            
+
             assertThat(testCreateUserTaskInterceptor.getBeforeCreateUserTaskCounter()).isEqualTo(1);
             assertThat(testCreateUserTaskInterceptor.getAfterCreateUserTaskCounter()).isEqualTo(1);
-            
+
         } finally {
             processEngineConfiguration.setCreateUserTaskInterceptor(null);
         }
@@ -303,11 +342,21 @@ public class UserTaskTest extends PluggableFlowableTestCase {
         assertThat(myExpressionTaskId).isEqualTo(actualTaskId);
     }
 
+    protected void assertErrorForProperty(String processDefinitionKey, Object candidateGroupsValue, Object candidateUsersValue, String expectedMessage) {
+        Map<String, Object> variableMap = new HashMap<>();
+        variableMap.put("taskCandidateGroups", candidateGroupsValue);
+        variableMap.put("taskCandidateUsers", candidateUsersValue);
+
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey(processDefinitionKey, variableMap))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageContaining(expectedMessage);
+    }
+
     protected class TestCreateUserTaskInterceptor implements CreateUserTaskInterceptor {
-        
+
         protected int beforeCreateUserTaskCounter = 0;
         protected int afterCreateUserTaskCounter = 0;
-        
+
         @Override
         public void beforeCreateUserTask(CreateUserTaskBeforeContext context) {
             beforeCreateUserTaskCounter++;

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/usertask/UserTaskTest.testUnsupportedPropertyType.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/usertask/UserTaskTest.testUnsupportedPropertyType.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="taskAssigneeExample" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:flowable="http://flowable.org/bpmn"
+  targetNamespace="Examples">
+  
+  <process id="unsupportedPropertyType">
+  
+    <startEvent id="start"/>
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="theTask" />
+    <userTask id="theTask" name="${taskName}"
+                           flowable:candidateGroups="${taskCandidateGroups}"
+                           flowable:candidateUsers="${taskCandidateUsers}">
+      <documentation><![CDATA[${taskDescription}]]></documentation>
+    </userTask>            
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
added validation for non supported types of candidates user and group
added variables for a limitation of candidateGroups and candidateUsers and per default no limit
added normalization of candidateGroups and candidateUsers as duplicate values are possible and also empty values see Tests
