### PR TITLE
Move to Spring Boot 2.5.4

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.9           The 
 org.springframework             spring-core                 5.3.9           The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.9           The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.9           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.5.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.5.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.5.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.5.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.5.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.5.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.5.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.5.2           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/modules/flowable-cxf/pom.xml
+++ b/modules/flowable-cxf/pom.xml
@@ -167,12 +167,12 @@
     <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>2.3.4</version>
+        <version>2.3.5</version>
     </dependency>
     <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-xjc</artifactId>
-        <version>2.3.4</version>
+        <version>2.3.5</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/modules/flowable-event-registry-spring/pom.xml
+++ b/modules/flowable-event-registry-spring/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>5.16.2</version>
+            <version>5.16.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-jms-spring-executor/pom.xml
+++ b/modules/flowable-jms-spring-executor/pom.xml
@@ -142,13 +142,13 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
-            <version>5.16.2</version>
+            <version>5.16.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>5.16.2</version>
+            <version>5.16.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.5.3</spring.boot.version>
+		<spring.boot.version>2.5.4</spring.boot.version>
 		<spring.framework.version>5.3.9</spring.framework.version>
-		<spring.security.version>5.5.1</spring.security.version>
+		<spring.security.version>5.5.2</spring.security.version>
 		<spring.amqp.version>2.3.10</spring.amqp.version>
-		<spring.kafka.version>2.7.4</spring.kafka.version>
+		<spring.kafka.version>2.7.6</spring.kafka.version>
 		<reactor-netty.version>1.0.6</reactor-netty.version>
 		<jackson.version>2.12.4</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>


### PR DESCRIPTION
Update dependencies and release notes can be found here: https://github.com/spring-projects/spring-boot/releases/tag/v2.5.4
