### PR TITLE
Extend TaskQuery capabilities for category

### DIFF
--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/task/HistoricTaskInstanceBaseResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/task/HistoricTaskInstanceBaseResource.java
@@ -126,13 +126,13 @@ public class HistoricTaskInstanceBaseResource {
         if (queryRequest.getTaskCategory() != null) {
             query.taskCategory(queryRequest.getTaskCategory());
         }
-        if (queryRequest.getTaskCategoryIn() != null) {
+        if (queryRequest.getTaskCategoryIn() != null && !queryRequest.getTaskCategoryIn().isEmpty()) {
             query.taskCategoryIn(queryRequest.getTaskCategoryIn());
         }
-        if (queryRequest.getTaskCategoryNotIn() != null) {
+        if (queryRequest.getTaskCategoryNotIn() != null && !queryRequest.getTaskCategoryNotIn().isEmpty()) {
             query.taskCategoryNotIn(queryRequest.getTaskCategoryNotIn());
         }
-        if (queryRequest.getTaskWithoutCategory() != null && Boolean.TRUE.equals(queryRequest.getTaskWithoutCategory())) {
+        if (Boolean.TRUE.equals(queryRequest.getTaskWithoutCategory())) {
             query.taskWithoutCategory();
         }
         if (queryRequest.getTaskDeleteReason() != null) {

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/task/HistoricTaskInstanceBaseResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/task/HistoricTaskInstanceBaseResource.java
@@ -126,6 +126,15 @@ public class HistoricTaskInstanceBaseResource {
         if (queryRequest.getTaskCategory() != null) {
             query.taskCategory(queryRequest.getTaskCategory());
         }
+        if (queryRequest.getTaskCategoryIn() != null) {
+            query.taskCategoryIn(queryRequest.getTaskCategoryIn());
+        }
+        if (queryRequest.getTaskCategoryNotIn() != null) {
+            query.taskCategoryNotIn(queryRequest.getTaskCategoryNotIn());
+        }
+        if (queryRequest.getTaskWithoutCategory() != null && Boolean.TRUE.equals(queryRequest.getTaskWithoutCategory())) {
+            query.taskWithoutCategory();
+        }
         if (queryRequest.getTaskDeleteReason() != null) {
             query.taskDeleteReason(queryRequest.getTaskDeleteReason());
         }

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/task/HistoricTaskInstanceCollectionResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/task/HistoricTaskInstanceCollectionResource.java
@@ -13,6 +13,7 @@
 
 package org.flowable.cmmn.rest.service.api.history.task;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -53,6 +54,9 @@ public class HistoricTaskInstanceCollectionResource extends HistoricTaskInstance
             @ApiImplicitParam(name = "taskDescription", dataType = "string", value = "The task description of the historic task instance.", paramType = "query"),
             @ApiImplicitParam(name = "taskDescriptionLike", dataType = "string", value = "The task description with like operator for the historic task instance.", paramType = "query"),
             @ApiImplicitParam(name = "taskCategory", dataType = "string", value = "Select tasks with the given category. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).", paramType = "query"),
+            @ApiImplicitParam(name = "taskCategoryIn", dataType = "string", value = "Select tasks with the given categories. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).", paramType = "query"),
+            @ApiImplicitParam(name = "taskCategoryNotIn", dataType = "string", value = "Select tasks not assigned to the given categories. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).", paramType = "query"),
+            @ApiImplicitParam(name = "taskWithoutCategory", dataType = "string", value = "Select tasks with no category assigned. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).", paramType = "query"),
             @ApiImplicitParam(name = "taskDeleteReason", dataType = "string", value = "The task delete reason of the historic task instance.", paramType = "query"),
             @ApiImplicitParam(name = "taskDeleteReasonLike", dataType = "string", value = "The task delete reason with like operator for the historic task instance.", paramType = "query"),
             @ApiImplicitParam(name = "taskAssignee", dataType = "string", value = "The assignee of the historic task instance.", paramType = "query"),
@@ -138,6 +142,18 @@ public class HistoricTaskInstanceCollectionResource extends HistoricTaskInstance
 
         if (allRequestParams.containsKey("taskCategory")) {
             queryRequest.setTaskCategory(allRequestParams.get("taskCategory"));
+        }
+
+        if (allRequestParams.containsKey("taskCategoryIn")) {
+            queryRequest.setTaskCategoryIn(Arrays.asList(allRequestParams.get("taskCategoryIn").split(",")));
+        }
+
+        if (allRequestParams.containsKey("taskCategoryNotIn")) {
+            queryRequest.setTaskCategoryNotIn(Arrays.asList(allRequestParams.get("taskCategoryNotIn").split(",")));
+        }
+
+        if (allRequestParams.containsKey("taskWithoutCategory") && Boolean.parseBoolean(allRequestParams.get("taskWithoutCategory"))) {
+            queryRequest.setTaskWithoutCategory(Boolean.TRUE);
         }
 
         if (allRequestParams.get("taskDeleteReason") != null) {

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/task/HistoricTaskInstanceQueryRequest.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/history/task/HistoricTaskInstanceQueryRequest.java
@@ -45,6 +45,9 @@ public class HistoricTaskInstanceQueryRequest extends PaginateRequest {
     protected String taskDefinitionKey;
     protected String taskDefinitionKeyLike;
     protected String taskCategory;
+    protected List<String> taskCategoryIn;
+    protected List<String> taskCategoryNotIn;
+    protected Boolean taskWithoutCategory;
     protected String taskDeleteReason;
     protected String taskDeleteReasonLike;
     protected String taskAssignee;
@@ -212,6 +215,30 @@ public class HistoricTaskInstanceQueryRequest extends PaginateRequest {
 
     public void setTaskCategory(String taskCategory) {
         this.taskCategory = taskCategory;
+    }
+
+    public void setTaskCategoryIn(List<String> taskCategoryIn) {
+        this.taskCategoryIn = taskCategoryIn;
+    }
+
+    public List<String> getTaskCategoryIn() {
+        return taskCategoryIn;
+    }
+
+    public void setTaskCategoryNotIn(List<String> taskCategoryNotIn) {
+        this.taskCategoryNotIn = taskCategoryNotIn;
+    }
+
+    public List<String> getTaskCategoryNotIn() {
+        return taskCategoryNotIn;
+    }
+
+    public void setTaskWithoutCategory(Boolean taskWithoutCategory) {
+        this.taskWithoutCategory = taskWithoutCategory;
+    }
+
+    public Boolean getTaskWithoutCategory() {
+        return taskWithoutCategory;
     }
 
     public String getTaskDeleteReason() {
@@ -470,5 +497,4 @@ public class HistoricTaskInstanceQueryRequest extends PaginateRequest {
     public void setIgnoreTaskAssignee(boolean ignoreTaskAssignee) {
         this.ignoreTaskAssignee = ignoreTaskAssignee;
     }
-
 }

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/task/TaskBaseResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/task/TaskBaseResource.java
@@ -322,6 +322,17 @@ public class TaskBaseResource {
         if (request.getCategory() != null) {
             taskQuery.taskCategory(request.getCategory());
         }
+        if (request.getCategoryIn() != null && !request.getCategoryIn().isEmpty()) {
+            taskQuery.taskCategoryIn(request.getCategoryIn());
+        }
+
+        if (request.getCategoryNotIn() != null && !request.getCategoryNotIn().isEmpty()) {
+            taskQuery.taskCategoryNotIn(request.getCategoryNotIn());
+        }
+
+        if (Boolean.TRUE.equals(request.getWithoutCategory())) {
+            taskQuery.taskWithoutCategory();
+        }
 
         if (restApiInterceptor != null) {
             restApiInterceptor.accessTaskInfoWithQuery(taskQuery, request);

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/task/TaskCollectionResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/task/TaskCollectionResource.java
@@ -105,6 +105,9 @@ public class TaskCollectionResource extends TaskBaseResource {
             @ApiImplicitParam(name = "withoutProcessInstanceId", dataType = "boolean", value = "If true, only returns tasks without a process instance id set. If false, the withoutProcessInstanceId parameter is ignored.", paramType = "query"),
             @ApiImplicitParam(name = "candidateOrAssigned", dataType = "string", value = "Select tasks that has been claimed or assigned to user or waiting to claim by user (candidate user or groups).", paramType = "query"),
             @ApiImplicitParam(name = "category", dataType = "string", value = "Select tasks with the given category. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).\n", paramType = "query"),
+            @ApiImplicitParam(name = "categoryIn", dataType = "string", value = "Select tasks for the given categories. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).\n", paramType = "query"),
+            @ApiImplicitParam(name = "categoryNotIn", dataType = "string", value = "Select tasks which are not assigned to the given categories. Does not return tasks without categories. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).\n", paramType = "query"),
+            @ApiImplicitParam(name = "withoutCategory", dataType = "string", value = "Select tasks without a category assigned. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).\n", paramType = "query"),
     })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Indicates request was successful and the tasks are returned"),
@@ -181,10 +184,7 @@ public class TaskCollectionResource extends TaskBaseResource {
         }
 
         if (requestParams.containsKey("candidateGroups")) {
-            String[] candidateGroups = requestParams.get("candidateGroups").split(",");
-            List<String> groups = new ArrayList<>(candidateGroups.length);
-            Collections.addAll(groups, candidateGroups);
-            request.setCandidateGroupIn(groups);
+            request.setCandidateGroupIn(csvToList("candidateGroups", requestParams));
         }
 
         if (requestParams.containsKey("ignoreAssignee") && Boolean.valueOf(requestParams.get("ignoreAssignee"))) {
@@ -311,6 +311,18 @@ public class TaskCollectionResource extends TaskBaseResource {
             request.setCategory(requestParams.get("category"));
         }
 
+        if (requestParams.containsKey("withoutCategory") && Boolean.valueOf(requestParams.get("withoutCategory"))) {
+            request.setWithoutCategory(Boolean.TRUE);
+        }
+
+        if (requestParams.containsKey("categoryIn")) {
+            request.setCategoryIn(csvToList("categoryIn", requestParams));
+        }
+
+        if (requestParams.containsKey("categoryNotIn")) {
+            request.setCategoryNotIn(csvToList("categoryNotIn", requestParams));
+        }
+
         return getTasksFromQueryRequest(request, requestParams);
     }
 
@@ -379,6 +391,13 @@ public class TaskCollectionResource extends TaskBaseResource {
         DataResponse<TaskResponse> dataResponse = new DataResponse<>();
         dataResponse.setData(restResponseFactory.createTaskResponseList(taskResultList));
         return dataResponse;
+    }
+
+    protected List<String> csvToList(String key, Map<String, String> requestParams) {
+        String[] candidateGroupsSplit = requestParams.get(key).split(",");
+        List<String> groups = new ArrayList<>(candidateGroupsSplit.length);
+        Collections.addAll(groups, candidateGroupsSplit);
+        return groups;
     }
 
 }

--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/task/TaskQueryRequest.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/runtime/task/TaskQueryRequest.java
@@ -80,6 +80,9 @@ public class TaskQueryRequest extends PaginateRequest {
     protected String category;
 
     private List<QueryVariable> taskVariables;
+    protected List<String> categoryIn;
+    protected List<String> categoryNotIn;
+    protected Boolean withoutCategory;
 
     public String getName() {
         return name;
@@ -485,5 +488,29 @@ public class TaskQueryRequest extends PaginateRequest {
 
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    public List<String> getCategoryIn() {
+        return categoryIn;
+    }
+
+    public void setCategoryIn(List<String> categoryIn) {
+        this.categoryIn = categoryIn;
+    }
+
+    public List<String> getCategoryNotIn() {
+        return categoryNotIn;
+    }
+
+    public void setCategoryNotIn(List<String> categoryNotIn) {
+        this.categoryNotIn = categoryNotIn;
+    }
+
+    public Boolean getWithoutCategory() {
+        return withoutCategory;
+    }
+
+    public void setWithoutCategory(Boolean withoutCategory) {
+        this.withoutCategory = withoutCategory;
     }
 }

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricTaskInstanceCollectionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricTaskInstanceCollectionResourceTest.java
@@ -154,7 +154,6 @@ public class HistoricTaskInstanceCollectionResourceTest extends BaseSpringRestTe
         }
     }
 
-    @Test
     public void testQueryTaskByCategory() throws Exception {
         Task t1 = taskService.newTask();
         t1.setName("t1");

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricTaskInstanceCollectionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricTaskInstanceCollectionResourceTest.java
@@ -35,6 +35,7 @@ import org.flowable.cmmn.rest.service.BaseSpringRestTestCase;
 import org.flowable.cmmn.rest.service.api.CmmnRestUrls;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.history.HistoricTaskInstance;
+import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -152,6 +153,37 @@ public class HistoricTaskInstanceCollectionResourceTest extends BaseSpringRestTe
             repositoryService.deleteDeployment(deployment.getId(), true);
         }
     }
+
+    @Test
+    public void testQueryTaskByCategory() throws Exception {
+        Task t1 = taskService.newTask();
+        t1.setName("t1");
+        t1.setCategory("Cat 1");
+        taskService.saveTask(t1);
+
+        Task t2 = taskService.newTask();
+        t2.setName("t2");
+        t2.setCategory("Cat 2");
+        taskService.saveTask(t2);
+
+        Task t3 = taskService.newTask();
+        t3.setName("t3");
+        taskService.saveTask(t3);
+
+        try {
+            String url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_HISTORIC_TASK_INSTANCES);
+            assertResultsPresentInDataResponse(url + "?taskCategory=" + encode("Cat 1"), 1, t1.getId());
+            assertResultsPresentInDataResponse(url + "?taskCategoryIn=" + encode("Cat 1"), 1, t1.getId());
+            assertResultsPresentInDataResponse(url + "?taskCategoryNotIn=" + encode("Cat 1"), 1, t2.getId());
+            assertResultsPresentInDataResponse(url + "?taskWithoutCategory=true", 1, t3.getId());
+
+        } finally {
+            taskService.deleteTask(t1.getId(), true);
+            taskService.deleteTask(t2.getId(), true);
+            taskService.deleteTask(t3.getId(), true);
+        }
+    }
+
 
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/twoHumanTaskCase.cmmn" })
     public void testQueryTaskInstancesWithCandidateGroup() throws Exception {

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
@@ -33,6 +33,7 @@ import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.rest.service.BaseSpringRestTestCase;
 import org.flowable.cmmn.rest.service.api.CmmnRestUrls;
 import org.flowable.task.api.Task;
+import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -275,6 +276,48 @@ public class HistoricTaskInstanceQueryResourceTest extends BaseSpringRestTestCas
         requestNode.put("taskCandidateGroup", "test");
         requestNode.put("ignoreTaskAssignee", true);
         assertResultsPresentInPostDataResponse(url, requestNode, task.getId());
+    }
+
+    @Test
+    public void testQueryTaskByCategory() throws Exception {
+        Task t1 = taskService.newTask();
+        t1.setName("t1");
+        t1.setCategory("Cat 1");
+        taskService.saveTask(t1);
+
+        Task t2 = taskService.newTask();
+        t2.setName("t2");
+        t2.setCategory("Cat 2");
+        taskService.saveTask(t2);
+
+        Task t3 = taskService.newTask();
+        t3.setName("t3");
+        taskService.saveTask(t3);
+
+        try {
+            String url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_HISTORIC_TASK_INSTANCE_QUERY);
+
+            ObjectNode requestNode = objectMapper.createObjectNode();
+            requestNode.put("taskCategory", "Cat 1");
+            assertResultsPresentInPostDataResponse(url, requestNode, t1.getId());
+
+            requestNode.removeAll() ;
+            requestNode.putArray("taskCategoryIn").add("Cat 1").add("non-existing");
+            assertResultsPresentInPostDataResponse(url, requestNode, t1.getId());
+
+            requestNode.removeAll() ;
+            requestNode.putArray("taskCategoryNotIn").add("Cat 1").add("non-existing");
+            assertResultsPresentInPostDataResponse(url, requestNode, t2.getId());
+
+            requestNode.removeAll() ;
+            requestNode.put("taskWithoutCategory", Boolean.TRUE);
+            assertResultsPresentInPostDataResponse(url, requestNode, t3.getId());
+
+        } finally {
+            taskService.deleteTask(t1.getId(), true);
+            taskService.deleteTask(t2.getId(), true);
+            taskService.deleteTask(t3.getId(), true);
+        }
     }
 
     protected void assertResultsPresentInPostDataResponse(String url, ObjectNode body, int numberOfResultsExpected, String... expectedTaskIds)

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/TaskCollectionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/TaskCollectionResourceTest.java
@@ -371,6 +371,15 @@ public class TaskCollectionResourceTest extends BaseSpringRestTestCase {
             // Category filtering
             url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_TASK_COLLECTION) + "?category=" + encode("some-category");
             assertResultsPresentInDataResponse(url, adhocTask.getId());
+
+            url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_TASK_COLLECTION) + "?categoryIn=" + encode("non-exisiting,some-category");
+            assertResultsPresentInDataResponse(url, adhocTask.getId());
+
+            url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_TASK_COLLECTION) + "?categoryNotIn=" + encode("some-category");
+            assertResultsPresentInDataResponse(url);
+
+            url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_TASK_COLLECTION) + "?withoutCategory=true";
+            assertResultsPresentInDataResponse(url, caseTask.getId());
             
             // Without process instance id filtering
             url = CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_TASK_COLLECTION) + "?withoutProcessInstanceId=true";

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/TaskQueryResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/TaskQueryResourceTest.java
@@ -275,7 +275,19 @@ public class TaskQueryResourceTest extends BaseSpringRestTestCase {
             requestNode.removeAll();
             requestNode.put("category", "some-category");
             assertResultsPresentInPostDataResponse(url, requestNode, adhocTask.getId());
-            
+
+            requestNode.removeAll();
+            requestNode.putArray("categoryIn").add("not-existing-category").add("some-category");
+            assertResultsPresentInPostDataResponse(url, requestNode, adhocTask.getId());
+
+            requestNode.removeAll();
+            requestNode.putArray("categoryNotIn").add("some-category");
+            assertResultsPresentInPostDataResponse(url, requestNode);
+
+            requestNode.removeAll();
+            requestNode.put("withoutCategory", Boolean.TRUE);
+            assertResultsPresentInPostDataResponse(url, requestNode, caseTask.getId());
+
             // Without process instance id filtering
             requestNode.removeAll();
             requestNode.put("withoutProcessInstanceId", true);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskQueryTest.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.engine.test.api.task;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -236,7 +237,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testQueryByNameInOr() {
-        List<String> taskNameList = Arrays.asList("testTask", "gonzoTask");
+        List<String> taskNameList = asList("testTask", "gonzoTask");
 
         TaskQuery query = taskService.createTaskQuery().or().taskNameIn(taskNameList).taskId("invalid");
         assertThat(query.list()).hasSize(7);
@@ -248,7 +249,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testQueryByNameInIgnoreCaseOr() {
-        List<String> taskNameList = Arrays.asList("testtask", "gonzotask");
+        List<String> taskNameList = asList("testtask", "gonzotask");
 
         TaskQuery query = taskService.createTaskQuery().or().taskNameInIgnoreCase(taskNameList).taskId("invalid");
         assertThat(query.list()).hasSize(7);
@@ -436,7 +437,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .extracting(Task::getFormKey)
                 .containsExactly("testFormKey");
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
                     .taskFormKey("testFormKey")
                     .list();
@@ -458,7 +459,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .extracting(Task::getFormKey)
                 .containsExactly("testFormKey");
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery().or()
                     .taskFormKey("testFormKey")
                     .list();
@@ -480,7 +481,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .extracting(Task::getFormKey)
                 .containsExactly("testFormKey");
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             List<HistoricTaskInstance> historicTasks = historyService.createHistoricTaskInstanceQuery()
                     .taskWithFormKey()
                     .list();
@@ -586,20 +587,20 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testQueryByAssigneeIds() {
-        TaskQuery query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("gonzo", "kermit"));
+        TaskQuery query = taskService.createTaskQuery().taskAssigneeIds(asList("gonzo", "kermit"));
         assertThat(query.count()).isEqualTo(1);
         assertThat(query.list()).hasSize(1);
         assertThat(query.singleResult()).isNotNull();
 
-        query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("kermit", "kermit2"));
+        query = taskService.createTaskQuery().taskAssigneeIds(asList("kermit", "kermit2"));
         assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
-            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("gonzo", "kermit")).count()).isEqualTo(1);
-            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("kermit", "kermit2")).count()).isZero();
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(asList("gonzo", "kermit")).count()).isEqualTo(1);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(asList("kermit", "kermit2")).count()).isZero();
         }
 
         org.flowable.task.api.Task adhocTask = taskService.newTask();
