### PR TITLE
Upgrade to Spring Boot 2.6.4

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -133,25 +133,25 @@ org.liquibase                   liquibase-core              4.5.0           Apac
 org.mybatis                     mybatis                     3.5.9           The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              2.0.7           The Apache Software License, Version 2.0
 org.mvel                        mvel2                       2.2.6.Final     The Apache Software License, Version 2.0
-org.slf4j                       jcl-over-slf4j              1.7.33          MIT License
-org.slf4j                       slf4j-api                   1.7.33          MIT License
-org.slf4j                       slf4j-log4j12               1.7.33          MIT License
-org.springframework             spring-beans                5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.15          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.15          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.6.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.6.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.6.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.6.1           The Apache Software License, Version 2.0
+org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
+org.slf4j                       slf4j-api                   1.7.36          MIT License
+org.slf4j                       slf4j-log4j12               1.7.36          MIT License
+org.springframework             spring-beans                5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.16          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.16          The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.6.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.6.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.6.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.6.2           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/modules/flowable-app-engine-rest/pom.xml
+++ b/modules/flowable-app-engine-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.45.v20220203</jetty.version>
         <flowable.artifact>
             org.flowable.app.rest
         </flowable.artifact>

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.44.v20210927</jetty.version>
+    <jetty.version>9.4.45.v20220203</jetty.version>
     <flowable.artifact>
       org.flowable.cmmn.rest
     </flowable.artifact>

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jetty.version>9.4.44.v20210927</jetty.version>
+		<jetty.version>9.4.45.v20220203</jetty.version>
 		<flowable.artifact>
 			org.flowable.content.rest
 		</flowable.artifact>

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.45.v20220203</jetty.version>
         <flowable.artifact>
             org.flowable.dmn.rest.service
         </flowable.artifact>

--- a/modules/flowable-event-registry-rest/pom.xml
+++ b/modules/flowable-event-registry-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.45.v20220203</jetty.version>
         <flowable.artifact>
             org.flowable.eventregistry.rest
         </flowable.artifact>

--- a/modules/flowable-event-registry-spring/pom.xml
+++ b/modules/flowable-event-registry-spring/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>5.16.3</version>
+            <version>5.16.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.45.v20220203</jetty.version>
         <flowable.artifact>
             org.flowable.form.rest
         </flowable.artifact>

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.45.v20220203</jetty.version>
         <flowable.osgi.import.pkg>*</flowable.osgi.import.pkg>
         <flowable.artifact>
             org.flowable.http

--- a/modules/flowable-jms-spring-executor/pom.xml
+++ b/modules/flowable-jms-spring-executor/pom.xml
@@ -142,13 +142,13 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
-            <version>5.16.3</version>
+            <version>5.16.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>5.16.3</version>
+            <version>5.16.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-osgi/src/test/java/org/flowable/osgi/blueprint/BlueprintBasicTest.java
+++ b/modules/flowable-osgi/src/test/java/org/flowable/osgi/blueprint/BlueprintBasicTest.java
@@ -126,7 +126,7 @@ public class BlueprintBasicTest {
                 mavenBundle().groupId("com.h2database").artifactId("h2").versionAsInProject(),
                 mavenBundle().groupId("org.mybatis").artifactId("mybatis").versionAsInProject(),
                 mavenBundle().groupId("org.liquibase").artifactId("liquibase-core").versionAsInProject(),
-                mavenBundle().groupId("org.slf4j").artifactId("slf4j-log4j12").versionAsInProject().noStart(),
+                mavenBundle().groupId("org.slf4j").artifactId("slf4j-reload4j").versionAsInProject().noStart(),
                 mavenBundle().groupId("org.junit.jupiter").artifactId("junit-jupiter-api").versionAsInProject(),
                 mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.fileinstall").versionAsInProject(),
                 mavenBundle().groupId("org.apache.aries.blueprint").artifactId("org.apache.aries.blueprint.core").versionAsInProject(),

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.45.v20220203</jetty.version>
         <flowable.artifact>
             org.flowable.rest
         </flowable.artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -15,17 +15,17 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.6.3</spring.boot.version>
-		<spring.framework.version>5.3.15</spring.framework.version>
-		<spring.security.version>5.6.1</spring.security.version>
+		<spring.framework.version>5.3.16</spring.framework.version>
+		<spring.security.version>5.6.2</spring.security.version>
 		<spring.amqp.version>2.4.2</spring.amqp.version>
-		<spring.kafka.version>2.8.1</spring.kafka.version>
-		<reactor-netty.version>1.0.14</reactor-netty.version>
+		<spring.kafka.version>2.8.3</spring.kafka.version>
+		<reactor-netty.version>1.0.16</reactor-netty.version>
 		<jackson.version>2.13.1</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>3.14.0</camel.version>
 		<cxf.version>3.4.2</cxf.version>
-		<slf4j.version>1.7.33</slf4j.version>
+		<slf4j.version>1.7.36</slf4j.version>
 		<groovy.version>4.0.0</groovy.version>
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 
@@ -795,7 +795,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.6.4.Final</version>
+				<version>5.6.5.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>
@@ -1267,7 +1267,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.1.1</version>
+					<version>3.3.2</version>
 					<configuration>
 						<source>${jdk.version}</source>
 					</configuration>


### PR DESCRIPTION
Release Notes:  
Spring Boot: https://github.com/spring-projects/spring-boot/releases/tag/v2.6.4
Spring Security: https://github.com/spring-projects/spring-security/releases/tag/5.6.2
Spring Framework: : https://github.com/spring-projects/spring-framework/releases/tag/v5.3.16

Supersedes update to Spring Security: https://github.com/flowable/flowable-engine/pull/3222

