### PR TITLE
Add debug logging before sending emails

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
@@ -13,6 +13,8 @@
 
 package org.flowable.cmmn.engine.impl.behavior.impl;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,8 +25,10 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.activation.DataSource;
+import javax.mail.internet.InternetAddress;
 import javax.naming.NamingException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -112,6 +116,24 @@ public class MailActivityBehavior extends CoreCmmnActivityBehavior {
             setCharset(email, charSetStr, planItemInstanceEntity.getTenantId());
             attach(email, files, dataSources);
 
+            if(LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Sending {} email"
+                                + " from '{}' (original value: '{}'),"
+                                + " to '{}' (original value: '{}'),"
+                                + " cc '{}' (original value: '{}'),"
+                                + " bcc '{}' (original value: '{}'),"
+                                + " with final headers '{}' (original headers: '{}', original charset value: '{}', original number of attachments: '{}'),"
+                                + " on host '{}'.",
+                        email instanceof HtmlEmail ? "html" : "text",
+                        email.getFromAddress() == null ? null : email.getFromAddress().getAddress(), fromStr,
+                        email.getToAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), toStr,
+                        email.getCcAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), ccStr,
+                        email.getBccAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), bccStr,
+                        email.getHeaders(), headersStr, charSetStr, files.size(),
+                        email.getHostName()
+                );
+            }
+            
             email.send();
 
         } catch (FlowableException e) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/MailActivityBehavior.java
@@ -117,14 +117,14 @@ public class MailActivityBehavior extends CoreCmmnActivityBehavior {
             attach(email, files, dataSources);
 
             if(LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Sending {} email"
+                LOGGER.debug("Sending of {} email by plan item '{}' (in tenant '{}')"
                                 + " from '{}' (original value: '{}'),"
                                 + " to '{}' (original value: '{}'),"
                                 + " cc '{}' (original value: '{}'),"
                                 + " bcc '{}' (original value: '{}'),"
                                 + " with final headers '{}' (original headers: '{}', original charset value: '{}', original number of attachments: '{}'),"
                                 + " on host '{}'.",
-                        email instanceof HtmlEmail ? "html" : "text",
+                        email instanceof HtmlEmail ? "html" : "text", planItemInstanceEntity.getId(), planItemInstanceEntity.getTenantId(),
                         email.getFromAddress() == null ? null : email.getFromAddress().getAddress(), fromStr,
                         email.getToAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), toStr,
                         email.getCcAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), ccStr,

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -128,14 +128,14 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
                 attach(email, files, dataSources);
 
                 if(LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Sending {} email"
+                    LOGGER.debug("Sending of {} email by execution '{}' (in tenant '{}')"
                                     + " from '{}' (original value: '{}'),"
                                     + " to '{}' (original value: '{}'),"
                                     + " cc '{}' (original value: '{}'),"
                                     + " bcc '{}' (original value: '{}'),"
                                     + " with final headers '{}' (original headers: '{}', original charset value: '{}', original number of attachments: '{}'),"
                                     + " on host '{}'.",
-                            email instanceof HtmlEmail ? "html" : "text",
+                            email instanceof HtmlEmail ? "html" : "text", execution.getId(), execution.getTenantId(),
                             email.getFromAddress() == null ? null : email.getFromAddress().getAddress(), fromStr,
                             email.getToAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), toStr,
                             email.getCcAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), ccStr,

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -26,7 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.activation.DataSource;
 import javax.mail.internet.InternetAddress;
@@ -113,7 +112,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
                 getFilesFromFields(attachments, execution, files, dataSources);
 
                 if (StringUtils.isAllEmpty(toStr, ccStr, bccStr)) {
-                    throw new FlowableException("No recipient could be found for sending email");
+                    throw new FlowableException("No recipient could be found for sending email: fields to ("+ getEmailExprText(to)+"), cc ("+ getEmailExprText(cc)+") and bcc ("+ getEmailExprText(bcc)+") are all resolved to an empty value");
                 }
 
                 email = createEmail(textStr, htmlStr, attachmentsExist(files, dataSources));
@@ -136,10 +135,10 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
                                     + " with final headers '{}' (original headers: '{}', original charset value: '{}', original number of attachments: '{}'),"
                                     + " on host '{}'.",
                             email instanceof HtmlEmail ? "html" : "text", execution.getId(), execution.getTenantId(),
-                            email.getFromAddress() == null ? null : email.getFromAddress().getAddress(), fromStr,
-                            email.getToAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), toStr,
-                            email.getCcAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), ccStr,
-                            email.getBccAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), bccStr,
+                            getEmailAddressForLog(email.getFromAddress()), fromStr,
+                            email.getToAddresses().stream().map(this::getEmailAddressForLog).filter(Objects::nonNull).collect(joining(",")), toStr,
+                            email.getCcAddresses().stream().map(this::getEmailAddressForLog).filter(Objects::nonNull).collect(joining(",")), ccStr,
+                            email.getBccAddresses().stream().map(this::getEmailAddressForLog).filter(Objects::nonNull).collect(joining(",")), bccStr,
                             email.getHeaders(), headersStr, charSetStr, files.size(),
                             email.getHostName()
                     );
@@ -154,6 +153,16 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
         }
 
         leave(execution);
+    }
+
+    private String getEmailExprText(Expression exp) {
+        //TODO: introduce email masking based on configuration?
+        return exp == null ? null : exp.getExpressionText();
+    }
+
+    private String getEmailAddressForLog(InternetAddress address) {
+        //TODO: introduce email masking based on configuration?
+        return address == null ? null : address.getAddress();
     }
 
     protected void addHeader(Email email, String headersStr) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -13,6 +13,8 @@
 
 package org.flowable.engine.impl.bpmn.behavior;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,8 +25,11 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.activation.DataSource;
