### PR TITLE
add special behaviour for the reactivation listener through parser

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/reactivation/Simple_Reactivation_Test_Case.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/reactivation/Simple_Reactivation_Test_Case.cmmn.xml
@@ -11,13 +11,7 @@
       <planItem id="planItem4" name="Stage B" definitionRef="expandedStage2">
         <entryCriterion id="entryCriterion1" sentryRef="sentry1"></entryCriterion>
       </planItem>
-      <planItem id="planItem5" name="Reactivate case" definitionRef="reactivateEventListener1">
-        <itemControl>
-          <extensionElements>
-            <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
-          </extensionElements>
-        </itemControl>
-      </planItem>
+      <planItem id="planItem5" name="Reactivate case" definitionRef="reactivateEventListener1"></planItem>
       <planItem id="planItem6" name="Task C" definitionRef="humanTask3">
         <itemControl>
           <extensionElements>
@@ -68,7 +62,7 @@
           </extensionElements>
         </humanTask>
       </stage>
-      <eventListener id="reactivateEventListener1" name="Reactivate case" flowable:eventType="reactivate" flowable:availableCondition="${caseInstance.getState() != 'active'}">
+      <eventListener id="reactivateEventListener1" name="Reactivate case" flowable:eventType="reactivate">
         <extensionElements>
           <flowable:startformkey><![CDATA[simpleReactivationCaseActionForm]]></flowable:startformkey>
           <flowable:startFormSameDeployment><![CDATA[true]]></flowable:startFormSameDeployment>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/reactivation/Simple_Reactivation_Test_Case_Multi_Reactivation_Elements.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/reactivation/Simple_Reactivation_Test_Case_Multi_Reactivation_Elements.cmmn.xml
@@ -19,20 +19,8 @@
         </itemControl>
         <entryCriterion id="entryCriterion2" sentryRef="sentry2"></entryCriterion>
       </planItem>
-      <planItem id="planItem6" name="Reactivate case" definitionRef="reactivateEventListener1">
-        <itemControl>
-          <extensionElements>
-            <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
-          </extensionElements>
-        </itemControl>
-      </planItem>
-      <planItem id="planItem7" name="Reactivate case 2" definitionRef="userEventListener2">
-        <itemControl>
-          <extensionElements>
-            <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
-          </extensionElements>
-        </itemControl>
-      </planItem>
+      <planItem id="planItem6" name="Reactivate case" definitionRef="reactivateEventListener1"></planItem>
+      <planItem id="planItem7" name="Reactivate case 2" definitionRef="userEventListener2"></planItem>
       <sentry id="sentry1">
         <extensionElements>
           <design:stencilid><![CDATA[EntryCriterion]]></design:stencilid>
@@ -82,7 +70,7 @@
           <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
         </extensionElements>
       </humanTask>
-      <eventListener id="reactivateEventListener1" name="Reactivate case" flowable:eventType="reactivate" flowable:availableCondition="${caseInstance.getState() != 'active'}">
+      <eventListener id="reactivateEventListener1" name="Reactivate case" flowable:eventType="reactivate">
         <extensionElements>
           <flowable:startformkey><![CDATA[simpleReactivationCaseActionForm]]></flowable:startformkey>
           <flowable:startFormSameDeployment><![CDATA[true]]></flowable:startFormSameDeployment>
@@ -91,7 +79,7 @@
           <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
         </extensionElements>
       </eventListener>
-      <eventListener id="userEventListener2" name="Reactivate case 2" flowable:eventType="reactivate" flowable:availableCondition="${caseInstance.getState() != 'active'}">
+      <eventListener id="userEventListener2" name="Reactivate case 2" flowable:eventType="reactivate">
         <extensionElements>
           <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
           <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>


### PR DESCRIPTION
Add ignore for completion rule and availability condition to the reactivation listener at runtime through its parser to avoid Design to add those rules when exporting.

#### Check List:
* Unit tests: YES
* Documentation: NO