### PR TITLE
Remove unnecessary final method modifier in a final class

### DIFF
--- a/modules/flowable-app-engine-rest/src/main/java/org/flowable/app/rest/AppRestUrls.java
+++ b/modules/flowable-app-engine-rest/src/main/java/org/flowable/app/rest/AppRestUrls.java
@@ -78,7 +78,7 @@ public final class AppRestUrls {
      * Creates an url based on the passed fragments and replaces any placeholders with the given arguments. The placeholders are following the {@link MessageFormat} convention (eg. {0} is replaced by
      * first argument value).
      */
-    public static final String createRelativeResourceUrl(String[] segments, Object... arguments) {
+    public static String createRelativeResourceUrl(String[] segments, Object... arguments) {
         return MessageFormat.format(StringUtils.join(segments, '/'), arguments);
     }
 }

--- a/modules/flowable-content-rest/src/main/java/org/flowable/content/rest/ContentRestUrls.java
+++ b/modules/flowable-content-rest/src/main/java/org/flowable/content/rest/ContentRestUrls.java
@@ -50,7 +50,7 @@ public final class ContentRestUrls {
      * Creates an url based on the passed fragments and replaces any placeholders with the given arguments. The placeholders are following the {@link MessageFormat} convention (eg. {0} is replaced by
      * first argument value).
      */
-    public static final String createRelativeResourceUrl(String[] segments, Object... arguments) {
+    public static String createRelativeResourceUrl(String[] segments, Object... arguments) {
         return MessageFormat.format(StringUtils.join(segments, '/'), arguments);
     }
 }

--- a/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/DmnRestUrls.java
+++ b/modules/flowable-dmn-rest/src/main/java/org/flowable/dmn/rest/service/api/DmnRestUrls.java
@@ -131,7 +131,7 @@ public final class DmnRestUrls {
      * Creates an url based on the passed fragments and replaces any placeholders with the given arguments. The placeholders are following the {@link MessageFormat} convention (eg. {0} is replaced by
      * first argument value).
      */
-    public static final String createRelativeResourceUrl(String[] segments, Object... arguments) {
+    public static String createRelativeResourceUrl(String[] segments, Object... arguments) {
         return MessageFormat.format(StringUtils.join(segments, '/'), arguments);
     }
 }

--- a/modules/flowable-form-rest/src/main/java/org/flowable/form/rest/FormRestUrls.java
+++ b/modules/flowable-form-rest/src/main/java/org/flowable/form/rest/FormRestUrls.java
@@ -85,7 +85,7 @@ public final class FormRestUrls {
      * Creates an url based on the passed fragments and replaces any placeholders with the given arguments. The placeholders are following the {@link MessageFormat} convention (eg. {0} is replaced by
      * first argument value).
      */
-    public static final String createRelativeResourceUrl(String[] segments, Object... arguments) {
+    public static String createRelativeResourceUrl(String[] segments, Object... arguments) {
         return MessageFormat.format(StringUtils.join(segments, '/'), arguments);
     }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestUrls.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/RestUrls.java
@@ -655,7 +655,7 @@ public final class RestUrls {
      * Creates an url based on the passed fragments and replaces any placeholders with the given arguments. The placeholders are following the {@link MessageFormat} convention (eg. {0} is replaced by
      * first argument value).
      */
-    public static final String createRelativeResourceUrl(String[] segments, Object... arguments) {
+    public static String createRelativeResourceUrl(String[] segments, Object... arguments) {
         return MessageFormat.format(StringUtils.join(segments, '/'), arguments);
     }
 }


### PR DESCRIPTION
Defining a method as `final` in a `final` class is not needed and potential confusing to those reading the code.

Part of the periodic check of the code base.
