### PR TITLE
Chore: Remove unused imports from commits starting around April

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CmmnVariableInstanceQueryImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CmmnVariableInstanceQueryImpl.java
@@ -17,7 +17,6 @@ import java.util.Set;
 
 import org.flowable.cmmn.api.runtime.VariableInstanceQuery;
 import org.flowable.cmmn.engine.CmmnEngineConfiguration;
-import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.query.QueryProperty;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.interceptor.CommandExecutor;

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/BulkMoveDeadLetterActionRequest.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/BulkMoveDeadLetterActionRequest.java
@@ -14,7 +14,6 @@
 package org.flowable.cmmn.rest.service.api;
 
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Class that represents a bulk action to be performed on a resource.

--- a/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DmnTaskTest.java
+++ b/modules/flowable-dmn-engine-configurator/src/test/java/org/flowable/dmn/test/runtime/DmnTaskTest.java
@@ -17,10 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 import org.flowable.dmn.engine.DmnEngineConfiguration;
 import org.flowable.engine.DecisionTableVariableManager;
@@ -36,6 +33,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/RuntimeVariablesTest.java
@@ -26,7 +26,6 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
-import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.api.persistence.entity.VariableInstance;
 import org.junit.jupiter.api.Test;
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
@@ -28,7 +28,6 @@ import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.eventsubscription.service.impl.EventSubscriptionQueryImpl;
-import org.flowable.job.api.Job;
 import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/variable/VariableListenerEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/variable/VariableListenerEventSubprocessTest.java
@@ -15,9 +15,6 @@ package org.flowable.engine.test.bpmn.event.variable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryEventSubprocessTest.java
@@ -27,7 +27,6 @@ import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.runtime.ActivityInstance;
-import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.eventregistry.api.EventDeployment;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/HistoricVariableInstanceTest.java
@@ -35,7 +35,6 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskQuery;
 import org.flowable.variable.api.history.HistoricVariableInstance;
-import org.flowable.variable.api.persistence.entity.VariableInstance;
 import org.flowable.variable.service.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.junit.jupiter.api.Test;
 

--- a/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/runtime/VariableInstanceQuery.java
+++ b/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/runtime/VariableInstanceQuery.java
@@ -16,7 +16,6 @@ package org.flowable.variable.api.runtime;
 import java.util.Set;
 
 import org.flowable.common.engine.api.query.Query;
-import org.flowable.variable.api.history.HistoricVariableInstanceQuery;
 import org.flowable.variable.api.persistence.entity.VariableInstance;
 
 /**


### PR DESCRIPTION
Made changes to order the imports to match standards too.

Replaces: https://github.com/flowable/flowable-engine/pull/3278
