### PR TITLE
Updated "List of process definitions" docs

### DIFF
--- a/docs/docusaurus/docs/bpmn/ch15-REST.md
+++ b/docs/docusaurus/docs/bpmn/ch15-REST.md
@@ -1070,7 +1070,7 @@ The response body will contain the binary resource-content for the requested res
 <td><p>latest</p></td>
 <td><p>No</p></td>
 <td><p>Boolean</p></td>
-<td><p>Only return the latest process definition versions. Can only be used together with 'key' and 'keyLike' parameters, using any other parameter will result in a 400-response.</p></td>
+<td><p>Only return the latest process definition versions. Can only be used together with 'key', 'keyLike', 'resourceName' and 'resourceNameLike' parameters, using any other parameter will result in a 400-response.</p></td>
 </tr>
 <tr class="even">
 <td><p>suspended</p></td>

--- a/docs/userguide/src/en/bpmn/ch15-REST.adoc
+++ b/docs/userguide/src/en/bpmn/ch15-REST.adoc
@@ -319,7 +319,7 @@ GET repository/process-definitions
 |categoryNotEquals|No|String|Only return process definitions which don't have the given category.
 |deploymentId|No|String|Only return process definitions which are part of a deployment with the given id.
 |startableByUser|No|String|Only return process definitions which can be started by the given user.
-|latest|No|Boolean|Only return the latest process definition versions. Can only be used together with 'key' and 'keyLike' parameters, using any other parameter will result in a 400-response.
+|latest|No|Boolean|Only return the latest process definition versions. Can only be used together with 'key', 'keyLike', 'resourceName' and 'resourceNameLike' parameters, using any other parameter will result in a 400-response.
 |suspended|No|Boolean|If +true+, only returns process definitions which are suspended. If +false+, only active process definitions (which are not suspended) are returned.
 |sort|No|'name' (default), 'id', 'key', 'category', 'deploymentId' and 'version'|Property to sort on, to be used together with the 'order'.
 |The general <<restPagingAndSort,paging and sorting query-parameters>> can be used for this URL.

--- a/docs/userguide/src/zh_CN/bpmn/ch15-REST.adoc
+++ b/docs/userguide/src/zh_CN/bpmn/ch15-REST.adoc
@@ -319,7 +319,7 @@ GET repository/process-definitions
 |categoryNotEquals|No|String|Only return process definitions which don't have the given category.
 |deploymentId|No|String|Only return process definitions which are part of a deployment with the given id.
 |startableByUser|No|String|Only return process definitions which can be started by the given user.
-|latest|No|Boolean|Only return the latest process definition versions. Can only be used together with 'key' and 'keyLike' parameters, using any other parameter will result in a 400-response.
+|latest|No|Boolean|Only return the latest process definition versions. Can only be used together with 'key', 'keyLike', 'resourceName' and 'resourceNameLike' parameters, using any other parameter will result in a 400-response.
 |suspended|No|Boolean|If +true+, only returns process definitions which are suspended. If +false+, only active process definitions (which are not suspended) are returned.
 |sort|No|'name' (default), 'id', 'key', 'category', 'deploymentId' and 'version'|Property to sort on, to be used together with the 'order'.
 |The general <<restPagingAndSort,paging and sorting query-parameters>> can be used for this URL.


### PR DESCRIPTION
The docs currently state that the latest parameter can only be used in combination with the "key(Like)" parameter but I've found it also works with the "resourceName(Like)" parameter.

#### Check List:
* Unit tests: NA
* Documentation: YES
