### PR TITLE
Upgrade to SpringBoot 2.5.7; forgot to update the notice.txt

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.32          MIT License
 org.slf4j                       slf4j-api                   1.7.32          MIT License
 org.slf4j                       slf4j-log4j12               1.7.32          MIT License
-org.springframework             spring-beans                5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.12          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.12          The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.13          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.5.3           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.5.3           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.5.3           The Apache Software License, Version 2.0


### PR DESCRIPTION
The upgrade to 2.5.7 also updated Spring Framework; this updates the `notice.txt` file
