### PR TITLE
Fix for escalation propagation to suspended execution

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/EscalationPropagation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/EscalationPropagation.java
@@ -217,7 +217,7 @@ public class EscalationPropagation {
             
             if (boundaryExecution != null && boundaryExecution.isSuspended()) {
                 String errorMessage = format("Cannot propagate escalation '%s' with code '%s', because execution '%s' is suspended.",
-                                boundaryExecution.getId(), escalationName, escalationCode);
+                                escalationName, escalationCode, boundaryExecution.getId());
                 throw new FlowableException(errorMessage);
             }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/EscalationPropagation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/EscalationPropagation.java
@@ -32,6 +32,7 @@ import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.FlowElementsContainer;
 import org.flowable.bpmn.model.Process;
 import org.flowable.bpmn.model.StartEvent;
+import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
 import org.flowable.common.engine.impl.util.CollectionUtil;
@@ -210,6 +211,12 @@ public class EscalationPropagation {
                         && childExecution.getActivityId().equals(event.getId())) {
                     boundaryExecution = childExecution;
                 }
+            }
+            
+            if (boundaryExecution != null && boundaryExecution.isSuspended()) {
+                String errorMessage = String.format("Escalation could not be propagated, because the process instance with ID %s, which catches it, is suspended.",
+                                boundaryExecution.getProcessInstanceId());
+                throw new FlowableException(errorMessage);
             }
 
             CommandContextUtil.getAgenda().planTriggerExecutionOperation(boundaryExecution);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/EscalationPropagation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/EscalationPropagation.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.impl.bpmn.helper;
 
+import static java.lang.String.format;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -214,8 +216,8 @@ public class EscalationPropagation {
             }
             
             if (boundaryExecution != null && boundaryExecution.isSuspended()) {
-                String errorMessage = String.format("Escalation could not be propagated, because the process instance with ID %s, which catches it, is suspended.",
-                                boundaryExecution.getProcessInstanceId());
+                String errorMessage = format("Cannot propagate escalation '%s' with code '%s', because execution '%s' is suspended.",
+                                boundaryExecution.getId(), escalationName, escalationCode);
                 throw new FlowableException(errorMessage);
             }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
