### PR TITLE
Upgrade to Spring Security 5.5.4

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.32          MIT License
 org.slf4j                       slf4j-api                   1.7.32          MIT License
 org.slf4j                       slf4j-log4j12               1.7.32          MIT License
-org.springframework             spring-beans                5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.13          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.13          The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.14          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.14          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.5.4           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.5.4           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.5.4           The Apache Software License, Version 2.0

--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.13          The 
 org.springframework             spring-core                 5.3.13          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.13          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.13          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.5.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.5.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.5.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.5.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.5.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.5.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.5.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.5.4           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.5.7</spring.boot.version>
-		<spring.framework.version>5.3.13</spring.framework.version>
-		<spring.security.version>5.5.3</spring.security.version>
+		<spring.framework.version>5.3.14</spring.framework.version>
+		<spring.security.version>5.5.4</spring.security.version>
 		<spring.amqp.version>2.3.12</spring.amqp.version>
 		<spring.kafka.version>2.7.9</spring.kafka.version>
-		<reactor-netty.version>1.0.6</reactor-netty.version>
-		<jackson.version>2.12.5</jackson.version>
+		<reactor-netty.version>1.0.14</reactor-netty.version>
+		<jackson.version>2.12.6</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
 		<camel.version>2.25.0</camel.version>


### PR DESCRIPTION
Release Notes here:  https://github.com/spring-projects/spring-security/releases/tag/5.5.4

This supersedes the SpringFramework 5.13.14 update [PR](https://github.com/flowable/flowable-engine/pull/3144)
