### PR TITLE
UI Modeler cannot import startEventCorrelationConfiguration value

### DIFF
--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/constants/CmmnStencilConstants.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/constants/CmmnStencilConstants.java
@@ -205,15 +205,16 @@ public interface CmmnStencilConstants {
 
     String PROPERTY_EVENT_LISTENER_AVAILABLE_CONDITION = "availablecondition";
 
-    String PROPERTY_EVENT_TYPE = "eventType";
-    
     String PROPERTY_EXTERNAL_WORKER_JOB_TOPIC = "topic";
-
+    /**
+     * Defines which event should create case. Use instead of PROPERTY_EVENT_TYPE="eventType"
+     */
     String PROPERTY_EVENT_REGISTRY_EVENT_KEY = "eventkey";
     String PROPERTY_EVENT_REGISTRY_EVENT_NAME = "eventname";
     String PROPERTY_EVENT_REGISTRY_IN_PARAMETERS = "eventinparameters";
     String PROPERTY_EVENT_REGISTRY_OUT_PARAMETERS = "eventoutparameters";
     String PROPERTY_EVENT_REGISTRY_CORRELATION_PARAMETERS = "eventcorrelationparameters";
+    String START_EVENT_CORRELATION_CONFIGURATION = "startEventCorrelationConfiguration";
     String PROPERTY_EVENT_REGISTRY_CHANNEL_KEY = "channelkey";
     String PROPERTY_EVENT_REGISTRY_CHANNEL_NAME = "channelname";
     String PROPERTY_EVENT_REGISTRY_CHANNEL_TYPE = "channeltype";

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/constants/CmmnStencilConstants.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/constants/CmmnStencilConstants.java
@@ -214,6 +214,7 @@ public interface CmmnStencilConstants {
     String PROPERTY_EVENT_REGISTRY_IN_PARAMETERS = "eventinparameters";
     String PROPERTY_EVENT_REGISTRY_OUT_PARAMETERS = "eventoutparameters";
     String PROPERTY_EVENT_REGISTRY_CORRELATION_PARAMETERS = "eventcorrelationparameters";
+    String PROPERTY_EVENT_REGISTRY_CORRELATION_PARAMETERS_AS_REFERENCE = "correcalationparamsasuniquereference";
     String START_EVENT_CORRELATION_CONFIGURATION = "startEventCorrelationConfiguration";
     String PROPERTY_EVENT_REGISTRY_CHANNEL_KEY = "channelkey";
     String PROPERTY_EVENT_REGISTRY_CHANNEL_NAME = "channelname";

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverter.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverter.java
@@ -203,11 +203,14 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
         String eventType = caseModel.getStartEventType();
         if (StringUtils.isNotEmpty(eventType)) {
             propertiesNode.put(PROPERTY_EVENT_REGISTRY_EVENT_KEY, eventType);
-            setPropertyValue(START_EVENT_CORRELATION_CONFIGURATION,getExtensionValue(START_EVENT_CORRELATION_CONFIGURATION, caseModel), propertiesNode);
             
             setPropertyValue(PROPERTY_EVENT_REGISTRY_EVENT_NAME, getExtensionValue("eventName", caseModel), propertiesNode);
             CmmnModelJsonConverterUtil.addEventOutParameters(caseModel.getExtensionElements().get("eventOutParameter"), propertiesNode, objectMapper);
             CmmnModelJsonConverterUtil.addEventCorrelationParameters(caseModel.getExtensionElements().get("eventCorrelationParameter"), propertiesNode, objectMapper);
+            if (StringUtils.isNotEmpty(getExtensionValue(START_EVENT_CORRELATION_CONFIGURATION, caseModel)) && "storeAsUniqueReferenceId".equals(
+                    getExtensionValue(START_EVENT_CORRELATION_CONFIGURATION, caseModel))) {
+                propertiesNode.put(PROPERTY_EVENT_REGISTRY_CORRELATION_PARAMETERS_AS_REFERENCE, true);
+            }
             
             setPropertyValue(PROPERTY_EVENT_REGISTRY_CHANNEL_KEY, getExtensionValue("channelKey", caseModel), propertiesNode);
             setPropertyValue(PROPERTY_EVENT_REGISTRY_CHANNEL_NAME, getExtensionValue("channelName", caseModel), propertiesNode);
@@ -385,6 +388,9 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
             addFlowableExtensionElementWithValue("eventName", CmmnJsonConverterUtil.getPropertyValueAsString(PROPERTY_EVENT_REGISTRY_EVENT_NAME, modelNode), caseModel);
             CmmnModelJsonConverterUtil.convertJsonToOutParameters(modelNode, caseModel);
             CmmnModelJsonConverterUtil.convertJsonToCorrelationParameters(modelNode, "eventCorrelationParameter", caseModel);
+            if (CmmnJsonConverterUtil.getPropertyValueAsBoolean(PROPERTY_EVENT_REGISTRY_CORRELATION_PARAMETERS_AS_REFERENCE, modelNode)) {
+                addFlowableExtensionElementWithValue(START_EVENT_CORRELATION_CONFIGURATION, "storeAsUniqueReferenceId", caseModel);
+            }
             
             addFlowableExtensionElementWithValue("channelKey", CmmnJsonConverterUtil.getPropertyValueAsString(PROPERTY_EVENT_REGISTRY_CHANNEL_KEY, modelNode), caseModel);
             addFlowableExtensionElementWithValue("channelName", CmmnJsonConverterUtil.getPropertyValueAsString(PROPERTY_EVENT_REGISTRY_CHANNEL_NAME, modelNode), caseModel);
@@ -407,10 +413,6 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
                 addFlowableExtensionElementWithValue("keyDetectionValue", jsonPointer, caseModel);
             }
         }
-
-
-        String startEventCorrelationConfiguration = CmmnJsonConverterUtil.getPropertyValueAsString(START_EVENT_CORRELATION_CONFIGURATION, modelNode);
-        addFlowableExtensionElementWithValue(START_EVENT_CORRELATION_CONFIGURATION, startEventCorrelationConfiguration, caseModel);
 
         JsonNode planModelShape = shapesArrayNode.get(0);
 

--- a/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverter.java
+++ b/modules/flowable-cmmn-json-converter/src/main/java/org/flowable/cmmn/editor/json/converter/CmmnJsonConverter.java
@@ -202,7 +202,8 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
         
         String eventType = caseModel.getStartEventType();
         if (StringUtils.isNotEmpty(eventType)) {
-            propertiesNode.put(PROPERTY_EVENT_TYPE, eventType);
+            propertiesNode.put(PROPERTY_EVENT_REGISTRY_EVENT_KEY, eventType);
+            setPropertyValue(START_EVENT_CORRELATION_CONFIGURATION,getExtensionValue(START_EVENT_CORRELATION_CONFIGURATION, caseModel), propertiesNode);
             
             setPropertyValue(PROPERTY_EVENT_REGISTRY_EVENT_NAME, getExtensionValue("eventName", caseModel), propertiesNode);
             CmmnModelJsonConverterUtil.addEventOutParameters(caseModel.getExtensionElements().get("eventOutParameter"), propertiesNode, objectMapper);
@@ -406,6 +407,10 @@ public class CmmnJsonConverter implements EditorJsonConstants, CmmnStencilConsta
                 addFlowableExtensionElementWithValue("keyDetectionValue", jsonPointer, caseModel);
             }
         }
