### PR TITLE
recreate new plan items for reactivation, not reusing existing ones

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/CmmnEngineAgenda.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/CmmnEngineAgenda.java
@@ -32,6 +32,8 @@ public interface CmmnEngineAgenda extends Agenda {
 
     void planCreatePlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity);
 
+    void planReactivatePlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity);
+
     void planCreatePlanItemInstanceForRepetitionOperation(PlanItemInstanceEntity planItemInstanceEntity);
 
     void planInitiatePlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/DefaultCmmnEngineAgenda.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/DefaultCmmnEngineAgenda.java
@@ -31,6 +31,7 @@ import org.flowable.cmmn.engine.impl.agenda.operation.InitStageInstanceOperation
 import org.flowable.cmmn.engine.impl.agenda.operation.InitiatePlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.OccurPlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.ReactivateCaseInstanceOperation;
+import org.flowable.cmmn.engine.impl.agenda.operation.ReactivatePlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.StartPlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.TerminateCaseInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.TerminatePlanItemInstanceOperation;
@@ -131,6 +132,11 @@ public class DefaultCmmnEngineAgenda extends AbstractAgenda implements CmmnEngin
     @Override
     public void planCreatePlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new CreatePlanItemInstanceOperation(commandContext, planItemInstanceEntity));
