### PR TITLE
Upgrade to SpringBoot 2.5.5 and SpringFramework 5.3.10

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.32          MIT License
 org.slf4j                       slf4j-api                   1.7.32          MIT License
 org.slf4j                       slf4j-log4j12               1.7.32          MIT License
-org.springframework             spring-beans                5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.9           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.9           The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.10          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.10          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.5.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.5.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.5.2           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,19 +14,19 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.5.4</spring.boot.version>
-		<spring.framework.version>5.3.9</spring.framework.version>
+		<spring.boot.version>2.5.5</spring.boot.version>
+		<spring.framework.version>5.3.10</spring.framework.version>
 		<spring.security.version>5.5.2</spring.security.version>
 		<spring.amqp.version>2.3.10</spring.amqp.version>
-		<spring.kafka.version>2.7.6</spring.kafka.version>
+		<spring.kafka.version>2.7.7</spring.kafka.version>
 		<reactor-netty.version>1.0.6</reactor-netty.version>
-		<jackson.version>2.12.4</jackson.version>
+		<jackson.version>2.12.5</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
 		<camel.version>2.25.0</camel.version>
 		<cxf.version>3.4.2</cxf.version>
 		<slf4j.version>1.7.32</slf4j.version>
-		<groovy.version>3.0.8</groovy.version>
+		<groovy.version>3.0.9</groovy.version>
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 
 		<junit.version>4.13.2</junit.version>
@@ -1253,7 +1253,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>3.2.3</version>
+					<version>3.3.2</version>
 					<configuration>
 						<failOnMissingWebXml>false</failOnMissingWebXml>
 						<archive>


### PR DESCRIPTION
Spring Boot 2.5.5 and Spring Framework 5.3.10 and various other dependency updates.

Release Notes:  https://github.com/spring-projects/spring-boot/releases/tag/v2.5.5

Successful run of `mvn clean test` locally