@@ -607,13 +608,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         adhocTask.setAssignee("testAssignee");
         taskService.saveTask(adhocTask);
 
-        query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("gonzo", "testAssignee"));
+        query = taskService.createTaskQuery().taskAssigneeIds(asList("gonzo", "testAssignee"));
         assertThat(query.count()).isEqualTo(2);
         assertThat(query.list()).hasSize(2);
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
-            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("gonzo", "testAssignee")).count()).isEqualTo(2);
+            assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(asList("gonzo", "testAssignee")).count()).isEqualTo(2);
         }
 
         taskService.deleteTask(adhocTask.getId(), true);
@@ -621,21 +622,21 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testQueryByAssigneeIdsOr() {
-        TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "kermit"));
+        TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(asList("gonzo", "kermit"));
         assertThat(query.count()).isEqualTo(1);
         assertThat(query.list()).hasSize(1);
         assertThat(query.singleResult()).isNotNull();
 
-        query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("kermit", "kermit2"));
+        query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(asList("kermit", "kermit2"));
         assertThat(query.count()).isZero();
         assertThat(query.list()).isEmpty();
         assertThat(query.singleResult()).isNull();
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
-            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "kermit")).count())
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(asList("gonzo", "kermit")).count())
                     .isEqualTo(1);
-            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("kermit", "kermit2")).count())
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(asList("kermit", "kermit2")).count())
                     .isZero();
         }
 
