### PR TITLE
Extract computation of failedJobRetryTimeCycleValue in JobRetryCmd to make it overridable

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/JobRetryCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/JobRetryCmd.java
@@ -71,10 +71,7 @@ public class JobRetryCmd implements Command<Object> {
         ExecutionEntity executionEntity = fetchExecutionEntity(commandContext, job.getExecutionId());
         FlowElement currentFlowElement = executionEntity != null ? executionEntity.getCurrentFlowElement() : null;
 
-        String failedJobRetryTimeCycleValue = null;
-        if (currentFlowElement instanceof ServiceTask) {
-            failedJobRetryTimeCycleValue = ((ServiceTask) currentFlowElement).getFailedJobRetryTimeCycleValue();
-        }
+        String failedJobRetryTimeCycleValue = getFailedJobRetryTimeCycleValue(currentFlowElement);
 
         if (executionEntity != null) {
             executionEntity.setActive(false);
@@ -157,6 +154,13 @@ public class JobRetryCmd implements Command<Object> {
                     processEngineConfiguration.getEngineCfgKey());
         }
 
+        return null;
+    }
+
+    protected static String getFailedJobRetryTimeCycleValue(FlowElement currentFlowElement) {
+        if (currentFlowElement instanceof ServiceTask) {
+            return ((ServiceTask) currentFlowElement).getFailedJobRetryTimeCycleValue();
+        }
         return null;
     }
 


### PR DESCRIPTION
At some point in our development, we needed to make the computation of the failedJobRetryTimeCycle to be computed dynamically during the execution of the serviceTask (depending for instance on some input parameters provided by the user).

We propose to extract the retrieval of the failedJobRetryTimeCycleValue in a dedicated protected method, to allow to override it for such customization.

Thank you in advance,

#### Check List:
* Unit tests: NA
* Documentation: NA
