### PR TITLE
Fixing empty or condition when there are no candidateGroups

### DIFF
--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -959,9 +959,9 @@
                 RES.ASSIGNEE_ is null and
               </if>
                 exists(select LINK.ID_ from ${prefix}ACT_RU_IDENTITYLINK LINK where LINK.TASK_ID_ = RES.ID_
-                and LINK.TYPE_ = 'candidate' and (LINK.USER_ID_ = #{userIdForCandidateAndAssignee} or
+                and LINK.TYPE_ = 'candidate' and (LINK.USER_ID_ = #{userIdForCandidateAndAssignee}
                 <if test="candidateGroups != null &amp;&amp; candidateGroups.size() &gt; 0">
-                    (
+                    or (
                     <foreach item="candidateGroupListItem" index="groupIndex" collection="safeCandidateGroups">
                         <if test="groupIndex &gt; 0">
                         or


### PR DESCRIPTION
Background information: https://forum.flowable.org/t/sql-exception-with-task-query-after-upgrade-to-6-7-0/8334