@@ -644,13 +645,13 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         adhocTask.setAssignee("testAssignee");
         taskService.saveTask(adhocTask);
 
-        query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "testAssignee"));
+        query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(asList("gonzo", "testAssignee"));
         assertThat(query.count()).isEqualTo(2);
         assertThat(query.list()).hasSize(2);
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
-            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "testAssignee")).count())
+            assertThat(historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(asList("gonzo", "testAssignee")).count())
                     .isEqualTo(2);
         }
 
@@ -692,7 +693,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("kermit").count()).isEqualTo(1);
             assertThat(taskService.createTaskQuery().taskId(adhocTask.getId()).or().taskId("invalid").taskInvolvedUser("fozzie").count()).isEqualTo(1);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().taskId(adhocTask.getId())
                         .or().taskId("invalid").taskInvolvedUser("fozzie").count()).isEqualTo(1);
             }
@@ -764,7 +765,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             assertThat(query.count()).isEqualTo(0);
             assertThat(query.list()).hasSize(0);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().taskId(adhocTask.getId()).or().taskId("invalid")
                         .taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
             }
@@ -800,7 +801,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             assertThat(taskService.createTaskQuery().or().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count())
                     .isEqualTo(2);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().
                         or().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count()).isEqualTo(2);
             }
@@ -827,7 +828,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             assertThat(taskService.createTaskQuery().or().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr().count())
                     .isEqualTo(2);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(
                         historyService.createHistoricTaskInstanceQuery().or().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).endOr()
                                 .count()).isEqualTo(2);
@@ -854,7 +855,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
             assertThat(taskService.createTaskQuery().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(
                         historyService.createHistoricTaskInstanceQuery().taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).count())
                         .isEqualTo(1);
@@ -883,7 +884,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
             assertThat(taskService.createTaskQuery().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().taskOwner("kermit").taskInvolvedGroups(Collections.singleton("testGroup")).count())
                         .isEqualTo(1);
             }
@@ -910,7 +911,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             assertThat(taskService.getIdentityLinksForTask(adhocTask.getId())).hasSize(1);
 
             assertThat(taskService.createTaskQuery().taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(
                         historyService.createHistoricTaskInstanceQuery().taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).count())
                         .isEqualTo(1);
@@ -939,7 +940,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
             assertThat(taskService.createTaskQuery().taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup"))
                         .count()).isEqualTo(1);
             }
@@ -968,7 +969,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
             assertThat(taskService.createTaskQuery().taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup"))
                     .count()).isEqualTo(1);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Collections.singletonList("kermit"))
                         .taskInvolvedGroups(Collections.singleton("testGroup")).count()).isEqualTo(1);
             }
@@ -998,7 +999,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                     .endOr()
                     .count()).isEqualTo(3);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery()
                         .or()
                         .taskOwnerLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup"))
@@ -1031,7 +1032,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                     .endOr()
                     .count()).isEqualTo(3);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery()
                         .or()
                         .taskAssigneeLike("ker%").taskInvolvedGroups(Collections.singleton("testGroup"))
@@ -1064,7 +1065,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                     .endOr()
                     .count()).isEqualTo(3);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery()
                         .or()
                         .taskAssigneeIds(Collections.singletonList("kermit")).taskInvolvedGroups(Collections.singleton("testGroup"))
@@ -1097,7 +1098,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                     .endOr()
                     .count()).isEqualTo(3);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery()
                         .or()
                         .taskAssignee("kermit").taskInvolvedGroups(Collections.singleton("testGroup"))
@@ -1137,7 +1138,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                     taskName("testName").
                     taskInvolvedGroups(Collections.singleton("testGroup")).
                     count()).isEqualTo(1);
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().
                         or().
                         taskName("testName").
@@ -1183,7 +1184,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                     taskCandidateGroupIn(Collections.singletonList("testGroup")).
                     count()).isEqualTo(1);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().
                         or().
                         taskName("testName").
@@ -1229,7 +1230,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                     taskCandidateUser("homer").
                     count()).isEqualTo(1);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().
                         or().
                         taskName("testName").
@@ -1245,6 +1246,316 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         } finally {
             deleteAllTasks();
         }
