### PR TITLE
Update to SpringBoot 2.6.8

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.20          The 
 org.springframework             spring-core                 5.3.20          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.20          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.20          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.6.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.6.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.6.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.6.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.6.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.6.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.6.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.6.5           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,13 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.6.7</spring.boot.version>
+		<spring.boot.version>2.6.8</spring.boot.version>
 		<spring.framework.version>5.3.20</spring.framework.version>
-		<spring.security.version>5.6.4</spring.security.version>
-		<spring.amqp.version>2.4.4</spring.amqp.version>
-		<spring.kafka.version>2.8.5</spring.kafka.version>
+		<spring.security.version>5.6.5</spring.security.version>
+		<spring.amqp.version>2.4.5</spring.amqp.version>
+		<spring.kafka.version>2.8.6</spring.kafka.version>
 		<reactor-netty.version>1.0.19</reactor-netty.version>
-		<jackson.version>2.13.2.1</jackson.version>
+		<jackson.version>2.13.3</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>3.14.0</camel.version>
@@ -795,7 +795,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.6.8.Final</version>
+				<version>5.6.9.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>
@@ -1012,7 +1012,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.3.4</version>
+				<version>42.3.5</version>
 			</dependency>
 			<dependency>
 				<groupId>xerces</groupId>


### PR DESCRIPTION
Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.6.8

Note: I did **not** upgrade to MySQL 8.0.29 from 8.0.19 because there was some reason in previous updates not to move off 8.0.19.

