### PR TITLE
Remove redundant initializers.

### DIFF
--- a/modules/flowable-app-engine-rest/src/main/java/org/flowable/app/rest/AppRestResponseFactory.java
+++ b/modules/flowable-app-engine-rest/src/main/java/org/flowable/app/rest/AppRestResponseFactory.java
@@ -70,7 +70,7 @@ public class AppRestResponseFactory {
         // Add additional metadata to the artifact-strings before returning
         List<AppDeploymentResourceResponse> responseList = new ArrayList<>(resourceList.size());
         for (String resourceId : resourceList) {
-            String contentType = null;
+            String contentType;
             if (resourceId.toLowerCase().endsWith(".app")) {
                 contentType = ContentType.APPLICATION_JSON.getMimeType();
             } else {

--- a/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/WebConfigurer.java
+++ b/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/WebConfigurer.java
@@ -50,7 +50,7 @@ public class WebConfigurer implements ServletContextListener {
 
         LOGGER.debug("Configuring Spring root application context");
 
-        AnnotationConfigWebApplicationContext rootContext = null;
+        AnnotationConfigWebApplicationContext rootContext;
 
         if (context == null) {
             rootContext = new AnnotationConfigWebApplicationContext();

--- a/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/service/BaseSpringRestTestCase.java
@@ -227,7 +227,7 @@ public class BaseSpringRestTestCase extends TestCase {
     }
 
     protected CloseableHttpResponse internalExecuteRequest(HttpUriRequest request, int expectedStatusCode, boolean addJsonContentType) {
-        CloseableHttpResponse response = null;
+        CloseableHttpResponse response;
         try {
             if (addJsonContentType && request.getFirstHeader(HttpHeaders.CONTENT_TYPE) == null) {
                 // Revert to default content-type

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngines.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngines.java
@@ -55,7 +55,7 @@ public abstract class AppEngines {
                 appEngines = new HashMap<>();
             }
             ClassLoader classLoader = AppEngines.class.getClassLoader();
-            Enumeration<URL> resources = null;
+            Enumeration<URL> resources;
             try {
                 resources = classLoader.getResources("flowable.app.cfg.xml");
             } catch (IOException e) {

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/db/EntityDependencyOrder.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/db/EntityDependencyOrder.java
@@ -33,7 +33,7 @@ import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEnt
 public class EntityDependencyOrder {
 
     public static List<Class<? extends Entity>> DELETE_ORDER = new ArrayList<>();
-    public static List<Class<? extends Entity>> INSERT_ORDER = new ArrayList<>();
+    public static List<Class<? extends Entity>> INSERT_ORDER;
 
     static {
 

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/deployer/AppDeployer.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/deployer/AppDeployer.java
@@ -42,7 +42,7 @@ public class AppDeployer implements EngineDeployer {
 
         AppEngineConfiguration appEngineConfiguration = CommandContextUtil.getAppEngineConfiguration();
         
-        AppModel appResourceModel = null;
+        AppModel appResourceModel;
         AppDeploymentEntity deploymentEntity = (AppDeploymentEntity) deployment;
         Map<String, EngineResource> resources = deploymentEntity.getResources();
         
@@ -91,7 +91,7 @@ public class AppDeployer implements EngineDeployer {
     
     protected AppDefinitionEntity getMostRecentVersionOfAppDefinition(AppModel appModel, String tenantId) {
         AppDefinitionEntityManager appDefinitionEntityManager = CommandContextUtil.getAppDefinitionEntityManager();
-        AppDefinitionEntity existingAppDefinition = null;
+        AppDefinitionEntity existingAppDefinition;
         if (tenantId != null && !tenantId.equals(AppEngineConfiguration.NO_TENANT_ID)) {
             existingAppDefinition = appDefinitionEntityManager.findLatestAppDefinitionByKeyAndTenantId(appModel.getKey(), tenantId);
         } else {
@@ -103,7 +103,7 @@ public class AppDeployer implements EngineDeployer {
     
     protected AppDefinitionEntity getPersistedInstanceOfAppDefinition(String key, String deploymentId, String tenantId) {
         AppDefinitionEntityManager appDefinitionEntityManager = CommandContextUtil.getAppDefinitionEntityManager();
-        AppDefinitionEntity persistedAppDefinitionEntity = null;
+        AppDefinitionEntity persistedAppDefinitionEntity;
         if (tenantId == null || AppEngineConfiguration.NO_TENANT_ID.equals(tenantId)) {
             persistedAppDefinitionEntity = appDefinitionEntityManager.findAppDefinitionByDeploymentAndKey(deploymentId, key);
         } else {

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/repository/AppDeploymentBuilderImpl.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/repository/AppDeploymentBuilderImpl.java
@@ -52,7 +52,7 @@ public class AppDeploymentBuilderImpl implements AppDeploymentBuilder {
             throw new FlowableException("inputStream for resource '" + resourceName + "' is null");
         }
 
-        byte[] bytes = null;
+        byte[] bytes;
         try {
             bytes = IoUtil.readInputStream(inputStream, resourceName);
         } catch (Exception e) {

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/FlowableAppTestCase.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/FlowableAppTestCase.java
@@ -54,7 +54,7 @@ public abstract class FlowableAppTestCase {
 
     protected static void initAppEngine() {
         try (InputStream inputStream = FlowableAppTestCase.class.getClassLoader().getResourceAsStream(FLOWABLE_APP_CFG_XML)) {
-            AppEngine appEngine = null;
+            AppEngine appEngine;
             if (inputStream != null) {
                 appEngine = AppEngineConfiguration.createAppEngineConfigurationFromInputStream(inputStream).buildAppEngine();
             } else {

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/impl/AppTestHelper.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/test/impl/AppTestHelper.java
@@ -42,7 +42,7 @@ public abstract class AppTestHelper {
 
     public static String annotationDeploymentSetUp(AppEngine appEngine, Class<?> testClass, String methodName) {
         String deploymentId = null;
-        Method method = null;
+        Method method;
         try {
             method = testClass.getMethod(methodName, (Class<?>[]) null);
         } catch (Exception e) {

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/ServiceTaskXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/ServiceTaskXMLConverter.java
@@ -78,7 +78,7 @@ public class ServiceTaskXMLConverter extends BaseBpmnXMLConverter {
     protected BaseElement convertXMLToElement(XMLStreamReader xtr, BpmnModel model) throws Exception {
         String serviceTaskType = BpmnXMLUtil.getAttributeValue(ATTRIBUTE_TYPE, xtr);
         
-        ServiceTask serviceTask = null;
+        ServiceTask serviceTask;
         if (ServiceTask.HTTP_TASK.equals(serviceTaskType)) {
             serviceTask = new HttpServiceTask();
             

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/ValuedDataObjectXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/ValuedDataObjectXMLConverter.java
@@ -142,7 +142,7 @@ public class ValuedDataObjectXMLConverter extends BaseBpmnXMLConverter {
 
             xtw.writeStartElement(FLOWABLE_EXTENSIONS_PREFIX, ELEMENT_DATA_VALUE, FLOWABLE_EXTENSIONS_NAMESPACE);
             if (dataObject.getValue() != null) {
-                String value = null;
+                String value;
                 if (dataObject instanceof DateDataObject) {
                     value = sdf.format(dataObject.getValue());
                 } else {

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/FlowableMapExceptionParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/FlowableMapExceptionParser.java
@@ -41,7 +41,7 @@ public class FlowableMapExceptionParser extends BaseChildElementParser {
         String andChildren = xtr.getAttributeValue(null, MAP_EXCEPTION_ANDCHILDREN);
         String rootCause = xtr.getAttributeValue(null, MAP_EXCEPTION_ROOTCAUSE);
         String exceptionClass = xtr.getElementText();
-        boolean hasChildrenBool = false;
+        boolean hasChildrenBool;
 
         if (StringUtils.isEmpty(andChildren) || "false".equals(andChildren.toLowerCase())) {
             hasChildrenBool = false;

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/export/BPMNDIExport.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/export/BPMNDIExport.java
@@ -40,7 +40,7 @@ public class BPMNDIExport implements BpmnXMLConstants {
         // BPMN DI information
         xtw.writeStartElement(BPMNDI_PREFIX, ELEMENT_DI_DIAGRAM, BPMNDI_NAMESPACE);
 
-        String processId = null;
+        String processId;
         if (!model.getPools().isEmpty()) {
             processId = "Collaboration";
         } else {

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/parser/ExtensionElementsParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/parser/ExtensionElementsParser.java
@@ -32,10 +32,9 @@ import org.flowable.bpmn.model.SubProcess;
 public class ExtensionElementsParser implements BpmnXMLConstants {
 
     public void parse(XMLStreamReader xtr, List<SubProcess> activeSubProcessList, Process activeProcess, BpmnModel model) throws Exception {
-        BaseElement parentElement = null;
+        BaseElement parentElement;
         if (!activeSubProcessList.isEmpty()) {
             parentElement = activeSubProcessList.get(activeSubProcessList.size() - 1);
-
         } else {
             parentElement = activeProcess;
         }

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/parser/SubProcessParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/parser/SubProcessParser.java
@@ -31,10 +31,9 @@ import org.flowable.bpmn.model.Transaction;
 public class SubProcessParser implements BpmnXMLConstants {
 
     public void parse(XMLStreamReader xtr, List<SubProcess> activeSubProcessList, Process activeProcess) {
-        SubProcess subProcess = null;
+        SubProcess subProcess;
         if (ELEMENT_TRANSACTION.equalsIgnoreCase(xtr.getLocalName())) {
             subProcess = new Transaction();
-
         } else if (ELEMENT_ADHOC_SUBPROCESS.equalsIgnoreCase(xtr.getLocalName())) {
             AdhocSubProcess adhocSubProcess = new AdhocSubProcess();
             String orderingAttributeValue = xtr.getAttributeValue(null, ATTRIBUTE_ORDERING);

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/AbstractConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/AbstractConverterTest.java
@@ -51,14 +51,14 @@ public abstract class AbstractConverterTest implements BpmnXMLConstants {
     @SuppressWarnings({ "unchecked", "rawtypes" })
 	protected Map<String, Map> parseBPMNDI(byte[] xml) throws Exception {
     	Map<String, Map> bpmnDIMap = new HashMap<>();
-    	Map<String, List<GraphicInfo>> edgesMap = null;
-    	Map<String, GraphicInfo> shapesMap = null;
+    	Map<String, List<GraphicInfo>> edgesMap;
+    	Map<String, GraphicInfo> shapesMap;
 
         XMLInputFactory xif = XMLInputFactory.newInstance();
         InputStreamReader in = new InputStreamReader(new ByteArrayInputStream(xml), StandardCharsets.UTF_8);
         XMLStreamReader xtr = xif.createXMLStreamReader(in);
 
-    	String diagramId = null;
+    	String diagramId;
     	while (xtr.hasNext() && !(xtr.isEndElement() && xtr.getLocalName().equalsIgnoreCase(ELEMENT_DEFINITIONS))) {
     		if (xtr.isStartElement() && xtr.getLocalName().equalsIgnoreCase(ELEMENT_DI_PLANE)) {
     			diagramId = xtr.getAttributeValue(null, ATTRIBUTE_DI_BPMNELEMENT);

--- a/modules/flowable-bpmn-layout/src/main/java/org/flowable/bpmn/BPMNLayout.java
+++ b/modules/flowable-bpmn-layout/src/main/java/org/flowable/bpmn/BPMNLayout.java
@@ -262,7 +262,7 @@ public class BPMNLayout extends mxGraphLayout {
                         }
                     }
 
-                    mxRectangle bounds = null;
+                    mxRectangle bounds;
 
                     if (horizontal) {
                         bounds = horizontalLayout(node, x0, y0, null);

--- a/modules/flowable-bpmn-layout/src/main/java/org/flowable/bpmn/BpmnAutoLayout.java
+++ b/modules/flowable-bpmn-layout/src/main/java/org/flowable/bpmn/BpmnAutoLayout.java
@@ -238,7 +238,7 @@ public class BpmnAutoLayout {
             boundaryPort.setId("boundary-event-" + boundaryEvent.getId());
             boundaryPort.setVertex(true);
 
-            Object portParent = null;
+            Object portParent;
             if (boundaryEvent.getAttachedToRefId() != null) {
                 portParent = generatedVertices.get(boundaryEvent.getAttachedToRefId());
             } else if (boundaryEvent.getAttachedToRef() != null) {
@@ -273,7 +273,7 @@ public class BpmnAutoLayout {
             Object sourceVertex = generatedVertices.get(sequenceFlow.getSourceRef());
             Object targetVertex = generatedVertices.get(sequenceFlow.getTargetRef());
 
-            String style = null;
+            String style;
 
             if (handledFlowElements.get(sequenceFlow.getSourceRef()) instanceof BoundaryEvent) {
                 // Sequence flow out of boundary events are handled in a
@@ -311,7 +311,7 @@ public class BpmnAutoLayout {
             Object sourceVertex = generatedVertices.get(association.getSourceRef());
             Object targetVertex = generatedVertices.get(association.getTargetRef());
 
-            String style = null;
+            String style;
 
             if (handledFlowElements.get(association.getSourceRef()) instanceof BoundaryEvent) {
                 // Sequence flow out of boundary events are handled in a different way,

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/BaseElement.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/BaseElement.java
@@ -61,7 +61,7 @@ public abstract class BaseElement implements HasExtensionAttributes {
 
     public void addExtensionElement(ExtensionElement extensionElement) {
         if (extensionElement != null && StringUtils.isNotEmpty(extensionElement.getName())) {
-            List<ExtensionElement> elementList = null;
+            List<ExtensionElement> elementList;
             if (!this.extensionElements.containsKey(extensionElement.getName())) {
                 elementList = new ArrayList<>();
                 this.extensionElements.put(extensionElement.getName(), elementList);
@@ -95,7 +95,7 @@ public abstract class BaseElement implements HasExtensionAttributes {
     @Override
     public void addAttribute(ExtensionAttribute attribute) {
         if (attribute != null && StringUtils.isNotEmpty(attribute.getName())) {
-            List<ExtensionAttribute> attributeList = null;
+            List<ExtensionAttribute> attributeList;
             if (!this.attributes.containsKey(attribute.getName())) {
                 attributeList = new ArrayList<>();
                 this.attributes.put(attribute.getName(), attributeList);

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/BpmnModel.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/BpmnModel.java
@@ -75,7 +75,7 @@ public class BpmnModel {
 
     public void addDefinitionsAttribute(ExtensionAttribute attribute) {
         if (attribute != null && StringUtils.isNotEmpty(attribute.getName())) {
-            List<ExtensionAttribute> attributeList = null;
+            List<ExtensionAttribute> attributeList;
             if (!this.definitionsAttributes.containsKey(attribute.getName())) {
                 attributeList = new ArrayList<>();
                 this.definitionsAttributes.put(attribute.getName(), attributeList);

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ExtensionElement.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ExtensionElement.java
@@ -65,7 +65,7 @@ public class ExtensionElement extends BaseElement {
 
     public void addChildElement(ExtensionElement childElement) {
         if (childElement != null && StringUtils.isNotEmpty(childElement.getName())) {
-            List<ExtensionElement> elementList = null;
+            List<ExtensionElement> elementList;
             if (!this.childElements.containsKey(childElement.getName())) {
                 elementList = new ArrayList<>();
                 this.childElements.put(childElement.getName(), elementList);

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ExtensionElementsXMLConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ExtensionElementsXMLConverter.java
@@ -379,7 +379,7 @@ public class ExtensionElementsXMLConverter extends CaseElementXmlConverter {
     protected void readEventType(XMLStreamReader xtr, ConversionHelper conversionHelper) {
         CmmnElement currentCmmnElement = conversionHelper.getCurrentCmmnElement();
 
-        String eventType = null;
+        String eventType;
         try {
 
             // Parsing and storing as an extension element, which means the export will work automatically

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/TaskXmlConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/TaskXmlConverter.java
@@ -44,7 +44,7 @@ public class TaskXmlConverter extends PlanItemDefinitionXmlConverter {
 
     @Override
     protected CmmnElement convert(XMLStreamReader xtr, ConversionHelper conversionHelper) {
-        Task task = null;
+        Task task;
         String type = xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE, CmmnXmlConstants.ATTRIBUTE_TYPE);
         String className = xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE, CmmnXmlConstants.ATTRIBUTE_CLASS);
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -1394,7 +1394,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
     }
     
     public void afterInitEventRegistryEventBusConsumer() {
-        EventRegistryEventConsumer cmmnEventRegistryEventConsumer = null;
+        EventRegistryEventConsumer cmmnEventRegistryEventConsumer;
         if (eventRegistryEventConsumer != null) {
             cmmnEventRegistryEventConsumer = eventRegistryEventConsumer;
         } else {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngines.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngines.java
@@ -55,7 +55,7 @@ public abstract class CmmnEngines {
                 cmmnEngines = new HashMap<>();
             }
             ClassLoader classLoader = CmmnEngines.class.getClassLoader();
-            Enumeration<URL> resources = null;
+            Enumeration<URL> resources;
             try {
                 resources = classLoader.getResources("flowable.cmmn.cfg.xml");
             } catch (IOException e) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractChangePlanItemInstanceStateOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractChangePlanItemInstanceStateOperation.java
@@ -61,8 +61,8 @@ public abstract class AbstractChangePlanItemInstanceStateOperation extends Abstr
         internalExecute();
         
         if (CommandContextUtil.getCmmnEngineConfiguration(commandContext).isLoggingSessionEnabled()) {
-            String loggingType = null;
-            String message = null;
+            String loggingType;
+            String message;
             if (oldState == null) {
                 loggingType = CmmnLoggingSessionConstants.TYPE_PLAN_ITEM_CREATED;
                 message = "Plan item instance created with type " + planItemInstanceEntity.getPlanItemDefinitionType() + 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractDeleteCaseInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/AbstractDeleteCaseInstanceOperation.java
@@ -57,7 +57,7 @@ public abstract class AbstractDeleteCaseInstanceOperation extends AbstractChange
             .recordCaseInstanceEnd(caseInstanceEntity, newState, cmmnEngineConfiguration.getClock().getCurrentTime());
 
         if (cmmnEngineConfiguration.isLoggingSessionEnabled()) {
-            String loggingType = null;
+            String loggingType;
             if (CaseInstanceState.TERMINATED.equals(getNewState())) {
                 loggingType = CmmnLoggingSessionConstants.TYPE_CASE_TERMINATED;
             } else {

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverter.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverter.java
@@ -636,7 +636,7 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
             if (associationsFound) {
                 List<Association> associations = associationMap.get(criterion.getId());
                 for (Association association : associations) {
-                    PlanItem criterionPlanItem = null;
+                    PlanItem criterionPlanItem;
                     if (association.getSourceRef().equals(criterion.getId())) {
                         criterionPlanItem = (PlanItem) association.getTargetElement();
                     } else {
@@ -817,7 +817,7 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
             double sourceDockersY = dockersNode.get(0).get(EDITOR_BOUNDS_Y).asDouble();
 
             String stencilId = CmmnJsonConverterUtil.getStencilId(sourceRefNode);
-            String sourceId = null;
+            String sourceId;
             if (STENCIL_ENTRY_CRITERION.equals(stencilId) || STENCIL_EXIT_CRITERION.equals(stencilId)) {
                 sourceId = CmmnJsonConverterUtil.getElementId(sourceRefNode);
             } else {
@@ -829,7 +829,7 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
             GraphicInfo sourceInfo = cmmnModel.getGraphicInfo(sourceId);
 
             stencilId = CmmnJsonConverterUtil.getStencilId(targetRefNode);
-            String targetId = null;
+            String targetId;
             if (STENCIL_ENTRY_CRITERION.equals(stencilId) || STENCIL_EXIT_CRITERION.equals(stencilId)) {
                 targetId = CmmnJsonConverterUtil.getElementId(targetRefNode);
             } else {
@@ -882,7 +882,7 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
                 }
             }
 
-            Line2D lastLine = null;
+            Line2D lastLine;
 
             if (dockersNode.size() > 2) {
                 for (int i = 1; i < dockersNode.size() - 1; i++) {

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverterUtil.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverterUtil.java
@@ -77,7 +77,7 @@ public class CmmnJsonConverterUtil implements EditorJsonConstants, CmmnStencilCo
     }
 
     public static String getElementId(JsonNode objectNode) {
-        String elementId = null;
+        String elementId;
         if (StringUtils.isNotEmpty(getPropertyValueAsString(PROPERTY_OVERRIDE_ID, objectNode))) {
             elementId = getPropertyValueAsString(PROPERTY_OVERRIDE_ID, objectNode).trim();
         } else {

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CriterionJsonConverter.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CriterionJsonConverter.java
@@ -74,7 +74,7 @@ public class CriterionJsonConverter extends BaseCmmnJsonConverter {
         ObjectNode dockNode = objectMapper.createObjectNode();
         GraphicInfo graphicInfo = cmmnModel.getGraphicInfo(criterion.getId());
 
-        GraphicInfo parentGraphicInfo = null;
+        GraphicInfo parentGraphicInfo;
         Stage planModel = cmmnModel.getPrimaryCase().getPlanModel();
         if (criterion.getAttachedToRefId() != null) {
             if (criterion.getAttachedToRefId().equals(planModel.getId())) {

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/BaseElement.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/BaseElement.java
@@ -59,7 +59,7 @@ public class BaseElement implements HasExtensionAttributes {
 
     public void addExtensionElement(ExtensionElement extensionElement) {
         if (extensionElement != null && extensionElement.getName() != null) {
-            List<ExtensionElement> elementList = null;
+            List<ExtensionElement> elementList;
             if (!this.extensionElements.containsKey(extensionElement.getName())) {
                 elementList = new ArrayList<>();
                 this.extensionElements.put(extensionElement.getName(), elementList);
@@ -93,7 +93,7 @@ public class BaseElement implements HasExtensionAttributes {
     @Override
     public void addAttribute(ExtensionAttribute attribute) {
         if (attribute != null && attribute.getName() != null) {
-            List<ExtensionAttribute> attributeList = null;
+            List<ExtensionAttribute> attributeList;
             if (!this.attributes.containsKey(attribute.getName())) {
                 attributeList = new ArrayList<>();
                 this.attributes.put(attribute.getName(), attributeList);

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/ExtensionElement.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/ExtensionElement.java
@@ -63,7 +63,7 @@ public class ExtensionElement extends BaseElement {
 
     public void addChildElement(ExtensionElement childElement) {
         if (childElement != null && childElement.getName() != null) {
-            List<ExtensionElement> elementList = null;
+            List<ExtensionElement> elementList;
             if (!this.childElements.containsKey(childElement.getName())) {
                 elementList = new ArrayList<>();
                 this.childElements.put(childElement.getName(), elementList);


### PR DESCRIPTION
The variable is always assigned a value further down in the code or an exception is thrown.   Initializing the variable is unneeded.

There are still around 600 or more occurrences of similar changes but submitting this to see if this change is acceptable.

Part of the periodic check of the code base.
