### PR TITLE
Chore update Spring Boot, Spring Security and Framework dependencies

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,22 +136,22 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
 org.slf4j                       slf4j-api                   1.7.36          MIT License
 org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.20          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.20          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.6.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.6.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.6.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.6.5           The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.21          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.21          The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.6.6           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.6.6           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.6.6           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.6.6           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/modules/flowable-app-engine-rest/pom.xml
+++ b/modules/flowable-app-engine-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <flowable.artifact>
             org.flowable.app.rest
         </flowable.artifact>

--- a/modules/flowable-cmmn-rest/pom.xml
+++ b/modules/flowable-cmmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.46.v20220331</jetty.version>
+    <jetty.version>9.4.48.v20220622</jetty.version>
     <flowable.artifact>
       org.flowable.cmmn.rest
     </flowable.artifact>

--- a/modules/flowable-content-rest/pom.xml
+++ b/modules/flowable-content-rest/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jetty.version>9.4.46.v20220331</jetty.version>
+		<jetty.version>9.4.48.v20220622</jetty.version>
 		<flowable.artifact>
 			org.flowable.content.rest
 		</flowable.artifact>

--- a/modules/flowable-dmn-rest/pom.xml
+++ b/modules/flowable-dmn-rest/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <flowable.artifact>
             org.flowable.dmn.rest.service
         </flowable.artifact>

--- a/modules/flowable-event-registry-rest/pom.xml
+++ b/modules/flowable-event-registry-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <flowable.artifact>
             org.flowable.eventregistry.rest
         </flowable.artifact>

--- a/modules/flowable-form-rest/pom.xml
+++ b/modules/flowable-form-rest/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <flowable.artifact>
             org.flowable.form.rest
         </flowable.artifact>

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <flowable.osgi.import.pkg>*</flowable.osgi.import.pkg>
         <flowable.artifact>
             org.flowable.http

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <flowable.artifact>
             org.flowable.rest
         </flowable.artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.6.8</spring.boot.version>
-		<spring.framework.version>5.3.20</spring.framework.version>
-		<spring.security.version>5.6.5</spring.security.version>
-		<spring.amqp.version>2.4.5</spring.amqp.version>
-		<spring.kafka.version>2.8.6</spring.kafka.version>
-		<reactor-netty.version>1.0.19</reactor-netty.version>
+		<spring.boot.version>2.6.9</spring.boot.version>
+		<spring.framework.version>5.3.21</spring.framework.version>
+		<spring.security.version>5.6.6</spring.security.version>
+		<spring.amqp.version>2.4.6</spring.amqp.version>
+		<spring.kafka.version>2.8.7</spring.kafka.version>
+		<reactor-netty.version>1.0.20</reactor-netty.version>
 		<jackson.version>2.13.3</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
@@ -1012,7 +1012,7 @@
 			<dependency>
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
-				<version>42.3.5</version>
+				<version>42.3.6</version>
 			</dependency>
 			<dependency>
 				<groupId>xerces</groupId>


### PR DESCRIPTION
Update Spring Boot to 2.6.9,  Security to 5.6.6 and Spring Framework to 5.3.21

Release notes for Spring Boot: https://github.com/spring-projects/spring-boot/releases/tag/v2.6.9
Release notes for Security: https://github.com/spring-projects/spring-security/releases/tag/5.6.6
Release notes for Framework: https://github.com/spring-projects/spring-framework/releases/tag/v5.3.21

This supersedes PR https://github.com/flowable/flowable-engine/pull/3349

BTW, there is a Spring Boot 2.7.1 that is also available; see https://github.com/spring-projects/spring-boot/releases/tag/v2.7.1

What is the plan to move to the 2.7.x branch?
