### PR TITLE
fixing bug on historic plan item instances not being created on collection based repetition

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/CmmnEngineAgenda.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/CmmnEngineAgenda.java
@@ -32,6 +32,8 @@ public interface CmmnEngineAgenda extends Agenda {
 
     void planCreatePlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity);
 
+    void planCreateRepeatedPlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity);
+
     void planReactivatePlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity);
 
     void planCreatePlanItemInstanceForRepetitionOperation(PlanItemInstanceEntity planItemInstanceEntity);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/DefaultCmmnEngineAgenda.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/DefaultCmmnEngineAgenda.java
@@ -20,6 +20,7 @@ import org.flowable.cmmn.engine.impl.agenda.operation.CompleteCaseInstanceOperat
 import org.flowable.cmmn.engine.impl.agenda.operation.CompletePlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.CreatePlanItemInstanceForRepetitionOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.CreatePlanItemInstanceOperation;
+import org.flowable.cmmn.engine.impl.agenda.operation.CreateRepeatedPlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.DisablePlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.DismissPlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.EnablePlanItemInstanceOperation;
@@ -132,6 +133,11 @@ public class DefaultCmmnEngineAgenda extends AbstractAgenda implements CmmnEngin
     @Override
     public void planCreatePlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity) {
         addOperation(new CreatePlanItemInstanceOperation(commandContext, planItemInstanceEntity));
+    }
+
+    @Override
+    public void planCreateRepeatedPlanItemInstanceOperation(PlanItemInstanceEntity planItemInstanceEntity) {
+        addOperation(new CreateRepeatedPlanItemInstanceOperation(commandContext, planItemInstanceEntity));
     }
 
     @Override

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractEvaluationCriteriaOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractEvaluationCriteriaOperation.java
@@ -805,6 +805,10 @@ public abstract class AbstractEvaluationCriteriaOperation extends AbstractCaseIn
         }
 
         PlanItemInstanceEntity childPlanItemInstanceEntity = copyAndInsertPlanItemInstance(commandContext, planItemInstanceEntity, localVariables, false, false);
