### PR TITLE
Make use of DynamicUserTaskCallback within InjectUserTaskInProcessIns…

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/InjectUserTaskInProcessInstanceCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/InjectUserTaskInProcessInstanceCmd.java
@@ -58,7 +58,7 @@ public class InjectUserTaskInProcessInstanceCmd extends AbstractDynamicInjection
         List<StartEvent> startEvents = process.findFlowElementsOfType(StartEvent.class);
         StartEvent initialStartEvent = null;
         for (StartEvent startEvent : startEvents) {
-            if (startEvent.getEventDefinitions().size() == 0) {
+            if (startEvent.getEventDefinitions().isEmpty()) {
                 initialStartEvent = startEvent;
                 break;
                 
@@ -101,6 +101,11 @@ public class InjectUserTaskInProcessInstanceCmd extends AbstractDynamicInjection
         SequenceFlow flowFromStart = new SequenceFlow(initialStartEvent.getId(), parallelGateway.getId());
         flowFromStart.setId(dynamicUserTaskBuilder.nextFlowId(process.getFlowElementMap()));
         process.addFlowElement(flowFromStart);
+
+        if (dynamicUserTaskBuilder.getDynamicUserTaskCallback() != null) {
+            dynamicUserTaskBuilder.getDynamicUserTaskCallback().handleCreatedDynamicUserTask(userTask,
+                    userTask.getSubProcess(), userTask.getParentContainer(), process);
+        }
         
         GraphicInfo elementGraphicInfo = bpmnModel.getGraphicInfo(initialStartEvent.getId());
         if (elementGraphicInfo != null) {


### PR DESCRIPTION
DynamicUserTaskBuilder offers the DynamicUserTaskCallback for callbacks after creating new UserTask. It is used by InjectParallelUserTaskCmd but not InjectUserTaskInProcessInstanceCmd. With this pull request we added the missing lines of code, that also InjectUserTaskInProcessInstanceCmd is using the feature of DynamicUserTaskCallback.