### PR TITLE
Terminate child plan items on parent completion

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractDeleteCaseInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractDeleteCaseInstanceOperation.java
@@ -74,8 +74,8 @@ public abstract class AbstractDeleteCaseInstanceOperation extends AbstractChange
         List<PlanItemInstanceEntity> childPlanItemInstances = caseInstanceEntity.getChildPlanItemInstances();
         if (childPlanItemInstances != null) {
             for (PlanItemInstanceEntity childPlanItemInstance : childPlanItemInstances) {
-                if (PlanItemInstanceState.ACTIVE.equals(childPlanItemInstance.getState())
-                        || PlanItemInstanceState.AVAILABLE.equals(childPlanItemInstance.getState())) {
+                // if the child plan item is not yet in a terminal state, terminate it
+                if (!PlanItemInstanceState.isInTerminalState(childPlanItemInstance)) {
                     changeStateForChildPlanItemInstance(childPlanItemInstance);
                 }
             }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractEvaluationCriteriaOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractEvaluationCriteriaOperation.java
@@ -235,8 +235,17 @@ public abstract class AbstractEvaluationCriteriaOperation extends AbstractCaseIn
             // check, if the plan item can be ignored for further processing and if so, immediately return
             if (planItem.getItemControl() != null && planItem.getItemControl().getParentCompletionRule() != null) {
                 ParentCompletionRule parentCompletionRule = planItem.getItemControl().getParentCompletionRule();
+
+                // first check for the always ignore rule
                 if (ParentCompletionRule.IGNORE.equals(parentCompletionRule.getType())) {
                     return true;
+                }
+
+                // now check, if we can ignore it because it was completed before
+                if (ParentCompletionRule.IGNORE_AFTER_FIRST_COMPLETION.equals(parentCompletionRule.getType())) {
+                    if (evaluationResult.hasCompletedPlanItemInstance(planItemInstanceEntity)) {
+                        return true;
+                    }
                 }
             }
 
@@ -268,7 +277,7 @@ public abstract class AbstractEvaluationCriteriaOperation extends AbstractCaseIn
 
         // create an evaluation result object, holding all evaluation results as well as a list of newly created child plan items, as to avoid concurrent
         // modification, we add them at the end of the evaluation loop to the parent container
-        PlanItemEvaluationResult evaluationResult = new PlanItemEvaluationResult();
+        PlanItemEvaluationResult evaluationResult = new PlanItemEvaluationResult(planItemInstances);
 
         // Check the existing plan item instances: this means the plan items that have been created and became available.
         // This does not include the plan items which haven't been created (for example because they're part of a stage which isn't active yet).

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CompleteCaseInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CompleteCaseInstanceOperation.java
@@ -38,7 +38,10 @@ public class CompleteCaseInstanceOperation extends AbstractDeleteCaseInstanceOpe
     
     @Override
     public void changeStateForChildPlanItemInstance(PlanItemInstanceEntity planItemInstanceEntity) {
-        CommandContextUtil.getAgenda(commandContext).planCompletePlanItemInstanceOperation(planItemInstanceEntity);
+        // terminate all child plan items not yet in an end state of the case itself (same way as with a stage for instance)
+        // if they would be completed, the history will contain completed plan item instances although they never "truly" completed
+        // specially important for cases supporting reactivation
+        CommandContextUtil.getAgenda(commandContext).planTerminatePlanItemInstanceOperation(planItemInstanceEntity, null, null);
     }
     
     @Override

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/util/PlanItemInstanceContainerUtil.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/util/PlanItemInstanceContainerUtil.java
@@ -88,6 +88,11 @@ public class PlanItemInstanceContainerUtil {
 
                     // if the plan item is active and not to be ignored, we can directly stop to look any further as it prevents the parent from being completed
                     if (ACTIVE_STATES.contains(planItemInstance.getState())) {
+                        // if the plan item is active, but was already completed and should be ignored after first completion, we can skip it for further investigation
+                        alreadyCompleted = isPlanItemAlreadyCompleted(commandContext, planItemInstance);
+                        if (shouldIgnorePlanItemForCompletion(commandContext, planItemInstance, alreadyCompleted)) {
+                            continue;
+                        }
                         return new CompletionEvaluationResult(false, false, planItemInstance);
                     }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
@@ -36,6 +36,7 @@ import org.flowable.cmmn.api.CmmnRepositoryService;
 import org.flowable.cmmn.api.CmmnRuntimeService;
 import org.flowable.cmmn.api.CmmnTaskService;
 import org.flowable.cmmn.api.DynamicCmmnService;
+import org.flowable.cmmn.api.history.HistoricPlanItemInstance;
 import org.flowable.cmmn.api.repository.CmmnDeployment;
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
@@ -205,6 +206,23 @@ public abstract class AbstractFlowableCmmnTestCase {
         List<String> originalStates = new ArrayList<>(planItemInstanceStates);
         for (String state : states) {
             assertTrue("State '" + state + "' not found in plan item instances states '" + originalStates + "'", planItemInstanceStates.remove(state));
+        }
+    }
+
+    protected void assertHistoricPlanItemInstanceState(List<HistoricPlanItemInstance> planItemInstances, String name, String ... states) {
+        List<String> planItemInstanceStates = planItemInstances.stream()
+            .filter(planItemInstance -> Objects.equals(name, planItemInstance.getName()))
+            .map(HistoricPlanItemInstance::getState)
+            .collect(Collectors.toList());
+
+        if (planItemInstanceStates.isEmpty()) {
+            fail("No historic plan item instances found with name " + name);
+        }
+
+        assertEquals("Incorrect number of states found: " + planItemInstanceStates + "", states.length, planItemInstanceStates.size());
+        List<String> originalStates = new ArrayList<>(planItemInstanceStates);
+        for (String state : states) {
+            assertTrue("State '" + state + "' not found in historic plan item instances states '" + originalStates + "'", planItemInstanceStates.remove(state));
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/TerminateChildPlanItemsOnAutoCompletionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/TerminateChildPlanItemsOnAutoCompletionTest.java
@@ -1,0 +1,155 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.COMPLETED;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.TERMINATED;
+
+import java.util.List;
+
+import org.flowable.cmmn.api.history.HistoricPlanItemInstance;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.flowable.common.engine.impl.identity.Authentication;
+import org.junit.Test;
+
+/**
+ * Testing child plan items termination on autocompletion of a case or stage to leave them in an end state and making sure they are not completed, but rather
+ * terminated.
+ *
+ * @author Micha Kiener
+ */
+public class TerminateChildPlanItemsOnAutoCompletionTest extends FlowableCmmnTestCase {
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/Case_Completion_With_Child_Items_Test.cmmn.xml")
+    public void terminateChildPlanItemsOnCaseCompletionTest() {
+        String previousUserId = Authentication.getAuthenticatedUserId();
+        try {
+            Authentication.setAuthenticatedUserId("JohnDoe");
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("caseCompletionWithChildItemsTest")
+                .start();
+
+            List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+            assertThat(planItemInstances).hasSize(5);
+            assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
+
+            assertPlanItemInstanceState(planItemInstances, "Ignore after first completion task", ACTIVE);
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Ignore after first completion task"));
+
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+            assertCaseInstanceEnded(caseInstance);
+
+            List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceCaseInstanceId(caseInstance.getId())
+                .list();
+
+            assertThat(historicPlanItems).hasSize(6);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Stage A", COMPLETED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Task A", COMPLETED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Manual task", TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Ignored task", TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Ignore after first completion task", COMPLETED, TERMINATED);
+        } finally {
+            Authentication.setAuthenticatedUserId(previousUserId);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/Stage_Completion_With_Child_Items_Test.cmmn.xml")
+    public void terminateChildPlanItemsOnStageCompletionTest() {
+        String previousUserId = Authentication.getAuthenticatedUserId();
+        try {
+            Authentication.setAuthenticatedUserId("JohnDoe");
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("stageCompletionWithChildItemsTest")
+                .start();
+
+            List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+            assertThat(planItemInstances).hasSize(5);
+            assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
+
+            assertPlanItemInstanceState(planItemInstances, "Ignore after first completion task", ACTIVE);
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Ignore after first completion task"));
+
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+            assertCaseInstanceEnded(caseInstance);
+
+            List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceCaseInstanceId(caseInstance.getId())
+                .list();
+
+            assertThat(historicPlanItems).hasSize(6);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Stage A", COMPLETED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Task A", COMPLETED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Manual task", TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Ignored task", TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Ignore after first completion task", COMPLETED, TERMINATED);
+        } finally {
+            Authentication.setAuthenticatedUserId(previousUserId);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/Case_And_Stage_Completion_With_Child_Items_Test.cmmn.xml")
+    public void terminateChildPlanItemsOnStageAndCaseCompletionTest() {
+        String previousUserId = Authentication.getAuthenticatedUserId();
+        try {
+            Authentication.setAuthenticatedUserId("JohnDoe");
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("caseAndStageCompletionWithChildItemsTest")
+                .start();
+
+            List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+            assertThat(planItemInstances).hasSize(8);
+            assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
+
+            assertPlanItemInstanceState(planItemInstances, "Ignore after first completion stage task", ACTIVE);
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Ignore after first completion stage task"));
+
+            planItemInstances = getPlanItemInstances(caseInstance.getId());
+            assertPlanItemInstanceState(planItemInstances, "Ignore after first completion task", ACTIVE);
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Ignore after first completion task"));
+
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+            assertCaseInstanceEnded(caseInstance);
+
+            List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery()
+                .planItemInstanceCaseInstanceId(caseInstance.getId())
+                .list();
+
+            assertThat(historicPlanItems).hasSize(10);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Stage A", COMPLETED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Task A", COMPLETED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Manual stage task", TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Ignored stage task", TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Ignore after first completion stage task", COMPLETED, TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Manual task", TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Ignored task", TERMINATED);
+            assertHistoricPlanItemInstanceState(historicPlanItems, "Ignore after first completion task", COMPLETED, TERMINATED);
+        } finally {
+            Authentication.setAuthenticatedUserId(previousUserId);
+        }
+    }
+
+}

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/Case_And_Stage_Completion_With_Child_Items_Test.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/Case_And_Stage_Completion_With_Child_Items_Test.cmmn.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+  <case id="caseAndStageCompletionWithChildItemsTest" name="Case And Stage Completion With Child Items Test" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false" autoComplete="true">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItem5" name="Stage A" definitionRef="expandedStage1"></planItem>
+      <planItem id="planItem6" name="Manual task" definitionRef="humanTask5">
+        <itemControl>
+          <manualActivationRule></manualActivationRule>
+        </itemControl>
+      </planItem>
+      <planItem id="planItem7" name="Ignored task" definitionRef="humanTask6">
+        <itemControl>
+          <extensionElements>
+            <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
+          </extensionElements>
+        </itemControl>
+      </planItem>
+      <planItem id="planItem8" name="Ignore after first completion task" definitionRef="humanTask7">
+        <itemControl>
+          <extensionElements>
+            <flowable:parentCompletionRule type="ignoreAfterFirstCompletion"></flowable:parentCompletionRule>
+          </extensionElements>
+          <repetitionRule flowable:counterVariable="repetitionCounter">
+            <extensionElements></extensionElements>
+          </repetitionRule>
+        </itemControl>
+      </planItem>
+      <stage id="expandedStage1" name="Stage A" autoComplete="true" flowable:includeInStageOverview="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItem1" name="Task A" definitionRef="humanTask1"></planItem>
+        <planItem id="planItem2" name="Manual stage task" definitionRef="humanTask2">
+          <itemControl>
+            <manualActivationRule></manualActivationRule>
+          </itemControl>
+        </planItem>
+        <planItem id="planItem3" name="Ignored stage task" definitionRef="humanTask3">
+          <itemControl>
+            <extensionElements>
+              <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
+            </extensionElements>
+          </itemControl>
+        </planItem>
+        <planItem id="planItem4" name="Ignore after first completion stage task" definitionRef="humanTask4">
+          <itemControl>
+            <extensionElements>
+              <flowable:parentCompletionRule type="ignoreAfterFirstCompletion"></flowable:parentCompletionRule>
+            </extensionElements>
+            <repetitionRule flowable:counterVariable="repetitionCounter">
+              <extensionElements></extensionElements>
+            </repetitionRule>
+          </itemControl>
+        </planItem>
+        <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+        <humanTask id="humanTask2" name="Manual stage task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+        <humanTask id="humanTask3" name="Ignored stage task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+        <humanTask id="humanTask4" name="Ignore after first completion stage task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+      </stage>
+      <humanTask id="humanTask5" name="Manual task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+      <humanTask id="humanTask6" name="Ignored task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+      <humanTask id="humanTask7" name="Ignore after first completion task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_caseAndStageCompletionWithChildItemsTest">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="585.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem5" cmmnElementRef="planItem5">
+        <dc:Bounds height="305.0" width="488.0" x="75.0" y="105.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+        <dc:Bounds height="80.0" width="100.0" x="121.0" y="151.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+        <dc:Bounds height="80.0" width="100.0" x="121.0" y="285.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+        <dc:Bounds height="80.0" width="100.0" x="255.0" y="285.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+        <dc:Bounds height="80.0" width="100.0" x="390.0" y="285.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem6" cmmnElementRef="planItem6">
+        <dc:Bounds height="80.0" width="100.0" x="121.0" y="480.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem7" cmmnElementRef="planItem7">
+        <dc:Bounds height="80.0" width="100.0" x="255.0" y="480.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem8" cmmnElementRef="planItem8">
+        <dc:Bounds height="80.0" width="100.0" x="390.0" y="480.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/Case_Completion_With_Child_Items_Test.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/Case_Completion_With_Child_Items_Test.cmmn.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+  <case id="caseCompletionWithChildItemsTest" name="Case Completion With Child Items Test" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false" autoComplete="true">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItem2" name="Stage A" definitionRef="expandedStage1"></planItem>
+      <planItem id="planItem3" name="Manual task" definitionRef="humanTask2">
+        <itemControl>
+          <manualActivationRule></manualActivationRule>
+        </itemControl>
+      </planItem>
+      <planItem id="planItem4" name="Ignored task" definitionRef="humanTask3">
+        <itemControl>
+          <extensionElements>
+            <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
+          </extensionElements>
+        </itemControl>
+      </planItem>
+      <planItem id="planItem5" name="Ignore after first completion task" definitionRef="humanTask4">
+        <itemControl>
+          <extensionElements>
+            <flowable:parentCompletionRule type="ignoreAfterFirstCompletion"></flowable:parentCompletionRule>
+          </extensionElements>
+          <repetitionRule flowable:counterVariable="repetitionCounter">
+            <extensionElements></extensionElements>
+          </repetitionRule>
+        </itemControl>
+      </planItem>
+      <stage id="expandedStage1" name="Stage A" flowable:includeInStageOverview="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItem1" name="Task A" definitionRef="humanTask1"></planItem>
+        <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+      </stage>
+      <humanTask id="humanTask2" name="Manual task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+      <humanTask id="humanTask3" name="Ignored task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+      <humanTask id="humanTask4" name="Ignore after first completion task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_caseCompletionWithChildItemsTest">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="504.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+        <dc:Bounds height="170.0" width="370.0" x="75.0" y="105.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+        <dc:Bounds height="80.0" width="100.0" x="121.0" y="151.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+        <dc:Bounds height="80.0" width="100.0" x="121.0" y="346.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+        <dc:Bounds height="80.0" width="100.0" x="270.0" y="346.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem5" cmmnElementRef="planItem5">
+        <dc:Bounds height="80.0" width="100.0" x="420.0" y="346.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/Stage_Completion_With_Child_Items_Test.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/Stage_Completion_With_Child_Items_Test.cmmn.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+  <case id="stageCompletionWithChildItemsTest" name="Stage Completion With Child Items Test" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItem5" name="Stage A" definitionRef="expandedStage1"></planItem>
+      <stage id="expandedStage1" name="Stage A" autoComplete="true" flowable:includeInStageOverview="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItem1" name="Task A" definitionRef="humanTask1"></planItem>
+        <planItem id="planItem2" name="Manual task" definitionRef="humanTask2">
+          <itemControl>
+            <manualActivationRule></manualActivationRule>
+          </itemControl>
+        </planItem>
+        <planItem id="planItem3" name="Ignored task" definitionRef="humanTask3">
+          <itemControl>
+            <extensionElements>
+              <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
+            </extensionElements>
+          </itemControl>
+        </planItem>
+        <planItem id="planItem4" name="Ignore after first completion task" definitionRef="humanTask4">
+          <itemControl>
+            <extensionElements>
+              <flowable:parentCompletionRule type="ignoreAfterFirstCompletion"></flowable:parentCompletionRule>
+            </extensionElements>
+            <repetitionRule flowable:counterVariable="repetitionCounter">
+              <extensionElements></extensionElements>
+            </repetitionRule>
+          </itemControl>
+        </planItem>
+        <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+        <humanTask id="humanTask2" name="Manual task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+        <humanTask id="humanTask3" name="Ignored task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+        <humanTask id="humanTask4" name="Ignore after first completion task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+      </stage>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_stageCompletionWithChildItemsTest">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="447.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem5" cmmnElementRef="planItem5">
+        <dc:Bounds height="305.0" width="488.0" x="75.0" y="105.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+        <dc:Bounds height="80.0" width="100.0" x="121.0" y="151.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+        <dc:Bounds height="80.0" width="100.0" x="121.0" y="285.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+        <dc:Bounds height="80.0" width="100.0" x="255.0" y="285.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+        <dc:Bounds height="80.0" width="100.0" x="390.0" y="285.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>


### PR DESCRIPTION
Making sure that not yet ended child plan items are terminated rather than completed on case and stage completion.

#### Check List:
* Unit tests: YES
* Documentation: NO
