### PR TITLE
add event support to the CMMN runtime, same as in the process runtime

### DIFF
--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnRuntimeService.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnRuntimeService.java
@@ -26,7 +26,13 @@ import org.flowable.cmmn.api.runtime.PlanItemInstanceTransitionBuilder;
 import org.flowable.cmmn.api.runtime.SignalEventListenerInstanceQuery;
 import org.flowable.cmmn.api.runtime.UserEventListenerInstanceQuery;
 import org.flowable.cmmn.api.runtime.VariableInstanceQuery;
+import org.flowable.common.engine.api.FlowableException;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.api.delegate.event.FlowableEvent;
+import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
+import org.flowable.common.engine.api.delegate.event.FlowableEventListener;
 import org.flowable.entitylink.api.EntityLink;
 import org.flowable.eventsubscription.api.EventSubscriptionQuery;
 import org.flowable.form.api.FormInfo;
@@ -339,4 +345,41 @@ public interface CmmnRuntimeService {
      */
     void updateBusinessStatus(String caseInstanceId, String businessStatus);
 
+    /**
+     * Adds an event-listener which will be notified of ALL events by the dispatcher.
+     *
+     * @param listenerToAdd
+     *     the listener to add
+     */
+    void addEventListener(FlowableEventListener listenerToAdd);
+
+    /**
+     * Adds an event-listener which will only be notified when an event occurs, which type is in the given types.
+     *
+     * @param listenerToAdd
+     *     the listener to add
+     * @param types
+     *     types of events the listener should be notified for
+     */
+    void addEventListener(FlowableEventListener listenerToAdd, FlowableEngineEventType... types);
+
+    /**
+     * Removes the given listener from this dispatcher. The listener will no longer be notified, regardless of the type(s) it was registered for in the first place.
+     *
+     * @param listenerToRemove
+     *     listener to remove
+     */
+    void removeEventListener(FlowableEventListener listenerToRemove);
+
+    /**
+     * Dispatches the given event to any listeners that are registered.
+     *
+     * @param event
+     *     event to dispatch.
+     * @throws FlowableException
+     *     if an exception occurs when dispatching the event or when the {@link FlowableEventDispatcher} is disabled.
+     * @throws FlowableIllegalArgumentException
+     *     when the given event is not suitable for dispatching.
+     */
+    void dispatchEvent(FlowableEvent event);
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AddEventListenerCommand.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AddEventListenerCommand.java
@@ -1,0 +1,56 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.api.delegate.event.FlowableEventListener;
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+
+/**
+ * This command is adding a listener to the event dispatcher of the case engine, either for specific event types or for all events.
+ *
+ * @author Micha Kiener
+ */
+public class AddEventListenerCommand  implements Command<Void> {
+
+    protected FlowableEventListener listener;
+    protected FlowableEngineEventType[] types;
+
+    public AddEventListenerCommand(FlowableEventListener listener, FlowableEngineEventType[] types) {
+        this.listener = listener;
+        this.types = types;
+    }
+
+    public AddEventListenerCommand(FlowableEventListener listener) {
+        super();
+        this.listener = listener;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        if (listener == null) {
+            throw new FlowableIllegalArgumentException("The listener to be registered must not be null.");
+        }
+
+        if (types != null) {
+            CommandContextUtil.getCmmnEngineConfiguration(commandContext).getEventDispatcher().addEventListener(listener, types);
+        } else {
+            CommandContextUtil.getCmmnEngineConfiguration(commandContext).getEventDispatcher().addEventListener(listener);
+        }
+
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/DispatchEventCommand.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/DispatchEventCommand.java
@@ -1,0 +1,53 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import org.flowable.cmmn.engine.CmmnEngineConfiguration;
+import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.common.engine.api.FlowableException;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.delegate.event.FlowableEvent;
+import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+
+/**
+ * This command dispatches an event within the case engine.
+ *
+ * @author Micha Kiener
+ */
+public class DispatchEventCommand implements Command<Void> {
+
+    protected FlowableEvent event;
+
+    public DispatchEventCommand(FlowableEvent event) {
+        this.event = event;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        if (event == null) {
+            throw new FlowableIllegalArgumentException("The event to be dispatched must not be null.");
+        }
+
+        CmmnEngineConfiguration cmmnEngineConfiguration = CommandContextUtil.getCmmnEngineConfiguration(commandContext);
+        FlowableEventDispatcher eventDispatcher = cmmnEngineConfiguration.getEventDispatcher();
+        if (eventDispatcher != null && eventDispatcher.isEnabled()) {
+            eventDispatcher.dispatchEvent(event, cmmnEngineConfiguration.getEngineCfgKey());
+        } else {
+            throw new FlowableException("Message dispatcher is disabled, cannot dispatch event.");
+        }
+
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveEventListenerCommand.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveEventListenerCommand.java
@@ -1,0 +1,45 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.delegate.event.FlowableEventListener;
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+
+/**
+ * This command removes an event listener from the case engine.
+ *
+ * @author Micha Kiener
+ */
+public class RemoveEventListenerCommand implements Command<Void> {
+
+    protected FlowableEventListener listener;
+
+    public RemoveEventListenerCommand(FlowableEventListener listener) {
+        super();
+        this.listener = listener;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        if (listener == null) {
+            throw new FlowableIllegalArgumentException("The event listener to be removed must not be null.");
+        }
+
+        CommandContextUtil.getCmmnEngineConfiguration(commandContext).getEventDispatcher().removeEventListener(listener);
+
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CmmnRuntimeServiceImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CmmnRuntimeServiceImpl.java
@@ -30,6 +30,7 @@ import org.flowable.cmmn.api.runtime.SignalEventListenerInstanceQuery;
 import org.flowable.cmmn.api.runtime.UserEventListenerInstanceQuery;
 import org.flowable.cmmn.api.runtime.VariableInstanceQuery;
 import org.flowable.cmmn.engine.CmmnEngineConfiguration;
+import org.flowable.cmmn.engine.impl.cmd.AddEventListenerCommand;
 import org.flowable.cmmn.engine.impl.cmd.AddIdentityLinkForCaseInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.ChangePlanItemStateCmd;
 import org.flowable.cmmn.engine.impl.cmd.CompleteCaseInstanceCmd;
@@ -37,6 +38,7 @@ import org.flowable.cmmn.engine.impl.cmd.CompleteStagePlanItemInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.DeleteCaseInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.DeleteIdentityLinkForCaseInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.DisablePlanItemInstanceCmd;
+import org.flowable.cmmn.engine.impl.cmd.DispatchEventCommand;
 import org.flowable.cmmn.engine.impl.cmd.EnablePlanItemInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.EvaluateCriteriaCmd;
 import org.flowable.cmmn.engine.impl.cmd.GetCaseVariableInstanceCmd;
@@ -55,6 +57,7 @@ import org.flowable.cmmn.engine.impl.cmd.GetStartFormModelCmd;
 import org.flowable.cmmn.engine.impl.cmd.GetVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.GetVariablesCmd;
 import org.flowable.cmmn.engine.impl.cmd.HasCaseInstanceVariableCmd;
+import org.flowable.cmmn.engine.impl.cmd.RemoveEventListenerCommand;
 import org.flowable.cmmn.engine.impl.cmd.RemoveLocalVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveLocalVariablesCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveVariableCmd;
@@ -72,6 +75,9 @@ import org.flowable.cmmn.engine.impl.cmd.StartPlanItemInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.TerminateCaseInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.TerminatePlanItemInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.TriggerPlanItemInstanceCmd;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.api.delegate.event.FlowableEvent;
+import org.flowable.common.engine.api.delegate.event.FlowableEventListener;
 import org.flowable.common.engine.impl.service.CommonEngineServiceImpl;
 import org.flowable.entitylink.api.EntityLink;
 import org.flowable.eventsubscription.api.EventSubscriptionQuery;
@@ -374,6 +380,26 @@ public class CmmnRuntimeServiceImpl extends CommonEngineServiceImpl<CmmnEngineCo
 
     public void changePlanItemState(ChangePlanItemStateBuilderImpl changePlanItemStateBuilder) {
         commandExecutor.execute(new ChangePlanItemStateCmd(changePlanItemStateBuilder, configuration));
+    }
+
+    @Override
+    public void addEventListener(FlowableEventListener listenerToAdd) {
+        commandExecutor.execute(new AddEventListenerCommand(listenerToAdd));
+    }
+
+    @Override
+    public void addEventListener(FlowableEventListener listenerToAdd, FlowableEngineEventType... types) {
+        commandExecutor.execute(new AddEventListenerCommand(listenerToAdd, types));
+    }
+
+    @Override
+    public void removeEventListener(FlowableEventListener listenerToRemove) {
+        commandExecutor.execute(new RemoveEventListenerCommand(listenerToRemove));
+    }
+
+    @Override
+    public void dispatchEvent(FlowableEvent event) {
+        commandExecutor.execute(new DispatchEventCommand(event));
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/event/CmmnRuntimeEventListenerSupportTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/event/CmmnRuntimeEventListenerSupportTest.java
@@ -1,0 +1,153 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.flowable.cmmn.api.event.FlowableCaseStartedEvent;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.flowable.common.engine.api.delegate.event.AbstractFlowableEventListener;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEvent;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.api.delegate.event.FlowableEvent;
+import org.flowable.common.engine.api.delegate.event.FlowableEventType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * This test is using the event support on the CMMN runtime service level.
+ *
+ * @author Micha Kiener
+ */
+public class CmmnRuntimeEventListenerSupportTest extends FlowableCmmnTestCase {
+
+    protected TestEventListener allEventListener;
+    protected TestEventListener caseStartedEventListener;
+
+    @Before
+    public void setUp() {
+        allEventListener = new TestEventListener();
+        caseStartedEventListener = new TestEventListener();
+        cmmnRuntimeService.addEventListener(allEventListener);
+        cmmnRuntimeService.addEventListener(caseStartedEventListener, FlowableEngineEventType.CASE_STARTED);
+    }
+
+    @After
+    public void tearDown() {
+        if (allEventListener != null) {
+            cmmnRuntimeService.removeEventListener(allEventListener);
+            cmmnRuntimeService.removeEventListener(caseStartedEventListener);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    public void testCaseInstanceStartEvents() {
+        List<FlowableEvent> events = new ArrayList<>();
+        allEventListener.eventConsumer = (flowableEvent) -> {
+            // we need to check for a case started event, as this listener will receive all events
+            if (flowableEvent instanceof FlowableCaseStartedEvent) {
+                events.add(flowableEvent);
+            }
+        };
+        caseStartedEventListener.eventConsumer = (flowableEvent) -> {
+            // this listener will only receive case started events as it was registered using the event type
+            events.add(flowableEvent);
+        };
+
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .businessKey("business key")
+                .name("name")
+                .start();
+
+        assertThat(events)
+            .extracting(FlowableEvent::getType)
+            .containsExactly(FlowableEngineEventType.CASE_STARTED, FlowableEngineEventType.CASE_STARTED);
+    }
+
+    @Test
+    public void testDispatchingEvent() {
+        List<FlowableEvent> events = new ArrayList<>();
+        allEventListener.eventConsumer = (flowableEvent) -> {
+            events.add(flowableEvent);
+        };
+        caseStartedEventListener.eventConsumer = (flowableEvent) -> {
+            // this listener must not catch the event, as it was registered using the case started event type
+            events.add(flowableEvent);
+        };
+
+        cmmnRuntimeService.dispatchEvent(new TestEvent());
+
+        assertThat(events).singleElement().isInstanceOf(TestEvent.class);
+    }
+
+    private static class TestEventListener extends AbstractFlowableEventListener {
+        private Consumer<FlowableEvent> eventConsumer;
+
+        @Override
+        public void onEvent(FlowableEvent event) {
+            if (eventConsumer != null) {
+                eventConsumer.accept(event);
+            }
+        }
+
+        @Override
+        public boolean isFailOnException() {
+            return true;
+        }
+    }
+
+    private static class TestEvent implements FlowableEngineEvent {
+
+        @Override
+        public String getExecutionId() {
+            return null;
+        }
+        @Override
+        public String getProcessInstanceId() {
+            return null;
+        }
+        @Override
+        public String getProcessDefinitionId() {
+            return null;
+        }
+        @Override
+        public String getScopeType() {
+            return null;
+        }
+        @Override
+        public String getScopeId() {
+            return null;
+        }
+        @Override
+        public String getSubScopeId() {
+            return null;
+        }
+        @Override
+        public String getScopeDefinitionId() {
+            return null;
+        }
+        @Override
+        public FlowableEventType getType() {
+            return () -> "TestEvent";
+        }
+    }
+
+}


### PR DESCRIPTION
Add support to register and remove event listeners directly through the CMMN runtime service as well as dispatching an event.

#### Check List:
* Unit tests: YES
* Documentation: NO
