### PR TITLE
Preventing double reactivation on directly linked plan items

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/CmmnEngineAgenda.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/CmmnEngineAgenda.java
@@ -12,11 +12,14 @@
  */
 package org.flowable.cmmn.engine.impl.agenda;
 
+import java.util.List;
+
 import org.flowable.cmmn.engine.impl.behavior.impl.ChildTaskActivityBehavior;
 import org.flowable.cmmn.engine.impl.criteria.PlanItemLifeCycleEvent;
 import org.flowable.cmmn.engine.impl.persistence.entity.CaseInstanceEntity;
 import org.flowable.cmmn.engine.impl.persistence.entity.PlanItemInstanceEntity;
 import org.flowable.cmmn.engine.interceptor.MigrationContext;
+import org.flowable.cmmn.model.PlanItem;
 import org.flowable.common.engine.impl.agenda.Agenda;
 
 /**
@@ -28,7 +31,7 @@ public interface CmmnEngineAgenda extends Agenda {
 
     void planReactivateCaseInstanceOperation(CaseInstanceEntity caseInstanceEntity);
 
-    void planReactivatePlanModelOperation(CaseInstanceEntity caseInstanceEntity);
+    void planReactivatePlanModelOperation(CaseInstanceEntity caseInstanceEntity, List<PlanItem> directlyReactivatedPlanItems);
 
     void planInitStageOperation(PlanItemInstanceEntity planItemInstanceEntity);
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/DefaultCmmnEngineAgenda.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/DefaultCmmnEngineAgenda.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.cmmn.engine.impl.agenda;
 
+import java.util.List;
+
 import org.flowable.cmmn.engine.impl.agenda.operation.ActivateAsyncPlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.ActivatePlanItemInstanceOperation;
 import org.flowable.cmmn.engine.impl.agenda.operation.ChangePlanItemInstanceToAvailableOperation;
@@ -44,6 +46,7 @@ import org.flowable.cmmn.engine.impl.criteria.PlanItemLifeCycleEvent;
 import org.flowable.cmmn.engine.impl.persistence.entity.CaseInstanceEntity;
 import org.flowable.cmmn.engine.impl.persistence.entity.PlanItemInstanceEntity;
 import org.flowable.cmmn.engine.interceptor.MigrationContext;
+import org.flowable.cmmn.model.PlanItem;
 import org.flowable.common.engine.impl.agenda.AbstractAgenda;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.slf4j.Logger;
@@ -107,8 +110,8 @@ public class DefaultCmmnEngineAgenda extends AbstractAgenda implements CmmnEngin
     }
 
     @Override
-    public void planReactivatePlanModelOperation(CaseInstanceEntity caseInstanceEntity) {
-        addOperation(new ReactivatePlanModelInstanceOperation(commandContext, caseInstanceEntity));
+    public void planReactivatePlanModelOperation(CaseInstanceEntity caseInstanceEntity, List<PlanItem> directlyReactivatedPlanItems) {
+        addOperation(new ReactivatePlanModelInstanceOperation(commandContext, caseInstanceEntity, directlyReactivatedPlanItems));
     }
 
     @Override

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CmmnOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CmmnOperation.java
@@ -86,19 +86,25 @@ public abstract class CmmnOperation implements Runnable {
      * @param commandContext the command context to run this method with
      * @param caseModel the case model the given stage or plan model is contained within
      * @param planItems the plan items of the stage to be checked for creation
+     * @param directlyReactivatedPlanItems an optional list of plan items already having been reactivated as part of phase 1 of a case reactivation, might be
+     *      null or empty, specially for a regular case
      * @param caseInstanceEntity the case instance entity, must be provided as it is used to check for a first time running case or a reactivated one
      * @param stagePlanItemInstanceEntity the optional stage plan item instance, if already available, might be null in very specific use cases (e.g. cross-stage activities, etc)
      * @param tenantId the id of the tenant to run within
      * @return the list of created plan item instances for this stage or plan model
      */
     protected List<PlanItemInstanceEntity> createPlanItemInstancesForNewOrReactivatedStage(CommandContext commandContext, Case caseModel, List<PlanItem> planItems,
-        CaseInstanceEntity caseInstanceEntity, PlanItemInstanceEntity stagePlanItemInstanceEntity, String tenantId) {
+        List<PlanItem> directlyReactivatedPlanItems, CaseInstanceEntity caseInstanceEntity, PlanItemInstanceEntity stagePlanItemInstanceEntity, String tenantId) {
         List<PlanItemInstanceEntity> newPlanItemInstances = new ArrayList<>();
         for (PlanItem planItem : planItems) {
 
             if (planItem.isInstanceLifecycleEnabled()) {
-                createPlanItemInstanceIfNeeded(commandContext, planItem, caseModel, caseInstanceEntity,
-                    stagePlanItemInstanceEntity, tenantId, newPlanItemInstances);
+                // check, if the plan item was already reactivated as part of phase 1 of a case reactivation and if so, skip it to prevent it from being
+                // reactivated more than once
+                if (directlyReactivatedPlanItems == null || directlyReactivatedPlanItems.stream().noneMatch(i -> i.getId().equals(planItem.getId()))) {
+                    createPlanItemInstanceIfNeeded(commandContext, planItem, caseModel, caseInstanceEntity,
+                        stagePlanItemInstanceEntity, tenantId, newPlanItemInstances);
+                }
 
             } else if (planItem.getPlanItemDefinition() != null && planItem.getPlanItemDefinition() instanceof PlanFragment){
                 // Some plan items (plan fragments) exist as plan item, but not as plan item instance
@@ -266,7 +272,6 @@ public abstract class CmmnOperation implements Runnable {
         }
 
         // if the case was reactivated, we need to check the reactivation rules, if any specified on the plan item or a default one on the listener
-        ReactivationRule reactivationRule = null;
         PlanItemControl itemControl = planItem.getItemControl();
         if (itemControl != null && itemControl.getReactivationRule() != null) {
             // evaluate the specific reactivation rule on the plan item directly as a first step

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/InitPlanModelInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/InitPlanModelInstanceOperation.java
@@ -33,10 +33,10 @@ public class InitPlanModelInstanceOperation extends AbstractCaseInstanceOperatio
         
         Case caseModel = CaseDefinitionUtil.getCase(caseInstanceEntity.getCaseDefinitionId());
         createPlanItemInstancesForNewOrReactivatedStage(commandContext, caseModel,
-                caseModel.getPlanModel().getPlanItems(),
-                caseInstanceEntity,
-                null,
-                caseInstanceEntity.getTenantId());
+            caseModel.getPlanModel().getPlanItems(), null,
+            caseInstanceEntity,
+            null,
+            caseInstanceEntity.getTenantId());
         
         CommandContextUtil.getAgenda(commandContext).planEvaluateCriteriaOperation(caseInstanceEntity.getId());
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/InitStageInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/InitStageInstanceOperation.java
@@ -47,7 +47,7 @@ public class InitStageInstanceOperation extends AbstractPlanItemInstanceOperatio
             .findById(planItemInstanceEntity.getCaseInstanceId());
 
         createPlanItemInstancesForNewOrReactivatedStage(commandContext, caseModel,
-                stage.getPlanItems(),
+                stage.getPlanItems(), null,
                 caseInstanceEntity,
                 planItemInstanceEntity,
                 planItemInstanceEntity.getTenantId());

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/ReactivatePlanModelInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/ReactivatePlanModelInstanceOperation.java
@@ -12,10 +12,13 @@
  */
 package org.flowable.cmmn.engine.impl.agenda.operation;
 
+import java.util.List;
+
 import org.flowable.cmmn.engine.impl.persistence.entity.CaseInstanceEntity;
 import org.flowable.cmmn.engine.impl.repository.CaseDefinitionUtil;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
 import org.flowable.cmmn.model.Case;
+import org.flowable.cmmn.model.PlanItem;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 
 /**
@@ -26,8 +29,11 @@ import org.flowable.common.engine.impl.interceptor.CommandContext;
  */
 public class ReactivatePlanModelInstanceOperation extends AbstractCaseInstanceOperation {
 
-    public ReactivatePlanModelInstanceOperation(CommandContext commandContext, CaseInstanceEntity caseInstanceEntity) {
+    protected List<PlanItem> directlyReactivatedPlanItems;
+
+    public ReactivatePlanModelInstanceOperation(CommandContext commandContext, CaseInstanceEntity caseInstanceEntity, List<PlanItem> directlyReactivatedPlanItems) {
         super(commandContext, null, caseInstanceEntity);
+        this.directlyReactivatedPlanItems = directlyReactivatedPlanItems;
     }
 
     @Override
@@ -36,7 +42,7 @@ public class ReactivatePlanModelInstanceOperation extends AbstractCaseInstanceOp
 
         Case caseModel = CaseDefinitionUtil.getCase(caseInstanceEntity.getCaseDefinitionId());
         createPlanItemInstancesForNewOrReactivatedStage(commandContext, caseModel,
-                caseModel.getPlanModel().getPlanItems(),
+                caseModel.getPlanModel().getPlanItems(), directlyReactivatedPlanItems,
                 caseInstanceEntity,
                 null,
                 caseInstanceEntity.getTenantId());

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/reactivation/PreventDoublePlanItemInitializationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/reactivation/PreventDoublePlanItemInitializationTest.java
@@ -1,0 +1,87 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.reactivation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.flowable.cmmn.api.runtime.PlanItemInstanceState.ACTIVE;
+
+import java.util.List;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.flowable.common.engine.impl.identity.Authentication;
+import org.junit.Test;
+
+public class PreventDoublePlanItemInitializationTest extends FlowableCmmnTestCase {
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/reactivation/Double_Plan_Item_Reactivation_Test.cmmn.xml")
+    public void preventPlanItemFromDoubleReactivation() {
+        String previousUserId = Authentication.getAuthenticatedUserId();
+        try {
+            Authentication.setAuthenticatedUserId("preventPlanItemFromDoubleReactivation_user");
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("doublePlanItemReactivationTest")
+                .start();
+            List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
+
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+            assertCaseInstanceEnded(caseInstance);
+
+            CaseInstance reactivatedCase = cmmnHistoryService.createCaseReactivationBuilder(caseInstance.getId()).reactivate();
+            assertThat(reactivatedCase).isNotNull();
+
+            planItemInstances = getPlanItemInstances(reactivatedCase.getId());
+            assertThat(planItemInstances).isNotNull().hasSize(3);
+            assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+            assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
+            assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
+        } finally {
+            Authentication.setAuthenticatedUserId(previousUserId);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/reactivation/Double_Stage_Reactivation_Test.cmmn.xml")
+    public void preventStageFromDoubleReactivation() {
+        String previousUserId = Authentication.getAuthenticatedUserId();
+        try {
+            Authentication.setAuthenticatedUserId("preventStageFromDoubleReactivation_user");
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("doubleStageReactivationTest")
+                .start();
+            List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+            cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
+
+            assertThat(cmmnRuntimeService.createPlanItemInstanceQuery().count()).isZero();
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().count()).isZero();
+            assertCaseInstanceEnded(caseInstance);
+
+            CaseInstance reactivatedCase = cmmnHistoryService.createCaseReactivationBuilder(caseInstance.getId()).reactivate();
+            assertThat(reactivatedCase).isNotNull();
+
+            planItemInstances = getPlanItemInstances(reactivatedCase.getId());
+            assertThat(planItemInstances).isNotNull().hasSize(4);
+            assertPlanItemInstanceState(planItemInstances, "Stage A", ACTIVE);
+            assertPlanItemInstanceState(planItemInstances, "Reactivation Stage", ACTIVE);
+            assertPlanItemInstanceState(planItemInstances, "Task A", ACTIVE);
+            assertPlanItemInstanceState(planItemInstances, "Task B", ACTIVE);
+        } finally {
+            Authentication.setAuthenticatedUserId(previousUserId);
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/reactivation/Double_Plan_Item_Reactivation_Test.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/reactivation/Double_Plan_Item_Reactivation_Test.cmmn.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+  <case id="doublePlanItemReactivationTest" name="Double Plan Item Reactivation Test" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItem2" name="Stage A" definitionRef="expandedStage1"></planItem>
+      <planItem id="planItem3" name="Task B" definitionRef="humanTask2">
+        <itemControl>
+          <extensionElements>
+            <flowable:parentCompletionRule type="ignore"></flowable:parentCompletionRule>
+          </extensionElements>
+        </itemControl>
+        <entryCriterion id="entryCriterion1" sentryRef="sentry1"></entryCriterion>
+      </planItem>
+      <planItem id="planItem4" definitionRef="reactivateEventListener1"></planItem>
+      <sentry id="sentry1">
+        <extensionElements>
+          <design:stencilid><![CDATA[EntryCriterion]]></design:stencilid>
+        </extensionElements>
+        <planItemOnPart id="sentryOnPart1" sourceRef="planItem4">
+          <standardEvent>occur</standardEvent>
+        </planItemOnPart>
+      </sentry>
+      <stage id="expandedStage1" name="Stage A" flowable:includeInStageOverview="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItem1" name="Task A" definitionRef="humanTask1"></planItem>
+        <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+      </stage>
+      <humanTask id="humanTask2" name="Task B" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+      <eventListener id="reactivateEventListener1" flowable:eventType="reactivate">
+        <extensionElements>
+          <design:stencilid><![CDATA[ReactivateEventListener]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+        </extensionElements>
+      </eventListener>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_doublePlanItemReactivationTest">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="501.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+        <dc:Bounds height="170.0" width="370.0" x="91.0" y="121.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+        <dc:Bounds height="80.0" width="100.0" x="136.0" y="166.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+        <dc:Bounds height="80.0" width="100.0" x="181.0" y="400.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_entryCriterion1" cmmnElementRef="entryCriterion1">
+        <dc:Bounds height="28.0" width="18.0" x="172.0" y="426.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+        <dc:Bounds height="30.0" width="30.0" x="95.0" y="425.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="CMMNEdge_connector1" cmmnElementRef="planItem4" targetCMMNElementRef="entryCriterion1">
+        <di:extension>
+          <flowable:docker type="source" x="15.0" y="15.0"></flowable:docker>
+          <flowable:docker type="target" x="9.0" y="14.0"></flowable:docker>
+        </di:extension>
+        <di:waypoint x="124.94999637726416" y="440.0"></di:waypoint>
+        <di:waypoint x="172.0" y="440.0"></di:waypoint>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/reactivation/Double_Stage_Reactivation_Test.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/reactivation/Double_Stage_Reactivation_Test.cmmn.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+  <case id="doubleStageReactivationTest" name="Double Stage Reactivation Test" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false" autoComplete="true">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItem2" name="Stage A" definitionRef="expandedStage1"></planItem>
+      <planItem id="planItem3" definitionRef="reactivateEventListener1"></planItem>
+      <planItem id="planItem5" name="Reactivation Stage" definitionRef="expandedStage2">
+        <entryCriterion id="entryCriterion1" sentryRef="sentry1"></entryCriterion>
+      </planItem>
+      <sentry id="sentry1">
+        <extensionElements>
+          <design:stencilid><![CDATA[EntryCriterion]]></design:stencilid>
+        </extensionElements>
+        <planItemOnPart id="sentryOnPart1" sourceRef="planItem3">
+          <standardEvent>occur</standardEvent>
+        </planItemOnPart>
+      </sentry>
+      <stage id="expandedStage1" name="Stage A" flowable:includeInStageOverview="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItem1" name="Task A" definitionRef="humanTask1"></planItem>
+        <humanTask id="humanTask1" name="Task A" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+      </stage>
+      <eventListener id="reactivateEventListener1" flowable:eventType="reactivate">
+        <extensionElements>
+          <design:stencilid><![CDATA[ReactivateEventListener]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+        </extensionElements>
+      </eventListener>
+      <stage id="expandedStage2" name="Reactivation Stage" flowable:includeInStageOverview="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItem4" name="Task B" definitionRef="humanTask2"></planItem>
+        <humanTask id="humanTask2" name="Task B" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+      </stage>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_doubleStageReactivationTest">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="501.0" width="581.0" x="30.0" y="45.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem2" cmmnElementRef="planItem2">
+        <dc:Bounds height="170.0" width="370.0" x="91.0" y="121.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem1" cmmnElementRef="planItem1">
+        <dc:Bounds height="80.0" width="100.0" x="136.0" y="166.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem3" cmmnElementRef="planItem3">
+        <dc:Bounds height="30.0" width="30.0" x="95.0" y="425.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem5" cmmnElementRef="planItem5">
+        <dc:Bounds height="170.0" width="370.0" x="196.0" y="355.5"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_entryCriterion1" cmmnElementRef="entryCriterion1">
+        <dc:Bounds height="28.0" width="18.0" x="187.0" y="426.5"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItem4" cmmnElementRef="planItem4">
+        <dc:Bounds height="80.0" width="100.0" x="241.0" y="406.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="CMMNEdge_connector1" cmmnElementRef="planItem3" targetCMMNElementRef="entryCriterion1">
+        <di:extension>
+          <flowable:docker type="source" x="15.0" y="15.0"></flowable:docker>
+          <flowable:docker type="target" x="9.0" y="14.0"></flowable:docker>
+        </di:extension>
+        <di:waypoint x="124.94970104041296" y="440.08691739088107"></di:waypoint>
+        <di:waypoint x="187.00502211383454" y="440.44786925941247"></di:waypoint>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>


### PR DESCRIPTION
fixing bug when a stage or waiting state plan item was directly related to a reactivation listener and got initialized twice

#### Check List:
* Unit tests: YES
* Documentation: NA