+    }
+
+    @Test
+    public void testWithoutCategory() {
+        deleteAllTasks();
+        try {
+            saveTaskWithCategory("t1", "Cat 1");
+            saveTaskWithCategory("t2", "Cat 1");
+            saveTaskWithCategory("t3", "Cat 2");
+            saveTaskWithCategory("t4", null);
+            saveTaskWithCategory("t5", null);
+
+            List<Task> noResult = taskService.createTaskQuery().taskName("t1").taskWithoutCategory().orderByTaskName().asc().list();
+            assertThat(noResult).extracting(Task::getName).isEmpty();
+
+            List<Task> noCategory = taskService.createTaskQuery().taskWithoutCategory().orderByTaskName().asc().list();
+            assertThat(noCategory).extracting(Task::getName).containsExactly("t4", "t5");
+
+            List<Task> likeAndNull = taskService.createTaskQuery().taskNameLike("t%").taskWithoutCategory().orderByTaskName().asc().list();
+            assertThat(likeAndNull).extracting(Task::getName).containsExactly("t4", "t5");
+
+            List<Task> t1AndNull = taskService.createTaskQuery().or().taskName("t1").taskWithoutCategory().endOr().orderByTaskName().asc().list();
+            assertThat(t1AndNull).extracting(Task::getName).containsExactly("t1", "t4", "t5");
+
+        } finally {
+            deleteAllTasks();
+        }
+    }
+
+    @Test
+    public void testWithoutCategoryHistory() {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
+            deleteAllTasks();
+            try {
+                saveTaskWithCategory("t1", "Cat 1");
+                saveTaskWithCategory("t2", "Cat 1");
+                saveTaskWithCategory("t3", "Cat 2");
+                saveTaskWithCategory("t4", null);
+                saveTaskWithCategory("t5", null);
+
+                List<HistoricTaskInstance> noResult = historyService.createHistoricTaskInstanceQuery().taskName("t1").taskWithoutCategory().orderByTaskName()
+                        .asc().list();
+                assertThat(noResult).extracting(HistoricTaskInstance::getName).isEmpty();
+
+                List<HistoricTaskInstance> noCategory = historyService.createHistoricTaskInstanceQuery().taskWithoutCategory().orderByTaskName().asc().list();
+                assertThat(noCategory).extracting(HistoricTaskInstance::getName).containsExactly("t4", "t5");
+
+                List<HistoricTaskInstance> likeAndNull = historyService.createHistoricTaskInstanceQuery().taskNameLike("t%").taskWithoutCategory()
+                        .orderByTaskName().asc().list();
+                assertThat(likeAndNull).extracting(HistoricTaskInstance::getName).containsExactly("t4", "t5");
+
+                List<HistoricTaskInstance> t1AndNull = historyService.createHistoricTaskInstanceQuery().or().taskName("t1").taskWithoutCategory().endOr()
+                        .orderByTaskName().asc().list();
+                assertThat(t1AndNull).extracting(HistoricTaskInstance::getName).containsExactly("t1", "t4", "t5");
+
+            } finally {
+                deleteAllTasks();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryByCategoryIn() {
+        deleteAllTasks();
+        try {
+            saveTaskWithCategory("t1", "Cat 1");
+            saveTaskWithCategory("t2", "Cat 1");
+            saveTaskWithCategory("t3", "Cat 2");
+            saveTaskWithCategory("t4", null);
+            saveTaskWithCategory("t5", "Cat 3");
+
+            assertThat(taskService.createTaskQuery()
+                    .taskCategoryIn(asList("Cat 1"))
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .containsExactly("t1", "t2");
+
+            assertThat(taskService.createTaskQuery()
+                    .taskCategoryIn(asList("Cat 1", "Cat 2"))
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .containsExactly("t1", "t2", "t3");
+
+            assertThat(taskService.createTaskQuery()
+                    .taskCategoryIn(asList("Cat 2"))
+                    .taskWithoutCategory()
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .isEmpty();
+
+            // Verify or cases behave like expected
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskCategory("Cat 1")
+                    .taskCategoryIn(asList("Cat 2"))
+                    .endOr()
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .containsExactly("t1", "t2", "t3");
+
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskCategoryIn(asList("Cat 2"))
+                    .taskName("t4")
+                    .endOr()
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName).containsExactly("t3", "t4");
+
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskWithoutCategory()
+                    .taskCategoryIn(asList("Cat 2"))
+                    .endOr()
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .containsExactly("t3", "t4");
+        } finally {
+            deleteAllTasks();
+        }
+    }
+
+    @Test
+    public void testQueryByCategoryInHistory() {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
+            deleteAllTasks();
+            try {
+                saveTaskWithCategory("t1", "Cat 1");
+                saveTaskWithCategory("t2", "Cat 1");
+                saveTaskWithCategory("t3", "Cat 2");
+                saveTaskWithCategory("t4", null);
+                saveTaskWithCategory("t5", "Cat 3");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .taskCategoryIn(asList("Cat 1"))
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .containsExactly("t1", "t2");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .taskCategoryIn(asList("Cat 1", "Cat 2"))
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .containsExactly("t1", "t2", "t3");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .taskCategoryIn(asList("Cat 2"))
+                        .taskWithoutCategory()
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .isEmpty();
+
+                // Verify or cases behave like expected
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskCategory("Cat 1")
+                        .taskCategoryIn(asList("Cat 2"))
+                        .endOr()
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .containsExactly("t1", "t2", "t3");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskCategoryIn(asList("Cat 2"))
+                        .taskName("t4")
+                        .endOr()
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName).containsExactly("t3", "t4");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskWithoutCategory()
+                        .taskCategoryIn(asList("Cat 2"))
+                        .endOr()
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .containsExactly("t3", "t4");
+            } finally {
+                deleteAllTasks();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryByCategoryInIllegalArguments() {
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCategoryIn(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCategoryIn(Collections.emptyList()))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCategoryIn(Arrays.asList("val", null)))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+    }
+
+    @Test
+    public void testQueryByCategoryInIllegalArgumentsHistory() {
+        assertThatThrownBy(() -> historyService.createHistoricTaskInstanceQuery().taskCategoryIn(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+        assertThatThrownBy(() -> historyService.createHistoricTaskInstanceQuery().taskCategoryIn(Collections.emptyList()))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+        assertThatThrownBy(() -> historyService.createHistoricTaskInstanceQuery().taskCategoryIn(Arrays.asList("val", null)))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+    }
+
+    @Test
+    public void testQueryByCategoryNotIn() {
+        deleteAllTasks();
+        try {
+            saveTaskWithCategory("t1", "Cat 1");
+            saveTaskWithCategory("t2", "Cat 1");
+            saveTaskWithCategory("t3", "Cat 2");
+            saveTaskWithCategory("t4", null);
+            saveTaskWithCategory("t5", "Cat 3");
+
+            assertThat(taskService.createTaskQuery()
+                    .taskCategoryNotIn(asList("Cat 1"))
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .containsExactly("t3", "t5");
+
+            assertThat(taskService.createTaskQuery()
+                    .taskCategoryNotIn(asList("Cat 1", "Cat 2"))
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .containsExactly("t5");
+
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskCategoryNotIn(asList("Cat 1", "Cat 2"))
+                    .taskWithoutCategory()
+                    .endOr()
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .containsExactly("t4", "t5");
+
+            assertThat(taskService.createTaskQuery()
+                    .or()
+                    .taskCategoryIn(asList("Cat 1"))
+                    .taskCategoryNotIn(asList("Cat 2"))
+                    .endOr()
+                    .orderByTaskName().asc().list())
+                    .extracting(Task::getName)
+                    .containsExactly("t1", "t2", "t5");
+
+        } finally {
+            deleteAllTasks();
+        }
+    }
+
+    @Test
+    public void testQueryByCategoryNotInHistory() {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
+            deleteAllTasks();
+            try {
+                saveTaskWithCategory("t1", "Cat 1");
+                saveTaskWithCategory("t2", "Cat 1");
+                saveTaskWithCategory("t3", "Cat 2");
+                saveTaskWithCategory("t4", null);
+                saveTaskWithCategory("t5", "Cat 3");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .taskCategoryNotIn(asList("Cat 1"))
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .containsExactly("t3", "t5");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .taskCategoryNotIn(asList("Cat 1", "Cat 2"))
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .containsExactly("t5");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskCategoryNotIn(asList("Cat 1", "Cat 2"))
+                        .taskWithoutCategory()
+                        .endOr()
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .containsExactly("t4", "t5");
+
+                assertThat(historyService.createHistoricTaskInstanceQuery()
+                        .or()
+                        .taskCategoryIn(asList("Cat 1"))
+                        .taskCategoryNotIn(asList("Cat 2"))
+                        .endOr()
+                        .orderByTaskName().asc().list())
+                        .extracting(HistoricTaskInstance::getName)
+                        .containsExactly("t1", "t2", "t5");
+
+            } finally {
+                deleteAllTasks();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryByCategoryNotInIllegalArguments() {
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCategoryNotIn(null))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCategoryNotIn(Collections.emptyList()))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+        assertThatThrownBy(() -> taskService.createTaskQuery().taskCategoryNotIn(Arrays.asList("val", null)))
+                .isExactlyInstanceOf(FlowableIllegalArgumentException.class);
+    }
+
+    private void saveTaskWithCategory(String t1, String category) {
+        Task t1Cat1 = taskService.newTask();
+        t1Cat1.setName(t1);
+        t1Cat1.setCategory(category);
+        taskService.saveTask(t1Cat1);
     }
 
     @Test
@@ -1275,7 +1586,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                     taskCandidateGroup("testGroup").
                     count()).isEqualTo(1);
 
-            if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
                 assertThat(historyService.createHistoricTaskInstanceQuery().
                         or().
                         taskName("testName").
@@ -1603,7 +1914,6 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         taskService.addCandidateGroup(magementTask.getId(), "management");
         createdTasks.add(magementTask.getId());
 
-
         List<Task> kermitCandidateTasks = taskService.createTaskQuery()
                 .taskCandidateUser("kermit")
                 .taskName("testTask")
@@ -1701,7 +2011,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(query.list()).isEmpty();
 
         // Unexisting groups or groups that don't have candidate tasks shouldn't influence other results
-        groups = Arrays.asList("management", "accountancy", "sales", "unexising");
+        groups = asList("management", "accountancy", "sales", "unexising");
         query = taskService.createTaskQuery().taskCandidateGroupIn(groups);
         assertThat(query.count()).isEqualTo(5);
         assertThat(query.list()).hasSize(5);
@@ -1726,7 +2036,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
     @Test
     public void testQueryByCandidateGroupInOr() {
-        List<String> groups = Arrays.asList("management", "accountancy");
+        List<String> groups = asList("management", "accountancy");
         TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(groups);
         assertThat(query.count()).isEqualTo(5);
         assertThat(query.list()).hasSize(5);
@@ -1753,7 +2063,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(query.list()).hasSize(5);
 
         // Unexisting groups or groups that don't have candidate tasks shouldn't influence other results
-        groups = Arrays.asList("management", "accountancy", "sales", "unexising");
+        groups = asList("management", "accountancy", "sales", "unexising");
         query = taskService.createTaskQuery().or().taskId("invalid").taskCandidateGroupIn(groups);
         assertThat(query.count()).isEqualTo(5);
         assertThat(query.list()).hasSize(5);
@@ -2007,16 +2317,16 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         List<org.flowable.task.api.Task> tasks = taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid")).list();
         assertThat(tasks)
-            .extracting(TaskInfo::getTaskDefinitionKey, TaskInfo::getName)
-            .containsExactlyInAnyOrder(
-                tuple("taskKey1", "Task A"),
-                tuple("taskKey123", "Task B")
-            );
+                .extracting(TaskInfo::getTaskDefinitionKey, TaskInfo::getName)
+                .containsExactlyInAnyOrder(
+                        tuple("taskKey1", "Task A"),
+                        tuple("taskKey123", "Task B")
+                );
 
-        assertThat(taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid")).count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().taskDefinitionKeys(asList("taskKey1", "taskKey123", "invalid")).count()).isEqualTo(2);
 
-        assertThat(taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).count()).isZero();
-        assertThat(taskService.createTaskQuery().taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).list()).isEmpty();
+        assertThat(taskService.createTaskQuery().taskDefinitionKeys(asList("invalid1", "invalid2")).count()).isZero();
+        assertThat(taskService.createTaskQuery().taskDefinitionKeys(asList("invalid1", "invalid2")).list()).isEmpty();
     }
 
     @Test
@@ -2035,10 +2345,10 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 tuple("taskKey123", "Task B")
             );
 
-        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeys(Arrays.asList("taskKey1", "taskKey123", "invalid")).endOr().count())
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeys(asList("taskKey1", "taskKey123", "invalid")).endOr().count())
                 .isEqualTo(2);
 
-        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).endOr().count())
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeys(asList("invalid1", "invalid2")).endOr().count())
                 .isZero();
 
         assertThat(taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeys(Arrays.asList("invalid1", "invalid2")).endOr().list())
@@ -2665,7 +2975,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count()).isEqualTo(13);
         includeIds = Collections.singletonList("unexisting");
         assertThat(taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count()).isZero();
