### PR TITLE
Fix for Boundary Events on Asynchronous Multi-Instance Activities

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
@@ -206,7 +206,7 @@ public class ContinueProcessOperation extends AbstractOperation {
         if (activityBehavior != null) {
             executeActivityBehavior(activityBehavior, flowNode);
             
-            if (!execution.isDeleted() && !execution.isEnded()) {
+            if (!execution.isDeleted() && !execution.isEnded() && execution.isMultiInstanceRoot()) {
                 // Create any boundary events, sub process boundary events will be created from the activity behavior
                 List<ExecutionEntity> boundaryEventExecutions = null;
                 List<BoundaryEvent> boundaryEvents = null;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -119,18 +119,14 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testTimerOnAsyncMultiInstanceActivity() {
-    	runtimeService.startProcessInstanceByKey("testTimerOnAsyncMultiInstanceActivity");
+        runtimeService.startProcessInstanceByKey("testTimerOnAsyncMultiInstanceActivity");
+        // async-continuation into the async multi-instance activity
+        for (Job job : managementService.createJobQuery().list()) {
+            managementService.executeJob(job.getId());
+        }
 
-    	// async-continuation into the async multi-instance activity
-		for(Job job: managementService.createJobQuery().list()) {
-			managementService.executeJob(job.getId());
-		}
-		
-		long timerJobCount = managementService.createTimerJobQuery().count();
-		
-		assertThat(timerJobCount).isEqualTo(1);
+        assertThat(managementService.createTimerJobQuery().count()).isEqualTo(1);
     }
-    
     
     @Test
     @Deployment

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -31,10 +31,12 @@ import org.flowable.engine.delegate.ExecutionListener;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.JobTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ActivityInstance;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
+import org.flowable.job.api.JobQuery;
 import org.flowable.job.api.TimerJobQuery;
 import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
@@ -114,6 +116,22 @@ public class BoundaryTimerEventTest extends PluggableFlowableTestCase {
         assertThat(task.getName()).isEqualTo("task outside subprocess");
     }
 
+    @Test
+    @Deployment
+    public void testTimerOnAsyncMultiInstanceActivity() {
+    	runtimeService.startProcessInstanceByKey("testTimerOnAsyncMultiInstanceActivity");
+
+    	// async-continuation into the async multi-instance activity
+		for(Job job: managementService.createJobQuery().list()) {
+			managementService.executeJob(job.getId());
+		}
+		
+		long timerJobCount = managementService.createTimerJobQuery().count();
+		
+		assertThat(timerJobCount).isEqualTo(1);
+    }
+    
+    
     @Test
     @Deployment
     public void testExpressionOnTimer() {

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testTimerOnAsyncMultiInstanceActivity.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testTimerOnAsyncMultiInstanceActivity.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="testTimerOnAsyncMultiInstanceActivity" isExecutable="true">
+    <startEvent id="startevent1" name="Start"/>
+    <userTask id="multiInstanceTask" name="Multi-Instance Task" activiti:async="true">
+      <multiInstanceLoopCharacteristics isSequential="false">
+        <loopCardinality>3</loopCardinality>
+      </multiInstanceLoopCharacteristics>
+    </userTask>
+    <sequenceFlow id="flow1" sourceRef="startevent1" targetRef="multiInstanceTask"/>
+    <endEvent id="endevent1" name="End"/>
+    <sequenceFlow id="flow2" sourceRef="multiInstanceTask" targetRef="endevent1"/>
+    <boundaryEvent id="boundarytimer1" name="Timer" attachedToRef="multiInstanceTask" cancelActivity="true">
+      <timerEventDefinition>
+        <timeDuration>PT2H</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <endEvent id="endevent2" name="End"/>
+    <sequenceFlow id="flow3" sourceRef="boundarytimer1" targetRef="endevent2"/>
+  </process>
+</definitions>


### PR DESCRIPTION
This contribution is a fix for the issue described in [the following forum discussion](https://forum.flowable.org/t/differences-in-boundary-event-behavior-on-sync-and-async-multi-instance-activities/7784): when a boundary event is attached to an asynchronous multi-instance activity, the corresponding boundary event is created `n+1` times upon activity execution, where `n` is the number of instances in the multi-instance activity.

In this contribution, an additional check is introduced for boundary event creation which assures that the events are only created for the multi-instance root execution. As a result, there will be only 1 boundary event created independently of the number of instances in the multi-instance activity.

#### Check List:
* Unit tests: YES
* Documentation: NA
