### PR TITLE
Update to Spring Security 5.6.2

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.33          MIT License
 org.slf4j                       slf4j-api                   1.7.33          MIT License
 org.slf4j                       slf4j-log4j12               1.7.33          MIT License
-org.springframework             spring-beans                5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.15          The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.16          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.6.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.6.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.6.2           The Apache Software License, Version 2.0

--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.15          The 
 org.springframework             spring-core                 5.3.15          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.15          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.15          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.6.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.6.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.6.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.6.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.6.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.6.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.6.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.6.2           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -133,9 +133,9 @@ org.liquibase                   liquibase-core              4.5.0           Apac
 org.mybatis                     mybatis                     3.5.9           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              2.0.7           The Apache Software License, Version 2.0
 org.mvel                        mvel2                       2.2.6.Final     The Apache Software License, Version 2.0
-org.slf4j                       jcl-over-slf4j              1.7.33          MIT License
-org.slf4j                       slf4j-api                   1.7.33          MIT License
-org.slf4j                       slf4j-log4j12               1.7.33          MIT License
+org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
+org.slf4j                       slf4j-api                   1.7.36          MIT License
+org.slf4j                       slf4j-log4j12               1.7.36          MIT License
 org.springframework             spring-beans                5.3.16          The Apache Software License, Version 2.0
 org.springframework             spring-core                 5.3.16          The Apache Software License, Version 2.0
 org.springframework             spring-context              5.3.16          The Apache Software License, Version 2.0

--- a/modules/flowable-osgi/pom.xml
+++ b/modules/flowable-osgi/pom.xml
@@ -96,19 +96,19 @@
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-junit4</artifactId>
-            <version>4.11.0</version>
+            <version>4.13.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-link-mvn</artifactId>
-            <version>4.11.0</version>
+            <version>4.13.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>
             <artifactId>pax-url-aether</artifactId>
-            <version>2.5.4</version>
+            <version>2.6.11</version>
             <type>bundle</type>
             <scope>test</scope>
         </dependency>
@@ -129,25 +129,25 @@
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-container-native</artifactId>
-            <version>4.11.0</version>
+            <version>4.13.5</version>
             <scope>test</scope>
         </dependency>
        <dependency>
             <groupId>org.apache.aries.blueprint</groupId>
             <artifactId>org.apache.aries.blueprint.core</artifactId>
-            <version>1.6.2</version>
+            <version>1.10.3</version>
             <scope>test</scope>
         </dependency>
        <dependency>
             <groupId>org.apache.aries.proxy</groupId>
             <artifactId>org.apache.aries.proxy</artifactId>
-            <version>1.0.1</version>
+            <version>1.1.12</version>
             <scope>test</scope>
         </dependency>
        <dependency>
             <groupId>org.apache.aries</groupId>
             <artifactId>org.apache.aries.util</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-osgi/pom.xml
+++ b/modules/flowable-osgi/pom.xml
@@ -96,19 +96,19 @@
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-junit4</artifactId>
-            <version>4.13.5</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-link-mvn</artifactId>
-            <version>4.13.5</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>
             <artifactId>pax-url-aether</artifactId>
-            <version>2.6.11</version>
+            <version>2.5.4</version>
             <type>bundle</type>
             <scope>test</scope>
         </dependency>
@@ -129,25 +129,25 @@
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-container-native</artifactId>
-            <version>4.13.5</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
        <dependency>
             <groupId>org.apache.aries.blueprint</groupId>
             <artifactId>org.apache.aries.blueprint.core</artifactId>
-            <version>1.10.3</version>
+            <version>1.6.2</version>
             <scope>test</scope>
         </dependency>
        <dependency>
             <groupId>org.apache.aries.proxy</groupId>
             <artifactId>org.apache.aries.proxy</artifactId>
-            <version>1.1.12</version>
+            <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
        <dependency>
             <groupId>org.apache.aries</groupId>
             <artifactId>org.apache.aries.util</artifactId>
-            <version>1.1.3</version>
+            <version>1.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-osgi/src/test/java/org/flowable/osgi/blueprint/BlueprintBasicTest.java
+++ b/modules/flowable-osgi/src/test/java/org/flowable/osgi/blueprint/BlueprintBasicTest.java
@@ -126,7 +126,7 @@ public class BlueprintBasicTest {
                 mavenBundle().groupId("com.h2database").artifactId("h2").versionAsInProject(),
                 mavenBundle().groupId("org.mybatis").artifactId("mybatis").versionAsInProject(),
                 mavenBundle().groupId("org.liquibase").artifactId("liquibase-core").versionAsInProject(),
-                mavenBundle().groupId("org.slf4j").artifactId("slf4j-log4j12").versionAsInProject().noStart(),
+                mavenBundle().groupId("org.slf4j").artifactId("slf4j-reload4j").versionAsInProject().noStart(),
                 mavenBundle().groupId("org.junit.jupiter").artifactId("junit-jupiter-api").versionAsInProject(),
                 mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.fileinstall").versionAsInProject(),
                 mavenBundle().groupId("org.apache.aries.blueprint").artifactId("org.apache.aries.blueprint.core").versionAsInProject(),

--- a/pom.xml
+++ b/pom.xml
@@ -15,17 +15,17 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.6.3</spring.boot.version>
-		<spring.framework.version>5.3.15</spring.framework.version>
-		<spring.security.version>5.6.1</spring.security.version>
+		<spring.framework.version>5.3.16</spring.framework.version>
+		<spring.security.version>5.6.2</spring.security.version>
 		<spring.amqp.version>2.4.2</spring.amqp.version>
 		<spring.kafka.version>2.8.1</spring.kafka.version>
-		<reactor-netty.version>1.0.14</reactor-netty.version>
+		<reactor-netty.version>1.0.16</reactor-netty.version>
 		<jackson.version>2.13.1</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>3.14.0</camel.version>
 		<cxf.version>3.4.2</cxf.version>
-		<slf4j.version>1.7.33</slf4j.version>
+		<slf4j.version>1.7.36</slf4j.version>
 		<groovy.version>4.0.0</groovy.version>
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 


### PR DESCRIPTION
Release Notes:  https://github.com/spring-projects/spring-security/releases/tag/5.6.2

Supersedes update to Spring Framework: https://github.com/flowable/flowable-engine/pull/3218