-        includeIds = Arrays.asList("unexisting", "oneTaskProcess");
+        includeIds = asList("unexisting", "oneTaskProcess");
         assertThat(taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count()).isEqualTo(1);
     }
 
@@ -2686,7 +2996,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .processDefinitionKeyIn(includeIds)
                 .count()).isZero();
 
-        includeIds = Arrays.asList("unexisting", "oneTaskProcess");
+        includeIds = asList("unexisting", "oneTaskProcess");
         assertThat(taskService.createTaskQuery()
                 .or().taskId("invalid")
                 .processDefinitionKeyIn(includeIds)
@@ -2823,11 +3133,11 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        assertThat(taskService.createTaskQuery().processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId())).count()).isEqualTo(2);
-        assertThat(taskService.createTaskQuery().processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId(), "unexisting")).count())
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(asList(processInstance1.getId(), processInstance2.getId())).count()).isEqualTo(2);
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(asList(processInstance1.getId(), processInstance2.getId(), "unexisting")).count())
                 .isEqualTo(2);
 
-        assertThat(taskService.createTaskQuery().processInstanceIdIn(Arrays.asList("unexisting1", "unexisting2")).count()).isZero();
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(asList("unexisting1", "unexisting2")).count()).isZero();
     }
 
     @Test
@@ -2836,14 +3146,14 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
         ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId()))
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(asList(processInstance1.getId(), processInstance2.getId()))
                 .count()).isEqualTo(2);
         assertThat(taskService.createTaskQuery().or().taskId("invalid")
-                .processInstanceIdIn(Arrays.asList(processInstance1.getId(), processInstance2.getId(), "unexisting")).count()).isEqualTo(2);
+                .processInstanceIdIn(asList(processInstance1.getId(), processInstance2.getId(), "unexisting")).count()).isEqualTo(2);
 
-        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList("unexisting1", "unexisting2")).count()).isZero();
+        assertThat(taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(asList("unexisting1", "unexisting2")).count()).isZero();
     }
-    
+
     @Test
     @Deployment(resources = { "org/flowable/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
     public void testWithoutProcessInstanceId() throws Exception {
@@ -3798,7 +4108,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult()).isNotNull();
         assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).count()).isEqualTo(1);
 
-        deploymentIds = Arrays.asList(deployment.getId(), "invalid");
+        deploymentIds = asList(deployment.getId(), "invalid");
         assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).singleResult()).isNotNull();
         assertThat(taskService.createTaskQuery().deploymentIdIn(deploymentIds).count()).isEqualTo(1);
 
@@ -3817,7 +4127,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count()).isEqualTo(1);
 
-        deploymentIds = Arrays.asList(deployment.getId(), "invalid");
+        deploymentIds = asList(deployment.getId(), "invalid");
         assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).singleResult()).isNotNull();
 
         assertThat(taskService.createTaskQuery().or().taskId("invalid").deploymentIdIn(deploymentIds).count()).isEqualTo(1);
@@ -3848,7 +4158,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("%Gonzo%").count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().taskNameLikeIgnoreCase("Task%").count()).isZero();
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
             assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%task%").count()).isEqualTo(12);
             assertThat(historyService.createHistoricTaskInstanceQuery().taskNameLikeIgnoreCase("%Task%").count()).isEqualTo(12);
@@ -3868,7 +4178,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
 
         assertThat(taskService.createTaskQuery().or().taskNameLikeIgnoreCase("ACCOUN%").taskDescriptionLikeIgnoreCase("%ESCR%").endOr().count()).isEqualTo(9);
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
             assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%task%").endOr()
                     .count()).isEqualTo(12);
@@ -3892,7 +4202,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("Gonzo%").count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().taskDescriptionLikeIgnoreCase("%manage%").count()).isZero();
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
             assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%task%").count()).isEqualTo(6);
             assertThat(historyService.createHistoricTaskInstanceQuery().taskDescriptionLikeIgnoreCase("%Task%").count()).isEqualTo(6);
@@ -3916,7 +4226,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%nzo%").count()).isEqualTo(1);
         assertThat(taskService.createTaskQuery().taskAssigneeLikeIgnoreCase("%doesnotexist%").count()).isZero();
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
             assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%gonzo%").count()).isEqualTo(1);
             assertThat(historyService.createHistoricTaskInstanceQuery().taskAssigneeLikeIgnoreCase("%GONZO%").count()).isEqualTo(1);
@@ -3938,7 +4248,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%nzo%").count()).isEqualTo(6);
         assertThat(taskService.createTaskQuery().taskOwnerLikeIgnoreCase("%doesnotexist%").count()).isZero();
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
             assertThat(historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%gonzo%").count()).isEqualTo(6);
             assertThat(historyService.createHistoricTaskInstanceQuery().taskOwnerLikeIgnoreCase("%GONZO%").count()).isEqualTo(6);
@@ -3964,7 +4274,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("business%").count()).isEqualTo(2);
         assertThat(taskService.createTaskQuery().processInstanceBusinessKeyLikeIgnoreCase("%doesnotexist%").count()).isZero();
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
             assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%key%").count()).isEqualTo(3);
             assertThat(historyService.createHistoricTaskInstanceQuery().processInstanceBusinessKeyLikeIgnoreCase("%KEY%").count()).isEqualTo(3);
