### PR TITLE
add unit tests around user event listener repetitions - 6.7

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventlistener/UserEventListenerTest.testUserEventRepetitionWithRepeatingEntryCriteriaAndMaxInstanceCountOne.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventlistener/UserEventListenerTest.testUserEventRepetitionWithRepeatingEntryCriteriaAndMaxInstanceCountOne.cmmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:flowable="http://flowable.org/cmmn"
+             targetNamespace="http://flowable.org/cmmn">
+    <case id="testUserEventRepetitionWithRepeatingEntryCriteriaAndMaxInstanceCountOne" name="testUserRepetitionRule">
+        <casePlanModel id="casePlanModel">
+            <planItem id="planItemTaskA" name="Task A" definitionRef="taskA">
+                <itemControl>
+                    <repetitionRule></repetitionRule>
+                </itemControl>
+                <entryCriterion sentryRef="sentryActivateTask"/>
+            </planItem>
+            <planItem id="planItemUserAction" name="Activate Task A" definitionRef="userAction">
+                <itemControl>
+                    <repetitionRule flowable:maxInstanceCount="1">
+                        <condition><![CDATA[${whileRepeatActivateTaskA}]]></condition>
+                    </repetitionRule>
+                </itemControl>
+            </planItem>
+
+            <sentry id="sentryActivateTask">
+                <planItemOnPart sourceRef="planItemUserAction">
+                    <standardEvent>occur</standardEvent>
+                </planItemOnPart>
+            </sentry>
+
+            <humanTask id="taskA" name="Task A"/>
+            <userEventListener id="userAction" name="Activate Task A"/>
+
+        </casePlanModel>
+    </case>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventlistener/UserEventListenerTest.testUserEventRepetitionWithRepeatingEntryCriteriaAndMaxInstanceCountOneInStage.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventlistener/UserEventListenerTest.testUserEventRepetitionWithRepeatingEntryCriteriaAndMaxInstanceCountOneInStage.cmmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:flowable="http://flowable.org/cmmn"
+             targetNamespace="http://flowable.org/cmmn">
+    <case id="testUserEventRepetitionWithRepeatingEntryCriteriaAndMaxInstanceCountOneInStage" name="testUserRepetitionRule">
+        <casePlanModel id="casePlanModel">
+            <planItem id="planItemStage1" name="Stage One" definitionRef="stage1"/>
+            <stage id="stage1" name="Stage One">
+                <planItem id="planItemTaskA" name="Task A" definitionRef="taskA">
+                    <itemControl>
+                        <repetitionRule></repetitionRule>
+                    </itemControl>
+                    <entryCriterion sentryRef="sentryActivateTask"/>
+                </planItem>
+                <planItem id="planItemUserAction" name="Activate Task A" definitionRef="userAction">
+                    <itemControl>
+                        <repetitionRule flowable:maxInstanceCount="1">
+                            <condition><![CDATA[${whileRepeatActivateTaskA}]]></condition>
+                        </repetitionRule>
+                    </itemControl>
+                </planItem>
+
+                <sentry id="sentryActivateTask">
+                    <planItemOnPart sourceRef="planItemUserAction">
+                        <standardEvent>occur</standardEvent>
+                    </planItemOnPart>
+                </sentry>
+
+                <humanTask id="taskA" name="Task A"/>
+                <userEventListener id="userAction" name="Activate Task A"/>
+            </stage>
+
+        </casePlanModel>
+    </case>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventlistener/UserEventListenerTest.testUserEventRepetitionWithRepeatingEntryCriteriaHavingMaxInstanceCountOneInStage.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventlistener/UserEventListenerTest.testUserEventRepetitionWithRepeatingEntryCriteriaHavingMaxInstanceCountOneInStage.cmmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:flowable="http://flowable.org/cmmn"
+             targetNamespace="http://flowable.org/cmmn">
+    <case id="testUserEventRepetitionWithRepeatingEntryCriteriaHavingMaxInstanceCountOneInStage" name="testUserRepetitionRule">
+        <casePlanModel id="casePlanModel">
+            <planItem id="planItemStage1" name="Stage One" definitionRef="stage1"/>
+            <stage id="stage1" name="Stage One">
+                <planItem id="planItemTaskA" name="Task A" definitionRef="taskA">
+                    <itemControl>
+                        <repetitionRule flowable:maxInstanceCount="1"></repetitionRule>
+                    </itemControl>
+                    <entryCriterion sentryRef="sentryActivateTask"/>
+                </planItem>
+                <planItem id="planItemUserAction" name="Activate Task A" definitionRef="userAction">
+                    <itemControl>
+                        <repetitionRule>
+                            <condition><![CDATA[${whileRepeatActivateTaskA}]]></condition>
+                        </repetitionRule>
+                    </itemControl>
+                </planItem>
+
+                <sentry id="sentryActivateTask">
+                    <planItemOnPart sourceRef="planItemUserAction">
+                        <standardEvent>occur</standardEvent>
+                    </planItemOnPart>
+                </sentry>
+
+                <humanTask id="taskA" name="Task A"/>
+                <userEventListener id="userAction" name="Activate Task A"/>
+            </stage>
+
+        </casePlanModel>
+    </case>
+</definitions>


### PR DESCRIPTION
Same as https://github.com/flowable/flowable-engine/pull/3283, but for 6.7.1 (where the tests are currently no longer passing).

#### Check List:
* Unit tests: YES 
* Documentation: NA
