### PR TITLE
Add missing UNCAUGHT_BPMN_ERROR enum

### DIFF
--- a/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/delegate/event/FlowableEngineEventType.java
+++ b/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/delegate/event/FlowableEngineEventType.java
@@ -347,6 +347,11 @@ public enum FlowableEngineEventType implements FlowableEventType {
      * The event is dispatched after the associated {@link #ENTITY_INITIALIZED} and the variables have been set.
      */
     CASE_STARTED,
+
+    /**
+     * An uncaught BPMN error has been thrown. The process did not have any handlers for that specific error. The event’s activityId will be empty.
+     */
+    UNCAUGHT_BPMN_ERROR,
     ;
 
     public static final FlowableEngineEventType[] EMPTY_ARRAY = new FlowableEngineEventType[] {};


### PR DESCRIPTION
#### Check List:
* Unit tests:  NO
* Documentation:  NA

UNCAUGHT_BPMN_ERROR is documented [here](https://flowable.com/open-source/docs/bpmn/ch03-Configuration/#supported-event-types) but is not defined in `org.flowable.common.engine.api.delegate.event.FlowableEngineEventType` as noted in this [forum post](https://forum.flowable.org/t/invalid-event-type-uncaught-bpmn-error/7726).