+
+
+        String startEventCorrelationConfiguration = CmmnJsonConverterUtil.getPropertyValueAsString(START_EVENT_CORRELATION_CONFIGURATION, modelNode);
+        addFlowableExtensionElementWithValue(START_EVENT_CORRELATION_CONFIGURATION, startEventCorrelationConfiguration, caseModel);
 
         JsonNode planModelShape = shapesArrayNode.get(0);
 

--- a/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/i18n/en.json
+++ b/modules/flowable-ui/flowable-ui-modeler-frontend/src/main/resources/static/modeler/i18n/en.json
@@ -1901,6 +1901,12 @@
             "TITLE" : "Store result variable transiently",
             "DESCRIPTION" : "Flag that marks that the result of the expression will not be persisted at the end of the database transaction."
           }
+        },
+        "EVENTREGISTRYCORRELATIONCONFIGURATIONPACKAGE" : {
+          "CORRELATIONPARAMSASUNIQUEREFERENCE" : {
+            "TITLE" : "Use correlation parameters as reference",
+            "DESCRIPTION" : "Flag that marks that start event correlation parameters will be stored as unique reference id for the case."
+          }
         }
       },
       "STENCILS" : {

--- a/modules/flowable-ui/flowable-ui-modeler-logic/src/main/resources/stencilset_cmmn.json
+++ b/modules/flowable-ui/flowable-ui-modeler-logic/src/main/resources/stencilset_cmmn.json
@@ -1152,6 +1152,16 @@
         "description" : "CMMN.PROPERTYPACKAGES.AVAILABLECONDITIONPACKAGE.AVAILABLECONDITION.DESCRIPTION",
         "popular" : true
       }]
