### PR TITLE
Chore: Add missing license header block

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/variable/SetVariableExpression.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/variable/SetVariableExpression.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.engine.test.bpmn.event.variable;
 
 import org.flowable.common.engine.api.delegate.Expression;


### PR DESCRIPTION
Code was pushed without the license header; finding one yesterday made me go look for more :)