+
+        // record the plan item being created based on the collection, so it gets synchronized to the history as well
+        CommandContextUtil.getAgenda(commandContext).planCreateRepeatedPlanItemInstanceOperation(childPlanItemInstanceEntity);
+
         // The repetition counter is 1 based
         setRepetitionCounter(childPlanItemInstanceEntity, index + 1);
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CmmnOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CmmnOperation.java
@@ -163,8 +163,6 @@ public abstract class CmmnOperation implements Runnable {
             .silentNameExpressionEvaluation(silentNameExpressionEvaluation)
             .create();
 
-        CommandContextUtil.getAgenda(commandContext).planCreateRepeatedPlanItemInstanceOperation(planItemInstanceEntity);
-
         return planItemInstanceEntity;
     }
     

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CmmnOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CmmnOperation.java
@@ -163,6 +163,8 @@ public abstract class CmmnOperation implements Runnable {
             .silentNameExpressionEvaluation(silentNameExpressionEvaluation)
             .create();
 
+        CommandContextUtil.getAgenda(commandContext).planCreateRepeatedPlanItemInstanceOperation(planItemInstanceEntity);
+
         return planItemInstanceEntity;
     }
     

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CreateRepeatedPlanItemInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CreateRepeatedPlanItemInstanceOperation.java
@@ -1,0 +1,55 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.agenda.operation;
+
+import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
+import org.flowable.cmmn.engine.impl.persistence.entity.PlanItemInstanceEntity;
+import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.cmmn.model.PlanItemTransition;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+
+/**
+ * A specific create operation for plan items being created out of a repetition where the repetition rule is actually treated as part of the main plan item
+ * and not within the create operation as it is usually been treated.
+ *
+ * @author Micha Kiener
+ */
+public class CreateRepeatedPlanItemInstanceOperation extends AbstractChangePlanItemInstanceStateOperation {
+
+    public CreateRepeatedPlanItemInstanceOperation(CommandContext commandContext, PlanItemInstanceEntity planItemInstanceEntity) {
+        super(commandContext, planItemInstanceEntity);
+    }
+
+    @Override
+    protected void internalExecute() {
+        CommandContextUtil.getCmmnHistoryManager(commandContext).recordPlanItemInstanceCreated(planItemInstanceEntity);
+        planItemInstanceEntity.setLastAvailableTime(getCurrentTime(commandContext));
+        CommandContextUtil.getCmmnHistoryManager(commandContext).recordPlanItemInstanceAvailable(planItemInstanceEntity);
+    }
+
+    @Override
+    public String getNewState() {
+        return PlanItemInstanceState.AVAILABLE;
+    }
+
+    @Override
+    public String getLifeCycleTransition() {
+        return PlanItemTransition.CREATE;
+    }
+
+    @Override
+    public String getOperationName() {
+        return "[Create reeated plan item]";
+    }
+
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CreateRepeatedPlanItemInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CreateRepeatedPlanItemInstanceOperation.java
@@ -49,7 +49,7 @@ public class CreateRepeatedPlanItemInstanceOperation extends AbstractChangePlanI
 
     @Override
     public String getOperationName() {
-        return "[Create reeated plan item]";
+        return "[Create repeated plan item]";
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
@@ -22,8 +22,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -180,6 +182,28 @@ public abstract class AbstractFlowableCmmnTestCase {
 
         assertNotNull(taskIds);
         assertEquals(1, taskIds.size());
+    }
+
+    protected void assertSamePlanItemState(CaseInstance c1) {
+        List<PlanItemInstance> runtimePlanItems = getAllPlanItemInstances(c1.getId());
+        List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(c1.getId()).list();
+
+        assertNotNull(runtimePlanItems);
+        assertNotNull(historicPlanItems);
+        assertEquals(runtimePlanItems.size(), historicPlanItems.size());
+
+        Map<String, HistoricPlanItemInstance> historyMap = new HashMap<>(historicPlanItems.size());
+        for (HistoricPlanItemInstance historicPlanItem : historicPlanItems) {
+            historyMap.put(historicPlanItem.getId(), historicPlanItem);
+        }
+
+        for (PlanItemInstance runtimePlanItem : runtimePlanItems) {
+            HistoricPlanItemInstance historicPlanItemInstance = historyMap.remove(runtimePlanItem.getId());
+            assertNotNull(historicPlanItemInstance);
+            assertEquals(runtimePlanItem.getState(), historicPlanItemInstance.getState());
+        }
+
+        assertEquals(historyMap.size(), 0);
     }
 
     protected void assertPlanItemInstanceState(CaseInstance caseInstance, String name, String ... states) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableAndConditionTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableAndConditionTest.java
@@ -69,6 +69,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // now let's complete all Tasks B -> nothing must happen additionally
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -87,6 +90,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 
     @Test
@@ -124,6 +130,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // now let's complete all Tasks B -> nothing must happen additionally
         List<PlanItemInstance> tasks = cmmnRuntimeService.createPlanItemInstanceQuery()
                 .caseInstanceId(caseInstance.getId())
@@ -142,6 +151,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 
     @Test
@@ -174,6 +186,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // complete all active tasks
         completeAllPlanItems(caseInstance.getId(), "Task B", 4);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
@@ -202,6 +217,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 
     @Test
@@ -234,6 +252,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // only complete two active Task B
         completePlanItemsWithItemValues(caseInstance.getId(), "Task B", 4, "A", "B");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
@@ -262,6 +283,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 
     @Test
@@ -297,6 +321,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task C", myCollection, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // if we change the collection variable, nothing else must happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", Arrays.asList("foo"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
@@ -331,6 +358,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Task C");
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 
     @Test
@@ -367,6 +397,9 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task C", myCollection, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // if we change the collection variable, nothing else must happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", Arrays.asList("foo"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
@@ -401,5 +434,8 @@ public class PlanItemRepetitionWithCollectionVariableAndConditionTest extends Fl
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Task C");
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/PlanItemRepetitionWithCollectionVariableTest.java
@@ -57,6 +57,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE, ACTIVE, ACTIVE, ACTIVE, AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
         // now let's complete all Tasks B -> nothing must happen additionally
@@ -77,6 +80,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 
     @Test
@@ -106,6 +112,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // complete all active tasks
         completeAllPlanItems(caseInstance.getId(), "Task B", 4);
         planItemInstances = getPlanItemInstances(caseInstance.getId());
@@ -126,6 +135,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // now let's complete all Tasks B -> nothing must happen additionally
         completeAllPlanItems(caseInstance.getId(), "Task B", 2);
 
@@ -134,6 +146,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 
     @Test
@@ -163,6 +178,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", taskOutputList, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // only complete two active Task B
         completePlanItemsWithItemValues(caseInstance.getId(), "Task B", 4, "A", "B");
         planItemInstances = getPlanItemInstances(caseInstance.getId());
@@ -183,6 +201,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task B", Arrays.asList("C", "D", "E", "F"), Arrays.asList(2, 3, 0, 1));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // now let's complete all Tasks B -> nothing must happen additionally
         completeAllPlanItems(caseInstance.getId(), "Task B", 4);
 
@@ -191,6 +212,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertPlanItemInstanceState(planItemInstances, "Task C", AVAILABLE);
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 
     @Test
@@ -218,6 +242,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
 
         assertPlanItemLocalVariables(caseInstance.getId(), "Task C", myCollection, Arrays.asList(0, 1, 2, 3));
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         // if we change the collection variable, nothing else must happen
         cmmnRuntimeService.setVariable(caseInstance.getId(), "myCollection", Arrays.asList("foo"));
         planItemInstances = getPlanItemInstances(caseInstance.getId());
@@ -242,6 +269,9 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
                 .orderByCreateTime().asc()
                 .list();
 
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
+
         assertThat(tasks).hasSize(4);
         for (PlanItemInstance task : tasks) {
             cmmnRuntimeService.triggerPlanItemInstance(task.getId());
@@ -252,5 +282,8 @@ public class PlanItemRepetitionWithCollectionVariableTest extends FlowableCmmnTe
         assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
         assertPlanItemInstanceState(planItemInstances, "Task B", AVAILABLE);
         assertNoPlanItemInstance(planItemInstances, "Task C");
+
+        // make sure we have synced the runtime and historic plan items, even with the collection of created plan items
+        assertSamePlanItemState(caseInstance);
     }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/reactivation/SimpleCaseReactivationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/reactivation/SimpleCaseReactivationTest.java
@@ -18,13 +18,11 @@ import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.COMPLETED;
 import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.TERMINATED;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.flowable.cmmn.api.history.HistoricCaseInstance;
-import org.flowable.cmmn.api.history.HistoricPlanItemInstance;
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstance;
 import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
@@ -156,7 +154,7 @@ public class SimpleCaseReactivationTest extends FlowableCmmnTestCase {
             assertCaseInstanceNotEnded(reactivatedCase);
 
             // the plan items must be equal for both the runtime as well as the history as of now
-            assertSamePlanItemState(historicCase, reactivatedCase);
+            assertSamePlanItemState(reactivatedCase);
 
             // make sure we have exactly the same variables as the historic case
             assertSameVariables(historicCase, reactivatedCase);
@@ -356,27 +354,5 @@ public class SimpleCaseReactivationTest extends FlowableCmmnTestCase {
 
     protected void assertHistoricVariableNotExisting(List<HistoricVariableInstance> variables, String name) {
         assertThat(variables.stream().filter(v -> v.getVariableName().equals(name)).collect(Collectors.toList())).isEmpty();
-    }
-
-    protected void assertSamePlanItemState(HistoricCaseInstance c1, CaseInstance c2) {
-        List<PlanItemInstance> runtimePlanItems = getAllPlanItemInstances(c2.getId());
-        List<HistoricPlanItemInstance> historicPlanItems = cmmnHistoryService.createHistoricPlanItemInstanceQuery().planItemInstanceCaseInstanceId(c1.getId()).list();
-
-        assertThat(runtimePlanItems).isNotNull();
-        assertThat(historicPlanItems).isNotNull();
-        assertThat(runtimePlanItems).hasSize(historicPlanItems.size());
-
-        Map<String, HistoricPlanItemInstance> historyMap = new HashMap<>(historicPlanItems.size());
-        for (HistoricPlanItemInstance historicPlanItem : historicPlanItems) {
-            historyMap.put(historicPlanItem.getId(), historicPlanItem);
-        }
-
-        for (PlanItemInstance runtimePlanItem : runtimePlanItems) {
-            HistoricPlanItemInstance historicPlanItemInstance = historyMap.remove(runtimePlanItem.getId());
-            assertThat(historicPlanItemInstance).isNotNull();
-            assertThat(runtimePlanItem.getState()).isEqualTo(historicPlanItemInstance.getState());
-        }
-
-        assertThat(historyMap).hasSize(0);
     }
 }


### PR DESCRIPTION
fixing and testing bug where plan items won't be created in history on a collection repetition operation

#### Check List:
* Unit tests: YES
* Documentation: NA
