### PR TITLE
Remove unused imports from pushes on April 27, May 14, and June 8, 2021.

### DIFF
--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/util/BpmnXmlConverterTestExtension.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/util/BpmnXmlConverterTestExtension.java
@@ -12,9 +12,6 @@
  */
 package org.flowable.editor.language.xml.util;
 
-import static org.flowable.editor.language.xml.util.XmlTestUtils.readXMLFile;
-import static org.flowable.editor.language.xml.util.XmlTestUtils.readXmlExportAndReadAgain;
-
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CmmnHistoryHelper.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CmmnHistoryHelper.java
@@ -20,7 +20,6 @@ import org.flowable.cmmn.engine.impl.persistence.entity.HistoricCaseInstanceEnti
 import org.flowable.cmmn.engine.impl.persistence.entity.HistoricMilestoneInstanceEntityManager;
 import org.flowable.cmmn.engine.impl.persistence.entity.HistoricPlanItemInstanceEntityManager;
 import org.flowable.cmmn.engine.impl.task.TaskHelper;
-import org.flowable.cmmn.engine.test.impl.CmmnHistoryTestHelper;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.identitylink.service.HistoricIdentityLinkService;
 import org.flowable.variable.service.impl.persistence.entity.HistoricVariableInstanceEntity;

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/caze/CaseInstanceResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/caze/CaseInstanceResource.java
@@ -37,7 +37,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.Api;

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngineConfiguration.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/DmnEngineConfiguration.java
@@ -108,9 +108,6 @@ import org.flowable.dmn.engine.impl.persistence.entity.data.impl.MybatisHistoric
 import org.flowable.dmn.image.DecisionRequirementsDiagramGenerator;
 import org.flowable.dmn.image.impl.DefaultDecisionRequirementsDiagramGenerator;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
 public class DmnEngineConfiguration extends AbstractEngineConfiguration
         implements DmnEngineConfigurationApi, HasExpressionManagerEngineConfiguration {
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/LiquibaseBasedSchemaManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/LiquibaseBasedSchemaManager.java
@@ -16,7 +16,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.logging.Level;
 
 import org.apache.commons.lang3.StringUtils;
@@ -35,7 +34,6 @@ import liquibase.database.DatabaseConnection;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
-import liquibase.hub.core.MockHubService;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.ui.LoggerUIService;
 

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ExecutionListenerValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/ExecutionListenerValidator.java
@@ -14,7 +14,6 @@ package org.flowable.validation.validator.impl;
 
 import java.util.List;
 
-import org.flowable.bpmn.model.BaseElement;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.FlowableListener;

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/OperationValidator.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/impl/OperationValidator.java
@@ -17,7 +17,6 @@ import java.util.List;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Interface;
 import org.flowable.bpmn.model.Operation;
-import org.flowable.bpmn.model.Process;
 import org.flowable.validation.ValidationError;
 import org.flowable.validation.validator.Problems;
 import org.flowable.validation.validator.ValidatorImpl;

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/cmmn/CmmnEngineAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/cmmn/CmmnEngineAutoConfigurationTest.java
@@ -56,7 +56,6 @@ import org.flowable.spring.boot.ProcessEngineAutoConfiguration;
 import org.flowable.spring.boot.ProcessEngineServicesAutoConfiguration;
 import org.flowable.spring.boot.app.AppEngineAutoConfiguration;
 import org.flowable.spring.boot.app.AppEngineServicesAutoConfiguration;
-import org.flowable.spring.boot.cmmn.Cmmn;
 import org.flowable.spring.boot.cmmn.CmmnEngineAutoConfiguration;
 import org.flowable.spring.boot.cmmn.CmmnEngineServicesAutoConfiguration;
 import org.flowable.spring.boot.idm.IdmEngineAutoConfiguration;


### PR DESCRIPTION
This supersedes this [PR](https://github.com/flowable/flowable-engine/pull/2928).
