### PR TITLE
Throw exception when a property is evaluated of a null base

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/de/odysseus/el/tree/impl/ast/AstProperty.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/de/odysseus/el/tree/impl/ast/AstProperty.java
@@ -66,10 +66,13 @@ public abstract class AstProperty extends AstNode {
 	@Override
 	public Object eval(Bindings bindings, ELContext context) {
 		Object base = prefix.eval(bindings, context);
+		Object property = getProperty(bindings, context);
 		if (base == null) {
+			if (property != null) {
+				throw new PropertyNotFoundException(LocalMessages.get("error.property.base.null", prefix));
+			}
 			return null;
 		}
-		Object property = getProperty(bindings, context);
 		if (property == null && strict) {
 			return null;
 		}


### PR DESCRIPTION
In this contribution, the issue is fixed described in [the following forum discussion](https://forum.flowable.org/t/astproperty-missing-exception-by-evaluation-of-a-property-of-a-null-base/7766/2): when a property is evaluated of a `null` base the corresponding method short circuits to `null`.

With the fix, stricter check is introduced which results in an exception when a property of a `null` base is requested.

#### Check List:
* Unit tests: NO
* Documentation: NA
