### PR TITLE
Add support for exporter and exporterVersion attributes for BPMN, CMMN and DMN

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
@@ -41,6 +41,8 @@ public interface BpmnXMLConstants {
     public static final String ATTRIBUTE_ID = "id";
     public static final String ATTRIBUTE_NAME = "name";
     public static final String ATTRIBUTE_TYPE = "type";
+    public static final String ATTRIBUTE_EXPORTER = "exporter";
+    public static final String ATTRIBUTE_EXPORTER_VERSION = "exporterVersion";
     public static final String ATTRIBUTE_DEFAULT = "default";
     public static final String ATTRIBUTE_ITEM_REF = "itemRef";
     public static final String ELEMENT_DEFINITIONS = "definitions";

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/export/DefinitionsRootExport.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/export/DefinitionsRootExport.java
@@ -60,6 +60,13 @@ public class DefinitionsRootExport implements BpmnXMLConstants {
             xtw.writeAttribute(TARGET_NAMESPACE_ATTRIBUTE, PROCESS_NAMESPACE);
         }
 
+        if (StringUtils.isNotEmpty(model.getExporter())) {
+            xtw.writeAttribute(BpmnXMLConstants.ATTRIBUTE_EXPORTER, model.getExporter());
+        }
+        if (StringUtils.isNotEmpty(model.getExporterVersion())) {
+            xtw.writeAttribute(BpmnXMLConstants.ATTRIBUTE_EXPORTER_VERSION, model.getExporterVersion());
+        }
+
         BpmnXMLUtil.writeCustomAttributes(model.getDefinitionsAttributes().values(), xtw, model.getNamespaces(), defaultAttributes);
     }
 }

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/parser/DefinitionsParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/parser/DefinitionsParser.java
@@ -28,11 +28,18 @@ import org.flowable.bpmn.model.ExtensionAttribute;
  */
 public class DefinitionsParser implements BpmnXMLConstants {
 
-    protected static final List<ExtensionAttribute> defaultAttributes = Arrays.asList(new ExtensionAttribute(TYPE_LANGUAGE_ATTRIBUTE), new ExtensionAttribute(EXPRESSION_LANGUAGE_ATTRIBUTE),
-            new ExtensionAttribute(TARGET_NAMESPACE_ATTRIBUTE));
+    protected static final List<ExtensionAttribute> defaultAttributes = Arrays.asList(
+            new ExtensionAttribute(TYPE_LANGUAGE_ATTRIBUTE),
+            new ExtensionAttribute(EXPRESSION_LANGUAGE_ATTRIBUTE),
+            new ExtensionAttribute(TARGET_NAMESPACE_ATTRIBUTE),
+            new ExtensionAttribute(ATTRIBUTE_EXPORTER),
+            new ExtensionAttribute(ATTRIBUTE_EXPORTER_VERSION)
+        );
 
     @SuppressWarnings("unchecked")
     public void parse(XMLStreamReader xtr, BpmnModel model) throws Exception {
+        model.setExporter(xtr.getAttributeValue(null, ATTRIBUTE_EXPORTER));
+        model.setExporterVersion(xtr.getAttributeValue(null, ATTRIBUTE_EXPORTER_VERSION));
         model.setTargetNamespace(xtr.getAttributeValue(null, TARGET_NAMESPACE_ATTRIBUTE));
         for (int i = 0; i < xtr.getNamespaceCount(); i++) {
             String prefix = xtr.getNamespacePrefix(i);

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ExporterAndVersionTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/ExporterAndVersionTest.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.editor.language.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.flowable.editor.language.xml.util.XmlTestUtils.exportAndReadXMLFile;
+
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.Process;
+import org.junit.jupiter.api.Test;
+
+class ExporterAndVersionTest {
+
+    @Test
+    public void convertModelToXML() {
+        BpmnModel bpmnModel = new BpmnModel();
+        Process process = new Process();
+        process.setId("myProcessWithExporter");
+        bpmnModel.addProcess(process);
+        bpmnModel.setExporter("Flowable");
+        bpmnModel.setExporterVersion("latest");
+        
+        BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+
+        assertThat(parsedModel.getExporter()).isEqualTo("Flowable");
+        assertThat(parsedModel.getExporterVersion()).isEqualTo("latest");
+    }
+}

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/BpmnModel.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/BpmnModel.java
@@ -54,6 +54,8 @@ public class BpmnModel {
     protected List<String> userTaskFormTypes;
     protected List<String> startEventFormTypes;
     protected Object eventSupport;
+    protected String exporter;
+    protected String exporterVersion;
 
     public Map<String, List<ExtensionAttribute>> getDefinitionsAttributes() {
         return definitionsAttributes;
@@ -647,5 +649,18 @@ public class BpmnModel {
 
     public void setEventSupport(Object eventSupport) {
         this.eventSupport = eventSupport;
+    }
+
+    public String getExporter() {
+        return exporter;
+    }
+    public void setExporter(String exporter) {
+        this.exporter = exporter;
+    }
+    public String getExporterVersion() {
+        return exporterVersion;
+    }
+    public void setExporterVersion(String exporterVersion) {
+        this.exporterVersion = exporterVersion;
     }
 }

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/DefinitionsRootExport.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/DefinitionsRootExport.java
@@ -49,5 +49,12 @@ public class DefinitionsRootExport implements CmmnXmlConstants {
         } else {
             xtw.writeAttribute(ATTRIBUTE_TARGET_NAMESPACE, CASE_NAMESPACE);
         }
+
+        if (StringUtils.isNotEmpty(model.getExporter())) {
+            xtw.writeAttribute(CmmnXmlConstants.ATTRIBUTE_EXPORTER, model.getExporter());
+        }
+        if (StringUtils.isNotEmpty(model.getExporterVersion())) {
+            xtw.writeAttribute(CmmnXmlConstants.ATTRIBUTE_EXPORTER_VERSION, model.getExporterVersion());
+        }
     }
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExporterAndVersionTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ExporterAndVersionTest.java
@@ -1,0 +1,43 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.test.cmmn.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.flowable.test.cmmn.converter.util.XmlTestUtils.exportAndReadXMLFile;
+
+import org.flowable.cmmn.model.Case;
+import org.flowable.cmmn.model.CmmnModel;
+import org.flowable.cmmn.model.Stage;
+import org.junit.jupiter.api.Test;
+
+class ExporterAndVersionTest {
+
+    @Test
+    public void convertModelToXML() {
+        CmmnModel cmmnModel = new CmmnModel();
+        Case caze = new Case();
+        Stage planModel = new Stage();
+        planModel.setPlanModel(true);
+        planModel.setId("planModel");
+        caze.setPlanModel(planModel);
+        caze.setId("caseId");
+        cmmnModel.addCase(caze);
+        cmmnModel.setExporter("Flowable");
+        cmmnModel.setExporterVersion("latest");
+        
+        CmmnModel parsedModel = exportAndReadXMLFile(cmmnModel);
+
+        assertThat(parsedModel.getExporter()).isEqualTo("Flowable");
+        assertThat(parsedModel.getExporterVersion()).isEqualTo("latest");
+    }
+}

--- a/modules/flowable-dmn-model/src/main/java/org/flowable/dmn/model/DmnDefinition.java
+++ b/modules/flowable-dmn-model/src/main/java/org/flowable/dmn/model/DmnDefinition.java
@@ -25,6 +25,8 @@ public class DmnDefinition extends NamedElement {
     protected String expressionLanguage;
     protected String typeLanguage;
     protected String namespace;
+    protected String exporter;
+    protected String exporterVersion;
     protected List<InputData> inputData = new ArrayList<>();
     protected List<ItemDefinition> itemDefinitions = new ArrayList<>();
     protected List<Decision> decisions = new ArrayList<>();
@@ -240,4 +242,16 @@ public class DmnDefinition extends NamedElement {
         decisionServiceDividerLocationMap.put(key, graphicInfoList);
     }
 
+    public String getExporter() {
+        return exporter;
+    }
+    public void setExporter(String exporter) {
+        this.exporter = exporter;
+    }
+    public String getExporterVersion() {
+        return exporterVersion;
+    }
+    public void setExporterVersion(String exporterVersion) {
+        this.exporterVersion = exporterVersion;
+    }
 }

--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/constants/DmnXMLConstants.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/constants/DmnXMLConstants.java
@@ -23,6 +23,8 @@ public interface DmnXMLConstants {
     String SCHEMA_NAMESPACE = "http://www.w3.org/2001/XMLSchema";
     String MODEL_NAMESPACE = "http://www.flowable.org/dmn";
     String TARGET_NAMESPACE_ATTRIBUTE = "targetNamespace";
+    String ATTRIBUTE_EXPORTER = "exporter";
+    String ATTRIBUTE_EXPORTER_VERSION = "exporterVersion";
     String FLOWABLE_EXTENSIONS_NAMESPACE = "http://flowable.org/dmn";
     String FLOWABLE_EXTENSIONS_PREFIX = "flowable";
     String DMNDI_NAMESPACE = "https://www.omg.org/spec/DMN/20191111/DMNDI/";

--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/DmnXMLConverter.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/DmnXMLConverter.java
@@ -261,6 +261,8 @@ public class DmnXMLConverter implements DmnXMLConstants {
                 if (ELEMENT_DEFINITIONS.equals(xtr.getLocalName())) {
                     model.setId(xtr.getAttributeValue(null, ATTRIBUTE_ID));
                     model.setName(xtr.getAttributeValue(null, ATTRIBUTE_NAME));
+                    model.setExporter(xtr.getAttributeValue(null, ATTRIBUTE_EXPORTER));
+                    model.setExporterVersion(xtr.getAttributeValue(null, ATTRIBUTE_EXPORTER_VERSION));
                     model.setNamespace(MODEL_NAMESPACE);
                     parentElement = model;
                 } else if (ELEMENT_DECISION.equals(xtr.getLocalName())) {
@@ -379,6 +381,12 @@ public class DmnXMLConverter implements DmnXMLConstants {
                 xtw.writeAttribute(ATTRIBUTE_NAME, model.getName());
             }
             xtw.writeAttribute(ATTRIBUTE_NAMESPACE, MODEL_NAMESPACE);
+            if (StringUtils.isNotEmpty(model.getExporter())) {
+                xtw.writeAttribute(DmnXMLConstants.ATTRIBUTE_EXPORTER, model.getExporter());
+            }
+            if (StringUtils.isNotEmpty(model.getExporterVersion())) {
+                xtw.writeAttribute(DmnXMLConstants.ATTRIBUTE_EXPORTER_VERSION, model.getExporterVersion());
+            }
 
             DmnXMLUtil.writeElementDescription(model, xtw);
             DmnXMLUtil.writeExtensionElements(model, xtw);

--- a/modules/flowable-dmn-xml-converter/src/test/java/org/flowable/dmn/xml/AdditionalConverterTest.java
+++ b/modules/flowable-dmn-xml-converter/src/test/java/org/flowable/dmn/xml/AdditionalConverterTest.java
@@ -41,6 +41,17 @@ public class AdditionalConverterTest extends AbstractConverterTest {
         validateModel(parsedModel);
     }
 
+    @Test
+    public void exporterAndVersion() throws Exception {
+        DmnDefinition dmnModel = readXMLFile();
+        dmnModel.setExporter("Flowable");
+        dmnModel.setExporterVersion("latest");
+        DmnDefinition parsedModel = exportAndReadXMLFile(dmnModel);
+        validateModel(parsedModel);
+        assertThat(parsedModel.getExporter()).isEqualTo("Flowable");
+        assertThat(parsedModel.getExporterVersion()).isEqualTo("latest");
+    }
+
     @Override
     protected String getResource() {
         return "full.dmn";


### PR DESCRIPTION
BPMN, CMMN and DMN all support the 'exporter' and 'exporterVersion' attribute. This would allow modeler / designer implementations to fill these with appropriate values