### PR TITLE
Allowing expressions to be resolved in the candidateStarters

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
@@ -13,7 +13,6 @@
 package org.flowable.cmmn.engine.impl.behavior.impl;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -41,6 +40,7 @@ import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.api.constant.ReferenceTypes;
 import org.flowable.common.engine.api.delegate.Expression;
 import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.impl.assignment.CandidateUtil;
 import org.flowable.common.engine.impl.el.ExpressionManager;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.common.engine.impl.logging.CmmnLoggingSessionConstants;
@@ -52,8 +52,6 @@ import org.flowable.task.service.impl.persistence.entity.TaskEntity;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
@@ -321,7 +319,7 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
             for (String candidateUser : candidateUsers) {
                 Expression userIdExpr = expressionManager.createExpression(candidateUser);
                 Object value = userIdExpr.getValue(planItemInstanceEntity);
-                Collection<String> candidates = extractCandidates(value);
+                Collection<String> candidates = CandidateUtil.extractCandidates(value);
                 List<IdentityLinkEntity> identityLinkEntities = cmmnEngineConfiguration.getIdentityLinkServiceConfiguration()
                         .getIdentityLinkService().addCandidateUsers(taskEntity.getId(), candidates);
 
@@ -352,7 +350,7 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
             for (String candidateGroup : candidateGroups) {
                 Expression groupIdExpr = expressionManager.createExpression(candidateGroup);
                 Object value = groupIdExpr.getValue(planItemInstanceEntity);
-                Collection<String> candidates = extractCandidates(value);
+                Collection<String> candidates = CandidateUtil.extractCandidates(value);
                 List<IdentityLinkEntity> identityLinkEntities = cmmnEngineConfiguration.getIdentityLinkServiceConfiguration()
                         .getIdentityLinkService().addCandidateGroups(taskEntity.getId(), candidates);
 
@@ -369,26 +367,6 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
                             allIdentityLinkEntities, taskEntity, planItemInstanceEntity, cmmnEngineConfiguration.getObjectMapper());
                 }
             }
-        }
-    }
-
-    protected Collection<String> extractCandidates(Object value) {
-        if (value instanceof String) {
-            return Arrays.asList(value.toString().split("[\\s]*,[\\s]*"));
-
-        } else if (value instanceof Collection) {
-            return (Collection<String>) value;
-
-        } else if (value instanceof ArrayNode) {
-            ArrayNode valueArrayNode = (ArrayNode) value;
-            Collection<String> candidates = new ArrayList<>(valueArrayNode.size());
-            for (JsonNode node : valueArrayNode) {
-                candidates.add(node.asText());
-            }
-
-            return candidates;
-        } else {
-            throw new FlowableException("Expression did not resolve to a string, collection of strings or an array node");
         }
     }
 

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/authorization/StartAuthorizationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/authorization/StartAuthorizationTest.java
@@ -314,4 +314,36 @@ public class StartAuthorizationTest extends FlowableCmmnTestCase {
         }
     }
 
