### PR TITLE
Upgrade to Spring Boot 2.6.6

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
 org.slf4j                       slf4j-api                   1.7.36          MIT License
 org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.17          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.17          The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.18          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.18          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.6.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.6.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.6.2           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.6.5</spring.boot.version>
-		<spring.framework.version>5.3.17</spring.framework.version>
+		<spring.boot.version>2.6.6</spring.boot.version>
+		<spring.framework.version>5.3.18</spring.framework.version>
 		<spring.security.version>5.6.2</spring.security.version>
 		<spring.amqp.version>2.4.3</spring.amqp.version>
 		<spring.kafka.version>2.8.4</spring.kafka.version>


### PR DESCRIPTION
Security Issue

Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.6.6

See: https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement

Fixes:  https://tanzu.vmware.com/security/cve-2022-22965

