### PR TITLE
Chore: Add missing license header block

### DIFF
--- a/modules/flowable-common-rest/src/test/java/org/flowable/common/rest/exception/BaseExceptionHandlerAdviceTest.java
+++ b/modules/flowable-common-rest/src/test/java/org/flowable/common/rest/exception/BaseExceptionHandlerAdviceTest.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.common.rest.exception;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;


### PR DESCRIPTION
Code was just pushed today without the license header
