### PR TITLE
Set owner and assignee on cases and processes through runtime service directly

### DIFF
--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnRuntimeService.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnRuntimeService.java
@@ -237,6 +237,36 @@ public interface CmmnRuntimeService {
      *             when the case instance doesn't exist.
      */
     List<StageResponse> getStageOverview(String caseInstanceId);
+
+    /**
+     * Set the new owner of a case instance.
+     *
+     * @param caseInstanceId the id of the case to set its new owner
+     * @param userId the id of the user to set as the new owner
+     */
+    void setOwner(String caseInstanceId, String userId);
+
+    /**
+     * Removes the owner of a case instance.
+     *
+     * @param caseInstanceId the id of the case to remove the owner from
+     */
+    void removeOwner(String caseInstanceId);
+
+    /**
+     * Set the new assignee of a case instance.
+     *
+     * @param caseInstanceId the id of the case to set its new assignee
+     * @param userId the id of the user to set as the new assignee
+     */
+    void setAssignee(String caseInstanceId, String userId);
+
+    /**
+     * Removes the assignee of a case instance.
+     *
+     * @param caseInstanceId the id of the case to remove the assignee from
+     */
+    void removeAssignee(String caseInstanceId);
     
     /**
      * Involves a user with a case instance. The type of identity link is defined by the given identityLinkType.

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AbstractCaseInstanceIdentityLinkCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AbstractCaseInstanceIdentityLinkCmd.java
@@ -1,0 +1,49 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.flowable.cmmn.api.CmmnRuntimeService;
+import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.identitylink.api.IdentityLink;
+
+/**
+ * An abstract command supporting functionality around identity link management for case instances.
+ *
+ * @author Micha Kiener
+ */
+public abstract class AbstractCaseInstanceIdentityLinkCmd {
+
+    protected void removeIdentityLinkType(String caseInstanceId, String identityType) {
+        List<IdentityLink> linksToRemove = new ArrayList<>(1);
+        for (IdentityLink identityLink : getCmmnRuntimeService().getIdentityLinksForCaseInstance(caseInstanceId)) {
+            if (identityLink.getType().equalsIgnoreCase(identityType)) {
+                linksToRemove.add(identityLink);
+            }
+        }
+        // remove links in a second loop as we might run into possible concurrent modification exceptions to the identity link list
+        for (IdentityLink identityLink : linksToRemove) {
+            if (identityLink.getUserId() != null) {
+                getCmmnRuntimeService().deleteUserIdentityLink(caseInstanceId, identityLink.getUserId(), identityLink.getType());
+            } else if (identityLink.getGroupId() != null) {
+                getCmmnRuntimeService().deleteGroupIdentityLink(caseInstanceId, identityLink.getGroupId(), identityLink.getType());
+            }
+        }
+    }
+
+    protected CmmnRuntimeService getCmmnRuntimeService() {
+        return CommandContextUtil.getCmmnRuntimeService();
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AbstractCaseInstanceIdentityLinkCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AbstractCaseInstanceIdentityLinkCmd.java
@@ -12,14 +12,11 @@
  */
 package org.flowable.cmmn.engine.impl.cmd;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.flowable.cmmn.engine.impl.persistence.entity.CaseInstanceEntity;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
-import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.cmmn.engine.impl.util.IdentityLinkUtil;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
-import org.flowable.identitylink.api.IdentityLink;
-import org.flowable.identitylink.service.IdentityLinkService;
 
 /**
  * An abstract command supporting functionality around identity link management for case instances.
@@ -28,22 +25,62 @@ import org.flowable.identitylink.service.IdentityLinkService;
  */
 public abstract class AbstractCaseInstanceIdentityLinkCmd {
 
-    protected void removeIdentityLinkType(CommandContext commandContext, String caseInstanceId, String identityType) {
-        List<IdentityLink> linksToRemove = new ArrayList<>(1);
-        for (IdentityLink identityLink : getIdentityLinkService(commandContext).findIdentityLinksByScopeIdAndType(caseInstanceId, ScopeTypes.CMMN)) {
-            if (identityLink.getType().equalsIgnoreCase(identityType)) {
-                linksToRemove.add(identityLink);
-            }
+    /**
+     * Returns the case instance entity for the given id, if it exists, otherwise an exception will be thrown.
+     *
+     * @param commandContext the command context within which the case instance is loaded
+     * @param caseInstanceId the id of the case instance to be loaded
+     * @return the case instance entity, if found, never null
+     * @throws FlowableIllegalArgumentException if the provided case instance id is not valid (could not be found)
+     */
+    protected CaseInstanceEntity getCaseInstanceEntity(CommandContext commandContext, String caseInstanceId) {
+        CaseInstanceEntity caseInstanceEntity = CommandContextUtil.getCaseInstanceEntityManager(commandContext).findById(caseInstanceId);
+        if (caseInstanceEntity == null) {
+            throw new FlowableIllegalArgumentException(
+                "The case instance with id '" + caseInstanceId + "' could not be found as an active case instance.");
         }
-        // remove links in a second loop as we might run into possible concurrent modification exceptions to the identity link list
-        for (IdentityLink identityLink : linksToRemove) {
-            getIdentityLinkService(commandContext).deleteScopeIdentityLink(caseInstanceId, ScopeTypes.CMMN,
-                identityLink.getUserId(), identityLink.getGroupId(), identityLink.getType());
-        }
+        return caseInstanceEntity;
     }
 
-    protected IdentityLinkService getIdentityLinkService(CommandContext commandContext) {
-        return CommandContextUtil.getIdentityLinkService(commandContext);
+    /**
+     * This will remove ALL identity links with the given type, no mather whether they are user or group based.
+     *
+     * @param commandContext the command context within which to remove the identity links
+     * @param caseInstanceId the id of the case instance to remove the identity links for
+     * @param identityType the identity link type (e.g. assignee or owner, etc) to be removed
+     */
+    protected void removeIdentityLinkType(CommandContext commandContext, String caseInstanceId, String identityType) {
+        CaseInstanceEntity caseInstanceEntity = getCaseInstanceEntity(commandContext, caseInstanceId);
+
+        // this will remove ALL identity links with the given identity type (for users AND groups)
+        IdentityLinkUtil.deleteCaseInstanceIdentityLinks(caseInstanceEntity, null, null, identityType,
+            CommandContextUtil.getCmmnEngineConfiguration(commandContext));
+    }
+
+    /**
+     * Creates a new identity link entry for the given case instance, which can either be a user or group based one, but not both the same time.
+     * If both the user and group ids are null, no new identity link is created.
+     *
+     * @param commandContext the command context within which to perform the identity link creation
+     * @param caseInstanceId the id of the case instance to create an identity link for
+     * @param userId the user id if this is a user based identity link, otherwise null
+     * @param groupId the group id if this is a group based identity link, otherwise null
+     * @param identityType the type of identity link (e.g. owner or assignee, etc)
+     */
+    protected void createIdentityLinkType(CommandContext commandContext, String caseInstanceId, String userId, String groupId, String identityType) {
+        // if both user and group ids are null, don't create an identity link
+        if (userId == null && groupId == null) {
+            return;
+        }
+
+        // if both are set the same time, throw an exception as this is not allowed
+        if (userId != null && groupId != null) {
+            throw new FlowableIllegalArgumentException("Either set the user id or the group id for an identity link, but not both the same time.");
+        }
+
+        CaseInstanceEntity caseInstanceEntity = getCaseInstanceEntity(commandContext, caseInstanceId);
+        IdentityLinkUtil.createCaseInstanceIdentityLink(caseInstanceEntity, userId, groupId, identityType,
+            CommandContextUtil.getCmmnEngineConfiguration(commandContext));
     }
 }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceAssigneeCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceAssigneeCmd.java
@@ -1,0 +1,42 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.identitylink.api.IdentityLinkType;
+
+
+/**
+ * Command to remove the current assignee from a case instance.
+ *
+ * @author Micha Kiener
+ */
+public class RemoveCaseInstanceAssigneeCmd extends AbstractCaseInstanceIdentityLinkCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String caseInstanceId;
+
+    public RemoveCaseInstanceAssigneeCmd(String caseInstanceId) {
+        this.caseInstanceId = caseInstanceId;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        removeIdentityLinkType(caseInstanceId, IdentityLinkType.ASSIGNEE);
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceAssigneeCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceAssigneeCmd.java
@@ -25,7 +25,6 @@ import org.flowable.identitylink.api.IdentityLinkType;
  * @author Micha Kiener
  */
 public class RemoveCaseInstanceAssigneeCmd extends AbstractCaseInstanceIdentityLinkCmd implements Command<Void>, Serializable {
-
     private static final long serialVersionUID = 1L;
 
     protected final String caseInstanceId;
@@ -36,7 +35,7 @@ public class RemoveCaseInstanceAssigneeCmd extends AbstractCaseInstanceIdentityL
 
     @Override
     public Void execute(CommandContext commandContext) {
-        removeIdentityLinkType(caseInstanceId, IdentityLinkType.ASSIGNEE);
+        removeIdentityLinkType(commandContext, caseInstanceId, IdentityLinkType.ASSIGNEE);
         return null;
     }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceAssigneeCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceAssigneeCmd.java
@@ -35,6 +35,7 @@ public class RemoveCaseInstanceAssigneeCmd extends AbstractCaseInstanceIdentityL
 
     @Override
     public Void execute(CommandContext commandContext) {
+        // remove ALL assignee identity links (there should only be one of course)
         removeIdentityLinkType(commandContext, caseInstanceId, IdentityLinkType.ASSIGNEE);
         return null;
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceOwnerCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceOwnerCmd.java
@@ -24,7 +24,6 @@ import org.flowable.identitylink.api.IdentityLinkType;
  * @author Micha Kiener
  */
 public class RemoveCaseInstanceOwnerCmd extends AbstractCaseInstanceIdentityLinkCmd implements Command<Void>, Serializable {
-
     private static final long serialVersionUID = 1L;
 
     protected final String caseInstanceId;
@@ -35,7 +34,7 @@ public class RemoveCaseInstanceOwnerCmd extends AbstractCaseInstanceIdentityLink
 
     @Override
     public Void execute(CommandContext commandContext) {
-        removeIdentityLinkType(caseInstanceId, IdentityLinkType.OWNER);
+        removeIdentityLinkType(commandContext, caseInstanceId, IdentityLinkType.OWNER);
         return null;
     }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceOwnerCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceOwnerCmd.java
@@ -34,6 +34,7 @@ public class RemoveCaseInstanceOwnerCmd extends AbstractCaseInstanceIdentityLink
 
     @Override
     public Void execute(CommandContext commandContext) {
+        // remove ALL owner identity links (there should only be one of course)
         removeIdentityLinkType(commandContext, caseInstanceId, IdentityLinkType.OWNER);
         return null;
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceOwnerCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RemoveCaseInstanceOwnerCmd.java
@@ -1,0 +1,41 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.identitylink.api.IdentityLinkType;
+
+/**
+ * Command to remove the current owner from a case instance.
+ *
+ * @author Micha Kiener
+ */
+public class RemoveCaseInstanceOwnerCmd extends AbstractCaseInstanceIdentityLinkCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String caseInstanceId;
+
+    public RemoveCaseInstanceOwnerCmd(String caseInstanceId) {
+        this.caseInstanceId = caseInstanceId;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        removeIdentityLinkType(caseInstanceId, IdentityLinkType.OWNER);
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceAssigneeCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceAssigneeCmd.java
@@ -14,7 +14,6 @@ package org.flowable.cmmn.engine.impl.cmd;
 
 import java.io.Serializable;
 
-import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.identitylink.api.IdentityLinkType;
@@ -37,9 +36,12 @@ public class SetCaseInstanceAssigneeCmd extends AbstractCaseInstanceIdentityLink
 
     @Override
     public Void execute(CommandContext commandContext) {
+        // remove ALL assignee identity links (there should only be one of course)
         removeIdentityLinkType(commandContext, caseInstanceId, IdentityLinkType.ASSIGNEE);
-        getIdentityLinkService(commandContext).createScopeIdentityLink(null, caseInstanceId, ScopeTypes.CMMN,
-            assigneeUserId, null, IdentityLinkType.ASSIGNEE);
+
+        // now add the new one, but only, if it is not null, which means using the setAssignee with a null value results in the same
+        // as removeAssignee
+        createIdentityLinkType(commandContext, caseInstanceId, assigneeUserId, null, IdentityLinkType.ASSIGNEE);
         return null;
     }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceAssigneeCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceAssigneeCmd.java
@@ -14,6 +14,7 @@ package org.flowable.cmmn.engine.impl.cmd;
 
 import java.io.Serializable;
 
+import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.identitylink.api.IdentityLinkType;
@@ -24,7 +25,6 @@ import org.flowable.identitylink.api.IdentityLinkType;
  * @author Micha Kiener
  */
 public class SetCaseInstanceAssigneeCmd extends AbstractCaseInstanceIdentityLinkCmd implements Command<Void>, Serializable {
-
     private static final long serialVersionUID = 1L;
 
     protected final String caseInstanceId;
@@ -37,8 +37,9 @@ public class SetCaseInstanceAssigneeCmd extends AbstractCaseInstanceIdentityLink
 
     @Override
     public Void execute(CommandContext commandContext) {
-        removeIdentityLinkType(caseInstanceId, IdentityLinkType.ASSIGNEE);
-        getCmmnRuntimeService().addUserIdentityLink(caseInstanceId, assigneeUserId, IdentityLinkType.ASSIGNEE);
+        removeIdentityLinkType(commandContext, caseInstanceId, IdentityLinkType.ASSIGNEE);
+        getIdentityLinkService(commandContext).createScopeIdentityLink(null, caseInstanceId, ScopeTypes.CMMN,
+            assigneeUserId, null, IdentityLinkType.ASSIGNEE);
         return null;
     }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceAssigneeCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceAssigneeCmd.java
@@ -1,0 +1,44 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.identitylink.api.IdentityLinkType;
+
+/**
+ * Command to set a new assignee on a case instance.
+ *
+ * @author Micha Kiener
+ */
+public class SetCaseInstanceAssigneeCmd extends AbstractCaseInstanceIdentityLinkCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String caseInstanceId;
+    protected final String assigneeUserId;
+
+    public SetCaseInstanceAssigneeCmd(String caseInstanceId, String assigneeUserId) {
+        this.caseInstanceId = caseInstanceId;
+        this.assigneeUserId = assigneeUserId;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        removeIdentityLinkType(caseInstanceId, IdentityLinkType.ASSIGNEE);
+        getCmmnRuntimeService().addUserIdentityLink(caseInstanceId, assigneeUserId, IdentityLinkType.ASSIGNEE);
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceOwnerCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceOwnerCmd.java
@@ -14,7 +14,6 @@ package org.flowable.cmmn.engine.impl.cmd;
 
 import java.io.Serializable;
 
-import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.identitylink.api.IdentityLinkType;
@@ -37,9 +36,12 @@ public class SetCaseInstanceOwnerCmd extends AbstractCaseInstanceIdentityLinkCmd
 
     @Override
     public Void execute(CommandContext commandContext) {
+        // remove ALL owner identity links (there should only be one of course)
         removeIdentityLinkType(commandContext, caseInstanceId, IdentityLinkType.OWNER);
-        getIdentityLinkService(commandContext).createScopeIdentityLink(null, caseInstanceId, ScopeTypes.CMMN,
-            ownerUserId, null, IdentityLinkType.OWNER);
+
+        // now add the new one, but only, if it is not null, which means using the setOwner with a null value results in the same
+        // as removeOwner
+        createIdentityLinkType(commandContext, caseInstanceId, ownerUserId, null, IdentityLinkType.OWNER);
         return null;
     }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceOwnerCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceOwnerCmd.java
@@ -1,0 +1,44 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.identitylink.api.IdentityLinkType;
+
+/**
+ * Command to set a new owner on a case instance and return the previous one, if any.
+ *
+ * @author Micha Kiener
+ */
+public class SetCaseInstanceOwnerCmd extends AbstractCaseInstanceIdentityLinkCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String caseInstanceId;
+    protected final String ownerUserId;
+
+    public SetCaseInstanceOwnerCmd(String caseInstanceId, String ownerUserId) {
+        this.caseInstanceId = caseInstanceId;
+        this.ownerUserId = ownerUserId;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        removeIdentityLinkType(caseInstanceId, IdentityLinkType.OWNER);
+        getCmmnRuntimeService().addUserIdentityLink(caseInstanceId, ownerUserId, IdentityLinkType.OWNER);
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceOwnerCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SetCaseInstanceOwnerCmd.java
@@ -14,6 +14,7 @@ package org.flowable.cmmn.engine.impl.cmd;
 
 import java.io.Serializable;
 
+import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.identitylink.api.IdentityLinkType;
@@ -24,7 +25,6 @@ import org.flowable.identitylink.api.IdentityLinkType;
  * @author Micha Kiener
  */
 public class SetCaseInstanceOwnerCmd extends AbstractCaseInstanceIdentityLinkCmd implements Command<Void>, Serializable {
-
     private static final long serialVersionUID = 1L;
 
     protected final String caseInstanceId;
@@ -37,8 +37,9 @@ public class SetCaseInstanceOwnerCmd extends AbstractCaseInstanceIdentityLinkCmd
 
     @Override
     public Void execute(CommandContext commandContext) {
-        removeIdentityLinkType(caseInstanceId, IdentityLinkType.OWNER);
-        getCmmnRuntimeService().addUserIdentityLink(caseInstanceId, ownerUserId, IdentityLinkType.OWNER);
+        removeIdentityLinkType(commandContext, caseInstanceId, IdentityLinkType.OWNER);
+        getIdentityLinkService(commandContext).createScopeIdentityLink(null, caseInstanceId, ScopeTypes.CMMN,
+            ownerUserId, null, IdentityLinkType.OWNER);
         return null;
     }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CmmnRuntimeServiceImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CmmnRuntimeServiceImpl.java
@@ -60,14 +60,18 @@ import org.flowable.cmmn.engine.impl.cmd.GetVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.GetVariablesCmd;
 import org.flowable.cmmn.engine.impl.cmd.HasCaseInstanceVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.HasPlanItemInstanceVariableCmd;
+import org.flowable.cmmn.engine.impl.cmd.RemoveCaseInstanceAssigneeCmd;
+import org.flowable.cmmn.engine.impl.cmd.RemoveCaseInstanceOwnerCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveEventListenerCommand;
 import org.flowable.cmmn.engine.impl.cmd.RemoveLocalVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveLocalVariablesCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveVariablesCmd;
+import org.flowable.cmmn.engine.impl.cmd.SetCaseInstanceAssigneeCmd;
 import org.flowable.cmmn.engine.impl.cmd.SetCaseInstanceBusinessKeyCmd;
 import org.flowable.cmmn.engine.impl.cmd.SetCaseInstanceBusinessStatusCmd;
 import org.flowable.cmmn.engine.impl.cmd.SetCaseInstanceNameCmd;
+import org.flowable.cmmn.engine.impl.cmd.SetCaseInstanceOwnerCmd;
 import org.flowable.cmmn.engine.impl.cmd.SetLocalVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.SetLocalVariablesCmd;
 import org.flowable.cmmn.engine.impl.cmd.SetVariableCmd;
@@ -334,6 +338,26 @@ public class CmmnRuntimeServiceImpl extends CommonEngineServiceImpl<CmmnEngineCo
     @Override
     public List<StageResponse> getStageOverview(String caseInstanceId) {
         return commandExecutor.execute(new GetStageOverviewCmd(caseInstanceId));
+    }
+
+    @Override
+    public void setOwner(String caseInstanceId, String userId) {
+        commandExecutor.execute(new SetCaseInstanceOwnerCmd(caseInstanceId, userId));
+    }
+
+    @Override
+    public void removeOwner(String caseInstanceId) {
+        commandExecutor.execute(new RemoveCaseInstanceOwnerCmd(caseInstanceId));
+    }
+
+    @Override
+    public void setAssignee(String caseInstanceId, String userId) {
+        commandExecutor.execute(new SetCaseInstanceAssigneeCmd(caseInstanceId, userId));
+    }
+
+    @Override
+    public void removeAssignee(String caseInstanceId) {
+        commandExecutor.execute(new RemoveCaseInstanceAssigneeCmd(caseInstanceId));
     }
 
     @Override

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceIdentityLinksTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/CaseInstanceIdentityLinksTest.java
@@ -24,6 +24,7 @@ import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.identitylink.api.IdentityLinkInfo;
+import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.task.api.Task;
 import org.junit.Test;
 
@@ -143,6 +144,52 @@ public class CaseInstanceIdentityLinksTest extends FlowableCmmnTestCase {
         assertThat(identityLinks)
             .extracting(IdentityLinkInfo::getGroupId)
             .containsExactly("admins");
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+    public void testCaseAssignee() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("oneTaskCase")
+            .start();
+
+        cmmnRuntimeService.setAssignee(caseInstance.getId(), "kermit");
+
+        List<IdentityLink> identityLinks = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                IdentityLink::getScopeType)
+            .containsExactly(
+                tuple(IdentityLinkType.ASSIGNEE, "kermit", null, caseInstance.getId(), ScopeTypes.CMMN)
+            );
+
+        cmmnRuntimeService.removeAssignee(caseInstance.getId());
+
+        assertThat(cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId()))
+            .isEmpty();
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+    public void testCaseOwner() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("oneTaskCase")
+            .start();
+
+        cmmnRuntimeService.setOwner(caseInstance.getId(), "kermit");
+
+        List<IdentityLink> identityLinks = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                IdentityLink::getScopeType)
+            .containsExactly(
+                tuple(IdentityLinkType.OWNER, "kermit", null, caseInstance.getId(), ScopeTypes.CMMN)
+            );
+
+        cmmnRuntimeService.removeOwner(caseInstance.getId());
+
+        assertThat(cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId()))
+            .isEmpty();
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/RuntimeService.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/RuntimeService.java
@@ -450,6 +450,36 @@ public interface RuntimeService {
     // ///////////////////////////////////////////////////////////////
 
     /**
+     * Set the new owner of a process instance.
+     *
+     * @param processInstanceId the id of the process to set its new owner
+     * @param userId the id of the user to set as the new owner
+     */
+    void setOwner(String processInstanceId, String userId);
+
+    /**
+     * Removes the owner of a process instance.
+     *
+     * @param processInstanceId the id of the process to remove the owner from
+     */
+    void removeOwner(String processInstanceId);
+
+    /**
+     * Set the new assignee of a process instance.
+     *
+     * @param processInstanceId the id of the process to set its new assignee
+     * @param userId the id of the user to set as the new assignee
+     */
+    void setAssignee(String processInstanceId, String userId);
+
+    /**
+     * Removes the assignee of a process instance.
+     *
+     * @param processInstanceId the id of the process to remove the assignee from
+     */
+    void removeAssignee(String processInstanceId);
+
+    /**
      * Involves a user with a process instance. The type of identity link is defined by the given identityLinkType.
      *
      * @param processInstanceId

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/RuntimeServiceImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/RuntimeServiceImpl.java
@@ -67,10 +67,14 @@ import org.flowable.engine.impl.cmd.MessageEventReceivedCmd;
 import org.flowable.engine.impl.cmd.RemoveEventConsumerCommand;
 import org.flowable.engine.impl.cmd.RemoveEventListenerCommand;
 import org.flowable.engine.impl.cmd.RemoveExecutionVariablesCmd;
+import org.flowable.engine.impl.cmd.RemoveProcessInstanceAssigneeCmd;
+import org.flowable.engine.impl.cmd.RemoveProcessInstanceOwnerCmd;
 import org.flowable.engine.impl.cmd.SetExecutionVariablesCmd;
+import org.flowable.engine.impl.cmd.SetProcessInstanceAssigneeCmd;
 import org.flowable.engine.impl.cmd.SetProcessInstanceBusinessKeyCmd;
 import org.flowable.engine.impl.cmd.SetProcessInstanceBusinessStatusCmd;
 import org.flowable.engine.impl.cmd.SetProcessInstanceNameCmd;
+import org.flowable.engine.impl.cmd.SetProcessInstanceOwnerCmd;
 import org.flowable.engine.impl.cmd.SignalEventReceivedCmd;
 import org.flowable.engine.impl.cmd.StartProcessInstanceAsyncCmd;
 import org.flowable.engine.impl.cmd.StartProcessInstanceByMessageCmd;
@@ -482,6 +486,26 @@ public class RuntimeServiceImpl extends CommonEngineServiceImpl<ProcessEngineCon
     @Override
     public void evaluateConditionalEvents(String processInstanceId, Map<String, Object> processVariables) {
         commandExecutor.execute(new EvaluateConditionalEventsCmd(processInstanceId, processVariables));
+    }
+
+    @Override
+    public void setOwner(String processInstanceId, String userId) {
+        commandExecutor.execute(new SetProcessInstanceOwnerCmd(processInstanceId, userId));
+    }
+
+    @Override
+    public void removeOwner(String processInstanceId) {
+        commandExecutor.execute(new RemoveProcessInstanceOwnerCmd(processInstanceId));
+    }
+
+    @Override
+    public void setAssignee(String processInstanceId, String userId) {
+        commandExecutor.execute(new SetProcessInstanceAssigneeCmd(processInstanceId, userId));
+    }
+
+    @Override
+    public void removeAssignee(String processInstanceId) {
+        commandExecutor.execute(new RemoveProcessInstanceAssigneeCmd(processInstanceId));
     }
 
     @Override

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AbstractProcessInstanceIdentityLinkCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AbstractProcessInstanceIdentityLinkCmd.java
@@ -12,13 +12,11 @@
  */
 package org.flowable.engine.impl.cmd;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
 import org.flowable.engine.impl.util.CommandContextUtil;
-import org.flowable.identitylink.api.IdentityLink;
-import org.flowable.identitylink.service.IdentityLinkService;
+import org.flowable.engine.impl.util.IdentityLinkUtil;
 
 /**
  * An abstract command supporting functionality around identity link management for process instances.
@@ -27,21 +25,59 @@ import org.flowable.identitylink.service.IdentityLinkService;
  */
 public abstract class AbstractProcessInstanceIdentityLinkCmd {
 
-    protected void removeIdentityLinkType(CommandContext commandContext, String processInstanceId, String identityType) {
-        List<IdentityLink> linksToRemove = new ArrayList<>(1);
-        for (IdentityLink identityLink : getIdentityLinkService(commandContext).findIdentityLinksByProcessInstanceId(processInstanceId)) {
-            if (identityLink.getType().equalsIgnoreCase(identityType)) {
-                linksToRemove.add(identityLink);
-            }
+    /**
+     * Returns the process instance entity for the given id, if it exists, otherwise an exception will be thrown.
+     *
+     * @param commandContext the command context within which the process instance is loaded
+     * @param processInstanceId the id of the process instance to be loaded
+     * @return the process instance entity, if found, never null
+     * @throws FlowableIllegalArgumentException if the provided process instance id is not valid
+     */
+    protected ExecutionEntity getProcessInstanceEntity(CommandContext commandContext, String processInstanceId) {
+        ExecutionEntity processInstance = CommandContextUtil.getExecutionEntityManager(commandContext).findById(processInstanceId);
+        if (processInstance == null) {
+            throw new FlowableIllegalArgumentException(
+                "The process instance with id '" + processInstanceId + "' could not be found as an active process instance.");
         }
-        // remove links in a second loop as we might run into possible concurrent modification exceptions to the identity link list
-        for (IdentityLink identityLink : linksToRemove) {
-            getIdentityLinkService(commandContext).deleteProcessInstanceIdentityLink(processInstanceId, identityLink.getUserId(), identityLink.getGroupId(),
-                identityLink.getType());
-        }
+        return processInstance;
     }
 
-    protected IdentityLinkService getIdentityLinkService(CommandContext commandContext) {
-        return CommandContextUtil.getIdentityLinkService(commandContext);
+    /**
+     * This will remove ALL identity links with the given type, no mather whether they are user or group based.
+     *
+     * @param commandContext the command context within which to remove the identity links
+     * @param processInstanceId the id of the process instance to remove the identity links for
+     * @param identityType the identity link type (e.g. assignee or owner, etc) to be removed
+     */
+    protected void removeIdentityLinkType(CommandContext commandContext, String processInstanceId, String identityType) {
+        ExecutionEntity processInstanceEntity = getProcessInstanceEntity(commandContext, processInstanceId);
+
+        // this will remove ALL identity links with the given identity type (for users AND groups)
+        IdentityLinkUtil.deleteProcessInstanceIdentityLinks(processInstanceEntity, null, null, identityType);
+    }
+
+    /**
+     * Creates a new identity link entry for the given process instance, which can either be a user or group based one, but not both the same time.
+     * If both the user and group ids are null, no new identity link is created.
+     *
+     * @param commandContext the command context within which to perform the identity link creation
+     * @param processInstanceId the id of the process instance to create an identity link for
+     * @param userId the user id if this is a user based identity link, otherwise null
+     * @param groupId the group id if this is a group based identity link, otherwise null
+     * @param identityType the type of identity link (e.g. owner or assignee, etc)
+     */
+    protected void createIdentityLinkType(CommandContext commandContext, String processInstanceId, String userId, String groupId, String identityType) {
+        // if both user and group ids are null, don't create an identity link
+        if (userId == null && groupId == null) {
+            return;
+        }
+
+        // if both are set the same time, throw an exception as this is not allowed
+        if (userId != null && groupId != null) {
+            throw new FlowableIllegalArgumentException("Either set the user id or the group id for an identity link, but not both the same time.");
+        }
+
+        ExecutionEntity processInstanceEntity = getProcessInstanceEntity(commandContext, processInstanceId);
+        IdentityLinkUtil.createProcessInstanceIdentityLink(processInstanceEntity, userId, groupId, identityType);
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AbstractProcessInstanceIdentityLinkCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/AbstractProcessInstanceIdentityLinkCmd.java
@@ -1,0 +1,49 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.cmd;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.impl.util.CommandContextUtil;
+import org.flowable.identitylink.api.IdentityLink;
+
+/**
+ * An abstract command supporting functionality around identity link management for process instances.
+ *
+ * @author Micha Kiener
+ */
+public abstract class AbstractProcessInstanceIdentityLinkCmd {
+
+    protected void removeIdentityLinkType(String processInstanceId, String identityType) {
+        List<IdentityLink> linksToRemove = new ArrayList<>(1);
+        for (IdentityLink identityLink : getRuntimeService().getIdentityLinksForProcessInstance(processInstanceId)) {
+            if (identityLink.getType().equalsIgnoreCase(identityType)) {
+                linksToRemove.add(identityLink);
+            }
+        }
+        // remove links in a second loop as we might run into possible concurrent modification exceptions to the identity link list
+        for (IdentityLink identityLink : linksToRemove) {
+            if (identityLink.getUserId() != null) {
+                getRuntimeService().deleteUserIdentityLink(processInstanceId, identityLink.getUserId(), identityLink.getType());
+            } else if (identityLink.getGroupId() != null) {
+                getRuntimeService().deleteGroupIdentityLink(processInstanceId, identityLink.getGroupId(), identityLink.getType());
+            }
+        }
+    }
+
+    protected RuntimeService getRuntimeService() {
+        return CommandContextUtil.getProcessEngineConfiguration().getRuntimeService();
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceAssigneeCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceAssigneeCmd.java
@@ -34,6 +34,7 @@ public class RemoveProcessInstanceAssigneeCmd extends AbstractProcessInstanceIde
 
     @Override
     public Void execute(CommandContext commandContext) {
+        // remove ALL assignee identity links (there should only be one of course)
         removeIdentityLinkType(commandContext, processInstanceId, IdentityLinkType.ASSIGNEE);
         return null;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceAssigneeCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceAssigneeCmd.java
@@ -24,7 +24,6 @@ import org.flowable.identitylink.api.IdentityLinkType;
  * @author Micha Kiener
  */
 public class RemoveProcessInstanceAssigneeCmd extends AbstractProcessInstanceIdentityLinkCmd implements Command<Void>, Serializable {
-
     private static final long serialVersionUID = 1L;
 
     protected final String processInstanceId;
@@ -35,7 +34,7 @@ public class RemoveProcessInstanceAssigneeCmd extends AbstractProcessInstanceIde
 
     @Override
     public Void execute(CommandContext commandContext) {
-        removeIdentityLinkType(processInstanceId, IdentityLinkType.ASSIGNEE);
+        removeIdentityLinkType(commandContext, processInstanceId, IdentityLinkType.ASSIGNEE);
         return null;
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceAssigneeCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceAssigneeCmd.java
@@ -1,0 +1,41 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.identitylink.api.IdentityLinkType;
+
+/**
+ * Command to remove the current assignee from a process instance.
+ *
+ * @author Micha Kiener
+ */
+public class RemoveProcessInstanceAssigneeCmd extends AbstractProcessInstanceIdentityLinkCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String processInstanceId;
+
+    public RemoveProcessInstanceAssigneeCmd(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        removeIdentityLinkType(processInstanceId, IdentityLinkType.ASSIGNEE);
+        return null;
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceOwnerCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceOwnerCmd.java
@@ -34,6 +34,7 @@ public class RemoveProcessInstanceOwnerCmd extends AbstractProcessInstanceIdenti
 
     @Override
     public Void execute(CommandContext commandContext) {
+        // remove ALL owner identity links (there should only be one of course)
         removeIdentityLinkType(commandContext, processInstanceId, IdentityLinkType.OWNER);
         return null;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceOwnerCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceOwnerCmd.java
@@ -1,0 +1,41 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.identitylink.api.IdentityLinkType;
+
+/**
+ * Command to remove the current owner from a process instance.
+ *
+ * @author Micha Kiener
+ */
+public class RemoveProcessInstanceOwnerCmd extends AbstractProcessInstanceIdentityLinkCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String processInstanceId;
+
+    public RemoveProcessInstanceOwnerCmd(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        removeIdentityLinkType(processInstanceId, IdentityLinkType.OWNER);
+        return null;
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceOwnerCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/RemoveProcessInstanceOwnerCmd.java
@@ -24,7 +24,6 @@ import org.flowable.identitylink.api.IdentityLinkType;
  * @author Micha Kiener
  */
 public class RemoveProcessInstanceOwnerCmd extends AbstractProcessInstanceIdentityLinkCmd implements Command<Void>, Serializable {
-
     private static final long serialVersionUID = 1L;
 
     protected final String processInstanceId;
@@ -35,7 +34,7 @@ public class RemoveProcessInstanceOwnerCmd extends AbstractProcessInstanceIdenti
 
     @Override
     public Void execute(CommandContext commandContext) {
-        removeIdentityLinkType(processInstanceId, IdentityLinkType.OWNER);
+        removeIdentityLinkType(commandContext, processInstanceId, IdentityLinkType.OWNER);
         return null;
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceAssigneeCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceAssigneeCmd.java
@@ -1,0 +1,44 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.identitylink.api.IdentityLinkType;
+
+/**
+ * Command to set a new assignee on a process instance and return the previous one, if any.
+ *
+ * @author Micha Kiener
+ */
+public class SetProcessInstanceAssigneeCmd extends AbstractProcessInstanceIdentityLinkCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String processInstanceId;
+    protected final String assigneeUserId;
+
+    public SetProcessInstanceAssigneeCmd(String processInstanceId, String assigneeUserId) {
+        this.processInstanceId = processInstanceId;
+        this.assigneeUserId = assigneeUserId;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        removeIdentityLinkType(processInstanceId, IdentityLinkType.ASSIGNEE);
+        getRuntimeService().addUserIdentityLink(processInstanceId, assigneeUserId, IdentityLinkType.ASSIGNEE);
+        return null;
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceAssigneeCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceAssigneeCmd.java
@@ -24,7 +24,6 @@ import org.flowable.identitylink.api.IdentityLinkType;
  * @author Micha Kiener
  */
 public class SetProcessInstanceAssigneeCmd extends AbstractProcessInstanceIdentityLinkCmd implements Command<Void>, Serializable {
-
     private static final long serialVersionUID = 1L;
 
     protected final String processInstanceId;
@@ -37,8 +36,8 @@ public class SetProcessInstanceAssigneeCmd extends AbstractProcessInstanceIdenti
 
     @Override
     public Void execute(CommandContext commandContext) {
-        removeIdentityLinkType(processInstanceId, IdentityLinkType.ASSIGNEE);
-        getRuntimeService().addUserIdentityLink(processInstanceId, assigneeUserId, IdentityLinkType.ASSIGNEE);
+        removeIdentityLinkType(commandContext, processInstanceId, IdentityLinkType.ASSIGNEE);
+        getIdentityLinkService(commandContext).createProcessInstanceIdentityLink(processInstanceId, assigneeUserId, null, IdentityLinkType.ASSIGNEE);
         return null;
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceAssigneeCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceAssigneeCmd.java
@@ -36,8 +36,12 @@ public class SetProcessInstanceAssigneeCmd extends AbstractProcessInstanceIdenti
 
     @Override
     public Void execute(CommandContext commandContext) {
+        // remove ALL assignee identity links (there should only be one of course)
         removeIdentityLinkType(commandContext, processInstanceId, IdentityLinkType.ASSIGNEE);
-        getIdentityLinkService(commandContext).createProcessInstanceIdentityLink(processInstanceId, assigneeUserId, null, IdentityLinkType.ASSIGNEE);
+
+        // now add the new one, but only, if it is not null, which means using the setAssignee with a null value results in the same
+        // as removeAssignee
+        createIdentityLinkType(commandContext, processInstanceId, assigneeUserId, null, IdentityLinkType.ASSIGNEE);
         return null;
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceOwnerCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceOwnerCmd.java
@@ -37,8 +37,12 @@ public class SetProcessInstanceOwnerCmd extends AbstractProcessInstanceIdentityL
 
     @Override
     public Void execute(CommandContext commandContext) {
+        // remove ALL owner identity links (there should only be one of course)
         removeIdentityLinkType(commandContext, processInstanceId, IdentityLinkType.OWNER);
-        getIdentityLinkService(commandContext).createProcessInstanceIdentityLink(processInstanceId, ownerUserId, null, IdentityLinkType.OWNER);
+
+        // now add the new one, but only, if it is not null, which means using the setOwner with a null value results in the same
+        // as removeOwner
+        createIdentityLinkType(commandContext, processInstanceId, ownerUserId, null, IdentityLinkType.OWNER);
         return null;
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceOwnerCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceOwnerCmd.java
@@ -25,7 +25,6 @@ import org.flowable.identitylink.api.IdentityLinkType;
  * @author Micha Kiener
  */
 public class SetProcessInstanceOwnerCmd extends AbstractProcessInstanceIdentityLinkCmd implements Command<Void>, Serializable {
-
     private static final long serialVersionUID = 1L;
 
     protected final String processInstanceId;
@@ -38,8 +37,8 @@ public class SetProcessInstanceOwnerCmd extends AbstractProcessInstanceIdentityL
 
     @Override
     public Void execute(CommandContext commandContext) {
-        removeIdentityLinkType(processInstanceId, IdentityLinkType.OWNER);
-        getRuntimeService().addUserIdentityLink(processInstanceId, ownerUserId, IdentityLinkType.OWNER);
+        removeIdentityLinkType(commandContext, processInstanceId, IdentityLinkType.OWNER);
+        getIdentityLinkService(commandContext).createProcessInstanceIdentityLink(processInstanceId, ownerUserId, null, IdentityLinkType.OWNER);
         return null;
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceOwnerCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetProcessInstanceOwnerCmd.java
@@ -1,0 +1,45 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.identitylink.api.IdentityLinkType;
+
+
+/**
+ * Command to set a new owner on a process instance and return the previous one, if any.
+ *
+ * @author Micha Kiener
+ */
+public class SetProcessInstanceOwnerCmd extends AbstractProcessInstanceIdentityLinkCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final String processInstanceId;
+    protected final String ownerUserId;
+
+    public SetProcessInstanceOwnerCmd(String processInstanceId, String ownerUserId) {
+        this.processInstanceId = processInstanceId;
+        this.ownerUserId = ownerUserId;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        removeIdentityLinkType(processInstanceId, IdentityLinkType.OWNER);
+        getRuntimeService().addUserIdentityLink(processInstanceId, ownerUserId, IdentityLinkType.OWNER);
+        return null;
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceIdentityLinksTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceIdentityLinksTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.task.Event;
 import org.flowable.engine.test.Deployment;
 import org.flowable.identitylink.api.IdentityLink;
@@ -178,5 +179,50 @@ public class ProcessInstanceIdentityLinksTest extends PluggableFlowableTestCase 
                 tuple("muppets", "custom", processInstanceId)
             );
     }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/runtime/IdentityLinksProcess.bpmn20.xml")
+    public void testProcessAssignee() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+            .processDefinitionKey("IdentityLinksProcess")
+            .start();
+
+        runtimeService.setAssignee(processInstance.getId(), "kermit");
+
+        List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(processInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+            .containsExactly(
+                tuple(IdentityLinkType.ASSIGNEE, "kermit", null, processInstance.getId())
+            );
+
+        runtimeService.removeAssignee(processInstance.getId());
+
+        assertThat(runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()))
+            .isEmpty();
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/runtime/IdentityLinksProcess.bpmn20.xml")
+    public void testProcessOwner() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+            .processDefinitionKey("IdentityLinksProcess")
+            .start();
+
+        runtimeService.setOwner(processInstance.getId(), "kermit");
+
+        List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(processInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+            .containsExactly(
+                tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId())
+            );
+
+        runtimeService.removeOwner(processInstance.getId());
+
+        assertThat(runtimeService.getIdentityLinksForProcessInstance(processInstance.getId()))
+            .isEmpty();
+    }
+
 
 }


### PR DESCRIPTION
Add direct support to set and remove the owner and assignee of a case or process through their runtime services.

#### Check List:
* Unit tests: YES
* Documentation: NA
