### PR TITLE
Enable template name override

### DIFF
--- a/k8s/flowable/templates/_helpers.tpl
+++ b/k8s/flowable/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Template name.
 */}}
 {{- define "flowable.template" -}}
-{{- .Template.Name | replace "flowable/templates/" "" | trimSuffix ".yaml" | trunc 63 -}}
+{{- default .Template.Name .Values.nameOverride | replace "flowable/templates/" "" | trimSuffix ".yaml" | trunc 63 -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
# Goal
Install flowable chart twice in the same cluster (for example as `dev` and `staging`)

## Steps to follow
- Already deployed flowable chart
- Override chart value `nameOverride: staging` and any other needed overrides like database etc.
- Deploy chart

## Expected result
- Two working flowable deployments, services, ingresses

## Actual result
- Deployment fails because the required `configmap` is already used and there is no way to override its name (as far as I can see).
```
Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists. Unable to continue with install: ConfigMap "rest-configmap" in namespace "default" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "flowable-staging": current value is "flowable"
```

## Solution

- Expected `configmap` is named by `template.name`; permit this to be overridden as chart name is.

#### Check List:
* Unit tests: NO
* Documentation: NA
