### PR TITLE
Upgrade to Spring Boot 2.5.0

### DIFF
--- a/modules/flowable-app-rest/src/test/java/org/flowable/rest/app/FlowableRestApplicationSecurityTest.java
+++ b/modules/flowable-app-rest/src/test/java/org/flowable/rest/app/FlowableRestApplicationSecurityTest.java
@@ -71,7 +71,8 @@ public class FlowableRestApplicationSecurityTest {
             "mappings",
             "caches",
             "caches-cache",
-            "health-path"
+            "health-path",
+            "configprops-prefix"
         )
     );
 

--- a/modules/flowable-cxf/pom.xml
+++ b/modules/flowable-cxf/pom.xml
@@ -167,12 +167,12 @@
     <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </dependency>
     <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-xjc</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/modules/flowable-event-registry-spring/pom.xml
+++ b/modules/flowable-event-registry-spring/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>5.16.1</version>
+            <version>5.16.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-jms-spring-executor/pom.xml
+++ b/modules/flowable-jms-spring-executor/pom.xml
@@ -142,13 +142,13 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
-            <version>5.16.1</version>
+            <version>5.16.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>5.16.1</version>
+            <version>5.16.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.38.v20210224</jetty.version>
+        <jetty.version>9.4.41.v20210516</jetty.version>
         <flowable.artifact>
             org.flowable.rest
         </flowable.artifact>

--- a/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationSecurityTest.java
+++ b/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationSecurityTest.java
@@ -73,7 +73,8 @@ public class FlowableUiApplicationSecurityTest {
             "mappings",
             "caches",
             "caches-cache",
-                "health-path"
+            "health-path",
+            "configprops-prefix"
         )
     );
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.4.4</spring.boot.version>
+		<spring.boot.version>2.5.0</spring.boot.version>
 		<spring.framework.version>5.3.7</spring.framework.version>
 		<spring.security.version>5.5.0</spring.security.version>
-		<spring.amqp.version>2.3.6</spring.amqp.version>
-		<spring.kafka.version>2.6.7</spring.kafka.version>
+		<spring.amqp.version>2.3.7</spring.amqp.version>
+		<spring.kafka.version>2.7.1</spring.kafka.version>
 		<reactor-netty.version>1.0.6</reactor-netty.version>
 		<jackson.version>2.12.3</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
@@ -775,7 +775,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.4.28.Final</version>
+				<version>5.4.30.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
The Spring Boot Release Notes are [here]( https://github.com/spring-projects/spring-boot/releases/tag/v2.5.0).   

I made the dependency updates that I found in the release notes and ran locally "mvn clean test" with no errors (distro profile).

FWIW, none of the jars that were changed are listed in distro/src/notice.txt. 

I **did **not** do** the following upgrades as they caused compile errors in flowable.http.common (and maybe else where):

- Upgrade to HttpClient5 5.0.4
- Upgrade to HttpCore5 5.1.1

There is a big jump from the version 4 jars currently used in the project and version 5.
