### PR TITLE
modularize channel processor

### DIFF
--- a/modules/flowable-event-registry-integration-test/pom.xml
+++ b/modules/flowable-event-registry-integration-test/pom.xml
@@ -129,6 +129,29 @@
             <artifactId>json-unit-assertj</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithDynamicChannelProcessorTest.java
+++ b/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithDynamicChannelProcessorTest.java
@@ -26,28 +26,18 @@ import org.flowable.engine.TaskService;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.eventregistry.api.EventDeployment;
-import org.flowable.eventregistry.api.EventRegistry;
 import org.flowable.eventregistry.api.EventRepositoryService;
 import org.flowable.eventregistry.impl.EventRegistryEngineConfiguration;
-import org.flowable.eventregistry.model.JmsInboundChannelModel;
-import org.flowable.eventregistry.spring.jms.JmsChannelModelProcessor;
 import org.flowable.spring.impl.test.FlowableSpringExtension;
 import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.jms.annotation.JmsListener;
-import org.springframework.jms.config.JmsListenerContainerFactory;
-import org.springframework.jms.config.JmsListenerEndpoint;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @SpringJUnitConfig(classes = ProcessWithDynamicChannelProcessorTestConfiguration.class)
 @ExtendWith(FlowableSpringExtension.class)

--- a/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithDynamicChannelProcessorTest.java
+++ b/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithDynamicChannelProcessorTest.java
@@ -1,0 +1,138 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.eventregistry.integrationtest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
+import org.flowable.engine.ProcessEngine;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.TaskService;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.Deployment;
+import org.flowable.eventregistry.api.EventDeployment;
+import org.flowable.eventregistry.api.EventRegistry;
+import org.flowable.eventregistry.api.EventRepositoryService;
+import org.flowable.eventregistry.impl.EventRegistryEngineConfiguration;
+import org.flowable.eventregistry.model.JmsInboundChannelModel;
+import org.flowable.eventregistry.spring.jms.JmsChannelModelProcessor;
+import org.flowable.spring.impl.test.FlowableSpringExtension;
+import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.jms.config.JmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerEndpoint;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@SpringJUnitConfig(classes = ProcessWithDynamicChannelProcessorTestConfiguration.class)
+@ExtendWith(FlowableSpringExtension.class)
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(properties = {
+        "application.test.jms-queue=test-queue"
+})
+public class ProcessWithDynamicChannelProcessorTest {
+
+    @Autowired
+    protected ProcessEngine processEngine;
+
+    @Autowired
+    protected RuntimeService runtimeService;
+
+    @Autowired
+    protected TaskService taskService;
+
+    @SpyBean
+    protected JmsTemplate jmsTemplate;
+
+    @Test
+    @Deployment(resources = { "org/flowable/eventregistry/integrationtest/testSendAndReceiveEventTaskWithCorrelationAndPayload.bpmn20.xml",
+            "org/flowable/eventregistry/integrationtest/one-header-correlation.event",
+            "org/flowable/eventregistry/integrationtest/one.channel",
+            "org/flowable/eventregistry/integrationtest/two.channel",
+            "org/flowable/eventregistry/integrationtest/two-outbound.channel"
+    })
+    public void testHeaderCorrelationEvent() {
+        try {
+            jmsTemplate.convertAndSend("test-queue", "{"
+                    + "    \"payload1\": \"kermit\","
+                    + "    \"payload2\": 123"
+                    + "}", messageProcessor -> {
+                messageProcessor.setStringProperty("headerProperty1", "123a");
+                messageProcessor.setStringProperty("headerProperty2", "header1");
+                return messageProcessor;
+            });
+
+            await("receive events")
+                    .atMost(Duration.ofSeconds(5))
+                    .pollInterval(Duration.ofMillis(200))
+                    .untilAsserted(() ->
+                            assertTrue(runtimeService.createProcessInstanceQuery()
+                                    .processDefinitionKey("process")
+                                    .variableValueEquals("customerIdVar", "123a")
+                                    .count() > 0)
+                    );
+            ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().processDefinitionKey("process")
+                    .variableValueEquals("customerIdVar", "123a")
+                    .singleResult();
+
+            assertThat(runtimeService.getVariable(processInstance.getId(), "headerValue1")).isNull();
+            assertThat(runtimeService.getVariable(processInstance.getId(), "headerValue2")).isEqualTo("header1");
+            assertThat(runtimeService.getVariable(processInstance.getId(), "value1")).isEqualTo("kermit");
+            assertThat(runtimeService.getVariable(processInstance.getId(), "value2")).isEqualTo(123);
+
+            Task activeTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            //FIXME: activeTask == null
+            taskService.complete(activeTask.getId());
+
+            assertThat(runtimeService.getVariable(processInstance.getId(), "value1")).isEqualTo("your-fake-reply");
+            assertThat(runtimeService.getVariable(processInstance.getId(), "value2")).isEqualTo(123);
+
+            assertThat(runtimeService.getVariable(processInstance.getId(), "headerValue1")).isEqualTo("123a");
+
+            Task finalTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            taskService.complete(finalTask.getId());
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count()).isZero();
+
+        } finally {
+            List<EventDeployment> eventDeployments = getEventRepositoryService().createDeploymentQuery().list();
+            for (EventDeployment eventDeployment : eventDeployments) {
+                getEventRepositoryService().deleteDeployment(eventDeployment.getId());
+            }
+        }
+    }
+
+    protected EventRepositoryService getEventRepositoryService() {
+        return getEventRegistryEngineConfiguration().getEventRepositoryService();
+    }
+
+    protected EventRegistryEngineConfiguration getEventRegistryEngineConfiguration() {
+        return (EventRegistryEngineConfiguration)
+                processEngine.getProcessEngineConfiguration().getEngineConfigurations().get(EngineConfigurationConstants.KEY_EVENT_REGISTRY_CONFIG);
+    }
+
+}

