### PR TITLE
PropertyPlaceholderConfigurer  Deprecated. as of 5.2

### DIFF
--- a/modules/flowable-engine-common/pom.xml
+++ b/modules/flowable-engine-common/pom.xml
@@ -144,6 +144,10 @@
             <artifactId>spring-beans</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
@@ -195,6 +199,7 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/cfg/BeansConfigurationHelper.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/cfg/BeansConfigurationHelper.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,9 +19,9 @@ import java.util.Collections;
 
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
-import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
@@ -41,7 +41,7 @@ public class BeansConfigurationHelper {
         // Do not eagerly initialize FactorBeans when getting BeanFactoryPostProcessor beans
         Collection<BeanFactoryPostProcessor> factoryPostProcessors = beanFactory.getBeansOfType(BeanFactoryPostProcessor.class, true, false).values();
         if (factoryPostProcessors.isEmpty()) {
-            factoryPostProcessors = Collections.singleton(new PropertyPlaceholderConfigurer());
+            factoryPostProcessors = Collections.singleton(new PropertySourcesPlaceholderConfigurer());
         }
         for (BeanFactoryPostProcessor factoryPostProcessor : factoryPostProcessors) {
             factoryPostProcessor.postProcessBeanFactory(beanFactory);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/cfg/BeansConfigurationHelper.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/cfg/BeansConfigurationHelper.java
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.flowable.common.engine.impl.cfg;
 
 import java.io.InputStream;


### PR DESCRIPTION
…tySourcesPlaceholderConfigurer instead which is more flexible through taking advantage of the Environment and PropertySource mechanisms.

#### Check List:
* Unit tests:  NO 
* Documentation: YES 
Deprecated. as of 5.2; use org.springframework.context.support.PropertySourcesPlaceholderConfigurer instead which is more flexible through taking advantage of the Environment and PropertySource mechanisms.
