### PR TITLE
UI Modeler export app crashes with duplicate entries

### DIFF
--- a/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionExportService.java
+++ b/modules/flowable-ui/flowable-ui-modeler-logic/src/main/java/org/flowable/ui/modeler/service/AppDefinitionExportService.java
@@ -96,6 +96,8 @@ public class AppDefinitionExportService extends BaseAppDefinitionService {
             ConverterContext converterContext = new ConverterContext(modelService, objectMapper);
 
             List<AppModelDefinition> modelDefinitions = appDefinition.getDefinition().getModels();
+            //get BPMN names that are added to app
+            List<String> exportedBpmnNames = modelDefinitions.stream().map(x->x.getName()).collect(Collectors.toList());
             if (CollectionUtils.isNotEmpty(modelDefinitions)) {
                 createBpmnZipEntries(modelDefinitions, zipOutputStream, converterContext);
             }
@@ -106,8 +108,11 @@ public class AppDefinitionExportService extends BaseAppDefinitionService {
             }
 
             Collection<Model> allProcessModels = converterContext.getAllProcessModels();
-            if (allProcessModels != null) {
-                createBpmnZipEntries(allProcessModels, zipOutputStream, converterContext);
+            //filter out BPMN names that were added to app directly
+            List<Model> unprocessedBpmnModels = allProcessModels.stream()
+                    .filter(x -> !exportedBpmnNames.contains(x.getName())).collect(Collectors.toList());
+            if (unprocessedBpmnModels != null) {
+                createBpmnZipEntries(unprocessedBpmnModels, zipOutputStream, converterContext);
             }
 
             Collection<Model> allCaseModels = converterContext.getAllCaseModels();


### PR DESCRIPTION
Create BPMN and CMMN models. a CMMN model is refering to some BPMN models. Add all models to application. Click Export Application in UI moder. Export crashes as it was added same BPMN entry multiple times.


#### Check List:
* Unit tests: NA (Minor UI behavior change)
* Documentation: NA (Minor UI behavior change)
