### PR TITLE
Improve user task name migration and allow migration of user task descriptions

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/migration/one-task-expression-name-v2.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/migration/one-task-expression-name-v2.cmmn.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:flowable="http://flowable.org/cmmn"
+             targetNamespace="http://flowable.org/cmmn">
+    <case id="testCase" name="One Task Test Case" flowable:initiatorVariableName="initiator"
+          flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+          <planItem id="planItem1" name="Human Task: ${myVar2}" definitionRef="humanTask1"/>
+            <humanTask id="humanTask1" name="Human Task: ${myVar2}">
+                <documentation>Description: ${myVar2}</documentation>
+            </humanTask>
+        </casePlanModel>
+    </case>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/migration/one-task-expression-name.cmmn.xml
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/migration/one-task-expression-name.cmmn.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:flowable="http://flowable.org/cmmn"
+             targetNamespace="http://flowable.org/cmmn">
+    <case id="testCase" name="One Task Test Case" flowable:initiatorVariableName="initiator"
+          flowable:candidateStarterGroups="flowableUser">
+        <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+          <planItem id="planItem1" name="Human Task: ${myVar1}" definitionRef="humanTask1"/>
+            <humanTask id="humanTask1" name="Human Task: ${myVar1}">
+                <documentation>Description: ${myVar1}</documentation>
+            </humanTask>
+        </casePlanModel>
+    </case>
+</definitions>

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -896,7 +896,7 @@ public abstract class AbstractDynamicStateManager {
 
             // Set name
             String name = null;
-            if(newFlowElement.getName() != null) {
+            if (newFlowElement.getName() != null) {
                 Object nameValue = expressionManager.createExpression(newFlowElement.getName()).getValue(childExecution);
                 if (nameValue != null) {
                     name = nameValue.toString();
@@ -906,7 +906,7 @@ public abstract class AbstractDynamicStateManager {
 
             // Set description
             String description = null;
-            if(newFlowElement.getDocumentation() != null) {
+            if (newFlowElement.getDocumentation() != null) {
                 Object descriptionValue = expressionManager.createExpression(newFlowElement.getDocumentation()).getValue(childExecution);
                 if (descriptionValue != null) {
                     description = descriptionValue.toString();

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/migration/one-task-rename-v2.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/migration/one-task-rename-v2.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="Examples">
+
+    <process id="one-task-rename" name="MyProcess" isExecutable="true">
+        <documentation>My process documentation</documentation>
+        <startEvent id="startEvent1"/>
+        <sequenceFlow id="seqFlow1Id" sourceRef="startEvent1" targetRef="userTask1Id"/>
+        <userTask id="userTask1Id" name="User Task: ${myVar2}">
+            <documentation>Description: ${myVar2}</documentation>
+        </userTask>
+        <sequenceFlow id="seqFlow2Id" sourceRef="userTask1Id" targetRef="endEvent1"/>
+        <endEvent id="endEvent1"/>
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/migration/one-task-rename-v3.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/migration/one-task-rename-v3.bpmn20.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="Examples">
+
+    <process id="one-task-rename" name="MyProcess" isExecutable="true">
+        <documentation>My process documentation</documentation>
+        <startEvent id="startEvent1"/>
+        <sequenceFlow id="seqFlow1Id" sourceRef="startEvent1" targetRef="userTask1Id"/>
+        <userTask id="userTask1Id"/>
+        <sequenceFlow id="seqFlow2Id" sourceRef="userTask1Id" targetRef="endEvent1"/>
+        <endEvent id="endEvent1"/>
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/migration/one-task-rename.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/migration/one-task-rename.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="Examples">
+
+    <process id="one-task-rename" name="MyProcess" isExecutable="true">
+        <documentation>My process documentation</documentation>
+        <startEvent id="startEvent1"/>
+        <sequenceFlow id="seqFlow1Id" sourceRef="startEvent1" targetRef="userTask1Id"/>
+        <userTask id="userTask1Id" name="User Task: ${myVar1}">
+            <documentation>Description: ${myVar1}</documentation>
+        </userTask>
+        <sequenceFlow id="seqFlow2Id" sourceRef="userTask1Id" targetRef="endEvent1"/>
+        <endEvent id="endEvent1"/>
+    </process>
+
+</definitions>


### PR DESCRIPTION
When migrating a process instance, User Tasks were renamed without evaluating the name through the ExpressionManager. Descriptions were not migrated so far. This PR addresses these points.