### PR TITLE
ReceiveTask  setValues() method type question

### DIFF
--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ReceiveTask.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/ReceiveTask.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ public class ReceiveTask extends Task {
         return clone;
     }
 
-    public void setValues(ManualTask otherElement) {
+    public void setValues(ReceiveTask otherElement) {
         super.setValues(otherElement);
     }
 }


### PR DESCRIPTION
#### Check List:
* Unit tests: NA
* Documentation: NA

Hello ,Is the (setValues()) method type of the receiveTask wrong, The current input parameter is ManualTask.
ManualTask should not appear in this location, Perhaps this is the negligence of your developers

This will cause us to always call the method of the parent class when we want to call the setValues method