+import javax.mail.internet.InternetAddress;
 import javax.naming.NamingException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -121,7 +126,24 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
                 setMailServerProperties(email, execution.getTenantId());
                 setCharset(email, charSetStr, execution.getTenantId());
                 attach(email, files, dataSources);
-    
+
+                if(LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Sending {} email"
+                                    + " from '{}' (original value: '{}'),"
+                                    + " to '{}' (original value: '{}'),"
+                                    + " cc '{}' (original value: '{}'),"
+                                    + " bcc '{}' (original value: '{}'),"
+                                    + " with final headers '{}' (original headers: '{}', original charset value: '{}', original number of attachments: '{}'),"
+                                    + " on host '{}'.",
+                            email instanceof HtmlEmail ? "html" : "text",
+                            email.getFromAddress() == null ? null : email.getFromAddress().getAddress(), fromStr,
+                            email.getToAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), toStr,
+                            email.getCcAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), ccStr,
+                            email.getBccAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), bccStr,
+                            email.getHeaders(), headersStr, charSetStr, files.size(),
+                            email.getHostName()
+                    );
+                }
                 email.send();
     
             } catch (FlowableException e) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -13,14 +13,18 @@
 
 package org.activiti.engine.impl.bpmn.behavior;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.activation.DataSource;
+import javax.mail.internet.InternetAddress;
 import javax.naming.NamingException;
 
 import org.activiti.engine.ActivitiException;
@@ -99,6 +103,24 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
             setCharset(email, charSetStr);
             attach(email, files, dataSources);
 
+            if(LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Sending {} email"
+                                + " from '{}' (original value: '{}'),"
+                                + " to '{}' (original value: '{}'),"
+                                + " cc '{}' (original value: '{}'),"
+                                + " bcc '{}' (original value: '{}'),"
+                                + " with final headers '{}' (original charset value: '{}', original number of attachments: '{}'),"
+                                + " on host '{}'.",
+                        email instanceof HtmlEmail ? "html" : "text",
+                        email.getFromAddress() == null ? null : email.getFromAddress().getAddress(), fromStr,
+                        email.getToAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), toStr,
+                        email.getCcAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), ccStr,
+                        email.getBccAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), bccStr,
+                        email.getHeaders(), charSetStr, files.size(),
+                        email.getHostName()
+                );
+            }
+            
             email.send();
 
         } catch (ActivitiException e) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -112,10 +112,10 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
                                 + " with final headers '{}' (original charset value: '{}', original number of attachments: '{}'),"
                                 + " on host '{}'.",
                         email instanceof HtmlEmail ? "html" : "text", execution.getId(), execution.getTenantId(),
-                        email.getFromAddress() == null ? null : email.getFromAddress().getAddress(), fromStr,
-                        email.getToAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), toStr,
-                        email.getCcAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), ccStr,
-                        email.getBccAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), bccStr,
+                        getEmailAddressForLog(email.getFromAddress()), fromStr,
+                        email.getToAddresses().stream().map(this::getEmailAddressForLog).filter(Objects::nonNull).collect(joining(",")), toStr,
+                        email.getCcAddresses().stream().map(this::getEmailAddressForLog).filter(Objects::nonNull).collect(joining(",")), ccStr,
+                        email.getBccAddresses().stream().map(this::getEmailAddressForLog).filter(Objects::nonNull).collect(joining(",")), bccStr,
                         email.getHeaders(), charSetStr, files.size(),
                         email.getHostName()
                 );
@@ -130,6 +130,15 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
         }
 
         leave((ActivityExecution) execution);
+    }
+
+    private String getToExprText(Expression exp) {
+        return exp == null ? null : exp.getExpressionText();
+    }
+
+    private String getEmailAddressForLog(InternetAddress address) {
+        //TODO: introduce email masking based on configuration?
+        return address == null ? null : address.getAddress();
     }
 
     private boolean attachmentsExist(List<File> files, List<DataSource> dataSources) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -104,14 +104,14 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
             attach(email, files, dataSources);
 
             if(LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Sending {} email"
+                LOGGER.debug("Sending of {} email by execution '{}' (in tenant '{}')"
                                 + " from '{}' (original value: '{}'),"
                                 + " to '{}' (original value: '{}'),"
                                 + " cc '{}' (original value: '{}'),"
                                 + " bcc '{}' (original value: '{}'),"
                                 + " with final headers '{}' (original charset value: '{}', original number of attachments: '{}'),"
                                 + " on host '{}'.",
-                        email instanceof HtmlEmail ? "html" : "text",
+                        email instanceof HtmlEmail ? "html" : "text", execution.getId(), execution.getTenantId(),
                         email.getFromAddress() == null ? null : email.getFromAddress().getAddress(), fromStr,
                         email.getToAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), toStr,
                         email.getCcAddresses().stream().filter(Objects::nonNull).map(InternetAddress::getAddress).collect(joining(",")), ccStr,


### PR DESCRIPTION
I recently had frequent issues around the resolution of email recipients (for example due to misconfiguration of the tenant-specific force-to parameter or because the bean called in the cc expression returned an incorrect value)
Due to the fact that many email parameters are calculated on-the-fly, errors with the mail activity are quite hard to analyze in non-local environments, and more debug logging would be very helpful.

#### Check List:
* Unit tests: NA
* Documentation: NA
