### PR TITLE
Update to Spring Security 5.6.4

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.20          The 
 org.springframework             spring-core                 5.3.20          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.20          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.20          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.6.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.6.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.6.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.6.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.6.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.6.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.6.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.6.4           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,10 @@
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.6.7</spring.boot.version>
 		<spring.framework.version>5.3.20</spring.framework.version>
-		<spring.security.version>5.6.3</spring.security.version>
+		<spring.security.version>5.6.4</spring.security.version>
 		<spring.amqp.version>2.4.4</spring.amqp.version>
 		<spring.kafka.version>2.8.5</spring.kafka.version>
-		<reactor-netty.version>1.0.16</reactor-netty.version>
+		<reactor-netty.version>1.0.19</reactor-netty.version>
 		<jackson.version>2.13.2.1</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>


### PR DESCRIPTION
Release Notes: https://github.com/spring-projects/spring-security/releases/tag/5.6.4

Fixes 2 CVEs:

- [CVE-2022-22975: Authorization Bypass in RegexRequestMatcher](https://spring.io/blog/2022/05/15/cve-2022-22975-authorization-bypass-in-regexrequestmatcher)
- [CVE-2022-22976: BCrypt skips salt rounds for work factor of 31](https://spring.io/blog/2022/05/15/cve-2022-22976-bcrypt-skips-salt-rounds-for-work-factor-of-31)