### PR TITLE
Add missing caseDefinitionId for case migration

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/CaseInstanceMigrationCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/CaseInstanceMigrationCmd.java
@@ -59,7 +59,7 @@ public class CaseInstanceMigrationCmd implements Command<Void> {
             throw new FlowableException("Must specify a case instance migration document to migrate");
         }
         
-        this.caseDefinitionId = null;
+        this.caseDefinitionId = caseDefinitionId;
         this.caseInstanceMigrationDocument = caseInstanceMigrationDocument;
         this.cmmnEngineConfiguration = cmmnEngineConfiguration;
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/CaseInstanceMigrationValidationCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/CaseInstanceMigrationValidationCmd.java
@@ -58,7 +58,7 @@ public class CaseInstanceMigrationValidationCmd implements Command<CaseInstanceM
         if (caseInstanceMigrationDocument == null) {
             throw new FlowableException("Must specify a case instance migration document to migrate");
         }
-        this.caseDefinitionId = null;
+        this.caseDefinitionId = caseDefinitionId;
         this.caseInstanceMigrationDocument = caseInstanceMigrationDocument;
         this.cmmnEngineConfiguration = cmmnEngineConfiguration;
     }


### PR DESCRIPTION
I tried to apply a case migration to all instances based on a specific case definition. Found out it wasn't working if I use the approach with just the case definition id – it's checking if the case definition is null, but then it's just setting it to null.

#### Check List:
* Unit tests: NO
* Documentation: NO
