### PR TITLE
add support for stage starting and ending events

### DIFF
--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/event/FlowableCaseStageEndedEvent.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/event/FlowableCaseStageEndedEvent.java
@@ -1,0 +1,48 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.api.event;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEntityEvent;
+
+
+/**
+ * An event representing a CMMN case stage being ended either manually through termination or with an exit sentry or by completing it.
+ *
+ * @author Micha Kiener
+ */
+public interface FlowableCaseStageEndedEvent extends FlowableEngineEntityEvent {
+    String ENDING_STATE_COMPLETED = PlanItemInstanceState.COMPLETED;
+    String ENDING_STATE_TERMINATED = PlanItemInstanceState.TERMINATED;
+
+    /**
+     * Returns the ending state of the case stage which can be {@link #ENDING_STATE_COMPLETED} or {@link #ENDING_STATE_TERMINATED}.
+     * @return the ending state of the stage
+     */
+    String getEndingState();
+
+    /**
+     * Returns the case instance the stage belongs to.
+     * @return the case instance
+     */
+    CaseInstance getCaseInstance();
+
+    /**
+     * Overwritten in order to return the stage plan item instance.
+     * @return the stage plan item instance
+     */
+    @Override
+    PlanItemInstance getEntity();
+}

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/event/FlowableCaseStageStartedEvent.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/event/FlowableCaseStageStartedEvent.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.api.event;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEntityEvent;
+
+/**
+ * An event representing a CMMN case stage being started.
+ *
+ * @author Micha Kiener
+ */
+public interface FlowableCaseStageStartedEvent extends FlowableEngineEntityEvent {
+
+    /**
+     * Returns the case instance the stage belongs to.
+     * @return the case instance
+     */
+    CaseInstance getCaseInstance();
+
+    /**
+     * Overwritten in order to return the stage plan item instance.
+     * @return the stage plan item instance
+     */
+    @Override
+    PlanItemInstance getEntity();
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CmmnOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CmmnOperation.java
@@ -57,6 +57,21 @@ public abstract class CmmnOperation implements Runnable {
      */
     public abstract String getCaseInstanceId();
 
+    /**
+     * Returns the case instance entity using the entity manager by getting the case instance id through {@link #getCaseInstanceId()} and returning
+     * the case instance entity accordingly. If there is no id provided, this method will return null, but not throw an exception.
+     *
+     * @return the case instance entity according the case instance id involved in this operation or null, if there is none involved
+     */
+    protected CaseInstanceEntity getCaseInstance() {
+        String caseId = getCaseInstanceId();
+        if (caseId == null) {
+            return null;
+        }
+
+        return CommandContextUtil.getCaseInstanceEntityManager(commandContext).findById(caseId);
+    }
+
     protected Stage getStage(PlanItemInstanceEntity planItemInstanceEntity) {
         PlanItemDefinition planItemDefinition = planItemInstanceEntity.getPlanItem().getPlanItemDefinition();
         if (planItemDefinition instanceof Stage) {
@@ -104,7 +119,7 @@ public abstract class CmmnOperation implements Runnable {
                         stagePlanItemInstanceEntity, tenantId, newPlanItemInstances);
                 }
 
-            } else if (planItem.getPlanItemDefinition() != null && planItem.getPlanItemDefinition() instanceof PlanFragment){
+            } else if (planItem.getPlanItemDefinition() != null && planItem.getPlanItemDefinition() instanceof PlanFragment) {
                 // Some plan items (plan fragments) exist as plan item, but not as plan item instance
                 PlanFragment planFragment = (PlanFragment) planItem.getPlanItemDefinition();
                 List<PlanItem> planFragmentPlanItems = planFragment.getDirectChildPlanItemsWithLifecycleEnabled();

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CompletePlanItemInstanceOperation.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/agenda/operation/CompletePlanItemInstanceOperation.java
@@ -12,11 +12,15 @@
  */
 package org.flowable.cmmn.engine.impl.agenda.operation;
 
+import org.flowable.cmmn.api.event.FlowableCaseStageEndedEvent;
 import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
+import org.flowable.cmmn.engine.impl.event.FlowableCmmnEventBuilder;
 import org.flowable.cmmn.engine.impl.persistence.entity.PlanItemInstanceEntity;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
 import org.flowable.cmmn.model.PlanItemTransition;
+import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 
 /**
  * @author Joram Barrez
@@ -57,8 +61,15 @@ public class CompletePlanItemInstanceOperation extends AbstractMovePlanItemInsta
         if (isStage(planItemInstanceEntity)) {
             // terminate any remaining child plan items (e.g. in enabled / available state), but don't complete them as it might lead
             // into wrong behavior resulting from it (e.g. triggering some follow-up actions on that completion event) and it will leave
-            // such implicitly completed plan items in complete state although they were never explicitly completed
+            // such implicitly completed plan items in complete state, although they were never explicitly completed
             exitChildPlanItemInstances(PlanItemTransition.COMPLETE, null, null);
+
+            // create stage ended with completion state event
+            FlowableEventDispatcher eventDispatcher = CommandContextUtil.getCmmnEngineConfiguration(commandContext).getEventDispatcher();
+            if (eventDispatcher != null && eventDispatcher.isEnabled()) {
+                eventDispatcher.dispatchEvent(FlowableCmmnEventBuilder.createStageEndedEvent(getCaseInstance(), planItemInstanceEntity,
+                        FlowableCaseStageEndedEvent.ENDING_STATE_COMPLETED), EngineConfigurationConstants.KEY_CMMN_ENGINE_CONFIG);
+            }
         }
 
         planItemInstanceEntity.setEndedTime(getCurrentTime(commandContext));

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/event/FlowableCaseStageEndedEventImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/event/FlowableCaseStageEndedEventImpl.java
@@ -1,0 +1,54 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.event;
+
+import org.flowable.cmmn.api.event.FlowableCaseStageEndedEvent;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.impl.event.FlowableEngineEventImpl;
+
+/**
+ * Implements a CMMN case stage ending event, holding the case and stage instances as well as the ending state of the stage.
+ *
+ * @author Micha Kiener
+ */
+public class FlowableCaseStageEndedEventImpl extends FlowableEngineEventImpl implements FlowableCaseStageEndedEvent {
+
+    protected CaseInstance caseInstance;
+    protected PlanItemInstance stageInstance;
+    protected String endingState;
+
+    public FlowableCaseStageEndedEventImpl(CaseInstance caseInstance, PlanItemInstance stageInstance, String endingState) {
+        super(FlowableEngineEventType.STAGE_ENDED, ScopeTypes.CMMN, caseInstance.getId(), stageInstance.getId(), caseInstance.getCaseDefinitionId());
+        this.caseInstance = caseInstance;
+        this.stageInstance = stageInstance;
+        this.endingState = endingState;
+    }
+
+    @Override
+    public String getEndingState() {
+        return endingState;
+    }
+
+    @Override
+    public CaseInstance getCaseInstance() {
+        return caseInstance;
+    }
+
+    @Override
+    public PlanItemInstance getEntity() {
+        return stageInstance;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/event/FlowableCaseStageStartedEventImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/event/FlowableCaseStageStartedEventImpl.java
@@ -1,0 +1,47 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.event;
+
+import org.flowable.cmmn.api.event.FlowableCaseStageStartedEvent;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.impl.event.FlowableEngineEventImpl;
+
+/**
+ * Implements a CMMN case stage started event, holding the case and stage instances.
+ *
+ * @author Micha Kiener
+ */
+public class FlowableCaseStageStartedEventImpl extends FlowableEngineEventImpl implements FlowableCaseStageStartedEvent {
+
+    protected CaseInstance caseInstance;
+    protected PlanItemInstance stageInstance;
+
+    public FlowableCaseStageStartedEventImpl(CaseInstance caseInstance, PlanItemInstance stageInstance) {
+        super(FlowableEngineEventType.STAGE_STARTED, ScopeTypes.CMMN, caseInstance.getId(), stageInstance.getId(), caseInstance.getCaseDefinitionId());
+        this.caseInstance = caseInstance;
+        this.stageInstance = stageInstance;
+    }
+
+    @Override
+    public CaseInstance getCaseInstance() {
+        return caseInstance;
+    }
+
+    @Override
+    public PlanItemInstance getEntity() {
+        return stageInstance;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/event/FlowableCmmnEventBuilder.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/event/FlowableCmmnEventBuilder.java
@@ -13,9 +13,11 @@
 package org.flowable.cmmn.engine.impl.event;
 
 import org.flowable.cmmn.api.event.FlowableCaseEndedEvent;
-import org.flowable.cmmn.api.event.FlowableCaseEndedEvent;
+import org.flowable.cmmn.api.event.FlowableCaseStageEndedEvent;
 import org.flowable.cmmn.api.event.FlowableCaseStartedEvent;
+import org.flowable.cmmn.api.event.FlowableCaseStageStartedEvent;
 import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEntityEvent;
 import org.flowable.common.engine.impl.event.FlowableEntityEventImpl;
@@ -33,6 +35,14 @@ public class FlowableCmmnEventBuilder {
 
     public static FlowableCaseEndedEvent createCaseEndedEvent(CaseInstance caseInstance, String endingState) {
         return new FlowableCaseEndedEventImpl(caseInstance, endingState);
+    }
+
+    public static FlowableCaseStageStartedEvent createStageStartedEvent(CaseInstance caseInstance, PlanItemInstance stageInstance) {
+        return new FlowableCaseStageStartedEventImpl(caseInstance, stageInstance);
+    }
+
+    public static FlowableCaseStageEndedEvent createStageEndedEvent(CaseInstance caseInstance, PlanItemInstance stageInstance, String endingState) {
+        return new FlowableCaseStageEndedEventImpl(caseInstance, stageInstance, endingState);
     }
 
     public static FlowableEntityEvent createTaskCreatedEvent(Task task) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/event/CaseStageEndedEventTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/event/CaseStageEndedEventTest.java
@@ -1,0 +1,293 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.flowable.cmmn.api.event.FlowableCaseStageEndedEvent;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.flowable.common.engine.api.delegate.event.AbstractFlowableEventListener;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.api.delegate.event.FlowableEvent;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Micha Kiener
+ */
+public class CaseStageEndedEventTest extends FlowableCmmnTestCase {
+    protected CustomEventListener stageListener;
+
+    @Before
+    public void setUp() {
+        stageListener = new CustomEventListener();
+        cmmnEngineConfiguration.getEventDispatcher().addEventListener(stageListener, FlowableEngineEventType.STAGE_ENDED);
+    }
+
+    @After
+    public void tearDown() {
+        if (stageListener != null) {
+            cmmnEngineConfiguration.getEventDispatcher().removeEventListener(stageListener);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/event/Case_Stage_Event_Test_Case.cmmn")
+    public void testCaseStageCompletedEvents() {
+        List<FlowableEvent> events = new ArrayList<>();
+        stageListener.eventConsumer = (flowableEvent) -> {
+            if (flowableEvent instanceof FlowableCaseStageEndedEvent) {
+                FlowableCaseStageEndedEvent caseStageEndedEvent = (FlowableCaseStageEndedEvent) flowableEvent;
+                CaseInstance eventCaseInstance = caseStageEndedEvent.getCaseInstance();
+                assertThat(caseStageEndedEvent.getProcessInstanceId()).isNull();
+                assertThat(caseStageEndedEvent.getExecutionId()).isNull();
+                assertThat(caseStageEndedEvent.getProcessDefinitionId()).isNull();
+                assertThat(caseStageEndedEvent.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+                assertThat(caseStageEndedEvent.getScopeId()).isNotNull().isEqualTo(eventCaseInstance.getId());
+                assertThat(caseStageEndedEvent.getSubScopeId()).isNotNull().isEqualTo(caseStageEndedEvent.getEntity().getId());
+                assertThat(caseStageEndedEvent.getScopeDefinitionId()).isNotNull().isEqualTo(eventCaseInstance.getCaseDefinitionId());
+
+                if (events.isEmpty()) {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage B");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.COMPLETED);
+                } else {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage A");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.COMPLETED);
+                }
+                events.add(flowableEvent);
+            }
+        };
+
+        // start the case which will also need to throw two stage started events (Stage A and embedded child Stage B)
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("caseStageEventTestCase")
+                .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertThat(planItemInstances).hasSize(6);
+        assertPlanItemInstanceState(planItemInstances, "Stage A", PlanItemInstanceState.ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", PlanItemInstanceState.ACTIVE);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
+        assertThat(events).hasSize(1);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task B"));
+        assertThat(events).hasSize(2);
+
+        assertCaseInstanceEnded(caseInstance.getId());
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/event/Case_Stage_Event_Test_Case.cmmn")
+    public void testCaseStageForceCompletedEvents() {
+        List<FlowableEvent> events = new ArrayList<>();
+        stageListener.eventConsumer = (flowableEvent) -> {
+            if (flowableEvent instanceof FlowableCaseStageEndedEvent) {
+                FlowableCaseStageEndedEvent caseStageEndedEvent = (FlowableCaseStageEndedEvent) flowableEvent;
+                CaseInstance eventCaseInstance = caseStageEndedEvent.getCaseInstance();
+                assertThat(caseStageEndedEvent.getProcessInstanceId()).isNull();
+                assertThat(caseStageEndedEvent.getExecutionId()).isNull();
+                assertThat(caseStageEndedEvent.getProcessDefinitionId()).isNull();
+                assertThat(caseStageEndedEvent.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+                assertThat(caseStageEndedEvent.getScopeId()).isNotNull().isEqualTo(eventCaseInstance.getId());
+                assertThat(caseStageEndedEvent.getSubScopeId()).isNotNull().isEqualTo(caseStageEndedEvent.getEntity().getId());
+                assertThat(caseStageEndedEvent.getScopeDefinitionId()).isNotNull().isEqualTo(eventCaseInstance.getCaseDefinitionId());
+
+                if (events.isEmpty()) {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage A");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.COMPLETED);
+                } else {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage B");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.TERMINATED);
+                }
+                events.add(flowableEvent);
+            }
+        };
+
+        // start the case which will also need to throw two stage started events (Stage A and embedded child Stage B)
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("caseStageEventTestCase")
+                .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertThat(planItemInstances).hasSize(6);
+        assertPlanItemInstanceState(planItemInstances, "Stage A", PlanItemInstanceState.ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", PlanItemInstanceState.ACTIVE);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Complete Stage A"));
+        assertThat(events).hasSize(2);
+
+        assertCaseInstanceEnded(caseInstance.getId());
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/event/Case_Stage_Event_Test_Case.cmmn")
+    public void testCaseStageForceCompletedAfterSubStageCompletedEvents() {
+        List<FlowableEvent> events = new ArrayList<>();
+        stageListener.eventConsumer = (flowableEvent) -> {
+            if (flowableEvent instanceof FlowableCaseStageEndedEvent) {
+                FlowableCaseStageEndedEvent caseStageEndedEvent = (FlowableCaseStageEndedEvent) flowableEvent;
+                CaseInstance eventCaseInstance = caseStageEndedEvent.getCaseInstance();
+                assertThat(caseStageEndedEvent.getProcessInstanceId()).isNull();
+                assertThat(caseStageEndedEvent.getExecutionId()).isNull();
+                assertThat(caseStageEndedEvent.getProcessDefinitionId()).isNull();
+                assertThat(caseStageEndedEvent.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+                assertThat(caseStageEndedEvent.getScopeId()).isNotNull().isEqualTo(eventCaseInstance.getId());
+                assertThat(caseStageEndedEvent.getSubScopeId()).isNotNull().isEqualTo(caseStageEndedEvent.getEntity().getId());
+                assertThat(caseStageEndedEvent.getScopeDefinitionId()).isNotNull().isEqualTo(eventCaseInstance.getCaseDefinitionId());
+
+                if (events.isEmpty()) {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage B");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.COMPLETED);
+                } else {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage A");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.COMPLETED);
+                }
+                events.add(flowableEvent);
+            }
+        };
+
+        // start the case which will also need to throw two stage started events (Stage A and embedded child Stage B)
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("caseStageEventTestCase")
+                .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertThat(planItemInstances).hasSize(6);
+        assertPlanItemInstanceState(planItemInstances, "Stage A", PlanItemInstanceState.ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", PlanItemInstanceState.ACTIVE);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
+        assertThat(events).hasSize(1);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Complete Stage A"));
+        assertThat(events).hasSize(2);
+
+        assertCaseInstanceEnded(caseInstance.getId());
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/event/Case_Stage_Event_Test_Case.cmmn")
+    public void testCaseStageForceExitEvents() {
+        List<FlowableEvent> events = new ArrayList<>();
+        stageListener.eventConsumer = (flowableEvent) -> {
+            if (flowableEvent instanceof FlowableCaseStageEndedEvent) {
+                FlowableCaseStageEndedEvent caseStageEndedEvent = (FlowableCaseStageEndedEvent) flowableEvent;
+                CaseInstance eventCaseInstance = caseStageEndedEvent.getCaseInstance();
+                assertThat(caseStageEndedEvent.getProcessInstanceId()).isNull();
+                assertThat(caseStageEndedEvent.getExecutionId()).isNull();
+                assertThat(caseStageEndedEvent.getProcessDefinitionId()).isNull();
+                assertThat(caseStageEndedEvent.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+                assertThat(caseStageEndedEvent.getScopeId()).isNotNull().isEqualTo(eventCaseInstance.getId());
+                assertThat(caseStageEndedEvent.getSubScopeId()).isNotNull().isEqualTo(caseStageEndedEvent.getEntity().getId());
+                assertThat(caseStageEndedEvent.getScopeDefinitionId()).isNotNull().isEqualTo(eventCaseInstance.getCaseDefinitionId());
+
+                if (events.isEmpty()) {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage A");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.TERMINATED);
+                } else {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage B");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.TERMINATED);
+                }
+                events.add(flowableEvent);
+            }
+        };
+
+        // start the case which will also need to throw two stage started events (Stage A and embedded child Stage B)
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("caseStageEventTestCase")
+                .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertThat(planItemInstances).hasSize(6);
+        assertPlanItemInstanceState(planItemInstances, "Stage A", PlanItemInstanceState.ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", PlanItemInstanceState.ACTIVE);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Exit Stage A"));
+        assertThat(events).hasSize(2);
+
+        assertCaseInstanceEnded(caseInstance.getId());
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/event/Case_Stage_Event_Test_Case.cmmn")
+    public void testCaseStageForceExitAfterSubStageCompletedEvents() {
+        List<FlowableEvent> events = new ArrayList<>();
+        stageListener.eventConsumer = (flowableEvent) -> {
+            if (flowableEvent instanceof FlowableCaseStageEndedEvent) {
+                FlowableCaseStageEndedEvent caseStageEndedEvent = (FlowableCaseStageEndedEvent) flowableEvent;
+                CaseInstance eventCaseInstance = caseStageEndedEvent.getCaseInstance();
+                assertThat(caseStageEndedEvent.getProcessInstanceId()).isNull();
+                assertThat(caseStageEndedEvent.getExecutionId()).isNull();
+                assertThat(caseStageEndedEvent.getProcessDefinitionId()).isNull();
+                assertThat(caseStageEndedEvent.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+                assertThat(caseStageEndedEvent.getScopeId()).isNotNull().isEqualTo(eventCaseInstance.getId());
+                assertThat(caseStageEndedEvent.getSubScopeId()).isNotNull().isEqualTo(caseStageEndedEvent.getEntity().getId());
+                assertThat(caseStageEndedEvent.getScopeDefinitionId()).isNotNull().isEqualTo(eventCaseInstance.getCaseDefinitionId());
+
+                if (events.isEmpty()) {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage B");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.COMPLETED);
+                } else {
+                    assertThat(caseStageEndedEvent.getEntity().getName()).isEqualTo("Stage A");
+                    assertThat(caseStageEndedEvent.getEndingState()).isEqualTo(PlanItemInstanceState.TERMINATED);
+                }
+                events.add(flowableEvent);
+            }
+        };
+
+        // start the case which will also need to throw two stage started events (Stage A and embedded child Stage B)
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("caseStageEventTestCase")
+                .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertThat(planItemInstances).hasSize(6);
+        assertPlanItemInstanceState(planItemInstances, "Stage A", PlanItemInstanceState.ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", PlanItemInstanceState.ACTIVE);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Task A"));
+        assertThat(events).hasSize(1);
+
+        cmmnRuntimeService.triggerPlanItemInstance(getPlanItemInstanceIdByName(planItemInstances, "Exit Stage A"));
+        assertThat(events).hasSize(2);
+
+        assertCaseInstanceEnded(caseInstance.getId());
+    }
+
+    public static class CustomEventListener extends AbstractFlowableEventListener {
+        private Consumer<FlowableEvent> eventConsumer;
+
+        @Override
+        public void onEvent(FlowableEvent event) {
+            if (eventConsumer != null) {
+                eventConsumer.accept(event);
+            }
+        }
+
+        @Override
+        public boolean isFailOnException() {
+            return false;
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/event/CaseStageStartedEventTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/event/CaseStageStartedEventTest.java
@@ -1,0 +1,107 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.flowable.cmmn.api.event.FlowableCaseStageStartedEvent;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.flowable.common.engine.api.delegate.event.AbstractFlowableEventListener;
+import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
+import org.flowable.common.engine.api.delegate.event.FlowableEvent;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Micha Kiener
+ */
+public class CaseStageStartedEventTest extends FlowableCmmnTestCase {
+    protected CustomEventListener stageListener;
+
+    @Before
+    public void setUp() {
+        stageListener = new CustomEventListener();
+        cmmnEngineConfiguration.getEventDispatcher().addEventListener(stageListener, FlowableEngineEventType.STAGE_STARTED);
+    }
+
+    @After
+    public void tearDown() {
+        if (stageListener != null) {
+            cmmnEngineConfiguration.getEventDispatcher().removeEventListener(stageListener);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/event/Case_Stage_Event_Test_Case.cmmn")
+    public void testCaseStageStartedEvents() {
+        List<FlowableEvent> events = new ArrayList<>();
+        stageListener.eventConsumer = (flowableEvent) -> {
+            if (flowableEvent instanceof FlowableCaseStageStartedEvent) {
+                FlowableCaseStageStartedEvent caseStageStartedEvent = (FlowableCaseStageStartedEvent) flowableEvent;
+                CaseInstance eventCaseInstance = caseStageStartedEvent.getCaseInstance();
+                assertThat(caseStageStartedEvent.getProcessInstanceId()).isNull();
+                assertThat(caseStageStartedEvent.getExecutionId()).isNull();
+                assertThat(caseStageStartedEvent.getProcessDefinitionId()).isNull();
+                assertThat(caseStageStartedEvent.getScopeType()).isEqualTo(ScopeTypes.CMMN);
+                assertThat(caseStageStartedEvent.getScopeId()).isNotNull().isEqualTo(eventCaseInstance.getId());
+                assertThat(caseStageStartedEvent.getSubScopeId()).isNotNull().isEqualTo(caseStageStartedEvent.getEntity().getId());
+                assertThat(caseStageStartedEvent.getScopeDefinitionId()).isNotNull().isEqualTo(eventCaseInstance.getCaseDefinitionId());
+
+                if (events.isEmpty()) {
+                    assertThat(caseStageStartedEvent.getEntity().getName()).isEqualTo("Stage A");
+                } else {
+                    assertThat(caseStageStartedEvent.getEntity().getName()).isEqualTo("Stage B");
+                }
+                events.add(flowableEvent);
+            }
+        };
+
+        // start the case which will also need to throw two stage started events (Stage A and embedded child Stage B)
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("caseStageEventTestCase")
+                .start();
+
+        List<PlanItemInstance> planItemInstances = getPlanItemInstances(caseInstance.getId());
+        assertThat(planItemInstances).hasSize(6);
+        assertPlanItemInstanceState(planItemInstances, "Stage A", PlanItemInstanceState.ACTIVE);
+        assertPlanItemInstanceState(planItemInstances, "Stage B", PlanItemInstanceState.ACTIVE);
+
+        assertThat(events).hasSize(2);
+    }
+
+    public static class CustomEventListener extends AbstractFlowableEventListener {
+        private Consumer<FlowableEvent> eventConsumer;
+
+        @Override
+        public void onEvent(FlowableEvent event) {
+            if (eventConsumer != null) {
+                eventConsumer.accept(event);
+            }
+        }
+
+        @Override
+        public boolean isFailOnException() {
+            return false;
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/event/Case_Stage_Event_Test_Case.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/event/Case_Stage_Event_Test_Case.cmmn
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn">
+  <case id="caseStageEventTestCase" name="Case Stage Event Test Case">
+    <casePlanModel id="onecaseplanmodel1" name="Case Stage Event Test Case">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItemexpandedStage1" name="Stage A" definitionRef="expandedStage1">
+        <exitCriterion id="exitCriterion2" sentryRef="sentryexitCriterion2" flowable:exitEventType="forceComplete"></exitCriterion>
+        <exitCriterion id="exitCriterion1" sentryRef="sentryexitCriterion1"></exitCriterion>
+      </planItem>
+      <sentry id="sentryexitCriterion2">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExitCriterion]]></design:stencilid>
+        </extensionElements>
+        <planItemOnPart id="sentryOnPartexitCriterion2" sourceRef="planItemuserEventListener2">
+          <standardEvent>occur</standardEvent>
+        </planItemOnPart>
+      </sentry>
+      <sentry id="sentryexitCriterion1">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExitCriterion]]></design:stencilid>
+        </extensionElements>
+        <planItemOnPart id="sentryOnPartexitCriterion1" sourceRef="planItemuserEventListener1">
+          <standardEvent>occur</standardEvent>
+        </planItemOnPart>
+      </sentry>
+      <stage id="expandedStage1" name="Stage A" autoComplete="true" flowable:includeInStageOverview="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItemexpandedStage2" name="Stage B" definitionRef="expandedStage2"></planItem>
+        <planItem id="planItemhumanTask2" name="Task B" definitionRef="humanTask2"></planItem>
+        <planItem id="planItemuserEventListener1" name="Exit Stage A" definitionRef="userEventListener1"></planItem>
+        <planItem id="planItemuserEventListener2" name="Complete Stage A" definitionRef="userEventListener2"></planItem>
+        <stage id="expandedStage2" name="Stage B" flowable:includeInStageOverview="true">
+          <extensionElements>
+            <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+          </extensionElements>
+          <planItem id="planItemhumanTask1" name="Task A" definitionRef="humanTask1"></planItem>
+          <humanTask id="humanTask1" name="Task A">
+            <extensionElements>
+              <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+              <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+              <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+            </extensionElements>
+          </humanTask>
+        </stage>
+        <humanTask id="humanTask2" name="Task B">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+        <userEventListener id="userEventListener1" name="Exit Stage A">
+          <extensionElements>
+            <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+          </extensionElements>
+        </userEventListener>
+        <userEventListener id="userEventListener2" name="Complete Stage A">
+          <extensionElements>
+            <design:stencilid><![CDATA[UserEventListener]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+          </extensionElements>
+        </userEventListener>
+      </stage>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_caseStageEventTestCase">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="519.0" width="664.0" x="30.0" y="45.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemexpandedStage1" cmmnElementRef="planItemexpandedStage1">
+        <dc:Bounds height="390.0" width="536.0" x="105.0" y="108.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_exitCriterion2" cmmnElementRef="exitCriterion2">
+        <dc:Bounds height="28.0" width="18.0" x="632.0" y="381.00000000000006"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_exitCriterion1" cmmnElementRef="exitCriterion1">
+        <dc:Bounds height="28.0" width="18.0" x="632.0" y="239.99999999999994"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemexpandedStage2" cmmnElementRef="planItemexpandedStage2">
+        <dc:Bounds height="165.0" width="265.0" x="165.0" y="168.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemhumanTask1" cmmnElementRef="planItemhumanTask1">
+        <dc:Bounds height="80.0" width="100.0" x="243.0" y="214.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemhumanTask2" cmmnElementRef="planItemhumanTask2">
+        <dc:Bounds height="80.0" width="100.0" x="243.0" y="355.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemuserEventListener1" cmmnElementRef="planItemuserEventListener1">
+        <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="505.99999999999994" y="238.7495"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemuserEventListener2" cmmnElementRef="planItemuserEventListener2">
+        <dc:Bounds height="30.500999999999976" width="30.49799999999999" x="506.00000000000006" y="379.7495"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="CMMNEdge_connector1" cmmnElementRef="planItemuserEventListener1" targetCMMNElementRef="exitCriterion1">
+        <di:extension>
+          <flowable:docker type="source" x="15.497999999999994" y="15.500999999999987"></flowable:docker>
+          <flowable:docker type="target" x="9.0" y="14.0"></flowable:docker>
+        </di:extension>
+        <di:waypoint x="536.9459667423886" y="254.21801317432312"></di:waypoint>
+        <di:waypoint x="632.0121116886256" y="254.01873578582092"></di:waypoint>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNEdge>
+      <cmmndi:CMMNEdge id="CMMNEdge_connector2" cmmnElementRef="planItemuserEventListener2" targetCMMNElementRef="exitCriterion2">
+        <di:extension>
+          <flowable:docker type="source" x="15.497999999999994" y="15.500999999999987"></flowable:docker>
+          <flowable:docker type="target" x="9.0" y="14.0"></flowable:docker>
+        </di:extension>
+        <di:waypoint x="536.9459667424093" y="395.2180131743231"></di:waypoint>
+        <di:waypoint x="632.0121116886256" y="395.0187357858209"></di:waypoint>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/delegate/event/FlowableEngineEventType.java
+++ b/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/delegate/event/FlowableEngineEventType.java
@@ -355,6 +355,18 @@ public enum FlowableEngineEventType implements FlowableEventType {
     CASE_ENDED,
 
     /**
+     * A stage instance (plan item) has been started (went into active state, not to be confused with the creation of the stage plan item).
+     * The event is being dispatched after the lifecycle listeners have been invoked.
+     */
+    STAGE_STARTED,
+
+    /**
+     * A stage instance (plan item) has been ended (either through completion, manual termination or an exit).
+     * The event is being dispatched after the lifecycle listeners have been invoked.
+     */
+    STAGE_ENDED,
+
+    /**
      * A change tenant id was executed.
      */
     CHANGE_TENANT_ID,


### PR DESCRIPTION
The same way we support case starting and ending events, we also want to support such events specific to stages as they represent an important state of a case lifecycle.

#### Check List:
* Unit tests: YES
* Documentation: NA
