### PR TITLE
Support user-supplied ingress class name

### DIFF
--- a/k8s/flowable/README.md
+++ b/k8s/flowable/README.md
@@ -41,6 +41,7 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `ingress.enabled`                             | Enables Ingres                                                                                                        | `true`                        |
 | `ingress.sslRedirect`                         | Enables SSL redirect                                                                                                  | `false`                       |
 | `ingress.useHost`                             | Enables host based routing using external `host.external` ( this must be a FQDN)                                      | `false`                       |
+| `ingress.class`                               | Ingress class name                                                                                                    | `nginx`                       |
 |<br/>|
 | `ui.enabled`                                | Enables Flowable UI (either enable Flowable UI or Flowable REST)                                                  | `false`                        |
 | `ui.replicas`                               | Number of replicated pods                                                                                             | `1`                           |

--- a/k8s/flowable/templates/ingress.yaml
+++ b/k8s/flowable/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     nginx.ingress.kubernetes.io/app-root: {{ .Values.rest.contextPath }}
     {{- end}}
     nginx.ingress.kubernetes.io/use-regex: "true"
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "{{ .Values.ingress.class }}"
     nginx.ingress.kubernetes.io/ssl-redirect: "{{ .Values.ingress.sslRedirect }}"
     {{- if .Values.ingress.clusterIssuer }}
     cert-manager.io/cluster-issuer: "{{ .Values.ingress.clusterIssuer }}"

--- a/k8s/flowable/values.yaml
+++ b/k8s/flowable/values.yaml
@@ -20,6 +20,7 @@ ingress:
   enabled: true
   sslRedirect: false
   useHost: false
+  class: nginx
   # To enable LetsEncrypt signed certificates rather than self-signed ones
   # you must deploy a ClusterIssuer object and specify the privateKeySecretRef's
   # name here


### PR DESCRIPTION
`nginx` was hard coded as the ingress class name. This change moves that
value to the values file under `.Values.ingress.class` so the default
behavour is preserved. But now the end user has the ability to change
that value if needed.

#### Check List:
* Unit tests: NA
* Documentation: YES