--- a/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithDynamicChannelProcessorTestConfiguration.java
+++ b/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithDynamicChannelProcessorTestConfiguration.java
@@ -1,0 +1,193 @@
+package org.flowable.eventregistry.integrationtest;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Session;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.flowable.eventregistry.api.EventRegistry;
+import org.flowable.eventregistry.model.JmsInboundChannelModel;
+import org.flowable.eventregistry.spring.jms.JmsChannelModelProcessor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerEndpoint;
+import org.springframework.jms.config.JmsListenerEndpointRegistry;
+import org.springframework.jms.connection.CachingConnectionFactory;
+import org.springframework.jms.core.JmsOperations;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.support.destination.DynamicDestinationResolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@Import(BpmnWithEventRegistryTestConfiguration.class)
+@EnableJms
+public class ProcessWithDynamicChannelProcessorTestConfiguration {
+
+    /*private class OnInternalRequestProcessorCondition implements Condition {
+
+        public OnInternalRequestProcessorCondition() {
+        }
+
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return true;
+        }
+    }*/
+    
+    @ConditionalOnExpression("true")//@Conditional(OnInternalRequestProcessorCondition.class)
+    @Bean
+    public InternalFakeRequestProcessor internalService(JmsTemplate jmsTemplate) {
+        return new InternalFakeRequestProcessor(jmsTemplate);
+    }
+
+    /**
+     * to be used only for the JmsListeners of InternalFakeRequestProcessor, as well as the ones from the channel models
+     * which are used to interact with the InternalFakeRequestProcessor
+     */
+    @ConditionalOnExpression("true")//@Conditional(OnInternalRequestProcessorCondition.class)
+    @Bean
+    public JmsListenerContainerFactory<?> testJmsListenerContainerFactory(ConnectionFactory connectionFactory) {
+        DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+
+        // configuration properties are Spring Boot defaults
+        factory.setPubSubDomain(false);
+        factory.setDestinationResolver(new DynamicDestinationResolver() {
+
+            @Override
+            public Destination resolveDestinationName(Session session, String destinationName, boolean pubSubDomain) throws JMSException {
+                if (destinationName.equals("EXT_QUEUE_IN")) {
+                    return resolveDestinationName(session, "another-test-queue", pubSubDomain);
+                } else if (destinationName.equals("EXT_QUEUE_OUT")) {
+                    return resolveDestinationName(session, "yet-another-test-queue", pubSubDomain);
+                }
+                return super.resolveDestinationName(session, destinationName, pubSubDomain);
+            }
+        });
+        factory.setSessionTransacted(true);
+        factory.setAutoStartup(true);
+
+        return factory;
+    }
+
+    /**
+     * to be used only for all other JmsListeners
+     */
+    @Bean
+    public JmsListenerContainerFactory<?> defaultJmsListenerContainerFactory(ConnectionFactory connectionFactory) {
+        DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+
+        // configuration properties are Spring Boot defaults
+        factory.setPubSubDomain(false);
+        factory.setSessionTransacted(true);
+        factory.setAutoStartup(true);
+        factory.setReceiveTimeout(Duration.ofSeconds(1).toMillis());
+
+        return factory;
+    }
+
+    @Bean
+    public JmsTemplate jmsTemplate(ConnectionFactory connectionFactory) {
+        JmsTemplate template = new JmsTemplate(connectionFactory);
+
+        template.setPubSubDomain(false);
+
+        return template;
+    }
+
+    @Bean
+    public CachingConnectionFactory cachingJmsConnectionFactory() {
+        // configuration properties are Spring Boot defaults
+        ActiveMQConnectionFactory activeMQConnectionFactory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+        activeMQConnectionFactory.setCloseTimeout((int) Duration.ofSeconds(15).toMillis());
+        activeMQConnectionFactory.setNonBlockingRedelivery(false);
+        activeMQConnectionFactory.setSendTimeout(0); // wait forever
+
+        CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(activeMQConnectionFactory);
+        cachingConnectionFactory.setCacheConsumers(false);
+        cachingConnectionFactory.setCacheProducers(true);
+        cachingConnectionFactory.setSessionCacheSize(1);
+
+        return cachingConnectionFactory;
+    }
+
+    @Bean
+    public JmsChannelModelProcessor testJmsChannelDefinitionProcessor(
+            JmsListenerEndpointRegistry endpointRegistry,
+            JmsOperations jmsOperations,
+            ObjectMapper objectMapper,
+            @Qualifier("defaultJmsListenerContainerFactory") JmsListenerContainerFactory<?> defaultJmsListenerContainerFactory,
+            @Qualifier("testJmsListenerContainerFactory") Optional<JmsListenerContainerFactory<?>> testJmsListenerContainerFactory) {
+
+        DynamicJmsChannelModelProcessor jmsChannelDeployer = new DynamicJmsChannelModelProcessor(
+                objectMapper);
+        jmsChannelDeployer.setEndpointRegistry(endpointRegistry);
+        jmsChannelDeployer.setJmsOperations(jmsOperations);
+        jmsChannelDeployer.setContainerFactory(defaultJmsListenerContainerFactory);
+
+        testJmsListenerContainerFactory.ifPresent(jmsChannelDeployer::setCustomContainerFactory);
+
+        return jmsChannelDeployer;
+    }
+
+    /**
+     * mocks an external service in order to run the application in environments where this service is not available
+     */
+    private static final class InternalFakeRequestProcessor {
+
+        private final JmsTemplate jmsTemplate;
+
+        public InternalFakeRequestProcessor(JmsTemplate jmsTemplate) {
+            this.jmsTemplate = jmsTemplate;
+        }
+
+        @JmsListener(destination = "EXT_QUEUE_OUT", containerFactory = "testJmsListenerContainerFactory")
+        public void replyToRequest(Object request) {
+            ObjectNode requestNode = (ObjectNode) request;
+            this.jmsTemplate.convertAndSend("EXT_QUEUE_IN", ((ObjectNode) new JsonMapper().createObjectNode().setAll(requestNode))
+                    .put("value1", requestNode.get("value1").textValue() + requestNode.get("value2").textValue())
+                    .put("value2", "your-fake-reply")
+            );
+        }
+    }
+    
+    private static final class DynamicJmsChannelModelProcessor extends JmsChannelModelProcessor {
+
+        private JmsListenerContainerFactory<?> customContainerFactory;
+
+        public DynamicJmsChannelModelProcessor(ObjectMapper objectMapper) {
+            super(objectMapper);
+        }
+
+        public void setCustomContainerFactory(JmsListenerContainerFactory<?> customContainerFactory) {
+            this.customContainerFactory = customContainerFactory;
+        }
+
+        @Override
+        protected JmsListenerEndpoint processInboundDefinition(String tenantId, EventRegistry eventRegistry, JmsInboundChannelModel jmsChannelModel) {
+            JmsListenerEndpoint endpoint = createJmsListenerEndpoint(jmsChannelModel, tenantId, eventRegistry);
+            if(jmsChannelModel.getDestination().contains("EXT_QUEUE") && customContainerFactory != null) {
+                registerEndpoint(endpoint, customContainerFactory);
+            } else {
+                registerEndpoint(endpoint, null);
+            }
+            return endpoint;
+        }
+    }
+}

