### PR TITLE
change DMNDI ids to static IDs instead of UUIDs

### DIFF
--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/DMNDIExport.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/xml/converter/DMNDIExport.java
@@ -53,7 +53,7 @@ public class DMNDIExport implements DmnXMLConstants {
             // DI shape
             for (Map.Entry<String, GraphicInfo> graphicInfoEntry : graphicInfoMap.entrySet()) {
                 xtw.writeStartElement(DMNDI_PREFIX, ELEMENT_DI_SHAPE, DMNDI_NAMESPACE);
-                xtw.writeAttribute(ATTRIBUTE_ID, DmnXMLUtil.getUniqueElementId("DMNShape"));
+                xtw.writeAttribute(ATTRIBUTE_ID, "DMNShape_" + graphicInfoEntry.getKey());
                 xtw.writeAttribute(ATTRIBUTE_DI_DMN_ELEMENT_REF, graphicInfoEntry.getKey());
 
                 createDmnShapeBounds(graphicInfoEntry.getValue(), xtw);
@@ -106,7 +106,7 @@ public class DMNDIExport implements DmnXMLConstants {
 
     protected static void createDmnEdge(String elementId, List<GraphicInfo> graphicInfoList, XMLStreamWriter xtw) throws Exception {
         xtw.writeStartElement(DMNDI_PREFIX, ELEMENT_DI_EDGE, DMNDI_NAMESPACE);
-        xtw.writeAttribute(ATTRIBUTE_ID, DmnXMLUtil.getUniqueElementId("DMNEdge"));
+        xtw.writeAttribute(ATTRIBUTE_ID, "DMNEdge_" + elementId);
         xtw.writeAttribute(ATTRIBUTE_DI_DMN_ELEMENT_REF, elementId);
 
         for (GraphicInfo graphicInfo : graphicInfoList) {

--- a/modules/flowable-dmn-xml-converter/src/test/java/org/flowable/dmn/xml/DiagramDiTest.java
+++ b/modules/flowable-dmn-xml-converter/src/test/java/org/flowable/dmn/xml/DiagramDiTest.java
@@ -17,7 +17,10 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import org.flowable.dmn.model.DmnDefinition;
 import org.flowable.dmn.model.GraphicInfo;
+import org.flowable.dmn.xml.converter.DmnXMLConverter;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.Charset;
 
 public class DiagramDiTest extends AbstractConverterTest {
 
@@ -32,6 +35,16 @@ public class DiagramDiTest extends AbstractConverterTest {
         DmnDefinition dmnModel = readXMLFile();
         DmnDefinition parsedModel = exportAndReadXMLFile(dmnModel);
         validateModel(parsedModel);
+    }
+
+    @Test
+    public void convertToModelAndBackAndEnsureXmlIsTheSame() throws Exception {
+        DmnDefinition dmnModel = readXMLFile();
+        String originalModelAsXml = new String(new DmnXMLConverter().convertToXML(dmnModel), Charset.defaultCharset());
+        DmnDefinition parsedModel = exportAndReadXMLFile(dmnModel);
+        String convertedModelAsXml = new String(new DmnXMLConverter().convertToXML(parsedModel), Charset.defaultCharset());
+
+        assertThat(convertedModelAsXml).isEqualTo(originalModelAsXml);
     }
 
     @Override


### PR DESCRIPTION
As of now IDs of DRD DI in decision services are changing for every export. This isn’t handy in case you would like to commit a DRD model on a VCS since you have unnecessary changes. This PR keeps existing IDs in case they are already available and re-uses them. Exporting a DRD twice will result in exactly the same DRD as before.

#### Check List:
* Unit tests: YES
* Documentation: NA
