### PR TITLE
injecting error code into execution on boundary / start error event

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
@@ -221,7 +221,7 @@ public interface BpmnXMLConstants {
     public static final String ATTRIBUTE_TASK_RULE_RULES = "rules";
     public static final String ATTRIBUTE_TASK_RULE_EXCLUDE = "exclude";
     public static final String ATTRIBUTE_TASK_RULE_CLASS = "class";
-    
+
     public static final String ATTRIBUTE_BUSINESS_KEY = "businessKey";
     public static final String ATTRIBUTE_INHERIT_BUSINESS_KEY = "inheritBusinessKey";
     public static final String ATTRIBUTE_SAME_DEPLOYMENT = "sameDeployment";
@@ -241,7 +241,7 @@ public interface BpmnXMLConstants {
     public static final String ATTRIBUTE_IOPARAMETER_TARGET = "target";
     public static final String ATTRIBUTE_IOPARAMETER_TARGET_EXPRESSION = "targetExpression";
     public static final String ATTRIBUTE_IOPARAMETER_TRANSIENT = "transient";
-    
+
     public static final String ATTRIBUTE_CASE_TASK_CASE_DEFINITION_KEY = "caseDefinitionKey";
     public static final String ATTRIBUTE_CASE_TASK_CASE_INSTANCE_NAME = "caseInstanceName";
 
@@ -280,44 +280,47 @@ public interface BpmnXMLConstants {
 
     public static final String ATTRIBUTE_BOUNDARY_ATTACHEDTOREF = "attachedToRef";
     public static final String ATTRIBUTE_BOUNDARY_CANCELACTIVITY = "cancelActivity";
-    
+
     public static final String ELEMENT_EVENT_CONDITIONALDEFINITION = "conditionalEventDefinition";
     public static final String ELEMENT_CONDITION = "condition";
 
     public static final String ELEMENT_EVENT_ERRORDEFINITION = "errorEventDefinition";
     public static final String ATTRIBUTE_ERROR_REF = "errorRef";
     public static final String ATTRIBUTE_ERROR_CODE = "errorCode";
-    
+    public static final String ATTRIBUTE_ERROR_VARIABLE_NAME = "errorVariableName";
+    public static final String ATTRIBUTE_ERROR_VARIABLE_TRANSIENT = "errorVariableTransient";
+    public static final String ATTRIBUTE_ERROR_VARIABLE_LOCAL_SCOPE = "errorVariableLocalScope";
+
     public static final String ELEMENT_EVENT_MESSAGEDEFINITION = "messageEventDefinition";
     public static final String ATTRIBUTE_MESSAGE_REF = "messageRef";
     public static final String ATTRIBUTE_MESSAGE_EXPRESSION = "messageExpression";
-    
+
     public static final String ELEMENT_EVENT_SIGNALDEFINITION = "signalEventDefinition";
     public static final String ATTRIBUTE_SIGNAL_REF = "signalRef";
     public static final String ATTRIBUTE_SIGNAL_EXPRESSION = "signalExpression";
     public static final String ATTRIBUTE_SCOPE = "scope";
-    
+
     public static final String ELEMENT_EVENT_TIMERDEFINITION = "timerEventDefinition";
     public static final String ATTRIBUTE_CALENDAR_NAME = "businessCalendarName";
     public static final String ATTRIBUTE_TIMER_DATE = "timeDate";
     public static final String ATTRIBUTE_TIMER_CYCLE = "timeCycle";
     public static final String ATTRIBUTE_END_DATE = "endDate";
     public static final String ATTRIBUTE_TIMER_DURATION = "timeDuration";
-    
+
     public static final String ELEMENT_EVENT_ESCALATIONDEFINITION = "escalationEventDefinition";
     public static final String ATTRIBUTE_ESCALATION_REF = "escalationRef";
     public static final String ATTRIBUTE_ESCALATION_CODE = "escalationCode";
-    
+
     public static final String ELEMENT_EVENT_TERMINATEDEFINITION = "terminateEventDefinition";
     public static final String ATTRIBUTE_TERMINATE_ALL = "terminateAll";
     public static final String ATTRIBUTE_TERMINATE_MULTI_INSTANCE = "terminateMultiInstance";
-    
+
     public static final String ELEMENT_EVENT_CANCELDEFINITION = "cancelEventDefinition";
-    
+
     public static final String ELEMENT_EVENT_COMPENSATEDEFINITION = "compensateEventDefinition";
     public static final String ATTRIBUTE_COMPENSATE_ACTIVITYREF = "activityRef";
     public static final String ATTRIBUTE_COMPENSATE_WAITFORCOMPLETION = "waitForCompletion";
-    
+
     public static final String ELEMENT_EVENT_CORRELATION_PARAMETER = "eventCorrelationParameter";
     public static final String ELEMENT_EVENT_IN_PARAMETER = "eventInParameter";
     public static final String ELEMENT_EVENT_OUT_PARAMETER = "eventOutParameter";
@@ -369,7 +372,7 @@ public interface BpmnXMLConstants {
     public static final String ATTRIBUTE_DATA_ID = "id";
     public static final String ATTRIBUTE_DATA_NAME = "name";
     public static final String ATTRIBUTE_DATA_ITEM_REF = "itemSubjectRef";
-    
+
     // only used by valued data objects
     public static final String ELEMENT_DATA_VALUE = "value";
 

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -538,39 +538,43 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
         }
         xtw.writeEndElement();
     }
-    
+
     protected void writeConditionalDefinition(Event parentEvent, ConditionalEventDefinition conditionalDefinition, BpmnModel model, XMLStreamWriter xtw) throws Exception {
         xtw.writeStartElement(ELEMENT_EVENT_CONDITIONALDEFINITION);
         boolean didWriteExtensionStartElement = BpmnXMLUtil.writeExtensionElements(conditionalDefinition, false, model.getNamespaces(), xtw);
         if (didWriteExtensionStartElement) {
             xtw.writeEndElement();
         }
-        
+
         if (StringUtils.isNotEmpty(conditionalDefinition.getConditionExpression())) {
             xtw.writeStartElement(ELEMENT_CONDITION);
             xtw.writeCharacters(conditionalDefinition.getConditionExpression());
             xtw.writeEndElement();
         }
-        
+
         xtw.writeEndElement();
     }
 
     protected void writeErrorDefinition(Event parentEvent, ErrorEventDefinition errorDefinition, BpmnModel model, XMLStreamWriter xtw) throws Exception {
         xtw.writeStartElement(ELEMENT_EVENT_ERRORDEFINITION);
         writeDefaultAttribute(ATTRIBUTE_ERROR_REF, errorDefinition.getErrorCode(), xtw);
+        writeQualifiedAttribute(ATTRIBUTE_ERROR_VARIABLE_NAME, errorDefinition.getErrorVariableName(), xtw);
+        writeQualifiedAttribute(ATTRIBUTE_ERROR_VARIABLE_LOCAL_SCOPE, errorDefinition.getErrorVariableLocalScope().toString(), xtw);
+        writeQualifiedAttribute(ATTRIBUTE_ERROR_VARIABLE_TRANSIENT, errorDefinition.getErrorVariableTransient().toString(), xtw);
+
         boolean didWriteExtensionStartElement = BpmnXMLUtil.writeExtensionElements(errorDefinition, false, model.getNamespaces(), xtw);
         if (didWriteExtensionStartElement) {
             xtw.writeEndElement();
         }
         xtw.writeEndElement();
     }
-    
+
     protected void writeEscalationDefinition(Event parentEvent, EscalationEventDefinition escalationDefinition, BpmnModel model,
                     XMLStreamWriter xtw) throws Exception {
-        
+
         xtw.writeStartElement(ELEMENT_EVENT_ESCALATIONDEFINITION);
         writeDefaultAttribute(ATTRIBUTE_ESCALATION_REF, escalationDefinition.getEscalationCode(), xtw);
-        
+
         boolean didWriteExtensionStartElement = BpmnXMLUtil.writeExtensionElements(escalationDefinition, false, model.getNamespaces(), xtw);
         if (didWriteExtensionStartElement) {
             xtw.writeEndElement();

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BoundaryEventXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BoundaryEventXMLConverter.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,7 @@ import org.flowable.bpmn.model.ExtensionElement;
  * @author Tijs Rademakers
  */
 public class BoundaryEventXMLConverter extends BaseBpmnXMLConverter {
-    
+
     protected Map<String, BaseChildElementParser> childParserMap = new HashMap<>();
 
     public BoundaryEventXMLConverter() {
@@ -97,7 +97,7 @@ public class BoundaryEventXMLConverter extends BaseBpmnXMLConverter {
             if (!(eventDef instanceof ErrorEventDefinition)) {
                 writeDefaultAttribute(ATTRIBUTE_BOUNDARY_CANCELACTIVITY, String.valueOf(boundaryEvent.isCancelActivity()).toLowerCase(), xtw);
             }
-            
+
         } else if (!boundaryEvent.getExtensionElements().isEmpty()) {
             List<ExtensionElement> eventTypeExtensionElements = boundaryEvent.getExtensionElements().get(BpmnXMLConstants.ELEMENT_EVENT_TYPE);
             if (eventTypeExtensionElements != null && !eventTypeExtensionElements.isEmpty()) {

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/ErrorEventDefinitionParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/ErrorEventDefinitionParser.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,14 @@ public class ErrorEventDefinitionParser extends BaseChildElementParser {
 
         ErrorEventDefinition eventDefinition = new ErrorEventDefinition();
         BpmnXMLUtil.addXMLLocation(eventDefinition, xtr);
-        eventDefinition.setErrorCode(xtr.getAttributeValue(null, "errorRef"));
+        eventDefinition.setErrorCode(xtr.getAttributeValue(null, ATTRIBUTE_ERROR_REF));
+        eventDefinition.setErrorVariableName(xtr.getAttributeValue(FLOWABLE_EXTENSIONS_NAMESPACE, ATTRIBUTE_ERROR_VARIABLE_NAME));
+
+        eventDefinition.setErrorVariableTransient(
+                Boolean.parseBoolean(xtr.getAttributeValue(FLOWABLE_EXTENSIONS_NAMESPACE, ATTRIBUTE_ERROR_VARIABLE_TRANSIENT)));
+
+        eventDefinition.setErrorVariableLocalScope(
+                Boolean.parseBoolean(xtr.getAttributeValue(FLOWABLE_EXTENSIONS_NAMESPACE, ATTRIBUTE_ERROR_VARIABLE_LOCAL_SCOPE)));
 
         BpmnXMLUtil.parseChildElements(ELEMENT_EVENT_ERRORDEFINITION, eventDefinition, xtr, model);
 

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ErrorEventDefinition.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ErrorEventDefinition.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,9 @@ package org.flowable.bpmn.model;
 public class ErrorEventDefinition extends EventDefinition {
 
     protected String errorCode;
+    protected String errorVariableName;
+    protected Boolean errorVariableTransient;
+    protected Boolean errorVariableLocalScope;
 
     public String getErrorCode() {
         return errorCode;
@@ -25,6 +28,30 @@ public class ErrorEventDefinition extends EventDefinition {
 
     public void setErrorCode(String errorCode) {
         this.errorCode = errorCode;
+    }
+
+    public String getErrorVariableName() {
+        return errorVariableName;
+    }
+
+    public void setErrorVariableName(String errorVariableName) {
+        this.errorVariableName = errorVariableName;
+    }
+
+    public Boolean getErrorVariableTransient() {
+        return errorVariableTransient;
+    }
+
+    public void setErrorVariableTransient(Boolean errorVariableTransient) {
+        this.errorVariableTransient = errorVariableTransient;
+    }
+
+    public Boolean getErrorVariableLocalScope() {
+        return errorVariableLocalScope;
+    }
+
+    public void setErrorVariableLocalScope(Boolean errorVariableLocalScope) {
+        this.errorVariableLocalScope = errorVariableLocalScope;
     }
 
     @Override
@@ -37,5 +64,8 @@ public class ErrorEventDefinition extends EventDefinition {
     public void setValues(ErrorEventDefinition otherDefinition) {
         super.setValues(otherDefinition);
         setErrorCode(otherDefinition.getErrorCode());
+        setErrorVariableName(otherDefinition.getErrorVariableName());
+        setErrorVariableLocalScope(otherDefinition.getErrorVariableLocalScope());
+        setErrorVariableTransient(otherDefinition.getErrorVariableTransient());
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ErrorPropagation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ErrorPropagation.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,9 +50,9 @@ import org.flowable.engine.impl.util.ProcessDefinitionUtil;
 
 /**
  * This class is responsible for finding and executing error handlers for BPMN Errors.
- * 
+ *
  * Possible error handlers include Error Intermediate Events and Error Event Sub-Processes.
- * 
+ *
  * @author Tijs Rademakers
  * @author Saeid Mirzaei
  */
@@ -76,13 +76,13 @@ public class ErrorPropagation {
                 }
             }
         }
-        
+
         if (rootProcessDefinitionIds.size() > 0) {
             for (String processDefinitionId : rootProcessDefinitionIds) {
                 eventMap.putAll(findCatchingEventsForProcess(processDefinitionId, errorCode));
             }
         }
-        
+
         eventMap.putAll(findCatchingEventsForProcess(execution.getProcessDefinitionId(), errorCode));
         if (eventMap.size() > 0) {
             executeCatch(eventMap, execution, errorCode);
@@ -95,7 +95,7 @@ public class ErrorPropagation {
 
     protected static void executeCatch(Map<String, List<Event>> eventMap, DelegateExecution delegateExecution, String errorId) {
         Set<String> toDeleteProcessInstanceIds = new HashSet<>();
-        
+
         Event matchingEvent = null;
         ExecutionEntity currentExecution = (ExecutionEntity) delegateExecution;
         ExecutionEntity parentExecution = null;
@@ -107,13 +107,13 @@ public class ErrorPropagation {
             } else {
                 parentExecution = currentExecution;
             }
-            
-            matchingEvent = getCatchEventFromList(eventMap.get(currentExecution.getActivityId() + 
+
+            matchingEvent = getCatchEventFromList(eventMap.get(currentExecution.getActivityId() +
                             "#" + currentExecution.getProcessDefinitionId()), parentExecution);
 
         } else {
             parentExecution = currentExecution.getParent();
-            
+
             // Traverse parents until one is found that is a scope and matches the activity the boundary event is defined on
             while (matchingEvent == null && parentExecution != null) {
                 FlowElementsContainer currentContainer = null;
@@ -129,9 +129,9 @@ public class ErrorPropagation {
                         if (CollectionUtil.isNotEmpty(events) && events.get(0) instanceof StartEvent) {
                             String refActivityId = refId.substring(0, refId.indexOf('#'));
                             String refProcessDefinitionId = refId.substring(refId.indexOf('#') + 1);
-                            if (parentExecution.getProcessDefinitionId().equals(refProcessDefinitionId) && 
+                            if (parentExecution.getProcessDefinitionId().equals(refProcessDefinitionId) &&
                                             currentContainer.getFlowElement(refActivityId) != null) {
-                                
+
                                 matchingEvent = getCatchEventFromList(events, parentExecution);
                                 String errorCode = getErrorCodeFromErrorEventDefinition(matchingEvent);
                                 if (StringUtils.isNotEmpty(errorCode)) {
@@ -148,13 +148,13 @@ public class ErrorPropagation {
                         if (parentExecution.getParentId() != null && parentExecution.getParent().isMultiInstanceRoot()) {
                             parentExecution = parentExecution.getParent();
                         }
-                        
-                        matchingEvent = getCatchEventFromList(eventMap.get(parentExecution.getActivityId() + 
+
+                        matchingEvent = getCatchEventFromList(eventMap.get(parentExecution.getActivityId() +
                                         "#" + parentExecution.getProcessDefinitionId()), parentExecution);
 
                     } else if (StringUtils.isNotEmpty(parentExecution.getParentId())) {
                         parentExecution = parentExecution.getParent();
-                        
+
                     } else {
                         if (parentExecution.getProcessInstanceId().equals(parentExecution.getRootProcessInstanceId()) == false) {
                             toDeleteProcessInstanceIds.add(parentExecution.getProcessInstanceId());
@@ -168,7 +168,7 @@ public class ErrorPropagation {
         }
 
         if (matchingEvent != null && parentExecution != null) {
-            
+
             for (String processInstanceId : toDeleteProcessInstanceIds) {
                 ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager();
                 ExecutionEntity processInstanceEntity = executionEntityManager.findById(processInstanceId);
@@ -190,9 +190,9 @@ public class ErrorPropagation {
                                     processEngineConfiguration.getEngineCfgKey());
                 }
             }
-            
+
             executeEventHandler(matchingEvent, parentExecution, currentExecution, errorId);
-            
+
         } else {
             throw new FlowableException("No matching parent execution for error code " + errorId + " found");
         }
@@ -201,23 +201,25 @@ public class ErrorPropagation {
     protected static void executeEventHandler(Event event, ExecutionEntity parentExecution, ExecutionEntity currentExecution, String errorId) {
         ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration();
         FlowableEventDispatcher eventDispatcher = null;
+
+        String errorCode = errorId;
+        BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(parentExecution.getProcessDefinitionId());
+        if (bpmnModel != null) {
+            String modelError = bpmnModel.getErrors().get(errorId);
+            if (modelError != null) {
+                errorCode = modelError;
+            }
+        }
+
         if (processEngineConfiguration != null) {
             eventDispatcher = processEngineConfiguration.getEventDispatcher();
         }
+
         if (eventDispatcher != null && eventDispatcher.isEnabled()) {
-            BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(parentExecution.getProcessDefinitionId());
-            if (bpmnModel != null) {
-
-                String errorCode = bpmnModel.getErrors().get(errorId);
-                if (errorCode == null) {
-                    errorCode = errorId;
-                }
-
-                processEngineConfiguration.getEventDispatcher().dispatchEvent(
-                        FlowableEventBuilder.createErrorEvent(FlowableEngineEventType.ACTIVITY_ERROR_RECEIVED, event.getId(), errorId, errorCode, parentExecution.getId(),
-                                parentExecution.getProcessInstanceId(), parentExecution.getProcessDefinitionId()),
-                        processEngineConfiguration.getEngineCfgKey());
-            }
+            processEngineConfiguration.getEventDispatcher().dispatchEvent(
+                    FlowableEventBuilder.createErrorEvent(FlowableEngineEventType.ACTIVITY_ERROR_RECEIVED, event.getId(), errorId, errorCode, parentExecution.getId(),
+                            parentExecution.getProcessInstanceId(), parentExecution.getProcessDefinitionId()),
+                    processEngineConfiguration.getEngineCfgKey());
         }
 
         if (event instanceof StartEvent) {
@@ -232,13 +234,14 @@ public class ErrorPropagation {
             }
 
             ExecutionEntity eventSubProcessExecution = executionEntityManager.createChildExecution(parentExecution);
+            injectErrorContext(event, eventSubProcessExecution, errorCode);
             if (event.getSubProcess() != null) {
                 eventSubProcessExecution.setCurrentFlowElement(event.getSubProcess());
                 CommandContextUtil.getActivityInstanceEntityManager().recordActivityStart(eventSubProcessExecution);
                 ExecutionEntity subProcessStartEventExecution = executionEntityManager.createChildExecution(eventSubProcessExecution);
                 subProcessStartEventExecution.setCurrentFlowElement(event);
                 CommandContextUtil.getAgenda().planContinueProcessOperation(subProcessStartEventExecution);
-                
+
             } else {
                 eventSubProcessExecution.setCurrentFlowElement(event);
                 CommandContextUtil.getAgenda().planContinueProcessOperation(eventSubProcessExecution);
@@ -254,7 +257,7 @@ public class ErrorPropagation {
                     boundaryExecution = childExecution;
                 }
             }
-
+            injectErrorContext(event, boundaryExecution, errorCode);
             CommandContextUtil.getAgenda().planTriggerExecutionOperation(boundaryExecution);
         }
     }
@@ -396,34 +399,34 @@ public class ErrorPropagation {
 
         return defaultExceptionMapping;
     }
-    
+
     protected static Event getCatchEventFromList(List<Event> events, ExecutionEntity parentExecution) {
         Event selectedEvent = null;
         String selectedEventErrorCode = null;
-        
+
         BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(parentExecution.getProcessDefinitionId());
         for (Event event : events) {
             String errorCode = getErrorCodeFromErrorEventDefinition(event);
             if (bpmnModel != null) {
                 errorCode = retrieveErrorCode(bpmnModel, errorCode);
             }
-            
+
             if (selectedEvent == null || (StringUtils.isEmpty(selectedEventErrorCode) && StringUtils.isNotEmpty(errorCode))) {
                 selectedEvent = event;
                 selectedEventErrorCode = errorCode;
             }
         }
-        
+
         return selectedEvent;
     }
-        
+
     protected static String getErrorCodeFromErrorEventDefinition(Event event) {
         for (EventDefinition eventDefinition : event.getEventDefinitions()) {
             if (eventDefinition instanceof ErrorEventDefinition) {
                 return ((ErrorEventDefinition) eventDefinition).getErrorCode();
             }
         }
-        
+
         return null;
     }
 
@@ -458,4 +461,35 @@ public class ErrorPropagation {
             throw (E) exc;
         }
     }
+
+    protected static void injectErrorContext(Event event, ExecutionEntity execution, String errorCode) {
+
+        for (EventDefinition eventDefinition : event.getEventDefinitions()) {
+            if (!(eventDefinition instanceof ErrorEventDefinition)) {
+                break;
+            }
+
+            ErrorEventDefinition definition = (ErrorEventDefinition) eventDefinition;
+            String variableName = definition.getErrorVariableName();
+
+            if (variableName == null || variableName.isEmpty()) {
+                break;
+            }
+
+            if (definition.getErrorVariableTransient()) {
+                if (definition.getErrorVariableLocalScope()) {
+                    execution.setTransientVariableLocal(variableName, errorCode);
+                } else {
+                    execution.setTransientVariable(variableName, errorCode);
+                }
+            } else {
+                if (definition.getErrorVariableLocalScope()) {
+                    execution.setVariableLocal(variableName, errorCode);
+                } else {
+                    execution.setVariable(variableName, errorCode);
+                }
+            }
+        }
+    }
+
 }

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/constants/StencilConstants.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/constants/StencilConstants.java
@@ -130,11 +130,14 @@ public interface StencilConstants {
 
     final String PROPERTY_SIGNALREF = "signalref";
     final String PROPERTY_SIGNALEXPRESSION = "signalexpression";
-    
+
     final String PROPERTY_CONDITIONAL_EVENT_CONDITION = "conditionaleventcondition";
 
     final String PROPERTY_ERRORREF = "errorref";
-    
+    final String PROPERTY_ERROR_VARIABLE_NAME = "errorvariablename";
+    final String PROPERTY_ERROR_VARIABLE_TRANSIENT = "errorvariabletransient";
+    final String PROPERTY_ERROR_VARIABLE_LOCAL_SCOPE = "errorvariablelocalscope";
+
     final String PROPERTY_ESCALATION_DEFINITIONS = "escalationdefinitions";
     final String PROPERTY_ESCALATION_DEFINITION_ID = "id";
     final String PROPERTY_ESCALATION_DEFINITION_NAME = "name";
@@ -347,7 +350,7 @@ public interface StencilConstants {
     final String PROPERTY_SHELLTASK_ERROR_REDIRECT = "shellerrorredirect";
     final String PROPERTY_SHELLTASK_CLEAN_ENV = "shellcleanenv";
     final String PROPERTY_SHELLTASK_DIRECTORY = "shelldirectory";
-    
+
     final String PROPERTY_EXTERNAL_WORKER_JOB_TOPIC = "topic";
 
     final String PROPERTY_EVENT_REGISTRY_EVENT_KEY = "eventkey";
@@ -362,14 +365,14 @@ public interface StencilConstants {
     final String PROPERTY_EVENT_REGISTRY_KEY_DETECTION_FIXED_VALUE = "keydetectionfixedvalue";
     final String PROPERTY_EVENT_REGISTRY_KEY_DETECTION_JSON_FIELD = "keydetectionjsonfield";
     final String PROPERTY_EVENT_REGISTRY_KEY_DETECTION_JSON_POINTER = "keydetectionjsonpointer";
-    
+
     final String PROPERTY_EVENT_REGISTRY_TRIGGER_EVENT_KEY = "triggereventkey";
     final String PROPERTY_EVENT_REGISTRY_TRIGGER_EVENT_NAME = "triggereventname";
     final String PROPERTY_EVENT_REGISTRY_TRIGGER_CHANNEL_KEY = "triggerchannelkey";
     final String PROPERTY_EVENT_REGISTRY_TRIGGER_CHANNEL_NAME = "triggerchannelname";
     final String PROPERTY_EVENT_REGISTRY_TRIGGER_CHANNEL_TYPE = "triggerchanneltype";
     final String PROPERTY_EVENT_REGISTRY_TRIGGER_CHANNEL_DESTINATION = "triggerchanneldestination";
-    
+
     final String PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME = "eventName";
     final String PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTTYPE = "eventType";
     final String PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME = "variableName";

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BaseBpmnJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BaseBpmnJsonConverter.java
@@ -228,7 +228,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                     }
                 }
             }
-            
+
         } else if (baseElement instanceof Gateway) {
             Gateway gateway = (Gateway) baseElement;
             propertiesNode.put(PROPERTY_ASYNCHRONOUS, gateway.isAsynchronous());
@@ -533,7 +533,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         formPropertiesNode.set("formProperties", propertiesArrayNode);
         propertiesNode.set(PROPERTY_FORM_PROPERTIES, formPropertiesNode);
     }
-    
+
     protected void addEventOutParameters(List<ExtensionElement> eventParameterElements, ObjectNode propertiesNode) {
         if (CollectionUtils.isEmpty(eventParameterElements)) {
             return;
@@ -553,7 +553,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         valueNode.set("outParameters", arrayNode);
         propertiesNode.set(PROPERTY_EVENT_REGISTRY_OUT_PARAMETERS, valueNode);
     }
-    
+
     protected void addEventOutIOParameters(List<IOParameter> eventParameters, ObjectNode propertiesNode) {
         if (CollectionUtils.isEmpty(eventParameters)) {
             return;
@@ -568,7 +568,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
             } else {
                 itemNode.put(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME, parameter.getSource());
             }
-            
+
             itemNode.put(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTTYPE, parameter.getAttributeValue(null, "sourceType"));
             itemNode.put(PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME, parameter.getTarget());
 
@@ -578,7 +578,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         valueNode.set("outParameters", arrayNode);
         propertiesNode.set(PROPERTY_EVENT_REGISTRY_OUT_PARAMETERS, valueNode);
     }
-    
+
     protected void addEventInParameters(List<ExtensionElement> eventParameterElements, ObjectNode propertiesNode) {
         if (CollectionUtils.isEmpty(eventParameterElements)) {
             return;
@@ -598,7 +598,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         valueNode.set("inParameters", arrayNode);
         propertiesNode.set(PROPERTY_EVENT_REGISTRY_IN_PARAMETERS, valueNode);
     }
-    
+
     protected void addEventInIOParameters(List<IOParameter> eventParameters, ObjectNode propertiesNode) {
         if (CollectionUtils.isEmpty(eventParameters)) {
             return;
@@ -613,7 +613,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
             } else {
                 itemNode.put(PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME, parameter.getSource());
             }
-            
+
             itemNode.put(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME, parameter.getTarget());
             itemNode.put(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTTYPE, parameter.getAttributeValue(null, "targetType"));
 
@@ -623,7 +623,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         valueNode.set("inParameters", arrayNode);
         propertiesNode.set(PROPERTY_EVENT_REGISTRY_IN_PARAMETERS, valueNode);
     }
-    
+
     protected void addEventCorrelationParameters(List<ExtensionElement> eventParameterElements, ObjectNode propertiesNode) {
         if (CollectionUtils.isEmpty(eventParameterElements)) {
             return;
@@ -763,6 +763,9 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                 ErrorEventDefinition errorDefinition = (ErrorEventDefinition) eventDefinition;
                 if (StringUtils.isNotEmpty(errorDefinition.getErrorCode())) {
                     propertiesNode.put(PROPERTY_ERRORREF, errorDefinition.getErrorCode());
+                    propertiesNode.put(PROPERTY_ERROR_VARIABLE_NAME, errorDefinition.getErrorVariableName());
+                    propertiesNode.put(PROPERTY_ERROR_VARIABLE_TRANSIENT, errorDefinition.getErrorVariableTransient());
+                    propertiesNode.put(PROPERTY_ERROR_VARIABLE_LOCAL_SCOPE, errorDefinition.getErrorVariableLocalScope());
                 }
 
             } else if (eventDefinition instanceof SignalEventDefinition) {
@@ -788,13 +791,13 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                 if (StringUtils.isNotEmpty(messageExpression)) {
                     propertiesNode.put(PROPERTY_MESSAGEEXPRESSION, messageExpression);
                 }
-                
+
             } else if (eventDefinition instanceof ConditionalEventDefinition) {
                 ConditionalEventDefinition conditionalDefinition = (ConditionalEventDefinition) eventDefinition;
                 if (StringUtils.isNotEmpty(conditionalDefinition.getConditionExpression())) {
                     propertiesNode.put(PROPERTY_CONDITIONAL_EVENT_CONDITION, conditionalDefinition.getConditionExpression());
                 }
-                
+
             } else if (eventDefinition instanceof EscalationEventDefinition) {
                 EscalationEventDefinition escalationDefinition = (EscalationEventDefinition) eventDefinition;
                 if (StringUtils.isNotEmpty(escalationDefinition.getEscalationCode())) {
@@ -822,7 +825,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                 TerminateEventDefinition terminateEventDefinition = (TerminateEventDefinition) eventDefinition;
                 propertiesNode.put(PROPERTY_TERMINATE_ALL, terminateEventDefinition.isTerminateAll());
                 propertiesNode.put(PROPERTY_TERMINATE_MULTI_INSTANCE, terminateEventDefinition.isTerminateMultiInstance());
-                
+
             } else if (eventDefinition instanceof CompensateEventDefinition) {
                 CompensateEventDefinition compensateEventDefinition = (CompensateEventDefinition) eventDefinition;
                 if (StringUtils.isNotEmpty(compensateEventDefinition.getActivityRef())) {
@@ -964,7 +967,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
 
         event.getEventDefinitions().add(eventDefinition);
     }
-    
+
     protected void convertJsonToEventOutParameters(JsonNode objectNode, FlowElement event) {
         JsonNode parametersNode = getProperty(PROPERTY_EVENT_REGISTRY_OUT_PARAMETERS, objectNode);
         parametersNode = BpmnJsonConverterUtil.validateIfNodeIsTextual(parametersNode);
@@ -977,7 +980,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                     String eventName = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME).asText();
                     String eventType = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTTYPE).asText();
                     String variableName = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME).asText();
-                    
+
                     addExtensionAttribute("source", eventName, extensionElement);
                     addExtensionAttribute("sourceType", eventType, extensionElement);
                     addExtensionAttribute("target", variableName, extensionElement);
@@ -985,7 +988,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
             }
         }
     }
-    
+
     protected void convertJsonToOutIOParameters(JsonNode objectNode, SendEventServiceTask task) {
         JsonNode parametersNode = getProperty(PROPERTY_EVENT_REGISTRY_OUT_PARAMETERS, objectNode);
         parametersNode = BpmnJsonConverterUtil.validateIfNodeIsTextual(parametersNode);
@@ -995,26 +998,26 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
             for (JsonNode parameterNode : parameterArray) {
                 if (parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME) != null && !parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME).isNull()) {
                     IOParameter parameterObject = new IOParameter();
-                    
+
                     String eventName = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME).asText();
                     String eventType = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTTYPE).asText();
                     String variableName = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME).asText();
-                    
+
                     parameterObject.setSource(eventName);
                     parameterObject.addAttribute(createExtensionAttribute("sourceType", eventType));
-                    
+
                     if ((variableName.contains("${") || variableName.contains("#{")) && variableName.contains("}")) {
                         parameterObject.setTargetExpression(variableName);
                     } else {
                         parameterObject.setTarget(variableName);
                     }
-                    
+
                     task.getEventOutParameters().add(parameterObject);
                 }
             }
         }
     }
-    
+
     protected void convertJsonToInParameters(JsonNode objectNode, Event event) {
         JsonNode parametersNode = getProperty(PROPERTY_EVENT_REGISTRY_IN_PARAMETERS, objectNode);
         parametersNode = BpmnJsonConverterUtil.validateIfNodeIsTextual(parametersNode);
@@ -1027,7 +1030,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                     String variableName = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME).asText();
                     String eventName = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME).asText();
                     String eventType = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTTYPE).asText();
-                    
+
                     addExtensionAttribute("source", variableName, extensionElement);
                     addExtensionAttribute("target", eventName, extensionElement);
                     addExtensionAttribute("targetType", eventType, extensionElement);
@@ -1035,7 +1038,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
             }
         }
     }
-    
+
     protected void convertJsonToInIOParameters(JsonNode objectNode, SendEventServiceTask task) {
         JsonNode parametersNode = getProperty(PROPERTY_EVENT_REGISTRY_IN_PARAMETERS, objectNode);
         parametersNode = BpmnJsonConverterUtil.validateIfNodeIsTextual(parametersNode);
@@ -1045,26 +1048,26 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
             for (JsonNode parameterNode : parameterArray) {
                 if (parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME) != null && !parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME).isNull()) {
                     IOParameter parameterObject = new IOParameter();
-                    
+
                     String variableName = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_VARIABLENAME).asText();
                     if ((variableName.contains("${") || variableName.contains("#{")) && variableName.contains("}")) {
                         parameterObject.setSourceExpression(variableName);
                     } else {
                         parameterObject.setSource(variableName);
                     }
-                    
+
                     String eventName = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTNAME).asText();
                     String eventType = parameterNode.get(PROPERTY_EVENT_REGISTRY_PARAMETER_EVENTTYPE).asText();
-                    
+
                     parameterObject.setTarget(eventName);
                     parameterObject.addAttribute(createExtensionAttribute("targetType", eventType));
-                    
+
                     task.getEventInParameters().add(parameterObject);
                 }
             }
         }
     }
-    
+
     protected void convertJsonToEventCorrelationParameters(JsonNode objectNode, String correlationPropertyName, FlowElement flowElement) {
         JsonNode parametersNode = getProperty(PROPERTY_EVENT_REGISTRY_CORRELATION_PARAMETERS, objectNode);
         parametersNode = BpmnJsonConverterUtil.validateIfNodeIsTextual(parametersNode);
@@ -1077,7 +1080,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                     String name = parameterNode.get(PROPERTY_EVENT_REGISTRY_CORRELATIONNAME).asText();
                     String type = parameterNode.get(PROPERTY_EVENT_REGISTRY_CORRELATIONTYPE).asText();
                     String value = parameterNode.get(PROPERTY_EVENT_REGISTRY_CORRELATIONVALUE).asText();
-                    
+
                     addExtensionAttribute("name", name, extensionElement);
                     addExtensionAttribute("type", type, extensionElement);
                     addExtensionAttribute("value", value, extensionElement);
@@ -1139,7 +1142,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         return aggregations;
 
     }
-    
+
     protected void convertJsonToConditionalDefinition(JsonNode objectNode, Event event) {
         String condition = getPropertyValueAsString(PROPERTY_CONDITIONAL_EVENT_CONDITION, objectNode);
         ConditionalEventDefinition eventDefinition = new ConditionalEventDefinition();
@@ -1148,7 +1151,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         }
         event.getEventDefinitions().add(eventDefinition);
     }
-    
+
     protected void convertJsonToEscalationDefinition(JsonNode objectNode, Event event) {
         String escalationRef = getPropertyValueAsString(PROPERTY_ESCALATIONREF, objectNode);
         EscalationEventDefinition eventDefinition = new EscalationEventDefinition();
@@ -1158,8 +1161,16 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
 
     protected void convertJsonToErrorDefinition(JsonNode objectNode, Event event) {
         String errorRef = getPropertyValueAsString(PROPERTY_ERRORREF, objectNode);
+        String errorVariableName = getPropertyValueAsString(PROPERTY_ERROR_VARIABLE_NAME, objectNode);
+        Boolean errorVariableLocalScope = JsonConverterUtil.getPropertyValueAsBoolean(PROPERTY_ERROR_VARIABLE_LOCAL_SCOPE, objectNode, true);
+        Boolean errorVariableTransient = JsonConverterUtil.getPropertyValueAsBoolean(PROPERTY_ERROR_VARIABLE_TRANSIENT, objectNode, true);
+
         ErrorEventDefinition eventDefinition = new ErrorEventDefinition();
         eventDefinition.setErrorCode(errorRef);
+        eventDefinition.setErrorVariableName(errorVariableName);
+        eventDefinition.setErrorVariableLocalScope(errorVariableLocalScope);
+        eventDefinition.setErrorVariableTransient(errorVariableTransient);
+
         event.getEventDefinitions().add(eventDefinition);
     }
 
@@ -1211,7 +1222,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
     protected void addField(String name, String propertyName, JsonNode elementNode, ServiceTask task) {
         addField(name, propertyName, null, elementNode, task);
     }
-    
+
     protected void addField(String name, String propertyName, String defaultValue, JsonNode elementNode, ServiceTask task) {
         FieldExtension field = new FieldExtension();
         field.setFieldName(name);
@@ -1259,7 +1270,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         }
         return resultString;
     }
-    
+
     protected ExtensionElement addFlowableExtensionElement(String name, FlowElement flowElement) {
         ExtensionElement extensionElement = new ExtensionElement();
         extensionElement.setName(name);
@@ -1268,23 +1279,23 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         flowElement.addExtensionElement(extensionElement);
         return extensionElement;
     }
-    
+
     protected ExtensionElement addFlowableExtensionElementWithValue(String name, String value, FlowElement flowElement) {
         ExtensionElement extensionElement = null;
         if (StringUtils.isNotEmpty(value)) {
             extensionElement = addFlowableExtensionElement(name, flowElement);
             extensionElement.setElementText(value);
         }
-        
+
         return extensionElement;
     }
-    
+
     public void addExtensionAttribute(String name, String value, ExtensionElement extensionElement) {
         ExtensionAttribute attribute = new ExtensionAttribute(name);
         attribute.setValue(value);
         extensionElement.addAttribute(attribute);
     }
-    
+
     public ExtensionAttribute createExtensionAttribute(String name, String value) {
         ExtensionAttribute attribute = new ExtensionAttribute(name);
         attribute.setValue(value);

--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BoundaryEventJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BoundaryEventJsonConverter.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -67,7 +67,7 @@ public class BoundaryEventJsonConverter extends BaseBpmnJsonConverter {
     protected String getStencilId(BaseElement baseElement) {
         BoundaryEvent boundaryEvent = (BoundaryEvent) baseElement;
         List<EventDefinition> eventDefinitions = boundaryEvent.getEventDefinitions();
-        
+
         if (eventDefinitions.isEmpty()) {
             if (boundaryEvent.getExtensionElements().get("eventType") != null && boundaryEvent.getExtensionElements().get("eventType").size() > 0) {
                 String eventType = boundaryEvent.getExtensionElements().get("eventType").get(0).getElementText();
@@ -76,7 +76,7 @@ public class BoundaryEventJsonConverter extends BaseBpmnJsonConverter {
                 }
             }
         }
-        
+
         if (eventDefinitions.size() != 1) {
             // return timer event as default;
             return STENCIL_EVENT_BOUNDARY_TIMER;
@@ -103,8 +103,7 @@ public class BoundaryEventJsonConverter extends BaseBpmnJsonConverter {
     }
 
     @Override
-    protected void convertElementToJson(ObjectNode propertiesNode, BaseElement baseElement,
-        BpmnJsonConverterContext converterContext) {
+    protected void convertElementToJson(ObjectNode propertiesNode, BaseElement baseElement, BpmnJsonConverterContext converterContext) {
         BoundaryEvent boundaryEvent = (BoundaryEvent) baseElement;
         ArrayNode dockersArrayNode = objectMapper.createArrayNode();
         ObjectNode dockNode = objectMapper.createObjectNode();
@@ -144,13 +143,13 @@ public class BoundaryEventJsonConverter extends BaseBpmnJsonConverter {
         if (STENCIL_EVENT_BOUNDARY_TIMER.equals(stencilId)) {
             convertJsonToTimerDefinition(elementNode, boundaryEvent);
             boundaryEvent.setCancelActivity(getPropertyValueAsBoolean(PROPERTY_CANCEL_ACTIVITY, elementNode));
-            
+
         } else if (STENCIL_EVENT_BOUNDARY_CONDITIONAL.equals(stencilId)) {
             convertJsonToConditionalDefinition(elementNode, boundaryEvent);
 
         } else if (STENCIL_EVENT_BOUNDARY_ERROR.equals(stencilId)) {
             convertJsonToErrorDefinition(elementNode, boundaryEvent);
-            
+
         } else if (STENCIL_EVENT_BOUNDARY_ESCALATION.equals(stencilId)) {
             convertJsonToEscalationDefinition(elementNode, boundaryEvent);
             boundaryEvent.setCancelActivity(getPropertyValueAsBoolean(PROPERTY_CANCEL_ACTIVITY, elementNode));
@@ -172,7 +171,7 @@ public class BoundaryEventJsonConverter extends BaseBpmnJsonConverter {
             CompensateEventDefinition compensateEventDefinition = new CompensateEventDefinition();
             boundaryEvent.getEventDefinitions().add(compensateEventDefinition);
             boundaryEvent.setCancelActivity(getPropertyValueAsBoolean(PROPERTY_CANCEL_ACTIVITY, elementNode));
-        
+
         } else if (STENCIL_EVENT_BOUNDARY_EVENT_REGISTRY.equals(stencilId)) {
             addReceiveEventExtensionElements(elementNode, boundaryEvent);
 
@@ -212,7 +211,7 @@ public class BoundaryEventJsonConverter extends BaseBpmnJsonConverter {
 
         return attachedRefId;
     }
-    
+
     @Override
     protected void setPropertyValue(String name, String value, ObjectNode propertiesNode) {
         if (StringUtils.isNotEmpty(value)) {

--- a/modules/flowable-json-converter/src/test/resources/test.boundaryerrorvariable.json
+++ b/modules/flowable-json-converter/src/test/resources/test.boundaryerrorvariable.json
@@ -1,0 +1,361 @@
+{
+    "modelId": "b66712ef-9158-11eb-9f7e-a8a15933affd",
+    "bounds": {
+        "lowerRight": {
+            "x": 1200,
+            "y": 1050
+        },
+        "upperLeft": {
+            "x": 0,
+            "y": 0
+        }
+    },
+    "properties": {
+        "process_id": "test_boundary_error_context",
+        "name": "TEST Boundary error context",
+        "documentation": "",
+        "process_author": "",
+        "process_version": "",
+        "process_namespace": "http://www.flowable.org/processdef",
+        "process_historylevel": "",
+        "isexecutable": true,
+        "dataproperties": "",
+        "executionlisteners": "",
+        "eventlisteners": "",
+        "signaldefinitions": "",
+        "messagedefinitions": "",
+        "escalationdefinitions": "",
+        "process_potentialstarteruser": "",
+        "process_potentialstartergroup": "",
+        "iseagerexecutionfetch": "false"
+    },
+    "childShapes": [{
+            "resourceId": "startEvent1",
+            "properties": {
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "executionlisteners": "",
+                "initiator": "",
+                "formkeydefinition": "",
+                "formreference": "",
+                "formfieldvalidation": true,
+                "formproperties": ""
+            },
+            "stencil": {
+                "id": "StartNoneEvent"
+            },
+            "childShapes": [],
+            "outgoing": [{
+                    "resourceId": "sid-24CBC99D-DB27-4E5B-B249-CC2A65A86ECC"
+                }],
+            "bounds": {
+                "lowerRight": {
+                    "x": 130,
+                    "y": 193
+                },
+                "upperLeft": {
+                    "x": 100,
+                    "y": 163
+                }
+            },
+            "dockers": []
+        }, {
+            "resourceId": "sid-6BE5DF20-07B4-44E3-9611-BE2CBB3F85CA",
+            "properties": {
+                "scriptformat": "",
+                "scripttext": "",
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "asynchronousdefinition": "false",
+                "exclusivedefinition": "false",
+                "executionlisteners": "",
+                "multiinstance_type": "None",
+                "multiinstance_variableaggregations": "",
+                "multiinstance_cardinality": "",
+                "multiinstance_collection": "",
+                "multiinstance_variable": "",
+                "multiinstance_condition": "",
+                "isforcompensation": "false",
+                "scriptautostorevariables": "false"
+            },
+            "stencil": {
+                "id": "ScriptTask"
+            },
+            "childShapes": [],
+            "outgoing": [{
+                    "resourceId": "sid-C3D75079-87E7-4559-A8F1-F83877AA2203"
+                }, {
+                    "resourceId": "sid-14AD2759-DEC8-4647-B7A1-8ACB436289E4"
+                }],
+            "bounds": {
+                "lowerRight": {
+                    "x": 340,
+                    "y": 218
+                },
+                "upperLeft": {
+                    "x": 240,
+                    "y": 138
+                }
+            },
+            "dockers": []
+        }, {
+            "resourceId": "sid-24CBC99D-DB27-4E5B-B249-CC2A65A86ECC",
+            "properties": {
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "conditionsequenceflow": "",
+                "executionlisteners": "",
+                "defaultflow": "false",
+                "skipexpression": ""
+            },
+            "stencil": {
+                "id": "SequenceFlow"
+            },
+            "childShapes": [],
+            "outgoing": [{
+                    "resourceId": "sid-6BE5DF20-07B4-44E3-9611-BE2CBB3F85CA"
+                }],
+            "bounds": {
+                "lowerRight": {
+                    "x": 239.78125,
+                    "y": 178
+                },
+                "upperLeft": {
+                    "x": 130.35546875,
+                    "y": 178
+                }
+            },
+            "dockers": [{
+                    "x": 15,
+                    "y": 15
+                }, {
+                    "x": 50,
+                    "y": 40
+                }],
+            "target": {
+                "resourceId": "sid-6BE5DF20-07B4-44E3-9611-BE2CBB3F85CA"
+            }
+        }, {
+            "resourceId": "sid-F6D0274A-8214-4D19-9EA0-758EB5B1524B",
+            "properties": {
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "executionlisteners": ""
+            },
+            "stencil": {
+                "id": "EndNoneEvent"
+            },
+            "childShapes": [],
+            "outgoing": [],
+            "bounds": {
+                "lowerRight": {
+                    "x": 508,
+                    "y": 192
+                },
+                "upperLeft": {
+                    "x": 480,
+                    "y": 164
+                }
+            },
+            "dockers": []
+        }, {
+            "resourceId": "sid-C3D75079-87E7-4559-A8F1-F83877AA2203",
+            "properties": {
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "conditionsequenceflow": "",
+                "executionlisteners": "",
+                "defaultflow": "false",
+                "skipexpression": ""
+            },
+            "stencil": {
+                "id": "SequenceFlow"
+            },
+            "childShapes": [],
+            "outgoing": [{
+                    "resourceId": "sid-F6D0274A-8214-4D19-9EA0-758EB5B1524B"
+                }],
+            "bounds": {
+                "lowerRight": {
+                    "x": 479.453125,
+                    "y": 178
+                },
+                "upperLeft": {
+                    "x": 340.40625,
+                    "y": 178
+                }
+            },
+            "dockers": [{
+                    "x": 50,
+                    "y": 40
+                }, {
+                    "x": 14,
+                    "y": 14
+                }],
+            "target": {
+                "resourceId": "sid-F6D0274A-8214-4D19-9EA0-758EB5B1524B"
+            }
+        }, {
+            "resourceId": "sid-14AD2759-DEC8-4647-B7A1-8ACB436289E4",
+            "properties": {
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "errorref": "DATASOURCE_ERROR",
+                "errorvariablename": "errorVariable",
+                "errorvariablestore": true,
+                "errorvariabletransient": true,
+                "errorvariablelocalscope": true
+            },
+            "stencil": {
+                "id": "BoundaryErrorEvent"
+            },
+            "childShapes": [],
+            "outgoing": [{
+                    "resourceId": "sid-B969EBE9-B8A0-4CC2-ABB9-CB5B08166D51"
+                }],
+            "bounds": {
+                "lowerRight": {
+                    "x": 299.5609063227486,
+                    "y": 233.24929321166033
+                },
+                "upperLeft": {
+                    "x": 269.5609063227486,
+                    "y": 203.24929321166033
+                }
+            },
+            "dockers": [{
+                    "x": 45,
+                    "y": 77
+                }]
+        }, {
+            "resourceId": "sid-0DC4E889-E45A-4192-8D85-66BF6440C114",
+            "properties": {
+                "scriptformat": "",
+                "scripttext": "",
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "asynchronousdefinition": "false",
+                "exclusivedefinition": "false",
+                "executionlisteners": "",
+                "multiinstance_type": "None",
+                "multiinstance_variableaggregations": "",
+                "multiinstance_cardinality": "",
+                "multiinstance_collection": "",
+                "multiinstance_variable": "",
+                "multiinstance_condition": "",
+                "isforcompensation": "false",
+                "scriptautostorevariables": "false"
+            },
+            "stencil": {
+                "id": "ScriptTask"
+            },
+            "childShapes": [],
+            "outgoing": [{
+                    "resourceId": "sid-016D4C8E-3897-4112-9261-5FA8DDB83A0B"
+                }],
+            "bounds": {
+                "lowerRight": {
+                    "x": 333.5609063227486,
+                    "y": 403
+                },
+                "upperLeft": {
+                    "x": 233.56090632274862,
+                    "y": 323
+                }
+            },
+            "dockers": []
+        }, {
+            "resourceId": "sid-B969EBE9-B8A0-4CC2-ABB9-CB5B08166D51",
+            "properties": {
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "conditionsequenceflow": "",
+                "executionlisteners": "",
+                "defaultflow": "false",
+                "skipexpression": ""
+            },
+            "stencil": {
+                "id": "SequenceFlow"
+            },
+            "childShapes": [],
+            "outgoing": [{
+                    "resourceId": "sid-0DC4E889-E45A-4192-8D85-66BF6440C114"
+                }],
+            "bounds": {
+                "lowerRight": {
+                    "x": 284.45243555846554,
+                    "y": 322.4197524749057
+                },
+                "upperLeft": {
+                    "x": 283.8412520870317,
+                    "y": 233.95051300750868
+                }
+            },
+            "dockers": [{
+                    "x": 15,
+                    "y": 15
+                }, {
+                    "x": 50,
+                    "y": 40
+                }],
+            "target": {
+                "resourceId": "sid-0DC4E889-E45A-4192-8D85-66BF6440C114"
+            }
+        }, {
+            "resourceId": "sid-016D4C8E-3897-4112-9261-5FA8DDB83A0B",
+            "properties": {
+                "overrideid": "",
+                "name": "",
+                "documentation": "",
+                "conditionsequenceflow": "",
+                "executionlisteners": "",
+                "defaultflow": "false",
+                "skipexpression": ""
+            },
+            "stencil": {
+                "id": "SequenceFlow"
+            },
+            "childShapes": [],
+            "outgoing": [{
+                    "resourceId": "sid-F6D0274A-8214-4D19-9EA0-758EB5B1524B"
+                }],
+            "bounds": {
+                "lowerRight": {
+                    "x": 494,
+                    "y": 363
+                },
+                "upperLeft": {
+                    "x": 333.8825689033544,
+                    "y": 192.0078125
+                }
+            },
+            "dockers": [{
+                    "x": 50,
+                    "y": 40
+                }, {
+                    "x": 494,
+                    "y": 363
+                }, {
+                    "x": 14,
+                    "y": 14
+                }],
+            "target": {
+                "resourceId": "sid-F6D0274A-8214-4D19-9EA0-758EB5B1524B"
+            }
+        }],
+    "stencil": {
+        "id": "BPMNDiagram"
+    },
+    "stencilset": {
+        "namespace": "http://b3mn.org/stencilset/bpmn2.0#",
+        "url": "../editor/stencilsets/bpmn2.0/bpmn2.0.json"
+    }
+}

--- a/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/i18n/en.json
+++ b/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/i18n/en.json
@@ -730,6 +730,20 @@
             "DESCRIPTION" : "Define the error name."
           }
         },
+        "ERRORVARIABLEPACKAGE" : {
+          "ERRORVARIABLENAME" : {
+            "TITLE" : "Error variable name",
+            "DESCRIPTION" : "Define the error variable name."
+          },          
+          "ERRORVARIABLETRANSIENT" : {
+            "TITLE" : "Store as transient variable",
+            "DESCRIPTION" : "Flag defines whether a variable will be stored transiently."
+          },
+          "ERRORVARIABLELOCALSCOPE" : {
+            "TITLE" : "Store to a local scope",
+            "DESCRIPTION" : "Flag defines whether variable will be stored to a local scope."
+          }          
+        },
         "ESCALATIONREFPACKAGE" : {
           "ESCALATIONREF" : {
             "TITLE" : "Escalation reference",

--- a/modules/flowable-ui/flowable-ui-modeler-logic/src/main/resources/stencilset_bpmn.json
+++ b/modules/flowable-ui/flowable-ui-modeler-logic/src/main/resources/stencilset_bpmn.json
@@ -1148,6 +1148,30 @@
         "popular" : true
       } ]
     }, {
+      "name" : "errorvariablepackage",
+      "properties" : [ {
+        "id" : "errorvariablename",
+        "type" : "String",
+        "title" : "BPMN.PROPERTYPACKAGES.ERRORVARIABLEPACKAGE.ERRORVARIABLENAME.TITLE",
+        "value" : "",
+        "description" : "BPMN.PROPERTYPACKAGES.ERRORVARIABLEPACKAGE.ERRORVARIABLENAME.DESCRIPTION",
+        "popular" : true
+      }, {
+        "id" : "errorvariabletransient",
+        "type" : "Boolean",
+        "title" : "BPMN.PROPERTYPACKAGES.ERRORVARIABLEPACKAGE.ERRORVARIABLETRANSIENT.TITLE",
+        "value" : "true",
+        "description" : "BPMN.PROPERTYPACKAGES.ERRORVARIABLEPACKAGE.ERRORVARIABLETRANSIENT.DESCRIPTION",
+        "popular" : true
+      }, {
+        "id" : "errorvariablelocalscope",
+        "type" : "Boolean",
+        "title" : "BPMN.PROPERTYPACKAGES.ERRORVARIABLEPACKAGE.ERRORVARIABLELOCALSCOPE.TITLE",
+        "value" : "true",
+        "description" : "BPMN.PROPERTYPACKAGES.ERRORVARIABLEPACKAGE.ERRORVARIABLELOCALSCOPE.DESCRIPTION",
+        "popular" : true
+      } ]
+    }, {
       "name" : "eventregistryeventpackage",
       "properties" : [ {
         "id" : "eventkey",
@@ -1676,7 +1700,7 @@
     "view" : "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<svg\n   xmlns=\"http://www.w3.org/2000/svg\"\n   xmlns:oryx=\"http://www.b3mn.org/oryx\"\n   width=\"40\"\n   height=\"40\"\n   version=\"1.0\">\n  <defs></defs>\n  <oryx:magnets>\n  \t<oryx:magnet oryx:cx=\"16\" oryx:cy=\"16\" oryx:default=\"yes\" />\n  </oryx:magnets>\n  <oryx:docker oryx:cx=\"16\" oryx:cy=\"16\" />\n  <g pointer-events=\"fill\">\n    <circle id=\"bg_frame\" cx=\"16\" cy=\"16\" r=\"15\" stroke=\"#585858\" fill=\"#ffffff\" stroke-width=\"1\"/>\n    \n    <path\n         stroke=\"#585858\"\n         style=\"fill:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10\"\n         d=\"M 22.820839,11.171502 L 19.36734,24.58992 L 13.54138,14.281819 L 9.3386512,20.071607 L 13.048949,6.8323057 L 18.996148,16.132659 L 22.820839,11.171502 z\"\n         id=\"errorPolygon\" />\n\t<text font-size=\"11\" \n\t\tid=\"text_name\" \n\t\tx=\"16\" y=\"33\" \n\t\toryx:align=\"top center\" \n\t\tstroke=\"#373e48\"\n\t></text>\n  </g>\n</svg>",
     "icon" : "startevent/error.png",
     "groups" : [ "BPMN.STENCILS.GROUPS.STARTEVENTS" ],
-    "propertyPackages" : [ "overrideidpackage", "namepackage", "documentationpackage", "executionlistenerspackage", "errorrefpackage", "interruptingpackage" ],
+    "propertyPackages" : [ "overrideidpackage", "namepackage", "documentationpackage", "executionlistenerspackage", "errorrefpackage", "errorvariablepackage", "interruptingpackage" ],
     "hiddenPropertyPackages" : [ ],
     "roles" : [ "sequence_start", "Startevents_all", "StartEventsMorph", "all" ]
   }, {
@@ -2019,7 +2043,7 @@
       "view" : "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<svg\n   xmlns=\"http://www.w3.org/2000/svg\"\n   xmlns:oryx=\"http://www.b3mn.org/oryx\"\n   width=\"40\"\n   height=\"40\"\n   version=\"1.0\">\n  <defs></defs>\n  <oryx:magnets>\n  \t<oryx:magnet oryx:cx=\"16\" oryx:cy=\"16\" oryx:default=\"yes\" />\n  </oryx:magnets>\n  <oryx:docker oryx:cx=\"16\" oryx:cy=\"16\" />\n  <g pointer-events=\"fill\">\n    <circle id=\"bg_frame\" cx=\"16\" cy=\"16\" r=\"15\" stroke=\"#585858\" fill=\"#ffffff\" stroke-width=\"1\"/>\n    <circle id=\"frame\" cx=\"16\" cy=\"16\" r=\"12\" stroke=\"#585858\" fill=\"none\" stroke-width=\"1\"/>\n    \n    <path\n         stroke=\"#585858\"\n         style=\"fill:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10\"\n         d=\"M 22.820839,11.171502 L 19.36734,24.58992 L 13.54138,14.281819 L 9.3386512,20.071607 L 13.048949,6.8323057 L 18.996148,16.132659 L 22.820839,11.171502 z\"\n         id=\"errorPolygon\" />\n\t<text font-size=\"11\" \n\t\tid=\"text_name\" \n\t\tx=\"16\" y=\"33\" \n\t\toryx:align=\"top center\" \n\t\tstroke=\"#373e48\"\n\t></text>\n  </g>\n</svg>",
       "icon" : "catching/error.png",
       "groups" : [ "BPMN.STENCILS.GROUPS.BOUNDARYEVENTS" ],
-      "propertyPackages" : [ "overrideidpackage", "namepackage", "documentationpackage", "errorrefpackage" ],
+      "propertyPackages" : [ "overrideidpackage", "namepackage", "documentationpackage", "errorrefpackage", "errorvariablepackage" ],
       "hiddenPropertyPackages" : [ ],
       "roles" : [ "sequence_start", "BoundaryEventsMorph", "IntermediateEventOnActivityBoundary" ]
     }, {


### PR DESCRIPTION
Motive for this feature is to enable generic BPMN error handling without the need to know in workflow design-time which error code will be thrown. 

ErrorEventDefinition gets three new properties:
- String errorVariableName, name of the variable containing error code, default null
- Boolean errorVariableTransient, whether variable should be transient, default true
- Boolean errorVariableLocalScope, whether variable should be stored in local scope, default true

If errorVariableName is not set nothing gets injected, this way backward compatibility is maintained, else, error code is stored into named variable. Scope and transience depends on flags.

Unit testing and documentation is missing since these are just proposed changes.