### PR TITLE
Chore: small code cleanups

### DIFF
--- a/modules/flowable-case-validation/src/main/java/org/flowable/cmmn/validation/CaseValidatorFactory.java
+++ b/modules/flowable-case-validation/src/main/java/org/flowable/cmmn/validation/CaseValidatorFactory.java
@@ -15,7 +15,6 @@
 package org.flowable.cmmn.validation;
 
 import org.flowable.cmmn.validation.validator.ValidatorSetFactory;
-import org.flowable.cmmn.validation.validator.impl.HumanTaskValidator;
 
 /**
  * @author Calin Cerchez

--- a/modules/flowable-case-validation/src/test/java/org/flowable/cmmn/validation/validator/impl/HumanTaskValidatorTest.java
+++ b/modules/flowable-case-validation/src/test/java/org/flowable/cmmn/validation/validator/impl/HumanTaskValidatorTest.java
@@ -25,7 +25,6 @@ import org.flowable.cmmn.model.CmmnModel;
 import org.flowable.cmmn.validation.CaseValidatorFactory;
 import org.flowable.cmmn.validation.validator.Problems;
 import org.flowable.cmmn.validation.validator.ValidationEntry;
-import org.flowable.cmmn.validation.validator.ValidatorSetFactory;
 import org.flowable.cmmn.validation.validator.ValidatorSetNames;
 import org.junit.Test;
 

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/PlanFragmentCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/PlanFragmentCmmnXmlConverterTest.java
@@ -103,7 +103,7 @@ public class PlanFragmentCmmnXmlConverterTest {
         PlanItemDefinition planItemDefinition = planItem.getPlanItemDefinition();
         if (planItemDefinition instanceof PlanFragment) {
             PlanFragment planFragment = (PlanFragment) planItemDefinition;
-            assertThat(planFragment.getPlanItems()).isEmpty();;
+            assertThat(planFragment.getPlanItems()).isEmpty();
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/EvaluateVariableEventListenersOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/EvaluateVariableEventListenersOperation.java
@@ -86,7 +86,7 @@ public class EvaluateVariableEventListenersOperation extends AbstractEvaluationC
                             changeTypeValue = configNode.get(VariableListenerEventDefinition.CHANGE_TYPE_PROPERTY).asText();
                         }
                     } catch (Exception e) {
-                        LOGGER.error("Error reading variable listener configuration value for " + eventSubscription.getActivityId(), e);
+                        LOGGER.error("Error reading variable listener configuration value for {}", eventSubscription.getActivityId(), e);
                     }
                 }
             

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/test/AbstractFlowableCmmnTestCase.java
@@ -228,7 +228,7 @@ public abstract class AbstractFlowableCmmnTestCase {
             fail("No plan item instances found with name " + name);
         }
 
-        assertEquals("Incorrect number of states found: " + planItemInstanceStates + "", states.length, planItemInstanceStates.size());
+        assertEquals("Incorrect number of states found: " + planItemInstanceStates, states.length, planItemInstanceStates.size());
         List<String> originalStates = new ArrayList<>(planItemInstanceStates);
         for (String state : states) {
             assertTrue("State '" + state + "' not found in plan item instances states '" + originalStates + "'", planItemInstanceStates.remove(state));
@@ -245,7 +245,7 @@ public abstract class AbstractFlowableCmmnTestCase {
             fail("No historic plan item instances found with name " + name);
         }
 
-        assertEquals("Incorrect number of states found: " + planItemInstanceStates + "", states.length, planItemInstanceStates.size());
+        assertEquals("Incorrect number of states found: " + planItemInstanceStates, states.length, planItemInstanceStates.size());
         List<String> originalStates = new ArrayList<>(planItemInstanceStates);
         for (String state : states) {
             assertTrue("State '" + state + "' not found in historic plan item instances states '" + originalStates + "'", planItemInstanceStates.remove(state));

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/EvaluateVariableListenerEventDefinitionsOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/EvaluateVariableListenerEventDefinitionsOperation.java
@@ -98,7 +98,7 @@ public class EvaluateVariableListenerEventDefinitionsOperation extends AbstractO
                             changeTypeValue = configNode.get(VariableListenerEventDefinition.CHANGE_TYPE_PROPERTY).asText();
                         }
                     } catch (Exception e) {
-                        LOGGER.error("Error reading variable listener configuration value for " + eventSubscription.getActivityId(), e);
+                        LOGGER.error("Error reading variable listener configuration value for {}", eventSubscription.getActivityId(), e);
                     }
                 }
                 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/BulkMoveTimerJobsToExecutableJobsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/BulkMoveTimerJobsToExecutableJobsTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
  */
 public class BulkMoveTimerJobsToExecutableJobsTest extends JobExecutorTestCase  {
 
-    private final static int NR_OF_TIMER_JOBS = AbstractDataManager.MAX_ENTRIES_IN_CLAUSE + (AbstractDataManager.MAX_ENTRIES_IN_CLAUSE/2);
+    private static final int NR_OF_TIMER_JOBS = AbstractDataManager.MAX_ENTRIES_IN_CLAUSE + (AbstractDataManager.MAX_ENTRIES_IN_CLAUSE/2);
 
     @Override
     protected void configureConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/BulkUpdateJobLockTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/jobexecutor/BulkUpdateJobLockTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
  */
 public class BulkUpdateJobLockTest extends JobExecutorTestCase  {
 
-    private final static int NR_JOBS = AbstractDataManager.MAX_ENTRIES_IN_CLAUSE + (AbstractDataManager.MAX_ENTRIES_IN_CLAUSE/2);
+    private static final int NR_JOBS = AbstractDataManager.MAX_ENTRIES_IN_CLAUSE + (AbstractDataManager.MAX_ENTRIES_IN_CLAUSE/2);
 
     @Override
     protected void configureConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {

--- a/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/ValidatorSetFactory.java
+++ b/modules/flowable-process-validation/src/main/java/org/flowable/validation/validator/ValidatorSetFactory.java
@@ -24,7 +24,6 @@ import org.flowable.validation.validator.impl.EventSubprocessValidator;
 import org.flowable.validation.validator.impl.EventValidator;
 import org.flowable.validation.validator.impl.ExclusiveGatewayValidator;
 import org.flowable.validation.validator.impl.ExecutionListenerValidator;
-import org.flowable.validation.validator.impl.ExternalInvocationTaskValidator;
 import org.flowable.validation.validator.impl.FlowElementValidator;
 import org.flowable.validation.validator.impl.FlowableEventListenerValidator;
 import org.flowable.validation.validator.impl.IntermediateCatchEventValidator;


### PR DESCRIPTION
- remove unused imports
- correct missorted modifiers
- use parameterized logging instead of concatenation
- remove concatenation of empty string
- remove dup semicolon
