### PR TITLE
Improve Script Engine caching for concurrent access (fixes #2993).

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptingEngines.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptingEngines.java
@@ -12,9 +12,9 @@
  */
 package org.flowable.common.engine.impl.scripting;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -50,7 +50,7 @@ public class ScriptingEngines {
 
     public ScriptingEngines(ScriptEngineManager scriptEngineManager) {
         this.scriptEngineManager = scriptEngineManager;
-        cachedEngines = new HashMap<>();
+        cachedEngines = new ConcurrentHashMap<>();
     }
 
     public ScriptingEngines addScriptEngineFactory(ScriptEngineFactory scriptEngineFactory) {
@@ -124,7 +124,7 @@ public class ScriptingEngines {
                     if (threadingParameter != null) {
                         // Add engine to cache as any non-null result from the
                         // threading-parameter indicates at least MT-access
-                        cachedEngines.put(language, scriptEngine);
+                        cachedEngines.putIfAbsent(language, scriptEngine);
                     }
                 }
             }


### PR DESCRIPTION
Without the `ConcurrentHashMap` it is possible that every thread will have its own copy of the map in its local registers.