### PR TITLE
Upgrade to Spring Framework 5.3.6

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.30          MIT License
 org.slf4j                       slf4j-api                   1.7.30          MIT License
 org.slf4j                       slf4j-log4j12               1.7.30          MIT License
-org.springframework             spring-beans                5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.5           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.5           The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.6           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.6           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.4.5           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.4.5           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.4.5           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.4.4</spring.boot.version>
-		<spring.framework.version>5.3.5</spring.framework.version>
+		<spring.framework.version>5.3.6</spring.framework.version>
 		<spring.security.version>5.4.5</spring.security.version>
 		<spring.amqp.version>2.3.6</spring.amqp.version>
 		<spring.kafka.version>2.6.7</spring.kafka.version>
-		<reactor-netty.version>1.0.3</reactor-netty.version>
+		<reactor-netty.version>1.0.6</reactor-netty.version>
 		<jackson.version>2.11.4</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>


### PR DESCRIPTION
Upgrade to Spring Framework 5.3.6

Release notes are [here](https://github.com/spring-projects/spring-framework/releases/tag/v5.3.6).

Upgraded reactor-netty version to 1.0.6 as that is the version that is part of the dependency upgrade to Reactor 2020.0.6.