+    }, {
+      "name" : "eventregistrycorrelationconfigurationpackage",
+      "properties" : [ {
+        "id" : "correcalationparamsasuniquereference",
+        "type" : "Boolean",
+        "title" : "CMMN.PROPERTYPACKAGES.EVENTREGISTRYCORRELATIONCONFIGURATIONPACKAGE.CORRELATIONPARAMSASUNIQUEREFERENCE.TITLE",
+        "value" : "",
+        "description" : "CMMN.PROPERTYPACKAGES.EVENTREGISTRYCORRELATIONCONFIGURATIONPACKAGE.CORRELATIONPARAMSASUNIQUEREFERENCE.DESCRIPTION",
+        "popular" : true
+      }]
     }
   ],
   "stencils" : [ {
@@ -1164,7 +1174,7 @@
     "groups" : [ "CMMN.STENCILS.GROUPS.DIAGRAM" ],
     "mayBeRoot" : true,
     "hide" : true,
-    "propertyPackages" : [ "case_idpackage", "namepackage", "documentationpackage", "case_initiatorvariablenamepackage", "case_authorpackage", "case_versionpackage", "case_namespacepackage", "eventregistryeventpackage", "eventregistryeventnamepackage", "eventregistryoutparameterspackage", "eventregistrycorrelationpackage", "eventregistrychannelkeypackage", "eventregistrychannelnamepackage", "eventregistrychanneltypepackage", "eventregistrychanneldestinationpackage", "eventregistrykeydetectionfixedvaluepackage", "eventregistrykeydetectionjsonfieldpackage", "eventregistrykeydetectionjsonpointerpackage"],
+    "propertyPackages" : [ "case_idpackage", "namepackage", "documentationpackage", "case_initiatorvariablenamepackage", "case_authorpackage", "case_versionpackage", "case_namespacepackage", "eventregistryeventpackage", "eventregistryeventnamepackage", "eventregistryoutparameterspackage", "eventregistrycorrelationpackage", "eventregistrycorrelationconfigurationpackage", "eventregistrychannelkeypackage", "eventregistrychannelnamepackage", "eventregistrychanneltypepackage", "eventregistrychanneldestinationpackage", "eventregistrykeydetectionfixedvaluepackage", "eventregistrykeydetectionjsonfieldpackage", "eventregistrykeydetectionjsonpointerpackage"],
     "hiddenPropertyPackages" : [ ],
     "roles" : [ ]
   }, {


### PR DESCRIPTION
Issue:
* After cmmn diagram import case startEventCorrelationConfiguration value is dropped
* Modeler UI do not support startEventCorrelationConfiguration field for this value configuration
* On import case eventType is mapped to wrong UI element is not visible on UI

Cause:
* Wrong mapping for eventType
* Missing implementation for startEventCorrelationConfiguration support

Solution:

* Fixed eventType mapping
* Implemented startEventCorrelationConfiguration import/export. As far startEventCorrelationConfiguration supports only "storeAsUniqueReferenceId"(for other passed values do nothing), in UI added checkbox to select this option and based on that startEventCorrelationConfiguration value is imported and exported

Unit tests: NA
Documentation: NA