### PR TITLE
Issue 3104: fix parameter name in API description

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskCollectionResource.java
@@ -85,7 +85,7 @@ public class TaskCollectionResource extends TaskBaseResource {
             @ApiImplicitParam(name = "createdOn", dataType = "string",format = "date-time", value = "Only return tasks which are created on the given date.", paramType = "query"),
             @ApiImplicitParam(name = "createdBefore", dataType = "string",format = "date-time", value = "Only return tasks which are created before the given date.", paramType = "query"),
             @ApiImplicitParam(name = "createdAfter", dataType = "string",format = "date-time", value = "Only return tasks which are created after the given date.", paramType = "query"),
-            @ApiImplicitParam(name = "dueOn", dataType = "string",format = "date-time", value = "Only return tasks which are due on the given date.", paramType = "query"),
+            @ApiImplicitParam(name = "dueDate", dataType = "string",format = "date-time", value = "Only return tasks which are due on the given date.", paramType = "query"),
             @ApiImplicitParam(name = "dueBefore", dataType = "string", format = "date-time", value = "Only return tasks which are due before the given date.", paramType = "query"),
             @ApiImplicitParam(name = "dueAfter", dataType = "string", format = "date-time", value = "Only return tasks which are due after the given date.", paramType = "query"),
             @ApiImplicitParam(name = "withoutDueDate", dataType = "boolean", value = "Only return tasks which do not have a due date. The property is ignored if the value is false.", paramType = "query"),


### PR DESCRIPTION
Per [issue 3104](https://github.com/flowable/flowable-engine/issues/3104) change the API description of `dueOn` to `dueDate` to match the code and the use in the [unit test](https://github.com/flowable/flowable-engine/blob/822c3e87a5dc03bc52652e7f5bef8b322bba917d/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCollectionResourceTest.java#L328).

Looking at the unit test it appears not to expect any milliseconds in the date in answer to the the second part of the original issue.

Fixes #3104