### PR TITLE
Update to Spring Boot 2.6.7

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.19          The 
 org.springframework             spring-core                 5.3.19          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.19          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.19          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.6.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.6.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.6.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.6.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.6.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.6.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.6.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.6.3           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/modules/flowable-app-engine-rest/pom.xml
+++ b/modules/flowable-app-engine-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.45.v20220203</jetty.version>
+        <jetty.version>9.4.46.v20220331</jetty.version>
         <flowable.artifact>
             org.flowable.app.rest
         </flowable.artifact>

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.45.v20220203</jetty.version>
+    <jetty.version>9.4.46.v20220331</jetty.version>
     <flowable.artifact>
       org.flowable.cmmn.rest
     </flowable.artifact>

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jetty.version>9.4.45.v20220203</jetty.version>
+		<jetty.version>9.4.46.v20220331</jetty.version>
 		<flowable.artifact>
 			org.flowable.content.rest
 		</flowable.artifact>

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.45.v20220203</jetty.version>
+        <jetty.version>9.4.46.v20220331</jetty.version>
         <flowable.artifact>
             org.flowable.dmn.rest.service
         </flowable.artifact>

--- a/modules/flowable-event-registry-rest/pom.xml
+++ b/modules/flowable-event-registry-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.45.v20220203</jetty.version>
+        <jetty.version>9.4.46.v20220331</jetty.version>
         <flowable.artifact>
             org.flowable.eventregistry.rest
         </flowable.artifact>

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.45.v20220203</jetty.version>
+        <jetty.version>9.4.46.v20220331</jetty.version>
         <flowable.artifact>
             org.flowable.form.rest
         </flowable.artifact>

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.45.v20220203</jetty.version>
+        <jetty.version>9.4.46.v20220331</jetty.version>
         <flowable.osgi.import.pkg>*</flowable.osgi.import.pkg>
         <flowable.artifact>
             org.flowable.http

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.45.v20220203</jetty.version>
+        <jetty.version>9.4.46.v20220331</jetty.version>
         <flowable.artifact>
             org.flowable.rest
         </flowable.artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,13 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.6.6</spring.boot.version>
+		<spring.boot.version>2.6.7</spring.boot.version>
 		<spring.framework.version>5.3.19</spring.framework.version>
-		<spring.security.version>5.6.2</spring.security.version>
-		<spring.amqp.version>2.4.3</spring.amqp.version>
-		<spring.kafka.version>2.8.4</spring.kafka.version>
+		<spring.security.version>5.6.3</spring.security.version>
+		<spring.amqp.version>2.4.4</spring.amqp.version>
+		<spring.kafka.version>2.8.5</spring.kafka.version>
 		<reactor-netty.version>1.0.16</reactor-netty.version>
-		<jackson.version>2.13.2</jackson.version>
+		<jackson.version>2.13.2.1</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>3.14.0</camel.version>
@@ -795,7 +795,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.6.7.Final</version>
+				<version>5.6.8.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>
@@ -1012,7 +1012,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.3.3</version>
+				<version>42.3.4</version>
 			</dependency>
 			<dependency>
 				<groupId>xerces</groupId>


### PR DESCRIPTION
Update to Spring Boot 2.6.7

Release Notes:  https://github.com/spring-projects/spring-boot/releases/tag/v2.6.7

Includes update to Spring Security