@@ -14,14 +14,14 @@ package org.flowable.engine.test.bpmn.event.escalation;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 /**
  * @author Tijs Rademakers
@@ -74,9 +74,9 @@ public class BoundaryEscalationEventTest extends PluggableFlowableTestCase {
         runtimeService.suspendProcessInstanceById(parentProcId);
 
         // Propagates escalation from the child process instance
-        Executable propagateEscalation = () -> managementService
+        ThrowingCallable propagateEscalation = () -> managementService
                         .executeJob(managementService.createJobQuery().processInstanceId(childProcId).singleResult().getId());
         String expectedErrorMessage = format("Cannot propagate escalation 'testChildEscalation' with code 'testEscalationCode', because execution '%s' is suspended.", boundaryEventExecutionId);
-        assertThrows(FlowableException.class, propagateEscalation, expectedErrorMessage);
+        assertThatThrownBy(propagateEscalation).isInstanceOf(FlowableException.class).hasMessage(expectedErrorMessage);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
@@ -69,13 +69,14 @@ public class BoundaryEscalationEventTest extends PluggableFlowableTestCase {
     public void testCatchEscalationOnCallActivitySuspendedParent() {
         String parentProcId = runtimeService.startProcessInstanceByKey("escalationParent").getId();
         String childProcId = runtimeService.createProcessInstanceQuery().processDefinitionKey("escalationChild").singleResult().getId();
+        String boundaryEventExecutionId = runtimeService.createExecutionQuery().activityId("boundaryEventId").singleResult().getId();
 
         runtimeService.suspendProcessInstanceById(parentProcId);
 
         // Propagates escalation from the child process instance
         Executable propagateEscalation = () -> managementService
                         .executeJob(managementService.createJobQuery().processInstanceId(childProcId).singleResult().getId());
-        String expectedErrorMessage = format("Escalation could not be propagated, because the process instance with ID %s, which catches it, is suspended.", parentProcId);
+        String expectedErrorMessage = format("Cannot propagate escalation 'testChildEscalation' with code 'testEscalationCode', because execution '%s' is suspended.", boundaryEventExecutionId);
         assertThrows(FlowableException.class, propagateEscalation, expectedErrorMessage);
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.java
@@ -77,6 +77,8 @@ public class BoundaryEscalationEventTest extends PluggableFlowableTestCase {
         ThrowingCallable propagateEscalation = () -> managementService
                         .executeJob(managementService.createJobQuery().processInstanceId(childProcId).singleResult().getId());
         String expectedErrorMessage = format("Cannot propagate escalation 'testChildEscalation' with code 'testEscalationCode', because execution '%s' is suspended.", boundaryEventExecutionId);
-        assertThatThrownBy(propagateEscalation).isInstanceOf(FlowableException.class).hasMessage(expectedErrorMessage);
+        assertThatThrownBy(propagateEscalation)
+        	.isInstanceOf(FlowableException.class)
+        	.hasMessage(expectedErrorMessage);
     }
 }

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.testCatchEscalationOnCallActivitySuspendedParent.child.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.testCatchEscalationOnCallActivitySuspendedParent.child.bpmn20.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/processdef">
-  <escalation id="testEscalation" name="testEscalation" escalationCode="testEscalation"></escalation>
+  <escalation id="testEscalation" name="testChildEscalation" escalationCode="testEscalationCode"></escalation>
   <process id="escalationChild" name="escalationChild" isExecutable="true">
-    <startEvent id="startEvent1" flowable:formFieldValidation="true"></startEvent>
-    <intermediateThrowEvent id="sid-9D4C6025-653C-4ED6-9D42-50E36F82B0D0" flowable:async="true">
+    <startEvent id="startEventId" flowable:formFieldValidation="true"></startEvent>
+    <intermediateThrowEvent id="intermediateThrowEventId" flowable:async="true">
       <escalationEventDefinition escalationRef="testEscalation"></escalationEventDefinition>
     </intermediateThrowEvent>
-    <userTask id="sid-FD8E7511-60C4-47F3-A913-3E3E22B29336" flowable:async="true" flowable:exclusive="false" flowable:formFieldValidation="true"></userTask>
-    <endEvent id="sid-44715608-5158-4EC0-9E4C-63FD700285D0"></endEvent>
-    <sequenceFlow id="sid-0271E216-0ED6-4616-9D2D-AA8A8A1A67AE" sourceRef="sid-FD8E7511-60C4-47F3-A913-3E3E22B29336" targetRef="sid-44715608-5158-4EC0-9E4C-63FD700285D0"></sequenceFlow>
-    <sequenceFlow id="sid-3C3A721E-1F67-4CAB-9277-364B8D5D388B" sourceRef="startEvent1" targetRef="sid-9D4C6025-653C-4ED6-9D42-50E36F82B0D0"></sequenceFlow>
-    <sequenceFlow id="sid-D294ECB7-D08F-431E-B310-D8BCA9061079" sourceRef="sid-9D4C6025-653C-4ED6-9D42-50E36F82B0D0" targetRef="sid-FD8E7511-60C4-47F3-A913-3E3E22B29336"></sequenceFlow>
+    <userTask id="userTaskId" flowable:async="true" flowable:exclusive="true" flowable:formFieldValidation="true"></userTask>
+    <endEvent id="endEventId"></endEvent>
+    <sequenceFlow id="sequenceFlow1Id" sourceRef="userTaskId" targetRef="endEventId"></sequenceFlow>
+    <sequenceFlow id="sequenceFlow2Id" sourceRef="startEventId" targetRef="intermediateThrowEventId"></sequenceFlow>
+    <sequenceFlow id="sequenceFlow3Id" sourceRef="intermediateThrowEventId" targetRef="userTaskId"></sequenceFlow>
   </process>
 </definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.testCatchEscalationOnCallActivitySuspendedParent.child.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.testCatchEscalationOnCallActivitySuspendedParent.child.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/processdef">
+  <escalation id="testEscalation" name="testEscalation" escalationCode="testEscalation"></escalation>
+  <process id="escalationChild" name="escalationChild" isExecutable="true">
+    <startEvent id="startEvent1" flowable:formFieldValidation="true"></startEvent>
+    <intermediateThrowEvent id="sid-9D4C6025-653C-4ED6-9D42-50E36F82B0D0" flowable:async="true">
+      <escalationEventDefinition escalationRef="testEscalation"></escalationEventDefinition>
+    </intermediateThrowEvent>
+    <userTask id="sid-FD8E7511-60C4-47F3-A913-3E3E22B29336" flowable:async="true" flowable:exclusive="false" flowable:formFieldValidation="true"></userTask>
+    <endEvent id="sid-44715608-5158-4EC0-9E4C-63FD700285D0"></endEvent>
+    <sequenceFlow id="sid-0271E216-0ED6-4616-9D2D-AA8A8A1A67AE" sourceRef="sid-FD8E7511-60C4-47F3-A913-3E3E22B29336" targetRef="sid-44715608-5158-4EC0-9E4C-63FD700285D0"></sequenceFlow>
+    <sequenceFlow id="sid-3C3A721E-1F67-4CAB-9277-364B8D5D388B" sourceRef="startEvent1" targetRef="sid-9D4C6025-653C-4ED6-9D42-50E36F82B0D0"></sequenceFlow>
+    <sequenceFlow id="sid-D294ECB7-D08F-431E-B310-D8BCA9061079" sourceRef="sid-9D4C6025-653C-4ED6-9D42-50E36F82B0D0" targetRef="sid-FD8E7511-60C4-47F3-A913-3E3E22B29336"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.testCatchEscalationOnCallActivitySuspendedParent.parent.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.testCatchEscalationOnCallActivitySuspendedParent.parent.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/processdef">
+  <escalation id="testEscalation" name="testEscalation" escalationCode="testEscalation"></escalation>
+  <process id="escalationParent" name="escalationParent" isExecutable="true">
+    <startEvent id="startEvent1" flowable:formFieldValidation="true"></startEvent>
+    <callActivity id="sid-37EF6664-2E8B-48A7-A967-174DEAA04455" flowable:async="false" calledElement="escalationChild" flowable:calledElementType="key" flowable:fallbackToDefaultTenant="false"></callActivity>
+    <endEvent id="sid-9A49A7A1-A922-48E4-A968-DFEA2A0F4373"></endEvent>
+    <sequenceFlow id="sid-71FC3699-B283-4A66-A6DF-9901C0E4A373" sourceRef="sid-37EF6664-2E8B-48A7-A967-174DEAA04455" targetRef="sid-9A49A7A1-A922-48E4-A968-DFEA2A0F4373"></sequenceFlow>
+    <sequenceFlow id="sid-0A715B64-B396-47B9-A92F-66E5BEA35A9C" sourceRef="startEvent1" targetRef="sid-37EF6664-2E8B-48A7-A967-174DEAA04455"></sequenceFlow>
+    <boundaryEvent id="sid-1FDCBAE0-05F2-4AEF-BFE1-89E2D9B65DCF" attachedToRef="sid-37EF6664-2E8B-48A7-A967-174DEAA04455" cancelActivity="false">
+      <escalationEventDefinition escalationRef="testEscalation"></escalationEventDefinition>
+    </boundaryEvent>
+    <userTask id="sid-20DA7F80-DB59-4184-9DCB-5693DF448120" flowable:async="true" flowable:formFieldValidation="true"></userTask>
+    <sequenceFlow id="sid-498A26CC-3294-495C-B64E-2BD5DD6308B9" sourceRef="sid-1FDCBAE0-05F2-4AEF-BFE1-89E2D9B65DCF" targetRef="sid-20DA7F80-DB59-4184-9DCB-5693DF448120"></sequenceFlow>
+    <endEvent id="sid-AA43E405-8D96-48FA-870B-14AF2730E375"></endEvent>
+    <sequenceFlow id="sid-35A18DE9-6180-48B5-ABF2-0266F3B8CDDE" sourceRef="sid-20DA7F80-DB59-4184-9DCB-5693DF448120" targetRef="sid-AA43E405-8D96-48FA-870B-14AF2730E375"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.testCatchEscalationOnCallActivitySuspendedParent.parent.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/escalation/BoundaryEscalationEventTest.testCatchEscalationOnCallActivitySuspendedParent.parent.bpmn20.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/processdef">
-  <escalation id="testEscalation" name="testEscalation" escalationCode="testEscalation"></escalation>
+  <escalation id="testEscalation" name="testParentEscalation" escalationCode="testEscalationCode"></escalation>
   <process id="escalationParent" name="escalationParent" isExecutable="true">
     <startEvent id="startEvent1" flowable:formFieldValidation="true"></startEvent>
-    <callActivity id="sid-37EF6664-2E8B-48A7-A967-174DEAA04455" flowable:async="false" calledElement="escalationChild" flowable:calledElementType="key" flowable:fallbackToDefaultTenant="false"></callActivity>
-    <endEvent id="sid-9A49A7A1-A922-48E4-A968-DFEA2A0F4373"></endEvent>
-    <sequenceFlow id="sid-71FC3699-B283-4A66-A6DF-9901C0E4A373" sourceRef="sid-37EF6664-2E8B-48A7-A967-174DEAA04455" targetRef="sid-9A49A7A1-A922-48E4-A968-DFEA2A0F4373"></sequenceFlow>
-    <sequenceFlow id="sid-0A715B64-B396-47B9-A92F-66E5BEA35A9C" sourceRef="startEvent1" targetRef="sid-37EF6664-2E8B-48A7-A967-174DEAA04455"></sequenceFlow>
-    <boundaryEvent id="sid-1FDCBAE0-05F2-4AEF-BFE1-89E2D9B65DCF" attachedToRef="sid-37EF6664-2E8B-48A7-A967-174DEAA04455" cancelActivity="false">
+    <callActivity id="callActivityId" flowable:async="false" calledElement="escalationChild" flowable:calledElementType="key" flowable:fallbackToDefaultTenant="false"></callActivity>
+    <endEvent id="endEvent1Id"></endEvent>
+    <sequenceFlow id="sequenceFlow1Id" sourceRef="callActivityId" targetRef="endEvent1Id"></sequenceFlow>
+    <sequenceFlow id="sequenceFlow2Id" sourceRef="startEvent1" targetRef="callActivityId"></sequenceFlow>
+    <boundaryEvent id="boundaryEventId" attachedToRef="callActivityId" cancelActivity="false">
       <escalationEventDefinition escalationRef="testEscalation"></escalationEventDefinition>
     </boundaryEvent>
-    <userTask id="sid-20DA7F80-DB59-4184-9DCB-5693DF448120" flowable:async="true" flowable:formFieldValidation="true"></userTask>
-    <sequenceFlow id="sid-498A26CC-3294-495C-B64E-2BD5DD6308B9" sourceRef="sid-1FDCBAE0-05F2-4AEF-BFE1-89E2D9B65DCF" targetRef="sid-20DA7F80-DB59-4184-9DCB-5693DF448120"></sequenceFlow>
-    <endEvent id="sid-AA43E405-8D96-48FA-870B-14AF2730E375"></endEvent>
-    <sequenceFlow id="sid-35A18DE9-6180-48B5-ABF2-0266F3B8CDDE" sourceRef="sid-20DA7F80-DB59-4184-9DCB-5693DF448120" targetRef="sid-AA43E405-8D96-48FA-870B-14AF2730E375"></sequenceFlow>
+    <userTask id="userTaskId" flowable:async="true" flowable:formFieldValidation="true"></userTask>
+    <sequenceFlow id="sequenceFlow3Id" sourceRef="boundaryEventId" targetRef="userTaskId"></sequenceFlow>
+    <endEvent id="endEvent2Id"></endEvent>
+    <sequenceFlow id="sequenceFlow4Id" sourceRef="userTaskId" targetRef="endEvent2Id"></sequenceFlow>
   </process>
 </definitions>


### PR DESCRIPTION
In this contribution, an issue is fixed when boundary escalation events on call activities get triggered even if the process instance they belong to is suspended.

With the fix, escalation propagation results in an error when the corresponding catching execution is suspended.

#### Check List:
* Unit tests: YES
* Documentation: NA