+    }
+
+    @Override
+    public void planReactivatePlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity) {
+        addOperation(new ReactivatePlanItemInstanceOperation(commandContext, planItemInstanceEntity));
     }
 
     @Override

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/ReactivatePlanItemInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/ReactivatePlanItemInstanceOperation.java
@@ -1,0 +1,72 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.agenda.operation;
+
+import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
+import org.flowable.cmmn.engine.impl.history.CmmnHistoryManager;
+import org.flowable.cmmn.engine.impl.persistence.entity.PlanItemInstanceEntity;
+import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.cmmn.model.PlanItemTransition;
+import org.flowable.cmmn.model.ReactivateEventListener;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+
+/**
+ * Reactivates a plan item as part of a case reactivation which is pretty similar to the {@link CreatePlanItemInstanceOperation}, but uses a different transition
+ * for the listeners as the newly created plan item instance is created as part of a reactivation process.
+ *
+ * @author Micha Kiener
+ */
+public class ReactivatePlanItemInstanceOperation extends AbstractChangePlanItemInstanceStateOperation {
+
+    public ReactivatePlanItemInstanceOperation(CommandContext commandContext, PlanItemInstanceEntity planItemInstanceEntity) {
+        super(commandContext, planItemInstanceEntity);
+    }
+
+    @Override
+    protected void internalExecute() {
+        CmmnHistoryManager cmmnHistoryManager = CommandContextUtil.getCmmnHistoryManager(commandContext);
+        cmmnHistoryManager.recordPlanItemInstanceReactivated(planItemInstanceEntity);
+
+        // Extending classes might override getNewState, so need to check the available state again
+        if (getNewState().equals(PlanItemInstanceState.AVAILABLE)) {
+            planItemInstanceEntity.setLastAvailableTime(getCurrentTime(commandContext));
+            cmmnHistoryManager.recordPlanItemInstanceAvailable(planItemInstanceEntity);
+        }
+    }
+
+    @Override
+    public String getNewState() {
+        if (isEventListenerWithAvailableCondition(planItemInstanceEntity.getPlanItem())) {
+            // We need a specific treatment of the reactivation event listener as it also has a condition to avoid being available at active state of the case,
+            // but when reactivating its plan item to actually trigger a case reactivation, we need to ignore that condition and directly go to available state
+            // to trigger the case reactivation
+            if (planItemInstanceEntity.getPlanItemDefinition() != null && planItemInstanceEntity.getPlanItemDefinition() instanceof ReactivateEventListener) {
+                return PlanItemInstanceState.AVAILABLE;
+            }
+            return PlanItemInstanceState.UNAVAILABLE;
+        } else {
+            return PlanItemInstanceState.AVAILABLE;
+        }
+    }
+
+    @Override
+    public String getLifeCycleTransition() {
+        return PlanItemTransition.REACTIVATE;
+    }
+
+    @Override
+    public String getOperationName() {
+        return "[Reactivate plan item]";
+    }
+
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CmmnHistoryManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CmmnHistoryManager.java
@@ -64,7 +64,9 @@ public interface CmmnHistoryManager {
     void recordTaskInfoChange(TaskEntity taskEntity, Date changeTime);
 
     void recordPlanItemInstanceCreated(PlanItemInstanceEntity planItemInstanceEntity);
-    
+
+    void recordPlanItemInstanceReactivated(PlanItemInstanceEntity planItemInstanceEntity);
+
     void recordPlanItemInstanceUpdated(PlanItemInstanceEntity planItemInstanceEntity);
 
     void recordPlanItemInstanceAvailable(PlanItemInstanceEntity planItemInstanceEntity);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CompositeCmmnHistoryManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CompositeCmmnHistoryManager.java
@@ -162,7 +162,14 @@ public class CompositeCmmnHistoryManager implements CmmnHistoryManager {
             historyManager.recordPlanItemInstanceCreated(planItemInstanceEntity);
         }
     }
-    
+
+    @Override
+    public void recordPlanItemInstanceReactivated(PlanItemInstanceEntity planItemInstanceEntity) {
+        for (CmmnHistoryManager historyManager : historyManagers) {
+            historyManager.recordPlanItemInstanceReactivated(planItemInstanceEntity);
+        }
+    }
+
     @Override
     public void recordPlanItemInstanceUpdated(PlanItemInstanceEntity planItemInstanceEntity) {
         for (CmmnHistoryManager historyManager : historyManagers) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/DefaultCmmnHistoryManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/DefaultCmmnHistoryManager.java
@@ -250,7 +250,19 @@ public class DefaultCmmnHistoryManager implements CmmnHistoryManager {
             historicPlanItemInstanceEntityManager.insert(historicPlanItemInstanceEntity);
         }
     }
-    
+
+    @Override
+    public void recordPlanItemInstanceReactivated(PlanItemInstanceEntity planItemInstanceEntity) {
+        if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+            HistoricPlanItemInstanceEntityManager historicPlanItemInstanceEntityManager = cmmnEngineConfiguration.getHistoricPlanItemInstanceEntityManager();
+            HistoricPlanItemInstanceEntity historicPlanItemInstanceEntity = historicPlanItemInstanceEntityManager.create(planItemInstanceEntity);
+            historicPlanItemInstanceEntity.setShowInOverview(evaluateShowInOverview(planItemInstanceEntity));
+
+            historicPlanItemInstanceEntityManager.insert(historicPlanItemInstanceEntity);
+            // TODO: do we need a specific flag to mark this entity being created because of a reactivation?
+        }
+    }
+
     @Override
     public void recordPlanItemInstanceUpdated(PlanItemInstanceEntity planItemInstanceEntity) {
         if (cmmnEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/async/AsyncCmmnHistoryManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/async/AsyncCmmnHistoryManager.java
@@ -265,7 +265,13 @@ public class AsyncCmmnHistoryManager extends AbstractAsyncCmmnHistoryManager {
     public void recordPlanItemInstanceCreated(PlanItemInstanceEntity planItemInstanceEntity) {
         recordPlanItemInstanceFull(planItemInstanceEntity, null);
     }
-    
+
+    @Override
+    public void recordPlanItemInstanceReactivated(PlanItemInstanceEntity planItemInstanceEntity) {
+        recordPlanItemInstanceFull(planItemInstanceEntity, null);
+        // TODO: do we need a specific reactivation flag to mark this item being created because of a reactivation?
+    }
+
     @Override
     public void recordPlanItemInstanceUpdated(PlanItemInstanceEntity planItemInstanceEntity) {
         recordPlanItemInstanceFull(planItemInstanceEntity, null);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/StateTransition.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/StateTransition.java
@@ -25,7 +25,11 @@ import org.flowable.cmmn.model.PlanItemDefinition;
 import org.flowable.cmmn.model.PlanItemTransition;
 
 /**
+ * Whenever a plan item or event listener changes its state as part of a CMMN engine operation, its current state and transition is checked to be valid.
+ * This static class supports methods for this check as well as initializes all possible states and their transitions.
+ *
  * @author Joram Barrez
+ * @author Micha Kiener
  */
 public class StateTransition {
     
@@ -34,7 +38,11 @@ public class StateTransition {
     // See 8.4.2 of CMMN 1.1 spec
     
     static {
-        addPlanItemTransition(null, PlanItemTransition.CREATE);
+        // a newly created plan item instance can either be used for creation (first time) or reactivation (case reactivation)
+        addPlanItemTransition(null,
+            PlanItemTransition.CREATE,
+            PlanItemTransition.REACTIVATE);
+
         addPlanItemTransition(PlanItemInstanceState.WAITING_FOR_REPETITION,
             PlanItemTransition.CREATE,
             PlanItemTransition.EXIT);
@@ -75,9 +83,9 @@ public class StateTransition {
                 PlanItemTransition.RESUME, 
                 PlanItemTransition.PARENT_RESUME, 
                 PlanItemTransition.EXIT);
-        
+
         addPlanItemTransition(PlanItemInstanceState.COMPLETED);
-        
+
         addPlanItemTransition(PlanItemInstanceState.TERMINATED);
     }
 
@@ -85,7 +93,10 @@ public class StateTransition {
 
     static {
 
-        addEventListenerTransition(null, PlanItemTransition.CREATE);
+        // a newly created event listener might be newly created (first time) or reactivated as part of the case reactivation
+        addEventListenerTransition(null,
+            PlanItemTransition.CREATE,
+            PlanItemTransition.REACTIVATE);
 
         addEventListenerTransition(PlanItemInstanceState.UNAVAILABLE,
             PlanItemTransition.INITIATE,

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/reactivation/SimpleCaseReactivationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/reactivation/SimpleCaseReactivationTest.java
@@ -15,6 +15,8 @@ package org.flowable.cmmn.test.reactivation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.COMPLETED;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.TERMINATED;
 
 import java.util.HashMap;
 import java.util.List;
@@ -139,8 +141,14 @@ public class SimpleCaseReactivationTest extends FlowableCmmnTestCase {
             assertThat(reactivatedCaze).isNotNull();
 
             List<PlanItemInstance> planItemInstances = getAllPlanItemInstances(reactivatedCaze.getId());
-            assertThat(planItemInstances).isNotNull().hasSize(6);
-            assertPlanItemInstanceState(planItemInstances, "Task C", ACTIVE);
+            assertThat(planItemInstances).isNotNull().hasSize(8);
+
+            // we need to have two reactivation listeners by now, one in terminated state (from the first case completion) and the second one needs to be
+            // in completion state as we just triggered it for case reactivation
+            assertPlanItemInstanceState(planItemInstances, "Reactivate case", TERMINATED, COMPLETED);
+
+            // the same for the task C, one instance needs to be active, the old one completed
+            assertPlanItemInstanceState(planItemInstances, "Task C", TERMINATED, ACTIVE);
             assertCaseInstanceNotEnded(reactivatedCaze);
 
             // the plan items must be equal for both the runtime as well as the history as of now


### PR DESCRIPTION
Instead of reusing existing plan items for reactivation, new ones are created with the same data and activated using a new reactivation operation similar to the create one.

#### Check List:
* Unit tests: YES
* Documentation: NO