--- a/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithDynamicChannelProcessorTestConfiguration.java
+++ b/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithDynamicChannelProcessorTestConfiguration.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.eventregistry.integrationtest;
 
 import java.time.Duration;
@@ -15,10 +27,7 @@ import org.flowable.eventregistry.spring.jms.JmsChannelModelProcessor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Condition;
-import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.jms.annotation.EnableJms;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
@@ -45,10 +54,10 @@ public class ProcessWithDynamicChannelProcessorTestConfiguration {
 
         @Override
         public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
-            return true;
+            return true;//this is for example based on the execution environment of the application
         }
     }*/
-    
+
     @ConditionalOnExpression("true")//@Conditional(OnInternalRequestProcessorCondition.class)
     @Bean
     public InternalFakeRequestProcessor internalService(JmsTemplate jmsTemplate) {
@@ -166,7 +175,7 @@ public class ProcessWithDynamicChannelProcessorTestConfiguration {
             );
         }
     }
-    
+
     private static final class DynamicJmsChannelModelProcessor extends JmsChannelModelProcessor {
 
         private JmsListenerContainerFactory<?> customContainerFactory;
@@ -182,7 +191,7 @@ public class ProcessWithDynamicChannelProcessorTestConfiguration {
         @Override
         protected JmsListenerEndpoint processInboundDefinition(String tenantId, EventRegistry eventRegistry, JmsInboundChannelModel jmsChannelModel) {
             JmsListenerEndpoint endpoint = createJmsListenerEndpoint(jmsChannelModel, tenantId, eventRegistry);
-            if(jmsChannelModel.getDestination().contains("EXT_QUEUE") && customContainerFactory != null) {
+            if (jmsChannelModel.getDestination().contains("EXT_QUEUE") && customContainerFactory != null) {
                 registerEndpoint(endpoint, customContainerFactory);
             } else {
                 registerEndpoint(endpoint, null);

--- a/modules/flowable-event-registry-integration-test/src/test/resources/org/flowable/eventregistry/integrationtest/testSendAndReceiveEventTaskWithCorrelationAndPayload.bpmn20.xml
+++ b/modules/flowable-event-registry-integration-test/src/test/resources/org/flowable/eventregistry/integrationtest/testSendAndReceiveEventTaskWithCorrelationAndPayload.bpmn20.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples"
+             xmlns:tns="Examples">
+
+    <process id="process">
+
+        <startEvent id="theStart">
+            <extensionElements>
+                <flowable:eventType>one</flowable:eventType>
+                <flowable:startEventCorrelationConfiguration>startNewInstance</flowable:startEventCorrelationConfiguration>
+                <flowable:eventOutParameter source="headerProperty1" target="customerIdVar"/>
+                <flowable:eventOutParameter source="headerProperty2" target="headerValue2"/>
+                <flowable:eventOutParameter source="payload1" target="value1" />
+                <flowable:eventOutParameter source="payload2" target="value2" />
+                <flowable:channelKey>one</flowable:channelKey>
+            </extensionElements>
+        </startEvent>
+
+        <sequenceFlow sourceRef="theStart" targetRef="sendAndReceiveEventTask"/>
+
+        <serviceTask id="sendAndReceiveEventTask" name="Send and receive event task" flowable:type="send-event" flowable:triggerable="true">
+            <extensionElements>
+                <flowable:eventType>one</flowable:eventType>
+                <flowable:eventInParameter source="${customerIdVar}" target="headerProperty1" />
+                <flowable:eventInParameter source="${headerValue2}" target="headerProperty2" />
+                <flowable:eventInParameter source="${value1}" target="payload1" />
+                <flowable:eventInParameter source="${value2}" target="payload2" />
+                <flowable:channelKey>two-outbound</flowable:channelKey>
+                <flowable:triggerEventType>one</flowable:triggerEventType>
+                <flowable:triggerEventCorrelationParameter name="headerProperty1" value="${customerIdVar}"/>
+                <flowable:eventOutParameter source="headerProperty1" target="headerValue1"/>
+                <flowable:eventOutParameter source="headerProperty2" target="headerValue2"/>
+                <flowable:eventOutParameter source="payload1" target="value1" />
+                <flowable:eventOutParameter source="payload2" target="value2" />
+                <flowable:triggerChannelKey>two</flowable:triggerChannelKey>
+            </extensionElements>
+        </serviceTask>
+
+        <sequenceFlow sourceRef="sendAndReceiveEventTask" targetRef="taskAfterEvents"/>
+
+        <userTask id="taskAfterEvents"/>
+
+        <sequenceFlow sourceRef="taskAfterEvents" targetRef="theEnd"/>
+        
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-event-registry-integration-test/src/test/resources/org/flowable/eventregistry/integrationtest/two-outbound.channel
+++ b/modules/flowable-event-registry-integration-test/src/test/resources/org/flowable/eventregistry/integrationtest/two-outbound.channel
@@ -1,0 +1,8 @@
+{
+    "name": "Two Outbound",
+    "key": "two-outbound",
+    "channelType": "outbound",
+    "type": "jms",
+    "destination": "EXT_QUEUE_OUT",
+    "serializerType": "json"
+}

--- a/modules/flowable-event-registry-integration-test/src/test/resources/org/flowable/eventregistry/integrationtest/two.channel
+++ b/modules/flowable-event-registry-integration-test/src/test/resources/org/flowable/eventregistry/integrationtest/two.channel
@@ -1,0 +1,11 @@
+{
+    "name": "Two Channel",
+    "key": "two",
+    "channelType": "inbound",
+    "type": "jms",
+    "destination": "EXT_QUEUE_IN",
+    "deserializerType": "json",
+    "channelEventKeyDetection": {
+        "fixedValue": "one"
+    }
+}

--- a/modules/flowable-event-registry-spring/src/main/java/org/flowable/eventregistry/spring/kafka/KafkaChannelDefinitionProcessor.java
+++ b/modules/flowable-event-registry-spring/src/main/java/org/flowable/eventregistry/spring/kafka/KafkaChannelDefinitionProcessor.java
@@ -62,7 +62,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * @author Filip Hrisafov
  */
-public class KafkaChannelDefinitionProcessor implements BeanFactoryAware, ApplicationContextAware, ApplicationListener<ContextRefreshedEvent>, ChannelModelProcessor {
+public class KafkaChannelDefinitionProcessor
+        implements BeanFactoryAware, ApplicationContextAware, ApplicationListener<ContextRefreshedEvent>, ChannelModelProcessor {
 
     public static final String CHANNEL_ID_PREFIX = "org.flowable.eventregistry.kafka.ChannelKafkaListenerEndpointContainer#";
 


### PR DESCRIPTION
In our project, we have to customize the registering of channels, where a custom container factory would be used for some pre-defined inbound channels only. In order to facilitate customization and extension of the existing channel processors, here is a proposal for a small modularization change.
(I also extracted an `unregisterEndpoint` method, to help keeping future change localized if at some point the opinions expressed in https://github.com/spring-projects/spring-framework/issues/24228 changed, or to allow easier customized endpoint unregistration.)

#### Check List:
* Unit tests: YES
* Documentation: NA
