### PR TITLE
fail to create table ACT_EVT_LOG on mysql

### DIFF
--- a/modules/flowable-engine/src/main/resources/org/flowable/db/create/flowable.mysql.create.engine.sql
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/create/flowable.mysql.create.engine.sql
@@ -100,7 +100,7 @@ create table ACT_EVT_LOG (
     PROC_INST_ID_ varchar(64),
     EXECUTION_ID_ varchar(64),
     TASK_ID_ varchar(64),
-    TIME_STAMP_ timestamp(3) not null,
+    TIME_STAMP_ timestamp(3) not null DEFAULT CURRENT_TIMESTAMP(3),
     USER_ID_ varchar(255),
     DATA_ LONGBLOB,
     LOCK_OWNER_ varchar(255),


### PR DESCRIPTION
Table ACT_EVT_LOG fail to create when mysql sql_mode is STRICT_TRANS_TABLES. And cause the next sql not executed.

#### Check List:
* Unit tests:  NA
* Documentation:  NA
