### PR TITLE
Improve (error) tracing for script invocations #3425

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -217,6 +217,7 @@ import org.flowable.cmmn.engine.impl.runtime.CmmnDynamicStateManager;
 import org.flowable.cmmn.engine.impl.runtime.CmmnRuntimeServiceImpl;
 import org.flowable.cmmn.engine.impl.runtime.DefaultCmmnDynamicStateManager;
 import org.flowable.cmmn.engine.impl.runtime.DynamicCmmnServiceImpl;
+import org.flowable.cmmn.engine.impl.scripting.CmmnEngineScriptTraceEnhancer;
 import org.flowable.cmmn.engine.impl.scripting.CmmnVariableScopeResolverFactory;
 import org.flowable.cmmn.engine.impl.task.DefaultCmmnTaskVariableScopeResolver;
 import org.flowable.cmmn.engine.impl.variable.CmmnAggregatedVariableType;
@@ -460,6 +461,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
     protected int expressionCacheSize = 4096;
     protected int expressionTextLengthCacheLimit = -1; // negative value to have no max length
 
+    // Scripting support
     protected ScriptingEngines scriptingEngines;
     protected ScriptBindingsFactory scriptBindingsFactory;
     protected List<ResolverFactory> resolverFactories;
@@ -1442,6 +1444,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
     protected void initScriptingEngines() {
         if (scriptingEngines == null) {
             scriptingEngines = new ScriptingEngines(scriptBindingsFactory);
+            scriptingEngines.setDefaultTraceEnhancer(new CmmnEngineScriptTraceEnhancer());
         }
     }
     

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/listener/ScriptTypeTaskListener.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/listener/ScriptTypeTaskListener.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
 import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.api.delegate.Expression;
+import org.flowable.common.engine.impl.scripting.ScriptEngineRequest;
 import org.flowable.common.engine.impl.scripting.ScriptingEngines;
 import org.flowable.task.service.delegate.DelegateTask;
 import org.flowable.task.service.delegate.TaskListener;
@@ -60,7 +61,12 @@ public class ScriptTypeTaskListener implements TaskListener {
             throw new FlowableIllegalStateException("Script content is null or evaluated to null for taskListener of type 'script'");
         }
 
