### PR TITLE
Update to Spring Framework 5.3.20

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
 org.slf4j                       slf4j-api                   1.7.36          MIT License
 org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.19          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.19          The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.20          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.20          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.6.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.6.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.6.2           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.6.6</spring.boot.version>
-		<spring.framework.version>5.3.19</spring.framework.version>
+		<spring.framework.version>5.3.20</spring.framework.version>
 		<spring.security.version>5.6.2</spring.security.version>
 		<spring.amqp.version>2.4.3</spring.amqp.version>
 		<spring.kafka.version>2.8.4</spring.kafka.version>


### PR DESCRIPTION
Spring Framework 5.3.20 includes 14 fixes and improvements
See: https://github.com/spring-projects/spring-framework/releases/tag/v5.3.20

In addition, the release include fixes for 2 vulnerabilities:

CVE-2022-22970
“Spring Framework DoS via Data Binding to MultipartFile or Servlet Part”
Denial of Service (DoS) attack in Spring MVC or Spring WebFlux applications that handle file uploads and rely on data binding to set a MultipartFile or javax.servlet.Part to a field in a model object.
Severity: [Medium]

CVE-2022-22971
“Spring Framework DoS with STOMP over WebSocket”
Denial of service (DoS) attack by authenticated users in Spring applications with a STOMP over WebSocket endpoint.
Severity: [Medium]