### PR TITLE
Chore: remove scripts made obsolete by UI refactoring

### DIFF
--- a/scripts/start-admin.sh
+++ b/scripts/start-admin.sh
@@ -1,2 +1,0 @@
-cd ../modules/flowable-ui-admin/
-./start.sh

--- a/scripts/start-idm.sh
+++ b/scripts/start-idm.sh
@@ -1,2 +1,0 @@
-cd ../modules/flowable-ui-idm/
-./start-idm.sh

--- a/scripts/start-modeler.sh
+++ b/scripts/start-modeler.sh
@@ -1,2 +1,0 @@
-cd ../modules/flowable-ui-modeler/
-./start-modeler.sh

--- a/scripts/start-ui.sh
+++ b/scripts/start-ui.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd ../modules/flowable-ui-task
-./start.sh


### PR DESCRIPTION
These scripts are now obsolete after the UI refactoring in the last release.