### PR TITLE
Task/refactor to variable container

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/scripting/CmmnVariableScopeResolver.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/scripting/CmmnVariableScopeResolver.java
@@ -18,8 +18,8 @@ import java.util.Set;
 
 import org.flowable.cmmn.engine.CmmnEngineConfiguration;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.flowable.common.engine.impl.scripting.Resolver;
-import org.flowable.variable.api.delegate.VariableScope;
 
 /**
  *
@@ -59,19 +59,19 @@ public class CmmnVariableScopeResolver implements Resolver {
     ));
 
     protected CmmnEngineConfiguration engineConfiguration;
-    protected VariableScope variableScope;
+    protected VariableContainer variableContainer;
 
-    public CmmnVariableScopeResolver(CmmnEngineConfiguration engineConfiguration, VariableScope variableScope) {
-        if (variableScope == null) {
-            throw new FlowableIllegalArgumentException("variableScope cannot be null");
+    public CmmnVariableScopeResolver(CmmnEngineConfiguration engineConfiguration, VariableContainer variableContainer) {
+        if (variableContainer == null) {
+            throw new FlowableIllegalArgumentException("variableContainer cannot be null");
         }
-        this.variableScope = variableScope;
+        this.variableContainer = variableContainer;
         this.engineConfiguration = engineConfiguration;
     }
 
     @Override
     public boolean containsKey(Object key) {
-        return variableScope.hasVariable((String) key) || KEYS.contains(key);
+        return variableContainer.hasVariable((String) key) || KEYS.contains(key);
     }
 
     @Override
@@ -92,10 +92,10 @@ public class CmmnVariableScopeResolver implements Resolver {
             return engineConfiguration.getCmmnTaskService();
 
         } else if (CASE_INSTANCE_KEY.equals(key) || PLAN_ITEM_INSTANCE_KEY.equals(key) || TASK_KEY.equals(key)) { // task/planItemInstance/caseInstance
-            return variableScope;
+            return variableContainer;
 
         } else {
-            return variableScope.getVariable((String) key);
+            return variableContainer.getVariable((String) key);
 
         }
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/scripting/CmmnVariableScopeResolverFactory.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/scripting/CmmnVariableScopeResolverFactory.java
@@ -13,6 +13,7 @@
 package org.flowable.cmmn.engine.impl.scripting;
 
 import org.flowable.cmmn.engine.CmmnEngineConfiguration;
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
 import org.flowable.common.engine.impl.scripting.Resolver;
 import org.flowable.common.engine.impl.scripting.ResolverFactory;
@@ -25,7 +26,7 @@ import org.flowable.variable.api.delegate.VariableScope;
 public class CmmnVariableScopeResolverFactory implements ResolverFactory {
 
     @Override
-    public Resolver createResolver(AbstractEngineConfiguration engineConfiguration, VariableScope variableScope) {
+    public Resolver createResolver(AbstractEngineConfiguration engineConfiguration, VariableContainer variableScope) {
         if (variableScope != null) {
             return new CmmnVariableScopeResolver((CmmnEngineConfiguration) engineConfiguration, variableScope);
         }

--- a/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/variable/VariableContainer.java
+++ b/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/variable/VariableContainer.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.common.engine.api.variable;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * @author Joram Barrez
  */
@@ -26,5 +29,13 @@ public interface VariableContainer {
     void setTransientVariable(String variableName, Object variableValue);
 
     String getTenantId();
+
+    /**
+     * Returns all variables.
+     */
+    default Map<String, Object> getVariables() {
+        // default for backwards compatibility
+        return Collections.emptyMap();
+    }
 
 }

--- a/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/variable/VariableContainer.java
+++ b/modules/flowable-engine-common-api/src/main/java/org/flowable/common/engine/api/variable/VariableContainer.java
@@ -12,9 +12,6 @@
  */
 package org.flowable.common.engine.api.variable;
 
-import java.util.Collections;
-import java.util.Map;
-
 /**
  * @author Joram Barrez
  */
