### PR TITLE
Upgrade to Spring Boot 2.5.6

### DIFF
--- a/modules/flowable5-compatibility-testdata/pom.xml
+++ b/modules/flowable5-compatibility-testdata/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.27</version>
+			<version>8.0.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>8.0.27</version>
+				<version>8.0.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mariadb.jdbc</groupId>


### PR DESCRIPTION
Dependency updates include:

- Spring Framework 5.3.12
- Spring Security 5.5.3
- AMQP 2.3.11
- Kafka 2.7.8

Release Notes: [https://github.com/spring-projects/spring-boot/releases/tag/v2.5.6](https://github.com/spring-projects/spring-boot/releases/tag/v2.5.6)

Note: I started to updated MySQL from 8.0.19 to 8.0.27 but remembered when I tried to move to 8.0.26 there was a request to back it out.

