### PR TITLE
Boundary Error Event properties import issue

### DIFF
--- a/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BaseBpmnJsonConverter.java
+++ b/modules/flowable-json-converter/src/main/java/org/flowable/editor/language/json/converter/BaseBpmnJsonConverter.java
@@ -765,17 +765,18 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                 ErrorEventDefinition errorDefinition = (ErrorEventDefinition) eventDefinition;
                 if (StringUtils.isNotEmpty(errorDefinition.getErrorCode())) {
                     propertiesNode.put(PROPERTY_ERRORREF, errorDefinition.getErrorCode());
-                    if (StringUtils.isNotEmpty(errorDefinition.getErrorVariableName())) {
-                        propertiesNode.put(PROPERTY_ERROR_VARIABLE_NAME, errorDefinition.getErrorVariableName());
-                    }
-                    
-                    if (errorDefinition.getErrorVariableTransient() != null) {
-                        propertiesNode.put(PROPERTY_ERROR_VARIABLE_TRANSIENT, errorDefinition.getErrorVariableTransient());
-                    }
-                    
-                    if (errorDefinition.getErrorVariableLocalScope() != null) {
-                        propertiesNode.put(PROPERTY_ERROR_VARIABLE_LOCAL_SCOPE, errorDefinition.getErrorVariableLocalScope());
-                    }
+                }
+
+                if (StringUtils.isNotEmpty(errorDefinition.getErrorVariableName())) {
+                    propertiesNode.put(PROPERTY_ERROR_VARIABLE_NAME, errorDefinition.getErrorVariableName());
+                }
+
+                if (errorDefinition.getErrorVariableTransient() != null) {
+                    propertiesNode.put(PROPERTY_ERROR_VARIABLE_TRANSIENT, errorDefinition.getErrorVariableTransient());
+                }
+
+                if (errorDefinition.getErrorVariableLocalScope() != null) {
+                    propertiesNode.put(PROPERTY_ERROR_VARIABLE_LOCAL_SCOPE, errorDefinition.getErrorVariableLocalScope());
                 }
 
             } else if (eventDefinition instanceof SignalEventDefinition) {


### PR DESCRIPTION
Issue:
After bpmn diagram import to modeler UI Boundary Error Event properties are dropped

Cause:
Json converter implemented in that way so that if error code is not set, then all properties are ignored

Details:
Modeler export works fine and exports all properties regardless if error code is set or not. Workflow application works in the same way and regardless if error code is set or not, it uses all set properties. Issue occurs only on diagram import to modeler UI. There are two scenarios how to use boundary error event based on BpmnError code:
1. Add error code for boundary error event and flowable based on that will do navigation. For that solution multiple boundary error events are needed and this makes diagram hard to read. Negative side - all possible error codes need to have boundary event added
2. Do not add boundary error event error code, but store BpmnError error code as variable and based on that design decisions using gateways. 

Solution:

Json converted updated to match export and flowable behavior

Unit tests: NA
Documentation: NA
