### PR TITLE
Remove unused imports

### DIFF
--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/util/BpmnXmlConverterTestExtension.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/util/BpmnXmlConverterTestExtension.java
@@ -12,9 +12,6 @@
  */
 package org.flowable.editor.language.xml.util;
 
-import static org.flowable.editor.language.xml.util.XmlTestUtils.readXMLFile;
-import static org.flowable.editor.language.xml.util.XmlTestUtils.readXmlExportAndReadAgain;
-
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CmmnHistoryHelper.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CmmnHistoryHelper.java
@@ -20,7 +20,6 @@ import org.flowable.cmmn.engine.impl.persistence.entity.HistoricCaseInstanceEnti
 import org.flowable.cmmn.engine.impl.persistence.entity.HistoricMilestoneInstanceEntityManager;
 import org.flowable.cmmn.engine.impl.persistence.entity.HistoricPlanItemInstanceEntityManager;
 import org.flowable.cmmn.engine.impl.task.TaskHelper;
-import org.flowable.cmmn.engine.test.impl.CmmnHistoryTestHelper;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.identitylink.service.HistoricIdentityLinkService;
 import org.flowable.variable.service.impl.persistence.entity.HistoricVariableInstanceEntity;

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/caze/CaseInstanceResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/caze/CaseInstanceResource.java
@@ -37,7 +37,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.Api;

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ExecutionListenerValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ExecutionListenerValidator.java
@@ -14,7 +14,6 @@ package org.flowable.validation.validator.impl;
 
 import java.util.List;
 
-import org.flowable.bpmn.model.BaseElement;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.FlowableListener;

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/OperationValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/OperationValidator.java
@@ -17,7 +17,6 @@ import java.util.List;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Interface;
 import org.flowable.bpmn.model.Operation;
-import org.flowable.bpmn.model.Process;
 import org.flowable.validation.ValidationError;
 import org.flowable.validation.validator.Problems;
 import org.flowable.validation.validator.ValidatorImpl;


### PR DESCRIPTION
Remove unused imports from pushes on April 27 and May 14, 2021.

This supersedes previous [PR](https://github.com/flowable/flowable-engine/pull/2918).
