### PR TITLE
Remove condition that has no effect; always true

### DIFF
--- a/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/WSDLImporter.java
+++ b/modules/flowable-cxf/src/main/java/org/flowable/engine/impl/webservice/WSDLImporter.java
@@ -211,14 +211,8 @@ public class WSDLImporter implements XMLImporter {
                             isFieldParameterTypeNeestedClass = true;
                         }
                     } while (!isFieldParameterTypeNeestedClass);
-                    if (isFieldParameterTypeNeestedClass) {
-                        // The parameter type is a nested class
-                        fieldParameterClass = ReflectUtil
-                                .loadClass(theClass.erasure().fullName() + "$" + fieldParameterType.name());
-                    } else {
-                        // The parameter type is not a nested class
-                        fieldParameterClass = ReflectUtil.loadClass(fieldParameterType.erasure().fullName());
-                    }
+                    // The parameter type is a nested class
+                    fieldParameterClass = ReflectUtil.loadClass(theClass.erasure().fullName() + "$" + fieldParameterType.name());
                 }
             } else {
                 fieldParameterClass = null;


### PR DESCRIPTION
Remove the test for `isFieldParameterTypeNesstedClass`  [I didn't fix the spelling] at line 214 as it is preceded by a `do-while` loop that ends only when `isFieldParameterTypeNesstedClass` is `true`.   The code as it was written could *never* enter the `else` condition. 

The condition may remain if the `while` test was changed to include the fact that the iterator ran through all the objects and didn't find a nested class.

Someone who knows the code well needs to decide which is the **proper** change.