### PR TITLE
Remove unnecessary null check before method call

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/DecisionTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/DecisionTaskActivityBehavior.java
@@ -92,7 +92,7 @@ public class DecisionTaskActivityBehavior extends TaskActivityBehavior implement
             tenantId(planItemInstanceEntity.getTenantId());
 
         String fallBackToDefaultTenantValue = getFieldString(STRING_DECISION_TABLE_FALLBACK_TO_DEFAULT_TENANT);
-        if (fallBackToDefaultTenantValue != null && Boolean.parseBoolean(fallBackToDefaultTenantValue)) {
+        if (Boolean.parseBoolean(fallBackToDefaultTenantValue)) {
             executeDecisionBuilder.fallbackToDefaultTenant();
         }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AddCommentCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AddCommentCmd.java
@@ -90,7 +90,7 @@ public class AddCommentCmd implements Command<Comment> {
             processDefinitionId = task.getProcessDefinitionId();
         }
 
-        if (processDefinitionId != null && Flowable5Util.isFlowable5ProcessDefinitionId(commandContext, processDefinitionId)) {
+        if (Flowable5Util.isFlowable5ProcessDefinitionId(commandContext, processDefinitionId)) {
             Flowable5CompatibilityHandler compatibilityHandler = Flowable5Util.getFlowable5CompatibilityHandler();
             return compatibilityHandler.addComment(taskId, processInstanceId, type, message);
         }


### PR DESCRIPTION
The method returns false for null so there is no need to check for it.

Part of the periodic check of the code base.