-        Object result = scriptingEngines.evaluate(script, language, delegateTask, false);
+        ScriptEngineRequest.Builder request = ScriptEngineRequest.builder()
+                .script(script)
+                .language(language)
+                .variableContainer(delegateTask)
+                .traceEnhancer(trace -> trace.addTraceTag("type", "taskListener"));
+        Object result = scriptingEngines.evaluate(request.build()).getResult();
 
         if (resultVariable != null) {
             String resultVariable = Objects.toString(this.resultVariable.getValue(delegateTask), null);

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/scripting/CmmnEngineScriptTraceEnhancer.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/scripting/CmmnEngineScriptTraceEnhancer.java
@@ -1,0 +1,70 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.scripting;
+
+import org.flowable.cmmn.api.delegate.DelegatePlanItemInstance;
+import org.flowable.cmmn.api.repository.CaseDefinition;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.engine.impl.repository.CaseDefinitionUtil;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.common.engine.impl.scripting.ScriptTraceEnhancer;
+import org.flowable.task.api.Task;
+
+/**
+ * Enhances script traces with scope information for the cmmn engine.
+ *
+ * @author Arthur Hupka-Merle
+ */
+public class CmmnEngineScriptTraceEnhancer implements ScriptTraceEnhancer {
+
+    private static final String EMPTY_INDICATOR = "<empty>";
+
+    @Override
+    public void enhanceScriptTrace(ScriptTraceContext scriptTrace) {
+        VariableContainer container = scriptTrace.getRequest().getVariableContainer();
+        if (container instanceof Task) {
+            Task task = (Task) container;
+            if (ScopeTypes.CMMN.equals((task.getScopeType()))) {
+                scriptTrace.addTraceTag("scopeType", ScopeTypes.CMMN);
+                CaseDefinition caseDefinition = CaseDefinitionUtil.getCaseDefinition(task.getScopeDefinitionId());
+                scriptTrace.addTraceTag("scopeDefinitionKey", caseDefinition.getKey());
+                scriptTrace.addTraceTag("scopeDefinitionId", caseDefinition.getId());
+                scriptTrace.addTraceTag("subScopeDefinitionKey", task.getTaskDefinitionKey());
+            }
+        } else if (container instanceof DelegatePlanItemInstance) {
+            scriptTrace.addTraceTag("scopeType", ScopeTypes.CMMN);
+            DelegatePlanItemInstance planItemInstance = (DelegatePlanItemInstance) container;
+            CaseDefinition caseDefinition = CaseDefinitionUtil.getCaseDefinition(planItemInstance.getCaseDefinitionId());
+            scriptTrace.addTraceTag("scopeDefinitionKey", caseDefinition.getKey());
+            scriptTrace.addTraceTag("scopeDefinitionId", planItemInstance.getCaseDefinitionId());
+            scriptTrace.addTraceTag("subScopeDefinitionKey", planItemInstance.getPlanItemDefinitionId());
+            addTenantId(scriptTrace, planItemInstance.getTenantId());
+        } else if (container instanceof CaseInstance) {
+            scriptTrace.addTraceTag("scopeType", ScopeTypes.CMMN);
+            CaseInstance caseInstance = (CaseInstance) container;
+            CaseDefinition caseDefinition = CaseDefinitionUtil.getCaseDefinition(caseInstance.getCaseDefinitionId());
+            scriptTrace.addTraceTag("scopeDefinitionKey", caseDefinition.getKey());
+            scriptTrace.addTraceTag("scopeDefinitionId", caseDefinition.getId());
+            addTenantId(scriptTrace, caseInstance.getTenantId());
+        }
+    }
+
+    protected void addTenantId(ScriptTraceContext scriptTrace, String tenantId) {
+        if (tenantId != null && !tenantId.isEmpty()) {
+            scriptTrace.addTraceTag("tenantId", tenantId);
+        } else {
+            scriptTrace.addTraceTag("tenantId", EMPTY_INDICATOR);
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/listener/TaskListenerTest.testListenerWithScriptThrowsNonFlowableException.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/listener/TaskListenerTest.testListenerWithScriptThrowsNonFlowableException.cmmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" targetNamespace="http://www.flowable.org/casedef">
+    <case id="testTaskListeners" name="testTaskListeners" flowable:initiatorVariableName="initiator">
+        <casePlanModel id="casePlanModel">
+            <planItem id="planItem4" name="ScriptJavascript" definitionRef="sid-B79A0634-B1BF-44B7-8AC5-35E9E17CC65B"></planItem>
+            <humanTask id="sid-B79A0634-B1BF-44B7-8AC5-35E9E17CC65B" name="ScriptJavascript">
+                <extensionElements>
+                    <flowable:taskListener event="create" type="script">
+                        <flowable:script language="javascript" resultVariable="javascriptResult">
+                            var scriptLocalVar = "XXXHello World from JavaScript";
+                            x = scriptError;
+                            retVal;
+                        </flowable:script>
+                    </flowable:taskListener>
+                </extensionElements>
+            </humanTask>
+        </casePlanModel>
+    </case>
+</definitions>

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/CompositeScriptTraceListener.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/CompositeScriptTraceListener.java
@@ -1,0 +1,39 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.common.engine.impl.scripting;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Composite implementation of {@link ScriptTraceListener}.
+ *
+ * @author Arthur Hupka-Merle
+ */
+public class CompositeScriptTraceListener implements ScriptTraceListener {
+
+    protected final List<ScriptTraceListener> listeners;
+
+    public CompositeScriptTraceListener(Collection<ScriptTraceListener> listeners) {
+        this.listeners = listeners != null ? new ArrayList<>(listeners) : Collections.emptyList();
+    }
+
+    @Override
+    public void onScriptTrace(ScriptTrace scriptTrace) {
+        for (ScriptTraceListener l : listeners) {
+            l.onScriptTrace(scriptTrace);
+        }
+    }
+}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/DefaultScriptTrace.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/DefaultScriptTrace.java
@@ -1,0 +1,65 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.common.engine.impl.scripting;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class DefaultScriptTrace implements ScriptTrace, ScriptTraceEnhancer.ScriptTraceContext {
+
+    protected Duration duration;
+    protected ScriptEngineRequest request;
+    protected Throwable exception;
+    protected Map<String, String> traceTags = new LinkedHashMap<>();
+
+    public DefaultScriptTrace(Duration duration, ScriptEngineRequest request, Throwable caughtException) {
+        this.duration = duration;
+        this.request = request;
+        this.exception = caughtException;
+    }
+
+    public static DefaultScriptTrace successTrace(Duration duration, ScriptEngineRequest request) {
+        return new DefaultScriptTrace(duration, request, null);
+    }
+
+    public static DefaultScriptTrace errorTrace(Duration duration, ScriptEngineRequest request, Throwable caughtException) {
+        return new DefaultScriptTrace(duration, request, caughtException);
+    }
+
+    @Override
+    public ScriptTraceEnhancer.ScriptTraceContext addTraceTag(String tag, String value) {
+        this.traceTags.put(tag, value);
+        return this;
+    }
+
+    @Override
+    public ScriptEngineRequest getRequest() {
+        return request;
+    }
+
+    @Override
+    public Throwable getException() {
+        return exception;
+    }
+
+    @Override
+    public Map<String, String> getTraceTags() {
+        return traceTags;
+    }
+
+    @Override
+    public Duration getDuration() {
+        return duration;
+    }
+}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/FlowableScriptEvaluationException.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/FlowableScriptEvaluationException.java
@@ -1,0 +1,57 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.common.engine.impl.scripting;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.flowable.common.engine.api.FlowableException;
+
+/**
+ * Thrown by ScriptingEngines in case script evaluation failed.
+ * <p>
+ * Provides access to the {@link ScriptTrace} for diagnostic purposes.
+ * </p>
+ */
+public class FlowableScriptEvaluationException extends FlowableException {
+
+    protected ScriptTrace errorTrace;
+
+    public FlowableScriptEvaluationException(ScriptTrace errorTrace, Throwable cause) {
+        super(createErrorMessage(errorTrace), cause);
+        this.errorTrace = errorTrace;
+    }
+
+    protected static String createErrorMessage(ScriptTrace trace) {
+        StringBuilder b = new StringBuilder();
+        Map<String, String> traceTags = trace.getTraceTags();
+        b.append(trace.getRequest().getLanguage());
+        b.append(" script evaluation failed: ");
+        if (trace.getException() != null && trace.getException().getMessage() != null) {
+            String message = trace.getException().getMessage();
+            b.append("'").append(message).append("'");
+        }
+
+        if (!traceTags.isEmpty()) {
+            b.append(" Trace: ");
+            b.append(traceTags.entrySet().stream()
+                    .map(k -> k.getKey() + "=" + k.getValue())
+                    .collect(Collectors.joining(", ")));
+        }
+        return b.toString();
+    }
+
+    public ScriptTrace getErrorTrace() {
+        return errorTrace;
+    }
+}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptEngineRequest.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptEngineRequest.java
@@ -21,7 +21,7 @@ import org.flowable.common.engine.api.variable.VariableContainer;
 /**
  * Request to execute a script in the scripting environment.
  * Use {@link ScriptEngineRequest#builder()} to create and configure instances.
-  */
+ */
 public class ScriptEngineRequest {
 
     protected final String language;
@@ -29,6 +29,7 @@ public class ScriptEngineRequest {
     protected final VariableContainer variableContainer;
     protected final List<Resolver> additionalResolvers;
     protected final boolean storeScriptVariables;
+    protected final ScriptTraceEnhancer traceEnhancer;
 
     /**
      * @return a new Builder instance to create a {@link ScriptEngineRequest}
@@ -47,6 +48,7 @@ public class ScriptEngineRequest {
         protected VariableContainer variableContainer;
         protected List<Resolver> additionalResolvers = new LinkedList<>();
         protected boolean storeScriptVariables;
+        protected ScriptTraceEnhancer traceEnhancer;
 
         protected Builder() {
         }
@@ -100,6 +102,18 @@ public class ScriptEngineRequest {
             return this;
         }
 
+        /**
+         * Configure an {@link ScriptTraceEnhancer}
+         * which is called, when a ScriptTrace is created.
+         * Allows to provide additional context information for a script trace by allow to "tag"
+         * the script invocation with additional meta information.
+         * Script traces are produced in case of errors and/or when a {@link ScriptTraceListener} is configured.
+         */
+        public Builder traceEnhancer(ScriptTraceEnhancer enhancer) {
+            this.traceEnhancer = enhancer;
+            return this;
+        }
+
         public ScriptEngineRequest build() {
             if (script == null || script.isEmpty()) {
                 throw new FlowableIllegalStateException("A script is required");
@@ -108,7 +122,8 @@ public class ScriptEngineRequest {
                     language,
                     variableContainer,
                     storeScriptVariables,
-                    additionalResolvers);
+                    additionalResolvers,
+                    traceEnhancer);
         }
     }
 
@@ -116,12 +131,14 @@ public class ScriptEngineRequest {
             String language,
             VariableContainer variableContainer,
             boolean storeScriptVariables,
-            List<Resolver> additionalResolvers) {
+            List<Resolver> additionalResolvers,
+            ScriptTraceEnhancer errorTraceEnhancer) {
         this.script = script;
         this.language = language;
         this.variableContainer = variableContainer;
         this.storeScriptVariables = storeScriptVariables;
         this.additionalResolvers = additionalResolvers;
+        this.traceEnhancer = errorTraceEnhancer;
     }
 
     /**
@@ -157,5 +174,13 @@ public class ScriptEngineRequest {
      */
     public List<Resolver> getAdditionalResolvers() {
         return additionalResolvers;
+    }
+
+
+    /**
+     * @see Builder#traceEnhancer(ScriptTraceEnhancer)
+     */
+    public ScriptTraceEnhancer getTraceEnhancer() {
+        return traceEnhancer;
     }
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptTrace.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptTrace.java
@@ -1,0 +1,39 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.common.engine.impl.scripting;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Captures meta information about a script invocation, like the start time,
+ * the duration of the script execution, tags, whether it ended with an exception, etc.
+ */
+public interface ScriptTrace {
+
+    ScriptEngineRequest getRequest();
+
+    Throwable getException();
+
+    Map<String, String> getTraceTags();
+
+    Duration getDuration();
+
+    default boolean hasException() {
+        return getException() != null;
+    }
+
+    default boolean isSuccess() {
+        return !hasException();
+    }
+}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptTraceEnhancer.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptTraceEnhancer.java
@@ -1,0 +1,59 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.common.engine.impl.scripting;
+
+/**
+ * Functional interface to enhance {@link ScriptTraceContext} information
+ * with metadata
+ *
+ * @author Arthur Hupka-Merle
+ */
+@FunctionalInterface
+public interface ScriptTraceEnhancer {
+
+    /**
+     * Allows to add information to script invocations by
+     * adding metadata like which can be used to trace the origin of a script invocation.
+     *
+     * @param scriptTrace the trace object to add information to
+     */
+    void enhanceScriptTrace(ScriptTraceContext scriptTrace);
+
+    /**
+     * Allows enhancing of {@link ScriptTrace ScriptTraces} with additional meta information.
+     *
+     * @author Arthur Hupka-Merle
+     */
+    interface ScriptTraceContext {
+
+        /**
+         * Adds a tracing tag to this script trace.
+         * Tags are used to identify the origin of a script invocation and can also
+         * be used to classify script invocations e.g. to distinguish different use-cases
+         * etc.
+         */
+        ScriptTraceContext addTraceTag(String key, String value);
+
+        /**
+         * @return the processed request which lead to this script trace.
+         */
+        ScriptEngineRequest getRequest();
+
+        /**
+         * @return the exception (if the request ended in an error). Or <code>null</code> if the
+         * request was successful.
+         */
+        Throwable getException();
+    }
+
+}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptTraceListener.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/ScriptTraceListener.java
@@ -1,0 +1,33 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.common.engine.impl.scripting;
+
+/**
+ * Listener interface notified after script invocations.
+ * For successful and/or not successful script invocations.
+ *
+ * @author Arthur Hupka-Merle
+ * @see CompositeScriptTraceListener
+ */
+public interface ScriptTraceListener {
+
+    /**
+     * Called after script invocation.
+     * Use {@link ScriptTrace#isSuccess()} or related methods to check
+     * if the script invocation was successful or resulted in an error.
+     *
+     * @param scriptTrace the script trace object
+     */
+    void onScriptTrace(ScriptTrace scriptTrace);
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/http/handler/ScriptHttpHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/http/handler/ScriptHttpHandler.java
@@ -44,7 +44,7 @@ public class ScriptHttpHandler extends AbstractScriptEvaluator implements HttpRe
     public void handleHttpRequest(VariableContainer execution, HttpRequest httpRequest, FlowableHttpClient client) {
         if (execution instanceof VariableScope) {
             ((VariableScope) execution).setTransientVariableLocal("httpRequest", httpRequest);
-            evaluateScriptRequest(createScriptRequest(execution));
+            evaluateScriptRequest(createScriptRequest(execution).traceEnhancer(trace -> trace.addTraceTag("type", "httpRequestHandler")));
         } else {
             throw new FlowableIllegalStateException(
                     "The given execution " + execution.getClass().getName() + " is not of type " + VariableScope.class.getName());
@@ -55,7 +55,7 @@ public class ScriptHttpHandler extends AbstractScriptEvaluator implements HttpRe
     public void handleHttpResponse(VariableContainer execution, HttpResponse httpResponse) {
         if (execution instanceof VariableScope) {
             ((VariableScope) execution).setTransientVariableLocal("httpResponse", httpResponse);
-            evaluateScriptRequest(createScriptRequest(execution));
+            evaluateScriptRequest(createScriptRequest(execution).traceEnhancer(trace -> trace.addTraceTag("type", "httpResponseHandler")));
         } else {
             throw new FlowableIllegalStateException(
                     "The given execution " + execution.getClass().getName() + " is not of type " + VariableScope.class.getName());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptExecutionListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptExecutionListener.java
@@ -29,6 +29,8 @@ public class ScriptExecutionListener extends AbstractScriptEvaluator implements 
 
     @Override
     public void notify(DelegateExecution execution) {
-        evaluateScriptRequest(createScriptRequest(execution).storeScriptVariables());
+        evaluateScriptRequest(createScriptRequest(execution)
+                .traceEnhancer(trace -> trace.addTraceTag("type", "executionListener"))
+                .storeScriptVariables());
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTaskListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTaskListener.java
@@ -34,6 +34,6 @@ public class ScriptTaskListener extends AbstractScriptEvaluator implements TaskL
 
     @Override
     public void notify(DelegateTask delegateTask) {
-        evaluateScriptRequest(createScriptRequest(delegateTask).storeScriptVariables());
+        evaluateScriptRequest(createScriptRequest(delegateTask).traceEnhancer(trace -> trace.addTraceTag("type", "taskListener")).storeScriptVariables());
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTypeExecutionListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTypeExecutionListener.java
@@ -35,7 +35,7 @@ public class ScriptTypeExecutionListener extends AbstractScriptEvaluator impleme
 
     @Override
     public void notify(DelegateExecution execution) {
-        evaluateScriptRequest(createScriptRequest(execution));
+        evaluateScriptRequest(createScriptRequest(execution).traceEnhancer(trace -> trace.addTraceTag("type", "executionListener")));
     }
 
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTypeTaskListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTypeTaskListener.java
@@ -42,6 +42,6 @@ public class ScriptTypeTaskListener extends AbstractScriptEvaluator implements T
 
     @Override
     public void notify(DelegateTask delegateTask) {
-        evaluateScriptRequest(createScriptRequest(delegateTask));
+        evaluateScriptRequest(createScriptRequest(delegateTask).traceEnhancer(trace -> trace.addTraceTag("type", "taskListener")));
     }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -360,6 +360,7 @@ import org.flowable.engine.impl.persistence.entity.data.impl.MybatisProcessDefin
 import org.flowable.engine.impl.persistence.entity.data.impl.MybatisProcessDefinitionInfoDataManager;
 import org.flowable.engine.impl.persistence.entity.data.impl.MybatisResourceDataManager;
 import org.flowable.engine.impl.repository.DefaultProcessDefinitionLocalizationManager;
+import org.flowable.engine.impl.scripting.ProcessEngineScriptTraceEnhancer;
 import org.flowable.engine.impl.scripting.VariableScopeResolverFactory;
 import org.flowable.engine.impl.util.ProcessInstanceHelper;
 import org.flowable.engine.impl.variable.BpmnAggregatedVariableType;
@@ -796,13 +797,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected Collection<ELResolver> preDefaultELResolvers;
     protected Collection<ELResolver> preBeanELResolvers;
     protected Collection<ELResolver> postDefaultELResolvers;
+    // SCRIPTING ///////////////////////////////////////////////////////
     protected List<String> customScriptingEngineClasses;
     protected ScriptingEngines scriptingEngines;
     protected ScriptBindingsFactory scriptBindingsFactory;
     protected List<ResolverFactory> resolverFactories;
     protected Collection<ResolverFactory> preDefaultResolverFactories;
     protected Collection<ResolverFactory> postDefaultResolverFactories;
-
+    // END SCRIPTING
     protected boolean isExpressionCacheEnabled = true;
     protected int expressionCacheSize = 4096;
     protected int expressionTextLengthCacheLimit = -1; // negative value to have no max length
@@ -2500,6 +2502,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     public void initScriptingEngines() {
         if (scriptingEngines == null) {
             scriptingEngines = new ScriptingEngines(scriptBindingsFactory);
+            scriptingEngines.setDefaultTraceEnhancer(new ProcessEngineScriptTraceEnhancer());
         }
     }
 
@@ -3723,6 +3726,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.listenerFactory = listenerFactory;
         return this;
     }
+
 
     public BpmnParseFactory getBpmnParseFactory() {
         return bpmnParseFactory;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/JuelFormEngine.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/form/JuelFormEngine.java
@@ -15,6 +15,7 @@ package org.flowable.engine.impl.form;
 import java.nio.charset.StandardCharsets;
 
 import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.common.engine.impl.scripting.ScriptEngineRequest;
 import org.flowable.common.engine.impl.scripting.ScriptingEngines;
 import org.flowable.engine.form.FormData;
 import org.flowable.engine.form.StartFormData;
@@ -41,7 +42,11 @@ public class JuelFormEngine implements FormEngine {
         }
         String formTemplateString = getFormTemplateString(startForm, startForm.getFormKey());
         ScriptingEngines scriptingEngines = CommandContextUtil.getProcessEngineConfiguration().getScriptingEngines();
-        return scriptingEngines.evaluate(formTemplateString, ScriptingEngines.DEFAULT_SCRIPTING_LANGUAGE, null);
+        ScriptEngineRequest scriptEngineRequest = ScriptEngineRequest.builder()
+                .language(ScriptingEngines.DEFAULT_SCRIPTING_LANGUAGE)
+                .script(formTemplateString)
+                .build();
+        return scriptingEngines.evaluate(scriptEngineRequest).getResult();
     }
 
     @Override

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/scripting/ProcessEngineScriptTraceEnhancer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/scripting/ProcessEngineScriptTraceEnhancer.java
@@ -1,0 +1,74 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.scripting;
+
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.api.variable.VariableContainer;
+import org.flowable.common.engine.impl.scripting.ScriptTraceEnhancer;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.impl.util.ProcessDefinitionUtil;
+import org.flowable.engine.repository.ProcessDefinition;
+import org.flowable.task.service.delegate.DelegateTask;
+
+/**
+ * Enhances script traces with scope information for the process engine.
+ *
+ * @author Arthur Hupka-Merle
+ */
+public class ProcessEngineScriptTraceEnhancer implements ScriptTraceEnhancer {
+
+    private static final String EMPTY_INDICATOR = "<empty>";
+
+    @Override
+    public void enhanceScriptTrace(ScriptTraceContext scriptTrace) {
+        VariableContainer container = scriptTrace.getRequest().getVariableContainer();
+        if (container instanceof DelegateExecution) {
+            scriptTrace.addTraceTag("scopeType", ScopeTypes.BPMN);
+            DelegateExecution execution = (DelegateExecution) scriptTrace.getRequest().getVariableContainer();
+            addScopeTags(execution.getProcessDefinitionId(), scriptTrace);
+            scriptTrace.addTraceTag("subScopeDefinitionKey", execution.getCurrentActivityId());
+            addTenantId(scriptTrace, execution.getTenantId());
+        } else if (container instanceof DelegateTask) {
+            DelegateTask task = (DelegateTask) scriptTrace.getRequest().getVariableContainer();
+            if (task.getProcessInstanceId() != null) {
+                scriptTrace.addTraceTag("scopeType", ScopeTypes.BPMN);
+                addScopeTags(task.getProcessDefinitionId(), scriptTrace);
+                scriptTrace.addTraceTag("subScopeDefinitionKey", task.getTaskDefinitionKey());
+                addTenantId(scriptTrace, task.getTenantId());
+            }
+        }
+    }
+
+    protected void addScopeTags(String processDefinitionId, ScriptTraceContext scriptTrace) {
+        ProcessDefinition processDefinition = getProcessDefinition(processDefinitionId);
+        if (processDefinition != null) {
+            scriptTrace.addTraceTag("scopeDefinitionKey", processDefinition.getKey());
+            scriptTrace.addTraceTag("scopeDefinitionId", processDefinition.getId());
+        }
+    }
+
+    protected void addTenantId(ScriptTraceContext scriptTrace, String tenantId) {
+        if (tenantId != null && !tenantId.isEmpty()) {
+            scriptTrace.addTraceTag("tenantId", tenantId);
+        } else {
+            scriptTrace.addTraceTag("tenantId", EMPTY_INDICATOR);
+        }
+    }
+
+    protected ProcessDefinition getProcessDefinition(String processDefinitionId) {
+        if (processDefinitionId != null) {
+            return ProcessDefinitionUtil.getProcessDefinition(processDefinitionId);
+        }
+        return null;
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/mgmt/ManagementServiceTest.java
@@ -104,7 +104,7 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
             managementService.moveTimerToExecutableJob(timerJob.getId());
             managementService.executeJob(timerJob.getId());
         })
-                .isExactlyInstanceOf(FlowableException.class)
+                .isInstanceOf(FlowableException.class)
                 .hasMessageContaining("This is an exception thrown from scriptTask");
 
         // Fetch the task to see that the exception that occurred is persisted
@@ -205,8 +205,8 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
         String correlationId = asyncJob.getCorrelationId();
         final String asyncId = asyncJob.getId();
         assertThatThrownBy(() -> managementService.executeJob(asyncId))
-                .isExactlyInstanceOf(FlowableException.class)
-                .hasMessageContaining("problem evaluating script");
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("script evaluation failed");
 
         asyncJob = managementService.createTimerJobQuery()
                 .processInstanceId(processInstance.getId())
@@ -222,8 +222,8 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
             Job job = managementService.moveTimerToExecutableJob(jobId);
             managementService.executeJob(job.getId());
         })
-                .isExactlyInstanceOf(FlowableException.class)
-                .hasMessageContaining("problem evaluating script");
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("script evaluation failed");
 
         asyncJob = managementService.createTimerJobQuery()
                 .processInstanceId(processInstance.getId())
@@ -237,8 +237,8 @@ public class ManagementServiceTest extends PluggableFlowableTestCase {
             Job job = managementService.moveTimerToExecutableJob(jobId2);
             managementService.executeJob(jobId2);
         })
-                .isExactlyInstanceOf(FlowableException.class)
-                .hasMessageContaining("problem evaluating script");
+                .isInstanceOf(FlowableException.class)
+                .hasMessageContaining("script evaluation failed");
 
         asyncJob = managementService.createDeadLetterJobQuery()
                 .processInstanceId(processInstance.getId())

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptExecutionListenerTest.java
@@ -65,7 +65,7 @@ public class ScriptExecutionListenerTest extends PluggableFlowableTestCase {
     public void testThrowNonFlowableException() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("scriptExecutionListenerProcess"))
                 .isInstanceOf(FlowableException.class)
-                .hasMessage("problem evaluating script: java.lang.RuntimeException: Illegal argument in listener in <eval> at line number 2 at column number 28")
+                .hasMessageContaining("java.lang.RuntimeException: Illegal argument in listener in <eval> at line number 2 at column number 28")
                 .getRootCause()
                 .isExactlyInstanceOf(RuntimeException.class)
                 .hasMessage("Illegal argument in listener");

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptTypeExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptTypeExecutionListenerTest.java
@@ -18,11 +18,12 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.List;
 
-import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.common.engine.impl.scripting.FlowableScriptEvaluationException;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.variable.api.history.HistoricVariableInstance;
@@ -59,11 +60,16 @@ public class ScriptTypeExecutionListenerTest extends PluggableFlowableTestCase {
     @Test
     @Deployment
     public void testThrowNonFlowableException() {
+        ProcessDefinition processDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("scriptExecutionListenerProcess")
+                .singleResult();
+
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("scriptExecutionListenerProcess"))
-                .isInstanceOf(FlowableException.class)
+                .isInstanceOf(FlowableScriptEvaluationException.class)
                 .hasMessage(
-                        "problem evaluating script: java.lang.RuntimeException: Illegal argument in listener in <eval> at line number 2 at column number 28")
-                .getRootCause()
+                        "JavaScript script evaluation failed: 'java.lang.RuntimeException: Illegal argument in listener in <eval> at line number 2 at column number 28' "
+                                + "Trace: scopeType=bpmn, scopeDefinitionKey=scriptExecutionListenerProcess, scopeDefinitionId=" + processDef.getId() + ","
+                                + " subScopeDefinitionKey=flow1, tenantId=<empty>, type=executionListener")
+                .rootCause()
                 .isExactlyInstanceOf(RuntimeException.class)
                 .hasMessage("Illegal argument in listener");
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
@@ -20,6 +20,7 @@ import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.task.api.history.HistoricTaskInstance;
@@ -64,13 +65,23 @@ public class ScriptTaskListenerTest extends PluggableFlowableTestCase {
                 .hasMessage("Illegal argument in listener");
     }
 
+    /**
+     * Tests error trace enhacement by {@link org.flowable.engine.impl.scripting.ProcessEngineScriptTraceEnhancer} and
+     * {@link org.flowable.engine.impl.bpmn.listener.ScriptTaskListener}
+     */
     @Test
     @Deployment
     public void testThrowNonFlowableException() {
-        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("scriptTaskListenerProcess"))
+        ProcessDefinition processDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("scriptTaskListenerProcess")
+                .singleResult();
+
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("scriptTaskListenerProcess").getProcessDefinitionId())
                 .isInstanceOf(FlowableException.class)
-                .hasMessage("problem evaluating script: java.lang.RuntimeException: Illegal argument in listener in <eval> at line number 2 at column number 7")
-                .getRootCause()
+                .hasMessage(
+                        "JavaScript script evaluation failed: 'java.lang.RuntimeException: Illegal argument in listener in <eval> at line number 2 at column number 7' Trace:"
+                                + " scopeType=bpmn, scopeDefinitionKey=scriptTaskListenerProcess, scopeDefinitionId=" + processDef.getId() + ","
+                                + " subScopeDefinitionKey=usertask1, tenantId=<empty>, type=taskListener")
+                .rootCause()
                 .isExactlyInstanceOf(RuntimeException.class)
                 .hasMessage("Illegal argument in listener");
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
@@ -20,12 +20,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.common.engine.impl.scripting.FlowableScriptEvaluationException;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.runtime.ProcessInstanceBuilder;
 import org.flowable.engine.test.Deployment;
@@ -361,5 +362,23 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
         // Expect evaluation of script supports expressions for language, payload and resultVariable
         Object task2ScriptListenerResult = runtimeService.getVariable(processInstance.getId(), "task2ScriptListenerResult");
         assertThat(task2ScriptListenerResult).as("Expected 'task2ScriptListenerResult' variable in variable scope").isEqualTo("usertask2ReturnVal");
+    }
+
+    /**
+     * Tests error trace enhancement by {@link org.flowable.engine.impl.scripting.ProcessEngineScriptTraceEnhancer} and
+     * {@link org.flowable.engine.impl.bpmn.listener.ScriptTypeTaskListener}
+     */
+    @Test
+    @Deployment(resources = { "org/flowable/examples/bpmn/tasklistener/TaskListenerTypeScript.bpmn20.xml" })
+    public void testTaskListenerTypeScriptSyntaxErrorInScript() {
+        ProcessDefinition processDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey("testProcessErrorInScript")
+                .singleResult();
+
+        assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcessErrorInScript"))
+                .isInstanceOf(FlowableScriptEvaluationException.class)
+                .hasMessageContaining(
+                        "groovy script evaluation failed: 'javax.script.ScriptException: groovy.lang.MissingPropertyException: No such property: syntaxError for class: Script")
+                .hasMessageContaining("Trace: scopeType=bpmn, scopeDefinitionKey=testProcessErrorInScript, scopeDefinitionId=" + processDef.getId() + ","
+                                + " subScopeDefinitionKey=p4usertask1, tenantId=<empty>, type=taskListener");
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/groovy/GroovyScriptTest.java
@@ -18,8 +18,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
-import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.impl.scripting.FlowableScriptEvaluationException;
 import org.flowable.common.engine.impl.util.CollectionUtil;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -82,9 +82,10 @@ public class GroovyScriptTest extends PluggableFlowableTestCase {
     @Deployment
     public void testScriptThrowsNonFlowableException() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("scriptExecution"))
-                .isExactlyInstanceOf(FlowableException.class)
-                .hasMessage("problem evaluating script: javax.script.ScriptException: java.lang.RuntimeException: Illegal argument in listener")
-                .getRootCause()
+                .isExactlyInstanceOf(FlowableScriptEvaluationException.class)
+                .hasMessageContaining(
+                        "groovy script evaluation failed: 'javax.script.ScriptException: java.lang.RuntimeException: Illegal argument in listener'")
+                .rootCause()
                 .isExactlyInstanceOf(RuntimeException.class)
                 .hasMessage("Illegal argument in listener");
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/variables/VariablesTest.java
@@ -30,8 +30,8 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.UUID;
 
-import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.common.engine.impl.scripting.FlowableScriptEvaluationException;
 import org.flowable.engine.impl.test.HistoryTestHelper;
 import org.flowable.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.DataObject;
@@ -1959,7 +1959,7 @@ public class VariablesTest extends PluggableFlowableTestCase {
         String taskId = task.getId();
         try {
             assertThatThrownBy(() -> formService.submitTaskFormData(taskId, new HashMap<>()))
-                    .isExactlyInstanceOf(FlowableException.class);
+                    .isExactlyInstanceOf(FlowableScriptEvaluationException.class);
         } finally {
             runtimeService.deleteProcessInstance(processId, "intentional exception in script task");
         }

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testErrorInScript.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testErrorInScript.bpmn20.xml
@@ -8,12 +8,12 @@
 
         <startEvent id="theStart"/>
 
-        <scriptTask id="theScriptTaskWithJsvaScriptWithoutFormat" >
+        <scriptTask id="theScriptTaskWithJuel" >
             <script>execution.setVariable("myVar", scriptVar)</script>
         </scriptTask>
 
-        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theScriptTaskWithJsvaScriptWithoutFormat"/>
-        <sequenceFlow id="flow2" sourceRef="theScriptTaskWithJsvaScriptWithoutFormat" targetRef="theEnd"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theScriptTaskWithJuel"/>
+        <sequenceFlow id="flow2" sourceRef="theScriptTaskWithJuel" targetRef="theEnd"/>
 
         <endEvent id="theEnd"/>
 

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testErrorInScriptJavaScript.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testErrorInScriptJavaScript.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="testErrorInScript">
+
+        <startEvent id="theStart"/>
+
+        <scriptTask id="theScriptTaskWithJavaScript" scriptFormat="JavaScript">
+            <script>
+                <![CDATA[ var foo = 1;  var jsError = foo.substring(0,1); ]]>
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theScriptTaskWithJavaScript"/>
+        <sequenceFlow id="flow2" sourceRef="theScriptTaskWithJavaScript" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/tasklistener/TaskListenerTypeScript.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/tasklistener/TaskListenerTypeScript.bpmn20.xml
@@ -51,4 +51,20 @@
         <sequenceFlow id="p3flow10" sourceRef="p3startevent1" targetRef="p3usertask1"/>
         <sequenceFlow id="p3flow12" sourceRef="p3usertask1" targetRef="p3endevent1"/>
     </process>
+
+    <process id="testProcessErrorInScript" name="testProcessErrorInScript">
+        <startEvent id="p4startevent1" name="Start"/>
+        <userTask id="p4usertask1" name="Task">
+            <extensionElements>
+                <flowable:taskListener id="myFailingTaskListener" event="create" type="script">
+                    <flowable:script language="groovy">
+                        syntaxError
+                    </flowable:script>
+                </flowable:taskListener>
+            </extensionElements>
+        </userTask>
+        <endEvent id="p4endevent1" name="End"/>
+        <sequenceFlow id="p4flow10" sourceRef="p4startevent1" targetRef="p4usertask1"/>
+        <sequenceFlow id="p4flow12" sourceRef="p4usertask1" targetRef="p4endevent1"/>
+    </process>
 </definitions>

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithScriptRequestHandlerThrowsException.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithScriptRequestHandlerThrowsException.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGetWithScriptSyntaxErrorInHandler" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[GET]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/test]]></flowable:string>
+        </flowable:field>
+        <flowable:httpRequestHandler type="script">
+          <flowable:script language="JavaScript">
+            var originalUrl = httpRequest.getUrl();
+            syntaxErrorInScript
+            originalUrl;
+          </flowable:script>
+        </flowable:httpRequestHandler>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGetWithScriptSyntaxErrorInHandler"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGetWithScriptSyntaxErrorInHandler" targetRef="theEnd"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithScriptRequestHandlerThrowsFlowableException.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithScriptRequestHandlerThrowsFlowableException.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGetWithScriptThrowingFlowableException" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[GET]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/test]]></flowable:string>
+        </flowable:field>
+        <flowable:httpRequestHandler type="script">
+          <flowable:script language="JavaScript">
+            <![CDATA[throw new org.flowable.common.engine.api.FlowableIllegalArgumentException("Illegal Argument thrown in script"); ]]>
+          </flowable:script>
+        </flowable:httpRequestHandler>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGetWithScriptThrowingFlowableException"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGetWithScriptThrowingFlowableException" targetRef="theEnd"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithScriptResponseHandlerThrowsException.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithScriptResponseHandlerThrowsException.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGetWithScriptSyntaxErrorInHandler" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[GET]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:9798/test]]></flowable:string>
+        </flowable:field>
+        <flowable:httpResponseHandler type="script">
+          <flowable:script language="JavaScript">
+            syntaxErrorInScript
+          </flowable:script>
+        </flowable:httpResponseHandler>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGetWithScriptSyntaxErrorInHandler"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGetWithScriptSyntaxErrorInHandler" targetRef="theEnd"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-osgi/src/main/java/org/flowable/osgi/OsgiScriptingEngines.java
+++ b/modules/flowable-osgi/src/main/java/org/flowable/osgi/OsgiScriptingEngines.java
@@ -53,17 +53,17 @@ public class OsgiScriptingEngines extends ScriptingEngines {
     }
 
     @Override
-    protected Object evaluate(String script, String language, Bindings bindings) {
+    protected Object evaluate(ScriptEngineRequest request, Bindings bindings) {
         ScriptEngine scriptEngine = null;
         try {
-            scriptEngine = Extender.resolveScriptEngine(language);
+            scriptEngine = Extender.resolveScriptEngine(request.getLanguage());
         } catch (InvalidSyntaxException e) {
             throw new FlowableException("problem resolving scripting engine: " + e.getMessage(), e);
         }
 
         if (scriptEngine == null) {
-            return super.evaluate(script, language, bindings);
+            return super.evaluate(request, bindings);
         }
-        return evaluate(scriptEngine, script, bindings);
+        return evaluate(scriptEngine, request, bindings);
     }
 }


### PR DESCRIPTION
* The ScriptEngines has been extended with APIs, such that clients can now tag script requests with meta information. This allows to add enough information to be able to trace down the origin in case a script invocation fails.
* The APIs have been designed to be flexible enough to also potentially use them as a source for operational analytics metrics using a `ScriptTraceListener` on `ScriptingEngines`.

#### Check List:
* Unit tests: YES 
* Documentation: NO 
* Fixes #3425
