### PR TITLE
Added DB2/LINUXPPC64LE detection

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -395,6 +395,7 @@ public abstract class AbstractEngineConfiguration {
         databaseTypeMappings.setProperty("DB2/LINUXX8664", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2/LINUXZ64", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2/LINUXPPC64", DATABASE_TYPE_DB2);
+        databaseTypeMappings.setProperty("DB2/LINUXPPC64LE", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2/400 SQL", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2/6000", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2 UDB iSeries", DATABASE_TYPE_DB2);

--- a/modules/flowable-ui/flowable-ui-modeler-conf/src/main/java/org/flowable/ui/modeler/conf/ModelerDatabaseConfiguration.java
+++ b/modules/flowable-ui/flowable-ui-modeler-conf/src/main/java/org/flowable/ui/modeler/conf/ModelerDatabaseConfiguration.java
@@ -85,6 +85,7 @@ public class ModelerDatabaseConfiguration {
         databaseTypeMappings.setProperty("DB2/LINUXX8664", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2/LINUXZ64", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2/LINUXPPC64", DATABASE_TYPE_DB2);
+        databaseTypeMappings.setProperty("DB2/LINUXPPC64LE", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2/400 SQL", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2/6000", DATABASE_TYPE_DB2);
         databaseTypeMappings.setProperty("DB2 UDB iSeries", DATABASE_TYPE_DB2);


### PR DESCRIPTION
Added DB2/LINUXPPC64LE to the database type list to fix the "Couldn't deduct database type from database product name" error found during testing on PPC. Interestingly, the type is present in `modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java` but absent in 2 other locations. I'm assuming it's just an oversight.

#### Check List:
* Unit tests: NA
* Documentation: NA

Fixes https://github.com/flowable/flowable-engine/issues/3031
