### PR TITLE
Upgrade to Spring Boot 2.5.3

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -133,21 +133,21 @@ org.liquibase                   liquibase-core              4.3.5           Apac
 org.mybatis                     mybatis                     3.5.6           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              2.0.6           The Apache Software License, Version 2.0
 org.mvel                        mvel2                       2.2.6.Final     The Apache Software License, Version 2.0
-org.slf4j                       jcl-over-slf4j              1.7.31          MIT License
-org.slf4j                       slf4j-api                   1.7.31          MIT License
-org.slf4j                       slf4j-log4j12               1.7.31          MIT License
-org.springframework             spring-beans                5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.8           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.8           The Apache Software License, Version 2.0
+org.slf4j                       jcl-over-slf4j              1.7.32          MIT License
+org.slf4j                       slf4j-api                   1.7.32          MIT License
+org.slf4j                       slf4j-log4j12               1.7.32          MIT License
+org.springframework             spring-beans                5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.9           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.5.1           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.5.1           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.5.1           The Apache Software License, Version 2.0

--- a/modules/flowable-app-engine-rest/pom.xml
+++ b/modules/flowable-app-engine-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.42.v20210604</jetty.version>
+        <jetty.version>9.4.43.v20210629</jetty.version>
         <flowable.artifact>
             org.flowable.app.rest
         </flowable.artifact>

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.42.v20210604</jetty.version>
+    <jetty.version>9.4.43.v20210629</jetty.version>
     <flowable.artifact>
       org.flowable.cmmn.rest
     </flowable.artifact>

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jetty.version>9.4.42.v20210604</jetty.version>
+		<jetty.version>9.4.43.v20210629</jetty.version>
 		<flowable.artifact>
 			org.flowable.content.rest
 		</flowable.artifact>

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.42.v20210604</jetty.version>
+        <jetty.version>9.4.43.v20210629</jetty.version>
         <flowable.artifact>
             org.flowable.dmn.rest.service
         </flowable.artifact>

--- a/modules/flowable-event-registry-rest/pom.xml
+++ b/modules/flowable-event-registry-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.42.v20210604</jetty.version>
+        <jetty.version>9.4.43.v20210629</jetty.version>
         <flowable.artifact>
             org.flowable.eventregistry.rest
         </flowable.artifact>

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.42.v20210604</jetty.version>
+        <jetty.version>9.4.43.v20210629</jetty.version>
         <flowable.artifact>
             org.flowable.form.rest
         </flowable.artifact>

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.42.v20210604</jetty.version>
+        <jetty.version>9.4.43.v20210629</jetty.version>
         <flowable.artifact>
             org.flowable.rest
         </flowable.artifact>

--- a/modules/flowable5-compatibility-testdata/pom.xml
+++ b/modules/flowable5-compatibility-testdata/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.14</version>
+			<version>8.0.26</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/modules/flowable5-compatibility-testdata/pom.xml
+++ b/modules/flowable5-compatibility-testdata/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.26</version>
+			<version>8.0.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,18 +14,18 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.5.2</spring.boot.version>
-		<spring.framework.version>5.3.8</spring.framework.version>
+		<spring.boot.version>2.5.3</spring.boot.version>
+		<spring.framework.version>5.3.9</spring.framework.version>
 		<spring.security.version>5.5.1</spring.security.version>
-		<spring.amqp.version>2.3.8</spring.amqp.version>
-		<spring.kafka.version>2.7.2</spring.kafka.version>
+		<spring.amqp.version>2.3.10</spring.amqp.version>
+		<spring.kafka.version>2.7.4</spring.kafka.version>
 		<reactor-netty.version>1.0.6</reactor-netty.version>
-		<jackson.version>2.12.3</jackson.version>
+		<jackson.version>2.12.4</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
 		<camel.version>2.25.0</camel.version>
 		<cxf.version>3.4.2</cxf.version>
-		<slf4j.version>1.7.31</slf4j.version>
+		<slf4j.version>1.7.32</slf4j.version>
 		<groovy.version>3.0.8</groovy.version>
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 
@@ -222,12 +222,12 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>8.0.19</version>
+				<version>8.0.26</version>
 			</dependency>
 			<dependency>
 				<groupId>com.ibm.db2</groupId>
 				<artifactId>jcc</artifactId>
-				<version>11.5.5.0</version>
+				<version>11.5.6.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.flowable</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>8.0.26</version>
+				<version>8.0.19</version>
 			</dependency>
 			<dependency>
 				<groupId>com.ibm.db2</groupId>


### PR DESCRIPTION
Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.5.3

Ran `mvn clean test` locally without error.

This replaces the Spring Framework upgrade (https://github.com/flowable/flowable-engine/pull/2982) as this includes that dependency update.