@@ -3990,7 +4300,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
         assertThat(taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("ON%").count()).isEqualTo(4);
         assertThat(taskService.createTaskQuery().processDefinitionKeyLikeIgnoreCase("%fake%").count()).isZero();
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
             assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("%one%").count()).isEqualTo(4);
             assertThat(historyService.createHistoricTaskInstanceQuery().processDefinitionKeyLikeIgnoreCase("%ONE%").count()).isEqualTo(4);
@@ -4008,7 +4318,7 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                         .taskOwnerLike("G%").endOr()
                         .count()).isEqualTo(12);
 
-        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+        if (isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
             // History
             assertThat(historyService.createHistoricTaskInstanceQuery().or().taskNameLikeIgnoreCase("%task%").taskDescriptionLikeIgnoreCase("%desc%")
                     .taskAssigneeLikeIgnoreCase("Gonz%")
@@ -4425,6 +4735,10 @@ public class TaskQueryTest extends PluggableFlowableTestCase {
                 .containsExactlyInAnyOrder(
                         tuple("my task", processWithStringValue.getId())
                 );
+    }
+
+    private boolean isHistoryLevelAtLeast(HistoryLevel level) {
+        return HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration);
     }
 
     /**

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceBaseResource.java
@@ -135,6 +135,15 @@ public class HistoricTaskInstanceBaseResource {
         if (queryRequest.getTaskCategory() != null) {
             query.taskCategory(queryRequest.getTaskCategory());
         }
+        if (queryRequest.getTaskCategoryIn() != null && !queryRequest.getTaskCategoryIn().isEmpty()) {
+            query.taskCategoryIn(queryRequest.getTaskCategoryIn());
+        }
+        if (queryRequest.getTaskCategoryNotIn() != null && !queryRequest.getTaskCategoryNotIn().isEmpty()) {
+            query.taskCategoryNotIn(queryRequest.getTaskCategoryNotIn());
+        }
+        if (Boolean.TRUE.equals(queryRequest.getTaskWithoutCategory())) {
+            query.taskWithoutCategory();
+        }
         if (queryRequest.getTaskDeleteReason() != null) {
             query.taskDeleteReason(queryRequest.getTaskDeleteReason());
         }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceCollectionResource.java
@@ -61,6 +61,9 @@ public class HistoricTaskInstanceCollectionResource extends HistoricTaskInstance
             @ApiImplicitParam(name = "taskDescription", dataType = "string", value = "The task description of the historic task instance.", paramType = "query"),
             @ApiImplicitParam(name = "taskDescriptionLike", dataType = "string", value = "The task description with like operator for the historic task instance.", paramType = "query"),
             @ApiImplicitParam(name = "taskCategory", dataType = "string", value = "Select tasks with the given category. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).", paramType = "query"),
+            @ApiImplicitParam(name = "taskCategoryIn", dataType = "string", value = "Select tasks with the given categories. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).", paramType = "query"),
+            @ApiImplicitParam(name = "taskCategoryNotIn", dataType = "string", value = "Select tasks not assigned to the given categories. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).", paramType = "query"),
+            @ApiImplicitParam(name = "taskWithoutCategory", dataType = "string", value = "Select tasks with no category assigned. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).", paramType = "query"),
             @ApiImplicitParam(name = "taskDeleteReason", dataType = "string", value = "The task delete reason of the historic task instance.", paramType = "query"),
             @ApiImplicitParam(name = "taskDeleteReasonLike", dataType = "string", value = "The task delete reason with like operator for the historic task instance.", paramType = "query"),
             @ApiImplicitParam(name = "taskAssignee", dataType = "string", value = "The assignee of the historic task instance.", paramType = "query"),
@@ -178,6 +181,18 @@ public class HistoricTaskInstanceCollectionResource extends HistoricTaskInstance
 
         if (allRequestParams.containsKey("taskCategory")) {
             queryRequest.setTaskCategory(allRequestParams.get("taskCategory"));
+        }
+
+        if (allRequestParams.containsKey("taskCategoryIn")) {
+            queryRequest.setTaskCategoryIn(Arrays.asList(allRequestParams.get("taskCategoryIn").split(",")));
+        }
+
+        if (allRequestParams.containsKey("taskCategoryNotIn")) {
+            queryRequest.setTaskCategoryNotIn(Arrays.asList(allRequestParams.get("taskCategoryNotIn").split(",")));
+        }
+
+        if (allRequestParams.containsKey("taskWithoutCategory") && Boolean.parseBoolean(allRequestParams.get("taskWithoutCategory"))) {
+            queryRequest.setTaskWithoutCategory(Boolean.TRUE);
         }
 
         if (allRequestParams.get("taskDeleteReason") != null) {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceQueryRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/history/HistoricTaskInstanceQueryRequest.java
@@ -48,6 +48,9 @@ public class HistoricTaskInstanceQueryRequest extends PaginateRequest {
     protected String taskDefinitionKeyLike;
     protected Collection<String> taskDefinitionKeys;
     protected String taskCategory;
+    protected List<String> taskCategoryIn;
+    protected List<String> taskCategoryNotIn;
+    protected Boolean taskWithoutCategory;
     protected String taskDeleteReason;
     protected String taskDeleteReasonLike;
     protected String taskAssignee;
@@ -245,6 +248,30 @@ public class HistoricTaskInstanceQueryRequest extends PaginateRequest {
 
     public void setTaskCategory(String taskCategory) {
         this.taskCategory = taskCategory;
+    }
+
+    public List<String> getTaskCategoryIn() {
+        return taskCategoryIn;
+    }
+
+    public void setTaskCategoryIn(List<String> taskCategoryIn) {
+        this.taskCategoryIn = taskCategoryIn;
+    }
+
+    public List<String> getTaskCategoryNotIn() {
+        return taskCategoryNotIn;
+    }
+
+    public void setTaskCategoryNotIn(List<String> taskCategoryNotIn) {
+        this.taskCategoryNotIn = taskCategoryNotIn;
+    }
+
+    public Boolean getTaskWithoutCategory() {
+        return taskWithoutCategory;
+    }
+
+    public void setTaskWithoutCategory(Boolean taskWithoutCategory) {
+        this.taskWithoutCategory = taskWithoutCategory;
     }
 
     public String getTaskDeleteReason() {

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskBaseResource.java
@@ -342,7 +342,18 @@ public class TaskBaseResource {
         if (request.getCategory() != null) {
             taskQuery.taskCategory(request.getCategory());
         }
-        
+        if (request.getCategoryIn() != null && !request.getCategoryIn().isEmpty()) {
+            taskQuery.taskCategoryIn(request.getCategoryIn());
+        }
+
+        if (request.getCategoryNotIn() != null && !request.getCategoryNotIn().isEmpty()) {
+            taskQuery.taskCategoryNotIn(request.getCategoryNotIn());
+        }
+
+        if (Boolean.TRUE.equals(request.getWithoutCategory())) {
+            taskQuery.taskWithoutCategory();
+        }
+
         if (restApiInterceptor != null) {
             restApiInterceptor.accessTaskInfoWithQuery(taskQuery, request);
         }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskBaseResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskBaseResource.java
@@ -342,6 +342,7 @@ public class TaskBaseResource {
         if (request.getCategory() != null) {
             taskQuery.taskCategory(request.getCategory());
         }
+
         if (request.getCategoryIn() != null && !request.getCategoryIn().isEmpty()) {
             taskQuery.taskCategoryIn(request.getCategoryIn());
         }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskCollectionResource.java
@@ -110,6 +110,9 @@ public class TaskCollectionResource extends TaskBaseResource {
             @ApiImplicitParam(name = "withoutTenantId", dataType = "boolean", value = "If true, only returns tasks without a tenantId set. If false, the withoutTenantId parameter is ignored.", paramType = "query"),
             @ApiImplicitParam(name = "candidateOrAssigned", dataType = "string", value = "Select tasks that has been claimed or assigned to user or waiting to claim by user (candidate user or groups).", paramType = "query"),
             @ApiImplicitParam(name = "category", dataType = "string", value = "Select tasks with the given category. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).\n", paramType = "query"),
+            @ApiImplicitParam(name = "categoryIn", dataType = "string", value = "Select tasks for the given categories. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).\n", paramType = "query"),
+            @ApiImplicitParam(name = "categoryNotIn", dataType = "string", value = "Select tasks which are not assigned to the given categories. Does not return tasks without categories. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).\n", paramType = "query"),
+            @ApiImplicitParam(name = "withoutCategory", dataType = "string", value = "Select tasks without a category assigned. Note that this is the task category, not the category of the process definition (namespace within the BPMN Xml).\n", paramType = "query"),
     })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Indicates request was successful and the tasks are returned"),
@@ -186,9 +189,7 @@ public class TaskCollectionResource extends TaskBaseResource {
         }
 
         if (requestParams.containsKey("candidateGroups")) {
-            String[] candidateGroups = requestParams.get("candidateGroups").split(",");
-            List<String> groups = new ArrayList<>(candidateGroups.length);
-            Collections.addAll(groups, candidateGroups);
+            List<String> groups = csvToList("candidateGroups", requestParams);
             request.setCandidateGroupIn(groups);
         }
 
@@ -332,6 +333,18 @@ public class TaskCollectionResource extends TaskBaseResource {
             request.setCategory(requestParams.get("category"));
         }
 
+        if (requestParams.containsKey("withoutCategory") && Boolean.valueOf(requestParams.get("withoutCategory"))) {
+            request.setWithoutCategory(Boolean.TRUE);
+        }
+
+        if (requestParams.containsKey("categoryIn")) {
+            request.setCategoryIn(csvToList("categoryIn", requestParams));
+        }
+
+        if (requestParams.containsKey("categoryNotIn")) {
+            request.setCategoryNotIn(csvToList("categoryNotIn", requestParams));
+        }
+
         return getTasksFromQueryRequest(request, requestParams);
     }
 
@@ -403,4 +416,10 @@ public class TaskCollectionResource extends TaskBaseResource {
         return dataResponse;
     }
 
+    protected List<String> csvToList(String key, Map<String, String> requestParams) {
+        String[] candidateGroupsSplit = requestParams.get(key).split(",");
+        List<String> groups = new ArrayList<>(candidateGroupsSplit.length);
+        Collections.addAll(groups, candidateGroupsSplit);
+        return groups;
+    }
 }

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskQueryRequest.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/runtime/task/TaskQueryRequest.java
@@ -81,6 +81,9 @@ public class TaskQueryRequest extends PaginateRequest {
     protected Boolean withoutTenantId;
     protected String candidateOrAssigned;
     protected String category;
+    protected List<String> categoryIn;
+    protected List<String> categoryNotIn;
+    protected Boolean withoutCategory;
 
     private List<QueryVariable> taskVariables;
     private List<QueryVariable> processInstanceVariables;
@@ -525,5 +528,29 @@ public class TaskQueryRequest extends PaginateRequest {
 
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    public List<String> getCategoryIn() {
+        return categoryIn;
+    }
+
+    public void setCategoryIn(List<String> categoryIn) {
+        this.categoryIn = categoryIn;
+    }
+
+    public List<String> getCategoryNotIn() {
+        return categoryNotIn;
+    }
+
+    public void setCategoryNotIn(List<String> categoryNotIn) {
+        this.categoryNotIn = categoryNotIn;
+    }
+
+    public Boolean getWithoutCategory() {
+        return withoutCategory;
+    }
+
+    public void setWithoutCategory(Boolean withoutCategory) {
+        this.withoutCategory = withoutCategory;
     }
 }

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCollectionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/runtime/TaskCollectionResourceTest.java
@@ -371,6 +371,15 @@ public class TaskCollectionResourceTest extends BaseSpringRestTestCase {
             url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?category=" + encode("some-category");
             assertResultsPresentInDataResponse(url, adhocTask.getId());
 
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?categoryIn=" + encode("some-other-category,some-category");
+            assertResultsPresentInDataResponse(url, adhocTask.getId());
+
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?categoryNotIn=" + encode("some-category");
+            assertResultsPresentInDataResponse(url);
+
+            url = RestUrls.createRelativeResourceUrl(RestUrls.URL_TASK_COLLECTION) + "?withoutCategory=true";
+            assertResultsPresentInDataResponse(url, processTask.getId());
+
             // Suspend process-instance to have a suspended task
             runtimeService.suspendProcessInstanceById(processInstance.getId());
 

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
@@ -311,7 +311,38 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
      * Only select tasks with the given category.
      */
     T taskCategory(String category);
-    
+
+    /**
+     * Only select tasks belonging to one of the categories in the given list.
+     *
+     * @param taskCategoryInList
+     * @throws FlowableIllegalArgumentException When passed category list is empty or <code>null</code> or contains <code>null String</code>.
+     */
+    T taskCategoryIn(Collection<String> taskCategoryInList);
+
+    /**
+     * Only select tasks with a defined category which do not belong to a category present in the given list.
+     * <p>
+     * NOTE: This method does <b>not</b> return tasks <b>without</b> category e.g. tasks having a null category.
+     * To include null categories, use {@code query.or().taskCategoryNotIn(...).taskWithoutCategory().endOr()}
+     * </p>
+     *
+     * @param taskCategoryNotInList
+     * @throws FlowableIllegalArgumentException When passed category list is empty or <code>null</code> or contains <code>null String</code>.
+     * @see #taskWithoutCategory
+     */
+    T taskCategoryNotIn(Collection<String> taskCategoryNotInList);
+
+    /**
+     * Selects tasks without category.
+     * <p>
+     * Can also be used in conjunction with other filter criteria to include tasks without category e.g. in or queries.
+     *
+     * @throws FlowableIllegalArgumentException When passed category list is empty or <code>null</code> or contains <code>null String</code>.
+     * @see #taskCategoryNotIn(Collection)
+     */
+    T taskWithoutCategory();
+
     /**
      * Only select tasks with form key.
      */

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQuery.java
@@ -316,15 +316,15 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
      * Only select tasks belonging to one of the categories in the given list.
      *
      * @param taskCategoryInList
-     * @throws FlowableIllegalArgumentException When passed category list is empty or <code>null</code> or contains <code>null String</code>.
+     * @throws FlowableIllegalArgumentException When passed category list is empty or <code>null</code> or contains <code>null</code> String.
      */
     T taskCategoryIn(Collection<String> taskCategoryInList);
 
     /**
      * Only select tasks with a defined category which do not belong to a category present in the given list.
      * <p>
-     * NOTE: This method does <b>not</b> return tasks <b>without</b> category e.g. tasks having a null category.
-     * To include null categories, use {@code query.or().taskCategoryNotIn(...).taskWithoutCategory().endOr()}
+     * NOTE: This method does <b>not</b> return tasks <b>without</b> category e.g. tasks having a <code>null</code> category.
+     * To include <code>null</code> categories, use <code>query.or().taskCategoryNotIn(...).taskWithoutCategory().endOr()</code>
      * </p>
      *
      * @param taskCategoryNotInList
@@ -336,9 +336,8 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
     /**
      * Selects tasks without category.
      * <p>
-     * Can also be used in conjunction with other filter criteria to include tasks without category e.g. in or queries.
-     *
-     * @throws FlowableIllegalArgumentException When passed category list is empty or <code>null</code> or contains <code>null String</code>.
+     * Can also be used in conjunction with other filter criteria to include tasks without category e.g. in <code>or</code> queries.
+     * </p>
      * @see #taskCategoryNotIn(Collection)
      */
     T taskWithoutCategory();

--- a/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQueryWrapper.java
+++ b/modules/flowable-task-service-api/src/main/java/org/flowable/task/api/TaskInfoQueryWrapper.java
@@ -16,11 +16,13 @@ package org.flowable.task.api;
  * This is a helper class to help you work with the {@link TaskInfoQuery}, without having to care about the awful generics.
  * 
  * Example usage:
- * 
+ * <pre>
+ * {@code
  * TaskInfoQueryWrapper taskInfoQueryWrapper = new TaskInfoQueryWrapper(taskService.createTaskQuery()); 
- * List&lt;? extends TaskInfo&gt; taskInfos = taskInfoQueryWrapper.getTaskInfoQuery().or()
- *    .taskNameLike("%task%") .taskDescriptionLike("%blah%"); .endOr() .list();
- * 
+ * List<? extends TaskInfo> taskInfos = taskInfoQueryWrapper.getTaskInfoQuery().or()
+ *    .taskNameLike("%task%").taskDescriptionLike("%blah%").endOr().list();
+ * }
+ * </pre>
  * First line can be switched to TaskInfoQueryWrapper taskInfoQueryWrapper = new TaskInfoQueryWrapper(historyService.createTaskQuery()); and the same methods can be used on the result.
  * 
  * @author Joram Barrez

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/HistoricTaskInstanceQueryImpl.java
@@ -133,6 +133,9 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     protected Date completedAfterDate;
     protected Date completedBeforeDate;
     protected String category;
+    protected Collection<String> categoryInList;
+    protected Collection<String> categoryNotInList;
+    protected boolean withoutCategory;
     protected boolean withFormKey;
     protected String formKey;
     protected String tenantId;
@@ -1552,6 +1555,53 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
     }
 
     @Override