+    @Test
+    @CmmnDeployment
+    public void testExpressionsInCandidateStarters() throws Exception {
+
+        setupUsersAndGroups();
+
+        try {
+            //test simple expression e.g. "${"user1"}"
+            CaseDefinition latestCaseDef = cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("expressionCase1").singleResult();
+            assertThat(latestCaseDef).isNotNull();
+            List<IdentityLink> links = cmmnRepositoryService.getIdentityLinksForCaseDefinition(latestCaseDef.getId());
+            assertThat(links).hasSize(2);
+            assertThat(extractProperty("groupId").from(links))
+                    .contains("group3");
+            assertThat(extractProperty("userId").from(links))
+                    .contains("user1");
+
+            //test comma-seperated candidates inside expression e.g. "${"user1,user2"}"
+            latestCaseDef = cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("expressionCase2").singleResult();
+            assertThat(latestCaseDef).isNotNull();
+            links = cmmnRepositoryService.getIdentityLinksForCaseDefinition(latestCaseDef.getId());
+            assertThat(links).hasSize(4);
+            assertThat(extractProperty("groupId").from(links))
+                    .contains("group2", "group3");
+            assertThat(extractProperty("userId").from(links))
+                    .contains("user1", "user2");
+        } finally {
+            tearDownUsersAndGroups();
+            Authentication.setAuthenticatedUserId(null);
+        }
+    }
+
 }

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/authorization/StartAuthorizationTest.testExpressionsInCandidateStarters.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/authorization/StartAuthorizationTest.testExpressionsInCandidateStarters.cmmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" 
+    xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" 
+    xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI"
+    xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:flowable="http://flowable.org/cmmn"
+    targetNamespace="http://flowable.org/cmmn">
+    
+    <case id="expressionCase1" flowable:candidateStarterUsers="${&quot;user1&quot;}" flowable:candidateStarterGroups="${&quot;group3&quot;}">
+        <casePlanModel id="myPlanModel1" name="My CasePlanModel">
+            <planItem id="planItem1" name="The task" definitionRef="theTask1" />
+            <humanTask id="theTask1" name="The Task" flowable:assignee="johnDoe" />
+        </casePlanModel>
+    </case>
+    
+    <case id="expressionCase2" flowable:candidateStarterUsers="${&quot;user1,user2&quot;}" flowable:candidateStarterGroups="${&quot;group2, group3&quot;}">
+        <casePlanModel id="myPlanModel2" name="My CasePlanModel">
+            <planItem id="planItem2" name="The task" definitionRef="theTask2" />
+            <humanTask id="theTask2" name="The Task" flowable:assignee="johnDoe" />
+        </casePlanModel>
+    </case>
+</definitions>

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/assignment/CandidateUtil.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/assignment/CandidateUtil.java
@@ -1,0 +1,36 @@
+package org.flowable.common.engine.impl.assignment;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+public class CandidateUtil {
+
+    public static Collection<String> extractCandidates(Object value) {
+        if (value instanceof Collection) {
+            return (Collection<String>) value;
+        } else if (value instanceof ArrayNode) {
+            ArrayNode valueArrayNode = (ArrayNode) value;
+            Collection<String> candidates = new ArrayList<>(valueArrayNode.size());
+            for (JsonNode node : valueArrayNode) {
+                candidates.add(node.asText());
+            }
+
+            return candidates;
+        } else if (value != null) {
+            String str = value.toString();
+            if (StringUtils.isNotEmpty(str)) {
+                return Arrays.asList(value.toString().split("[\\s]*,[\\s]*"));
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/assignment/CandidateUtil.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/assignment/CandidateUtil.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.common.engine.impl.assignment;
 
 import java.util.ArrayList;

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.java
@@ -377,4 +377,39 @@ public class StartAuthorizationTest extends PluggableFlowableTestCase {
         }
     }
 
+    @Test
+    @Deployment
+    public void testExpressionsInCandidateStarters() throws Exception {
+
+        setUpUsersAndGroups();
+
+        try {
+            //test simple expression e.g. "${"user1"}"
+            ProcessDefinition latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("ExpressionProcess1").singleResult();
+            assertThat(latestProcessDef).isNotNull();
+            List<IdentityLink> links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
+            assertThat(links)
+                    .extracting(IdentityLink::getUserId, IdentityLink::getGroupId)
+                    .containsExactlyInAnyOrder(
+                            tuple("user1", null),
+                            tuple(null, "group3")
+                    );
+
+            //test comma-seperated candidates inside expression e.g. "${"user1,user2"}"
+            latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("ExpressionProcess2").singleResult();
+            assertThat(latestProcessDef).isNotNull();
+            links = repositoryService.getIdentityLinksForProcessDefinition(latestProcessDef.getId());
+            assertThat(links)
+                    .extracting(IdentityLink::getUserId, IdentityLink::getGroupId)
+                    .containsExactlyInAnyOrder(
+                            tuple("user1", null),
+                            tuple("user2", null),
+                            tuple(null, "group2"),
+                            tuple(null, "group3")
+                    );
+        } finally {
+            tearDownUsersAndGroups();
+        }
+    }
+
 }

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.testExpressionsInCandidateStarters.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/authorization/StartAuthorizationTest.testExpressionsInCandidateStarters.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:flowable="http://flowable.org/bpmn" targetNamespace="Examples">
+
+	<process id="ExpressionProcess1" name="ExpressionProcess1" flowable:candidateStarterUsers="${&quot;user1&quot;}" flowable:candidateStarterGroups="${&quot;group3&quot;}">
+		<startEvent id="start1" />
+		<sequenceFlow id="flow11" sourceRef="start1" targetRef="end1" />
+		<endEvent id="end1" />
+	</process>
+
+	<process id="ExpressionProcess2" name="ExpressionProcess2" flowable:candidateStarterUsers="${&quot;user1,user2&quot;}" flowable:candidateStarterGroups="${&quot;group2, group3&quot;}">
+		<startEvent id="start2" />
+		<sequenceFlow id="flow12" sourceRef="start2" targetRef="end2" />
+		<endEvent id="end2" />
+	</process>
+
+</definitions>


### PR DESCRIPTION
Allowing expressions to be resolved in the candidateStarterUser and candidateStarterGroup fields in CMMN and BPMN + Unit tests + moving extractCandidates function to Util class in flowable-engine-common

#### Check List:
* Unit tests: YES
* Documentation: NA
