### PR TITLE
added _drawExternalWorkerServiceTask function in bpmn-draw.js so that…

### DIFF
--- a/modules/flowable-ui/flowable-ui-task-frontend/src/main/resources/static/display/bpmn-draw.js
+++ b/modules/flowable-ui/flowable-ui-task-frontend/src/main/resources/static/display/bpmn-draw.js
@@ -235,6 +235,13 @@ function _drawSendEventServiceTask(element)
     _addHoverLogic(element, "rect", ACTIVITY_STROKE_COLOR);
 }
 
+function _drawExternalWorkerServiceTask(element)
+{
+	_drawTask(element);
+	_drawServiceTaskIcon(paper, element.x + 4, element.y + 4);
+	_addHoverLogic(element, "rect", ACTIVITY_STROKE_COLOR);
+}
+
 function _drawHttpServiceTask(element)
 {
     _drawTask(element);


### PR DESCRIPTION
… diagram recognizes external tasks in tasks app

Diagram is not displayed properly in Tasks App when there are external tasks used. This PR fixes that issue

#### Check List:
* Unit tests: YES
* Documentation: YES
