### PR TITLE
#2860: The Flowable 6.6.0 BpmnXMLConverter doesn't write out data association model nodes

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
@@ -29,11 +29,13 @@ import org.flowable.bpmn.converter.export.MultiInstanceExport;
 import org.flowable.bpmn.converter.util.BpmnXMLUtil;
 import org.flowable.bpmn.model.Activity;
 import org.flowable.bpmn.model.Artifact;
+import org.flowable.bpmn.model.Assignment;
 import org.flowable.bpmn.model.BaseElement;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.CancelEventDefinition;
 import org.flowable.bpmn.model.CompensateEventDefinition;
 import org.flowable.bpmn.model.ConditionalEventDefinition;
+import org.flowable.bpmn.model.DataAssociation;
 import org.flowable.bpmn.model.DataObject;
 import org.flowable.bpmn.model.ErrorEventDefinition;
 import org.flowable.bpmn.model.EscalationEventDefinition;
@@ -224,6 +226,16 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
             final Activity activity = (Activity) baseElement;
             MultiInstanceExport.writeMultiInstance(activity, model, xtw);
 
+        }
+
+        if (baseElement instanceof Activity) {
+            final Activity activity = (Activity) baseElement;
+            for (DataAssociation dataInputAssociation : activity.getDataInputAssociations()) {
+                writeDataAssociation(ELEMENT_INPUT_ASSOCIATION, dataInputAssociation, xtw);
+            }
+            for (DataAssociation dataOutputtAssociation : activity.getDataOutputAssociations()) {
+                writeDataAssociation(ELEMENT_OUTPUT_ASSOCIATION, dataOutputtAssociation, xtw);
+            }
         }
 
         writeAdditionalChildElements(baseElement, model, xtw);
