### PR TITLE
Upgrade to SpringBoot 2.6.1

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -127,9 +127,9 @@ org.apache.httpcomponents       httpclient                  4.5.13          Apac
 org.apache.httpcomponents       httpcore                    4.4.14          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.13          Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy                      3.0.8           The Apache Software License, Version 2.0
-org.codehaus.groovy             groovy-jsr223               3.0.8           The Apache Software License, Version 2.0
-org.liquibase                   liquibase-core              4.3.5           Apache License, Version 2.0
+org.codehaus.groovy             groovy                      3.0.9           The Apache Software License, Version 2.0
+org.codehaus.groovy             groovy-jsr223               3.0.9           The Apache Software License, Version 2.0
+org.liquibase                   liquibase-core              4.5.0           Apache License, Version 2.0
 org.mybatis                     mybatis                     3.5.7           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              2.0.6           The Apache Software License, Version 2.0
 org.mvel                        mvel2                       2.2.6.Final     The Apache Software License, Version 2.0
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.13          The 
 org.springframework             spring-core                 5.3.13          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.13          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.13          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.5.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.5.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.5.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.5.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.6.0           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.6.0           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.6.0           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.6.0           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/modules/flowable-app-rest/src/test/java/org/flowable/rest/app/FlowableRestApplicationTest.java
+++ b/modules/flowable-app-rest/src/test/java/org/flowable/rest/app/FlowableRestApplicationTest.java
@@ -37,7 +37,6 @@ public class FlowableRestApplicationTest {
             .containsExactly(
                 "configurationProperties",
                 "Inlined Test Properties",
-                "test",
                 "servletConfigInitParams",
                 "servletContextInitParams",
                 "systemProperties",

--- a/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationTest.java
+++ b/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationTest.java
@@ -49,7 +49,6 @@ public class FlowableUiApplicationTest {
             .containsExactly(
                 "configurationProperties",
                 "Inlined Test Properties",
-                "test",
                 "servletConfigInitParams",
                 "servletContextInitParams",
                 "systemProperties",

--- a/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationWithEnabledJmsKafkaAndRabbitTest.java
+++ b/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationWithEnabledJmsKafkaAndRabbitTest.java
@@ -53,7 +53,6 @@ public class FlowableUiApplicationWithEnabledJmsKafkaAndRabbitTest {
             .containsExactly(
                 "configurationProperties",
                 "Inlined Test Properties",
-                "test",
                 "servletConfigInitParams",
                 "servletContextInitParams",
                 "systemProperties",

--- a/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationWithEnabledJmsTest.java
+++ b/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationWithEnabledJmsTest.java
@@ -49,7 +49,6 @@ public class FlowableUiApplicationWithEnabledJmsTest {
             .containsExactly(
                 "configurationProperties",
                 "Inlined Test Properties",
-                "test",
                 "servletConfigInitParams",
                 "servletContextInitParams",
                 "systemProperties",

--- a/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationWithEnabledKafkaTest.java
+++ b/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationWithEnabledKafkaTest.java
@@ -49,7 +49,6 @@ public class FlowableUiApplicationWithEnabledKafkaTest {
             .containsExactly(
                 "configurationProperties",
                 "Inlined Test Properties",
-                "test",
                 "servletConfigInitParams",
                 "servletContextInitParams",
                 "systemProperties",

--- a/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationWithEnabledRabbitTest.java
+++ b/modules/flowable-ui/flowable-ui-app/src/test/java/org/flowable/ui/application/FlowableUiApplicationWithEnabledRabbitTest.java
@@ -49,7 +49,6 @@ public class FlowableUiApplicationWithEnabledRabbitTest {
             .containsExactly(
                 "configurationProperties",
                 "Inlined Test Properties",
-                "test",
                 "servletConfigInitParams",
                 "servletContextInitParams",
                 "systemProperties",

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.6.0</spring.boot.version>
+		<spring.boot.version>2.6.1</spring.boot.version>
 		<spring.framework.version>5.3.13</spring.framework.version>
 		<spring.security.version>5.6.0</spring.security.version>
 		<spring.amqp.version>2.4.0</spring.amqp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.5.7</spring.boot.version>
+		<spring.boot.version>2.6.0</spring.boot.version>
 		<spring.framework.version>5.3.13</spring.framework.version>
-		<spring.security.version>5.5.3</spring.security.version>
-		<spring.amqp.version>2.3.12</spring.amqp.version>
-		<spring.kafka.version>2.7.9</spring.kafka.version>
+		<spring.security.version>5.6.0</spring.security.version>
+		<spring.amqp.version>2.4.0</spring.amqp.version>
+		<spring.kafka.version>2.8.0</spring.kafka.version>
 		<reactor-netty.version>1.0.6</reactor-netty.version>
 		<jackson.version>2.12.5</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
@@ -30,11 +30,11 @@
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 
 		<junit.version>4.13.2</junit.version>
-		<junit.jupiter.version>5.7.2</junit.jupiter.version>
+		<junit.jupiter.version>5.8.0</junit.jupiter.version>
 		<hikari.version>3.4.5</hikari.version>
 		<maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
 		<maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
-		<mockito.version>3.12.2</mockito.version>
+		<mockito.version>4.0.0</mockito.version>
 		<testcontainers.version>1.12.4</testcontainers.version>
 
 		<oracle.jdbc.version>12.2.0.1</oracle.jdbc.version>
@@ -790,7 +790,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.4.32.Final</version>
+				<version>5.6.0.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
@@ -993,7 +993,7 @@
 			<dependency>
 				<groupId>org.liquibase</groupId>
 				<artifactId>liquibase-core</artifactId>
-				<version>4.3.5</version>
+				<version>4.5.0</version>
 				<exclusions>
 					<exclusion>
 						<groupId>javax.xml.bind</groupId>
@@ -1010,7 +1010,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.2.22</version>
+				<version>42.3.0</version>
 			</dependency>
 			<dependency>
 				<groupId>xerces</groupId>


### PR DESCRIPTION
Release notes for 2.6.0 are [here](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes).

Instead of opening a new PR I just changed the `pom.xml` and updated the title.
 
Release notes for 2.6.1 are [here](https://github.com/spring-projects/spring-boot/releases/tag/v2.6.1).

Ran locally `mvn clean test` on `distro` profile without error.

When I was updating the `notice.txt` file I noticed an entry for `commons-pool`; I can't seem to find any reference to it in any of the `pom.xml` files but I left it in.  I also noticed that the groovy version was old (that I corrected).