@@ -29,13 +26,5 @@ public interface VariableContainer {
     void setTransientVariable(String variableName, Object variableValue);
 
     String getTenantId();
-
-    /**
-     * Returns all variables.
-     */
-    default Map<String, Object> getVariables() {
-        // default for backwards compatibility
-        return Collections.emptyMap();
-    }
 
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/BeansResolverFactory.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/BeansResolverFactory.java
@@ -13,8 +13,8 @@
 
 package org.flowable.common.engine.impl.scripting;
 
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
-import org.flowable.variable.api.delegate.VariableScope;
 
 /**
  * @author Tom Baeyens
@@ -24,7 +24,7 @@ public class BeansResolverFactory implements ResolverFactory, Resolver {
     protected AbstractEngineConfiguration engineConfiguration;
 
     @Override
-    public Resolver createResolver(AbstractEngineConfiguration processEngineConfiguration, VariableScope variableScope) {
+    public Resolver createResolver(AbstractEngineConfiguration processEngineConfiguration, VariableContainer variableContainer) {
         this.engineConfiguration = processEngineConfiguration;
         return this;
     }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ResolverFactory.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ResolverFactory.java
@@ -14,6 +14,7 @@
 package org.flowable.common.engine.impl.scripting;
 
 
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
 import org.flowable.variable.api.delegate.VariableScope;
 
@@ -23,6 +24,6 @@ import org.flowable.variable.api.delegate.VariableScope;
  */
 public interface ResolverFactory {
 
-    Resolver createResolver(AbstractEngineConfiguration engineConfiguration, VariableScope variableScope);
+    Resolver createResolver(AbstractEngineConfiguration engineConfiguration, VariableContainer variableContainer);
 
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptBindings.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptBindings.java
@@ -15,6 +15,7 @@ package org.flowable.common.engine.impl.scripting;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import javax.script.Bindings;
 import javax.script.SimpleScriptContext;
 
 import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.variable.api.delegate.VariableScope;
 
 /**
  * @author Tom Baeyens
@@ -89,22 +91,22 @@ public class ScriptBindings implements Bindings {
 
     @Override
     public Set<Map.Entry<String, Object>> entrySet() {
-        return variableContainer.getVariables().entrySet();
+        return getVariables().entrySet();
     }
 
     @Override
     public Set<String> keySet() {
-        return variableContainer.getVariables().keySet();
+        return getVariables().keySet();
     }
 
     @Override
     public int size() {
-        return variableContainer.getVariables().size();
+        return getVariables().size();
     }
 
     @Override
     public Collection<Object> values() {
-        return variableContainer.getVariables().values();
+        return getVariables().values();
     }
 
     @Override
@@ -139,4 +141,10 @@ public class ScriptBindings implements Bindings {
         UNSTORED_KEYS.add(unstoredKey);
     }
 
+    protected Map<String, Object> getVariables() {
+        if (this.variableContainer instanceof VariableScope) {
+            return ((VariableScope) this.variableContainer).getVariables();
+        }
+        return Collections.emptyMap();
+    }
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptBindings.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptBindings.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import javax.script.Bindings;
 import javax.script.SimpleScriptContext;
 
-import org.flowable.variable.api.delegate.VariableScope;
+import org.flowable.common.engine.api.variable.VariableContainer;
 
 /**
  * @author Tom Baeyens
@@ -39,18 +39,18 @@ public class ScriptBindings implements Bindings {
     protected static final Set<String> UNSTORED_KEYS = new HashSet<>(Arrays.asList("out", "out:print", "lang:import", "context", "elcontext", "print", "println", "nashorn.global"));
 
     protected List<Resolver> scriptResolvers;
-    protected VariableScope variableScope;
+    protected VariableContainer variableContainer;
     protected Bindings defaultBindings;
     protected boolean storeScriptVariables = true; // By default everything is stored (backwards compatibility)
 
-    public ScriptBindings(List<Resolver> scriptResolvers, VariableScope variableScope) {
+    public ScriptBindings(List<Resolver> scriptResolvers, VariableContainer variableContainer) {
         this.scriptResolvers = scriptResolvers;
-        this.variableScope = variableScope;
+        this.variableContainer = variableContainer;
         this.defaultBindings = new SimpleScriptContext().getBindings(SimpleScriptContext.ENGINE_SCOPE);
     }
 
-    public ScriptBindings(List<Resolver> scriptResolvers, VariableScope variableScope, boolean storeScriptVariables) {
-        this(scriptResolvers, variableScope);
+    public ScriptBindings(List<Resolver> scriptResolvers, VariableContainer variableContainer, boolean storeScriptVariables) {
+        this(scriptResolvers, variableContainer);
         this.storeScriptVariables = storeScriptVariables;
     }
 
@@ -79,8 +79,8 @@ public class ScriptBindings implements Bindings {
         if (storeScriptVariables) {
             Object oldValue = null;
             if (!UNSTORED_KEYS.contains(name)) {
-                oldValue = variableScope.getVariable(name);
-                variableScope.setVariable(name, value);
+                oldValue = variableContainer.getVariable(name);
+                variableContainer.setVariable(name, value);
                 return oldValue;
             }
         }
@@ -89,22 +89,22 @@ public class ScriptBindings implements Bindings {
 
     @Override
     public Set<Map.Entry<String, Object>> entrySet() {
-        return variableScope.getVariables().entrySet();
+        return variableContainer.getVariables().entrySet();
     }
 
     @Override
     public Set<String> keySet() {
-        return variableScope.getVariables().keySet();
+        return variableContainer.getVariables().keySet();
     }
 
     @Override
     public int size() {
-        return variableScope.getVariables().size();
+        return variableContainer.getVariables().size();
     }
 
     @Override
     public Collection<Object> values() {
-        return variableScope.getVariables().values();
+        return variableContainer.getVariables().values();
     }
 
     @Override

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptBindingsFactory.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptBindingsFactory.java
@@ -18,8 +18,8 @@ import java.util.List;
 
 import javax.script.Bindings;
 
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
-import org.flowable.variable.api.delegate.VariableScope;
 
 /**
  * @author Tom Baeyens
@@ -35,18 +35,18 @@ public class ScriptBindingsFactory {
         this.resolverFactories = resolverFactories;
     }
 
-    public Bindings createBindings(VariableScope variableScope) {
-        return new ScriptBindings(createResolvers(variableScope), variableScope);
+    public Bindings createBindings(VariableContainer variableContainer) {
+        return new ScriptBindings(createResolvers(variableContainer), variableContainer);
     }
 
-    public Bindings createBindings(VariableScope variableScope, boolean storeScriptVariables) {
-        return new ScriptBindings(createResolvers(variableScope), variableScope, storeScriptVariables);
+    public Bindings createBindings(VariableContainer variableContainer, boolean storeScriptVariables) {
+        return new ScriptBindings(createResolvers(variableContainer), variableContainer, storeScriptVariables);
     }
 
-    protected List<Resolver> createResolvers(VariableScope variableScope) {
+    protected List<Resolver> createResolvers(VariableContainer variableContainer) {
         List<Resolver> scriptResolvers = new ArrayList<>();
         for (ResolverFactory scriptResolverFactory : resolverFactories) {
-            Resolver resolver = scriptResolverFactory.createResolver(engineConfiguration, variableScope);
+            Resolver resolver = scriptResolverFactory.createResolver(engineConfiguration, variableContainer);
             if (resolver != null) {
                 scriptResolvers.add(resolver);
             }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptingEngines.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptingEngines.java
@@ -25,7 +25,7 @@ import javax.script.ScriptException;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.flowable.common.engine.api.FlowableException;
-import org.flowable.variable.api.delegate.VariableScope;
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,25 +70,25 @@ public class ScriptingEngines {
         }
     }
 
-    public ScriptEvaluation evaluateWithEvaluationResult(String script, String language, VariableScope variableScope) {
-        Bindings bindings = createBindings(variableScope);
+    public ScriptEvaluation evaluateWithEvaluationResult(String script, String language, VariableContainer variableContainer) {
+        Bindings bindings = createBindings(variableContainer);
         Object result = evaluate(script, language, bindings);
 
         return new ScriptEvaluationImpl(bindings, result);
     }
 
-    public ScriptEvaluation evaluateWithEvaluationResult(String script, String language, VariableScope variableScope, boolean storeScriptVariables) {
-        Bindings bindings = createBindings(variableScope, storeScriptVariables);
+    public ScriptEvaluation evaluateWithEvaluationResult(String script, String language, VariableContainer variableContainer, boolean storeScriptVariables) {
+        Bindings bindings = createBindings(variableContainer, storeScriptVariables);
         Object result = evaluate(script, language, bindings);
 
         return new ScriptEvaluationImpl(bindings, result);
     }
 
-    public Object evaluate(String script, String language, VariableScope variableScope) {
-        return evaluateWithEvaluationResult(script, language, variableScope).getResult();
+    public Object evaluate(String script, String language, VariableContainer variableContainer) {
+        return evaluateWithEvaluationResult(script, language, variableContainer).getResult();
     }
 
-    public Object evaluate(String script, String language, VariableScope variableScope, boolean storeScriptVariables) {
+    public Object evaluate(String script, String language, VariableContainer variableScope, boolean storeScriptVariables) {
         return evaluateWithEvaluationResult(script, language, variableScope, storeScriptVariables).getResult();
     }
 
@@ -167,13 +167,13 @@ public class ScriptingEngines {
     }
 
     /** override to build a spring aware ScriptingEngines */
-    protected Bindings createBindings(VariableScope variableScope) {
-        return scriptBindingsFactory.createBindings(variableScope);
+    protected Bindings createBindings(VariableContainer variableContainer) {
+        return scriptBindingsFactory.createBindings(variableContainer);
     }
 
     /** override to build a spring aware ScriptingEngines */
-    protected Bindings createBindings(VariableScope variableScope, boolean storeScriptVariables) {
-        return scriptBindingsFactory.createBindings(variableScope, storeScriptVariables);
+    protected Bindings createBindings(VariableContainer variableContainer, boolean storeScriptVariables) {
+        return scriptBindingsFactory.createBindings(variableContainer, storeScriptVariables);
     }
 
     public ScriptBindingsFactory getScriptBindingsFactory() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/scripting/VariableScopeResolverFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/scripting/VariableScopeResolverFactory.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.engine.impl.scripting;
 
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
 import org.flowable.common.engine.impl.scripting.Resolver;
 import org.flowable.common.engine.impl.scripting.ResolverFactory;
@@ -25,9 +26,9 @@ import org.flowable.variable.api.delegate.VariableScope;
 public class VariableScopeResolverFactory implements ResolverFactory {
 
     @Override
-    public Resolver createResolver(AbstractEngineConfiguration engineConfiguration, VariableScope variableScope) {
-        if (variableScope != null) {
-            return new VariableScopeResolver((ProcessEngineConfigurationImpl) engineConfiguration, variableScope);
+    public Resolver createResolver(AbstractEngineConfiguration engineConfiguration, VariableContainer variableContainer) {
+        if (variableContainer instanceof VariableScope) {
+            return new VariableScopeResolver((ProcessEngineConfigurationImpl) engineConfiguration, (VariableScope) variableContainer);
         }
         return null;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockResolverFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/test/mock/MockResolverFactory.java
@@ -12,10 +12,10 @@
  */
 package org.flowable.engine.test.mock;
 
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
 import org.flowable.common.engine.impl.scripting.Resolver;
 import org.flowable.common.engine.impl.scripting.ResolverFactory;
-import org.flowable.variable.api.delegate.VariableScope;
 
 /**
  * This is a bridge resolver, making available any objects registered through {@link org.flowable.engine.test.mock.Mocks#register} inside scripts supported by process execution. <br>
@@ -51,7 +51,7 @@ import org.flowable.variable.api.delegate.VariableScope;
  */
 public class MockResolverFactory implements ResolverFactory {
     @Override
-    public Resolver createResolver(AbstractEngineConfiguration engineConfiguration, VariableScope variableScope) {
+    public Resolver createResolver(AbstractEngineConfiguration engineConfiguration, VariableContainer variableContainer) {
         return new Resolver() {
 
             @Override

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/OsgiScriptingEngines.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/OsgiScriptingEngines.java
@@ -17,6 +17,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 
 import org.flowable.common.engine.api.FlowableException;
+import org.flowable.common.engine.api.variable.VariableContainer;
 import org.flowable.common.engine.impl.scripting.ScriptBindingsFactory;
 import org.flowable.common.engine.impl.scripting.ScriptEvaluation;
 import org.flowable.common.engine.impl.scripting.ScriptingEngines;
@@ -37,23 +38,23 @@ public class OsgiScriptingEngines extends ScriptingEngines {
     }
 
     @Override
-    public ScriptEvaluation evaluateWithEvaluationResult(String script, String language, VariableScope variableScope) {
-        return super.evaluateWithEvaluationResult(script, language, variableScope);
+    public ScriptEvaluation evaluateWithEvaluationResult(String script, String language, VariableContainer variableContainer) {
+        return super.evaluateWithEvaluationResult(script, language, variableContainer);
     }
 
     @Override
-    public ScriptEvaluation evaluateWithEvaluationResult(String script, String language, VariableScope variableScope, boolean storeScriptVariables) {
-        return super.evaluateWithEvaluationResult(script, language, variableScope, storeScriptVariables);
+    public ScriptEvaluation evaluateWithEvaluationResult(String script, String language, VariableContainer variableContainer, boolean storeScriptVariables) {
+        return super.evaluateWithEvaluationResult(script, language, variableContainer, storeScriptVariables);
     }
 
     @Override
-    public Object evaluate(String script, String language, VariableScope variableScope) {
-        return super.evaluate(script, language, variableScope);
+    public Object evaluate(String script, String language, VariableContainer variableContainer) {
+        return super.evaluate(script, language, variableContainer);
     }
 
     @Override
-    public Object evaluate(String script, String language, VariableScope variableScope, boolean storeScriptVariables) {
-        return super.evaluate(script, language, variableScope, storeScriptVariables);
+    public Object evaluate(String script, String language, VariableContainer variableContainer, boolean storeScriptVariables) {
+        return super.evaluate(script, language, variableContainer, storeScriptVariables);
     }
 
     @Override


### PR DESCRIPTION
A refactoring to change the ScriptingEngines to take a VariableContainer  instead of a VariableScope (much smaller, easier-to-handle and delegate-to interface).

This refactoring makes it much easier to add additional variables to the script execution context, because VariableContainer is basically a map. VariablScope on the other hand is pretty broad and very hard to implement or provide delegation implementations. 