@@ -635,5 +647,34 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
 
     protected void writeQualifiedAttribute(String attributeName, String value, XMLStreamWriter xtw) throws Exception {
         BpmnXMLUtil.writeQualifiedAttribute(attributeName, value, xtw);
+    }
+
+    protected void writeDataAssociation(String elementName, DataAssociation dataAssociation, XMLStreamWriter xtw) throws Exception {
+        xtw.writeStartElement(elementName);
+        writeDefaultAttribute(ATTRIBUTE_ID, dataAssociation.getId(), xtw);
+        if (!StringUtils.isEmpty(dataAssociation.getSourceRef())) {
+            xtw.writeStartElement(ELEMENT_SOURCE_REF);
+            xtw.writeCharacters(dataAssociation.getSourceRef());
+            xtw.writeEndElement();
+        }
+        xtw.writeStartElement(ELEMENT_TARGET_REF);
+        xtw.writeCharacters(dataAssociation.getTargetRef());
+        xtw.writeEndElement();
+        if (!StringUtils.isEmpty(dataAssociation.getTransformation())) {
+            xtw.writeStartElement(ELEMENT_TRANSFORMATION);
+            xtw.writeCharacters(dataAssociation.getTransformation());
+            xtw.writeEndElement();
+        }
+        for (Assignment assignment : dataAssociation.getAssignments()) {
+            xtw.writeStartElement(ELEMENT_ASSIGNMENT);
+            xtw.writeStartElement(ELEMENT_FROM);
+            xtw.writeCharacters(assignment.getFrom());
+            xtw.writeEndElement();
+            xtw.writeStartElement(ELEMENT_TO);
+            xtw.writeCharacters(assignment.getTo());
+            xtw.writeEndElement();
+            xtw.writeEndElement();
+        }
+        xtw.writeEndElement();
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ActivityWithDataAssociationsConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ActivityWithDataAssociationsConverterTest.java
@@ -14,9 +14,10 @@
 
 package org.flowable.editor.language.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.flowable.bpmn.converter.BpmnXMLConverter;
 import org.flowable.bpmn.model.Activity;
 import org.flowable.bpmn.model.BpmnModel;
@@ -38,10 +39,10 @@ class ActivityWithDataAssociationsConverterTest {
         List<DataAssociation> dataInputAssociations = activity.getDataInputAssociations();
         List<DataAssociation> dataOutputAssociations = activity.getDataOutputAssociations();
 
-        Assertions.assertThat(dataInputAssociations.isEmpty()).isFalse();
-        Assertions.assertThat(dataOutputAssociations.isEmpty()).isFalse();
-        Assertions.assertThat(dataInputAssociations.get(0).getTransformation()).isEqualTo("${dataOutputOfServiceTask.prettyPrint}");
-        Assertions.assertThat(dataOutputAssociations.get(0).getAssignments().isEmpty()).isFalse();
-        Assertions.assertThat(dataOutputAssociations.get(0).getAssignments().get(0).getFrom()).isEqualTo("${dataInputOfProcess.prefix}");
+        assertThat(dataInputAssociations.isEmpty()).isFalse();
+        assertThat(dataOutputAssociations.isEmpty()).isFalse();
+        assertThat(dataInputAssociations.get(0).getTransformation()).isEqualTo("${dataOutputOfServiceTask.prettyPrint}");
+        assertThat(dataOutputAssociations.get(0).getAssignments().isEmpty()).isFalse();
+        assertThat(dataOutputAssociations.get(0).getAssignments().get(0).getFrom()).isEqualTo("${dataInputOfProcess.prefix}");
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ActivityWithDataAssociationsConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ActivityWithDataAssociationsConverterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.flowable.editor.language.xml;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.flowable.bpmn.converter.BpmnXMLConverter;
+import org.flowable.bpmn.model.Activity;
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.DataAssociation;
+import org.flowable.common.engine.impl.util.io.BytesStreamSource;
+import org.flowable.editor.language.xml.util.BpmnXmlConverterTest;
+
+/**
+ * @author Calin Cerchez
+ */
+class ActivityWithDataAssociationsConverterTest {
+
+    @BpmnXmlConverterTest("activityWithDataAssociations.bpmn")
+    void testWriteDataAssociations(BpmnModel model) {
+        BpmnXMLConverter bpmnXMLConverter = new BpmnXMLConverter();
+        byte[] output = bpmnXMLConverter.convertToXML(model);
+        BpmnModel parsedBpmnModel = bpmnXMLConverter.convertToBpmnModel(new BytesStreamSource(output), true, true);
+        Activity activity = (Activity) parsedBpmnModel.getFlowElement("servicetask");
+        List<DataAssociation> dataInputAssociations = activity.getDataInputAssociations();
+        List<DataAssociation> dataOutputAssociations = activity.getDataOutputAssociations();
+
+        Assertions.assertThat(dataInputAssociations.isEmpty()).isFalse();
+        Assertions.assertThat(dataOutputAssociations.isEmpty()).isFalse();
+        Assertions.assertThat(dataInputAssociations.get(0).getTransformation()).isEqualTo("${dataOutputOfServiceTask.prettyPrint}");
+        Assertions.assertThat(dataOutputAssociations.get(0).getAssignments().isEmpty()).isFalse();
+        Assertions.assertThat(dataOutputAssociations.get(0).getAssignments().get(0).getFrom()).isEqualTo("${dataInputOfProcess.prefix}");
+    }
+}

--- a/modules/flowable-bpmn-converter/src/test/resources/activityWithDataAssociations.bpmn
+++ b/modules/flowable-bpmn-converter/src/test/resources/activityWithDataAssociations.bpmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    typeLanguage="http://www.w3.org/2001/XMLSchema"
+    expressionLanguage="http://www.w3.org/1999/XPath"
+    targetNamespace="http://www.flowable.org/test">
+  <process id="process" name="process1" isExecutable="true">
+    <dataObject name="input" id="inputObject_1" itemSubjectRef="xsd:string"/>
+    <dataObject name="output" id="outputObject_1" itemSubjectRef="xsd:string"/>
+    <endEvent id="sid-F7795B38-72CD-41A4-9549-6CFB7D3E5FB5"></endEvent>
+    <sequenceFlow id="sid-C6C56AC3-9561-49E0-A58A-624F6CB8BB82" sourceRef="sid-F62B554B-FF4F-475E-94FF-A3F44EDA6A6A" targetRef="servicetask"></sequenceFlow>
+    <serviceTask id="servicetask" name="Service task">
+       <dataInputAssociation id="dataAssociation-inputObject">
+        <sourceRef>inputObject_1</sourceRef>
+        <targetRef>servicetask</targetRef>
+        <transformation>${dataOutputOfServiceTask.prettyPrint}</transformation>
+       </dataInputAssociation>
+       <dataOutputAssociation id="dataAssociation-outputObject">
+        <sourceRef>servicetask</sourceRef>
+        <targetRef>outputObject_1</targetRef>
+        <assignment>
+         <from>${dataInputOfProcess.prefix}</from>
+         <to>${dataInputOfServiceTask.prefix}</to>
+        </assignment>
+       </dataOutputAssociation>
+    </serviceTask>
+    <startEvent id="sid-F62B554B-FF4F-475E-94FF-A3F44EDA6A6A"></startEvent>
+    <sequenceFlow id="sid-91C0F3A0-649F-462E-A1C1-1CE499FEDE3E" sourceRef="servicetask" targetRef="sid-F7795B38-72CD-41A4-9549-6CFB7D3E5FB5"></sequenceFlow>
+  </process>
+</definitions>


### PR DESCRIPTION
The Flowable 6.6.0 BpmnXMLConverter doesn't write out data association model nodes

#### Check List:
* Unit tests: YES
* Documentation: NO
* Fixes #2860
