### PR TITLE
Chore: remove duplicate and unused imports

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -71,7 +71,6 @@ import org.flowable.cmmn.engine.impl.el.CmmnExpressionManager;
 import org.flowable.cmmn.engine.impl.eventregistry.CmmnEventRegistryEventConsumer;
 import org.flowable.cmmn.engine.impl.form.DefaultFormFieldHandler;
 import org.flowable.cmmn.engine.impl.function.IsPlanItemCompletedExpressionFunction;
-import org.flowable.cmmn.engine.impl.function.TaskGetFunctionDelegate;
 import org.flowable.cmmn.engine.impl.function.IsStageCompletableExpressionFunction;
 import org.flowable.cmmn.engine.impl.function.TaskGetFunctionDelegate;
 import org.flowable.cmmn.engine.impl.history.CmmnHistoryManager;

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -30,8 +30,6 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.UUID;
 
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;


### PR DESCRIPTION
In recent pushes:

- one duplicate import (in cmmn-engine merge)
- two unused imports (in flowable-engine test file)
