### PR TITLE
Corrected duplicate operationId in flowable-swagger-process openapi specification

### DIFF
--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/management/HistoryJobCollectionResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/management/HistoryJobCollectionResource.java
@@ -54,7 +54,7 @@ public class HistoryJobCollectionResource {
     @Autowired(required=false)
     protected CmmnRestApiInterceptor restApiInterceptor;
 
-    @ApiOperation(value = "List history jobs", tags = { "Jobs" }, nickname = "listDeadLetterJobs")
+    @ApiOperation(value = "List history jobs", tags = { "Jobs" }, nickname = "listHistoryJobs")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "id", dataType = "string", value = "Only return the job with the given id", paramType = "query"),
             @ApiImplicitParam(name = "withException", dataType = "boolean", value = "If true, only return jobs for which an exception occurred while executing it. If false, this parameter is ignored.", paramType = "query"),

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/HistoryJobCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/management/HistoryJobCollectionResource.java
@@ -54,7 +54,7 @@ public class HistoryJobCollectionResource {
     @Autowired(required=false)
     protected BpmnRestApiInterceptor restApiInterceptor;
 
-    @ApiOperation(value = "List history jobs", tags = { "Jobs" }, nickname = "listDeadLetterJobs")
+    @ApiOperation(value = "List history jobs", tags = { "Jobs" }, nickname = "listHistoryJobs")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "id", dataType = "string", value = "Only return the job with the given id", paramType = "query"),
             @ApiImplicitParam(name = "withException", dataType = "boolean", value = "If true, only return jobs for which an exception occurred while executing it. If false, this parameter is ignored.", paramType = "query"),


### PR DESCRIPTION
Fixed the following validation message when the flowable-swagger-process.yaml was validated:
"attribute paths.'/management/history-jobs'(get).operationId is repeated"

https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fdeveloper-docs.flowable.com%2Fswagger-docs%2F3.11.0%2Fprocess%2Fflowable-swagger-process.yaml

#### Check List:
* Unit tests: NA
* Documentation: NA
