### PR TITLE
Update HikariCP to version 4.0.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
 		<junit.version>4.13.2</junit.version>
 		<junit.jupiter.version>5.8.2</junit.jupiter.version>
-		<hikari.version>3.4.5</hikari.version>
+		<hikari.version>4.0.3</hikari.version>
 		<maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
 		<maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
 		<mockito.version>4.0.0</mockito.version>


### PR DESCRIPTION
This version is also used by Spring Boot 2.6.x.

Version 5 can not be used, because it requires Java 11.
