### PR TITLE
Update logging levels in job service.

### DIFF
--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AcquireAsyncJobsDueRunnable.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AcquireAsyncJobsDueRunnable.java
@@ -221,7 +221,7 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
 
             }
         } catch (Throwable e) {
-            LOGGER.error("exception for engine {} during async job acquisition: {}", getEngineName(), e.getMessage(), e);
+            LOGGER.warn("exception for engine {} during async job acquisition: {}", getEngineName(), e.getMessage(), e);
         }
 
         return asyncExecutor.getDefaultAsyncJobAcquireWaitTimeInMillis();

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AcquireTimerJobsRunnable.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AcquireTimerJobsRunnable.java
@@ -214,7 +214,7 @@ public class AcquireTimerJobsRunnable implements Runnable {
             logOptimisticLockingException(optimisticLockingException);
 
         } catch (Throwable e) {
-            LOGGER.error("exception during timer job acquisition: {}", e.getMessage(), e);
+            LOGGER.warn("exception during timer job acquisition: {}", e.getMessage(), e);
             millisToWait = asyncExecutor.getDefaultTimerJobAcquireWaitTimeInMillis();
 
         }
@@ -237,7 +237,7 @@ public class AcquireTimerJobsRunnable implements Runnable {
             unlockTimerJobs(timerJobs); // jobs have been acquired before, so need to unlock when exception happens here
 
         } catch (Throwable t) {
-            LOGGER.error("exception during timer job move: {}", t.getMessage(), t);
+            LOGGER.warn("exception during timer job move: {}", t.getMessage(), t);
             unlockTimerJobs(timerJobs); // jobs have been acquired before, so need to unlock when exception happens here
 
         }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/ResetExpiredJobsRunnable.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/ResetExpiredJobsRunnable.java
@@ -129,7 +129,7 @@ public class ResetExpiredJobsRunnable implements Runnable {
                     LOGGER.debug("Optimistic lock exception while resetting locked jobs for engine {}", asyncExecutor.getJobServiceConfiguration().getEngineName(), e);
 
                 } else {
-                    LOGGER.error("exception during resetting expired jobs: {} for engine {}", e.getMessage(), 
+                    LOGGER.warn("exception during resetting expired jobs: {} for engine {}", e.getMessage(),
                                     asyncExecutor.getJobServiceConfiguration().getEngineName(), e);
                     hasExpiredJobs = false; // will stop the loop
 


### PR DESCRIPTION
Update the logging level for some exception cases from error to warn in the job service.

Cause:
These errors occur in our k8s environment when the primary database server fails over to a secondary. This failover can take up to a few seconds to occur resulting in the database being inaccessible during that time.

Justification:
Often an error message in the logs is an indicator that a system administrator must perform some investigation and work to resolve the issue. However, here that is not the case since the the logic will retry. To reduce the amount of information that a system administrator needs to look through, we would like to update the logging here to warn to reflect that an immediate action isn't required. If the warning continues, then a system administrator should investigate.

#### Check List:
* Unit tests: NA
* Documentation:  NA
