### PR TITLE
Upgrade to Spring Security 5.5.1

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -133,9 +133,9 @@ org.liquibase                   liquibase-core              4.3.5           Apac
 org.mybatis                     mybatis                     3.5.6           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              2.0.6           The Apache Software License, Version 2.0
 org.mvel                        mvel2                       2.2.6.Final     The Apache Software License, Version 2.0
-org.slf4j                       jcl-over-slf4j              1.7.30          MIT License
-org.slf4j                       slf4j-api                   1.7.30          MIT License
-org.slf4j                       slf4j-log4j12               1.7.30          MIT License
+org.slf4j                       jcl-over-slf4j              1.7.31          MIT License
+org.slf4j                       slf4j-api                   1.7.31          MIT License
+org.slf4j                       slf4j-log4j12               1.7.31          MIT License
 org.springframework             spring-beans                5.3.8           The Apache Software License, Version 2.0
 org.springframework             spring-core                 5.3.8           The Apache Software License, Version 2.0
 org.springframework             spring-context              5.3.8           The Apache Software License, Version 2.0
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.8           The 
 org.springframework             spring-core                 5.3.8           The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.8           The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.8           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.5.0           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.5.0           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.5.0           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.5.0           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.5.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.5.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.5.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.5.1           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.5.1</spring.boot.version>
 		<spring.framework.version>5.3.8</spring.framework.version>
-		<spring.security.version>5.5.0</spring.security.version>
+		<spring.security.version>5.5.1</spring.security.version>
 		<spring.amqp.version>2.3.8</spring.amqp.version>
 		<spring.kafka.version>2.7.2</spring.kafka.version>
 		<reactor-netty.version>1.0.6</reactor-netty.version>
@@ -25,7 +25,7 @@
 		<mule.version>3.8.0</mule.version>
 		<camel.version>2.25.0</camel.version>
 		<cxf.version>3.4.2</cxf.version>
-		<slf4j.version>1.7.30</slf4j.version>
+		<slf4j.version>1.7.31</slf4j.version>
 		<groovy.version>3.0.8</groovy.version>
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 


### PR DESCRIPTION
Release notes: https://github.com/spring-projects/spring-security/releases/tag/5.5.1

Only dependency that needed updating was `org.slf4j`.