+    public HistoricTaskInstanceQuery taskCategoryIn(Collection<String> taskCategoryInList) {
+        checkTaskCategoryList(taskCategoryInList);
+
+        if (inOrStatement) {
+            currentOrQueryObject.categoryInList = taskCategoryInList;
+        } else {
+            this.categoryInList = taskCategoryInList;
+        }
+        return this;
+    }
+
+    @Override
+    public HistoricTaskInstanceQuery taskCategoryNotIn(Collection<String> taskCategoryNotInList) {
+        checkTaskCategoryList(taskCategoryNotInList);
+        if (inOrStatement) {
+            currentOrQueryObject.categoryNotInList = taskCategoryNotInList;
+        } else {
+            this.categoryNotInList = taskCategoryNotInList;
+        }
+        return this;
+    }
+
+    protected void checkTaskCategoryList(Collection<String> taskCategoryInList) {
+        if (taskCategoryInList == null) {
+            throw new FlowableIllegalArgumentException("Task category list is null");
+        }
+        if (taskCategoryInList.isEmpty()) {
+            throw new FlowableIllegalArgumentException("Task category list is empty");
+        }
+        for (String processCategory : taskCategoryInList) {
+            if (processCategory == null) {
+                throw new FlowableIllegalArgumentException("None of the given task categories can be null");
+            }
+        }
+    }
+
+    @Override
+    public HistoricTaskInstanceQuery taskWithoutCategory() {
+        if (inOrStatement) {
+            currentOrQueryObject.withoutCategory = true;
+        } else {
+            this.withoutCategory = true;
+        }
+        return this;
+    }
+
+    @Override
     public HistoricTaskInstanceQuery taskWithFormKey() {
         if (inOrStatement) {
             currentOrQueryObject.withFormKey = true;
@@ -2131,6 +2181,18 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
 
     public String getCategory() {
         return category;
+    }
+
+    public Collection<String> getCategoryInList() {
+        return categoryInList;
+    }
+
+    public Collection<String> getCategoryNotInList() {
+        return categoryNotInList;
+    }
+
+    public boolean isWithoutCategory() {
+        return withoutCategory;
     }
 
     public boolean isWithFormKey() {

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/TaskQueryImpl.java
@@ -102,6 +102,9 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     protected Date createTimeBefore;
     protected Date createTimeAfter;
     protected String category;
+    protected Collection<String> categoryInList;
+    protected Collection<String> categoryNotInList;
+    protected boolean withoutCategory;
     protected boolean withFormKey;
     protected String formKey;
     protected String taskDefinitionId;
@@ -959,6 +962,52 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
             this.category = category;
         }
         return this;
+    }
+
+    @Override
+    public TaskQuery taskCategoryIn(Collection<String> taskCategoryInList) {
+        checkTaskCategoryList(taskCategoryInList);
+        if (orActive) {
+            currentOrQueryObject.categoryInList = taskCategoryInList;
+        } else {
+            this.categoryInList = taskCategoryInList;
+        }
+        return this;
+    }
+
+    @Override
+    public TaskQuery taskCategoryNotIn(Collection<String> taskCategoryNotInList) {
+        checkTaskCategoryList(taskCategoryNotInList);
+        if (orActive) {
+            currentOrQueryObject.categoryNotInList = taskCategoryNotInList;
+        } else {
+            this.categoryNotInList = taskCategoryNotInList;
+        }
+        return this;
+    }
+
+    @Override
+    public TaskQuery taskWithoutCategory() {
+        if (orActive) {
+            currentOrQueryObject.withoutCategory = true;
+        } else {
+            this.withoutCategory = true;
+        }
+        return this;
+    }
+
+    protected void checkTaskCategoryList(Collection<String> taskCategoryInList) {
+        if (taskCategoryInList == null) {
+            throw new FlowableIllegalArgumentException("Task category list is null");
+        }
+        if (taskCategoryInList.isEmpty()) {
+            throw new FlowableIllegalArgumentException("Task category list is empty");
+        }
+        for (String category : taskCategoryInList) {
+            if (category == null) {
+                throw new FlowableIllegalArgumentException("None of the given task categories can be null");
+            }
+        }
     }
 
     @Override
@@ -2201,6 +2250,18 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
 
     public String getCategory() {
         return category;
+    }
+
+    public Collection<String> getCategoryInList() {
+        return categoryInList;
+    }
+
+    public Collection<String> getCategoryNotInList() {
+        return categoryNotInList;
+    }
+
+    public boolean isWithoutCategory() {
+        return withoutCategory;
     }
 
     public boolean isWithFormKey() {

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/HistoricTaskInstance.xml
@@ -1272,6 +1272,23 @@
       <if test="category != null">
         and ${queryTablePrefix}CATEGORY_ = #{category}
       </if>
+      <if test="categoryInList != null &amp;&amp; !categoryInList.empty">
+          and ${queryTablePrefix}CATEGORY_ IN
+          <foreach item="taskCategory" index="index" collection="categoryInList"
+                   open="(" separator="," close=")">
+              #{taskCategory}
+          </foreach>
+      </if>
+      <if test="categoryNotInList != null &amp;&amp; !categoryNotInList.empty">
+          and ${queryTablePrefix}CATEGORY_ NOT IN
+          <foreach item="taskCategory" index="index" collection="categoryNotInList"
+                   open="(" separator="," close=")">
+              #{taskCategory}
+          </foreach>
+      </if>
+      <if test="withoutCategory">
+          and ${queryTablePrefix}CATEGORY_ IS NULL
+      </if>
       <if test="withFormKey">
         and ${queryTablePrefix}FORM_KEY_ IS NOT NULL
       </if>
@@ -1530,6 +1547,23 @@
       </if>
       <if test="orQueryObject.category != null">
         or ${queryTablePrefix}CATEGORY_ = #{orQueryObject.category}
+      </if>
+      <if test="orQueryObject.categoryInList != null &amp;&amp; !orQueryObject.categoryInList.empty">
+          or ${queryTablePrefix}CATEGORY_ IN
+          <foreach item="taskCategory" index="index" collection="orQueryObject.categoryInList"
+                   open="(" separator="," close=")">
+              #{taskCategory}
+          </foreach>
+      </if>
+      <if test="orQueryObject.categoryNotInList != null &amp;&amp; !orQueryObject.categoryNotInList.empty">
+          or ${queryTablePrefix}CATEGORY_ NOT IN
+          <foreach item="taskCategory" index="index" collection="orQueryObject.categoryNotInList"
+                   open="(" separator="," close=")">
+              #{taskCategory}
+          </foreach>
+      </if>
+      <if test="orQueryObject.withoutCategory">
+        or ${queryTablePrefix}CATEGORY_ IS NULL
       </if>
       <if test="orQueryObject.withFormKey">
         or ${queryTablePrefix}FORM_KEY_ IS NOT NULL

--- a/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
+++ b/modules/flowable-task-service/src/main/resources/org/flowable/task/service/db/mapping/entity/Task.xml
@@ -754,6 +754,23 @@
       <if test="category != null">
         and RES.CATEGORY_ = #{category}
       </if>
+      <if test="categoryInList != null &amp;&amp; !categoryInList.empty">
+          and RES.CATEGORY_ IN
+          <foreach item="taskCategory" index="index" collection="categoryInList"
+                   open="(" separator="," close=")">
+              #{taskCategory}
+          </foreach>
+      </if>
+      <if test="categoryNotInList != null &amp;&amp; !categoryNotInList.empty">
+          and RES.CATEGORY_ NOT IN
+          <foreach item="taskCategory" index="index" collection="categoryNotInList"
+                     open="(" separator="," close=")">
+              #{taskCategory}
+            </foreach>
+      </if>
+      <if test="withoutCategory">
+        and RES.CATEGORY_ IS NULL
+      </if>
       <if test="withFormKey">
         and RES.FORM_KEY_ IS NOT NULL
       </if>
@@ -1289,6 +1306,23 @@
             </if>
             <if test="orQueryObject.category != null">
               or RES.CATEGORY_ = #{orQueryObject.category}
+            </if>
+            <if test="orQueryObject.categoryInList != null &amp;&amp; !orQueryObject.categoryInList.empty">
+                or RES.CATEGORY_ IN
+                <foreach item="taskCategory" index="index" collection="orQueryObject.categoryInList"
+                         open="(" separator="," close=")">
+                    #{taskCategory}
+                </foreach>
+            </if>
+            <if test="orQueryObject.categoryNotInList != null &amp;&amp; !orQueryObject.categoryNotInList.empty">
+                or RES.CATEGORY_ NOT IN
+                <foreach item="taskCategory" index="index" collection="orQueryObject.categoryNotInList"
+                         open="(" separator="," close=")">
+                    #{taskCategory}
+                </foreach>
+            </if>
+            <if test="orQueryObject.withoutCategory">
+                or RES.CATEGORY_ IS NULL
             </if>
             <if test="orQueryObject.withFormKey">
               or RES.FORM_KEY_ IS NOT NULL


### PR DESCRIPTION
* Added 'taskCategoryIn' query method
* Added 'taskCategoryNotIn' query method
* Added 'withoutCategory' to query for tasks without category

#### Check List:
* Unit tests: YES 
* Documentation: NA
