### PR TITLE
Upgrade to Spring Boot 2.5.1

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.30          MIT License
 org.slf4j                       slf4j-api                   1.7.30          MIT License
 org.slf4j                       slf4j-log4j12               1.7.30          MIT License
-org.springframework             spring-beans                5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.7           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.7           The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.8           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.8           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.5.0           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.5.0           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.5.0           The Apache Software License, Version 2.0

--- a/modules/flowable-app-engine-rest/pom.xml
+++ b/modules/flowable-app-engine-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.38.v20210224</jetty.version>
+        <jetty.version>9.4.42.v20210604</jetty.version>
         <flowable.artifact>
             org.flowable.app.rest
         </flowable.artifact>

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.38.v20210224</jetty.version>
+    <jetty.version>9.4.42.v20210604</jetty.version>
     <flowable.artifact>
       org.flowable.cmmn.rest
     </flowable.artifact>

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jetty.version>9.4.38.v20210224</jetty.version>
+		<jetty.version>9.4.42.v20210604</jetty.version>
 		<flowable.artifact>
 			org.flowable.content.rest
 		</flowable.artifact>

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.38.v20210224</jetty.version>
+        <jetty.version>9.4.42.v20210604</jetty.version>
         <flowable.artifact>
             org.flowable.dmn.rest.service
         </flowable.artifact>

--- a/modules/flowable-event-registry-rest/pom.xml
+++ b/modules/flowable-event-registry-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.38.v20210224</jetty.version>
+        <jetty.version>9.4.42.v20210604</jetty.version>
         <flowable.artifact>
             org.flowable.eventregistry.rest
         </flowable.artifact>

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.38.v20210224</jetty.version>
+        <jetty.version>9.4.42.v20210604</jetty.version>
         <flowable.artifact>
             org.flowable.form.rest
         </flowable.artifact>

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.41.v20210516</jetty.version>
+        <jetty.version>9.4.42.v20210604</jetty.version>
         <flowable.artifact>
             org.flowable.rest
         </flowable.artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.5.0</spring.boot.version>
-		<spring.framework.version>5.3.7</spring.framework.version>
+		<spring.boot.version>2.5.1</spring.boot.version>
+		<spring.framework.version>5.3.8</spring.framework.version>
 		<spring.security.version>5.5.0</spring.security.version>
-		<spring.amqp.version>2.3.7</spring.amqp.version>
-		<spring.kafka.version>2.7.1</spring.kafka.version>
+		<spring.amqp.version>2.3.8</spring.amqp.version>
+		<spring.kafka.version>2.7.2</spring.kafka.version>
 		<reactor-netty.version>1.0.6</reactor-netty.version>
 		<jackson.version>2.12.3</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
@@ -30,7 +30,7 @@
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 
 		<junit.version>4.13.2</junit.version>
-		<junit.jupiter.version>5.7.1</junit.jupiter.version>
+		<junit.jupiter.version>5.7.2</junit.jupiter.version>
 		<hikari.version>3.4.5</hikari.version>
 		<maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
 		<maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
@@ -775,7 +775,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.4.30.Final</version>
+				<version>5.4.32.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.5.1

Includes the SpringFramework in this [PR](https://github.com/flowable/flowable-engine/pull/2950) which I will now close.


