### PR TITLE
support owner and assignee within case builder API

### DIFF
--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceBuilder.java
@@ -17,17 +17,32 @@ import java.util.Map;
 /**
  * @author Joram Barrez
  * @author Tijs Rademakers
+ * @author Micha Kiener
  */
 public interface CaseInstanceBuilder {
 
+    /**
+     * Set the case definition to be used for creating a new case instance by its id. If both the case definition id and the key
+     * are set, the id takes precedence and the key will be ignored. At least one of them needs to be specified within the builder.
+     *
+     * @param caseDefinitionId the id of the case definition the new case should be based on
+     * @return the case instance builder for method chaining
+     */
     CaseInstanceBuilder caseDefinitionId(String caseDefinitionId);
 
+    /**
+     * Set the case definition to be used for creating a new case instance by its key. If both the case definition id and the key
+     * are set, the id takes precedence and the key will be ignored. At least one of them needs to be specified within the builder.
+     *
+     * @param caseDefinitionKey the key of the case definition the new case should be based on
+     * @return the case instance builder for method chaining
+     */
     CaseInstanceBuilder caseDefinitionKey(String caseDefinitionKey);
     
     /**
-     * When looking up for a case definition by key it would first lookup for a case definition
+     * When looking up for a case definition by key it would first look up for a case definition
      * within the given parent deployment.
-     * Then it would fallback to the latest case definition with the given key.
+     * Then it would fall back to the latest case definition with the given key.
      * <p>
      * This is typically needed when the CaseInstanceBuilder is called for example
      * from the process engine to start a case instance and it needs to
@@ -36,6 +51,13 @@ public interface CaseInstanceBuilder {
      */
     CaseInstanceBuilder caseDefinitionParentDeploymentId(String parentDeploymentId);
 
+    /**
+     * If the new case instance should have a predefined id, you can set it using this method.
+     * If that predefined id is set, it will be used instead of creating a new one automatically.
+     *
+     * @param caseInstanceId the id of the new case instance to be used
+     * @return the case instance builder for method chaining
+     */
     CaseInstanceBuilder predefinedCaseInstanceId(String caseInstanceId);
 
     CaseInstanceBuilder name(String name);
@@ -53,6 +75,20 @@ public interface CaseInstanceBuilder {
     CaseInstanceBuilder transientVariable(String variableName, Object value);
 
     CaseInstanceBuilder tenantId(String tenantId);
+
+    /**
+     * Set the owner of the case to be created to the given user id.
+     * @param userId the id of the user to become the owner of the case
+     * @return the case instance builder for method chaining
+     */
+    CaseInstanceBuilder owner(String userId);
+
+    /**
+     * Set the assignee of the case to be created to the given user id.
+     * @param userId the id of the user to become the assignee of the case
+     * @return the case instance builder for method chaining
+     */
+    CaseInstanceBuilder assignee(String userId);
     
     /**
      * Indicator to override the tenant id of the case definition with the provided value.
@@ -66,7 +102,14 @@ public interface CaseInstanceBuilder {
      * and the variables matched with the {@link org.flowable.form.api.FormInfo}.
      */
     CaseInstanceBuilder startFormVariables(Map<String, Object> formVariables);
-    
+
+    /**
+     * Saves the outcome of the start form for the case, if this case should be started out of a start form.
+     * You can additionally save any form variables along with the outcome and start the case using {@link #startWithForm()}.
+     *
+     * @param outcome the outcome to be registered in the builder
+     * @return the case instance builder for method chaining
+     */
     CaseInstanceBuilder outcome(String outcome);
 
     /**
@@ -109,10 +152,29 @@ public interface CaseInstanceBuilder {
      */
     CaseInstanceBuilder fallbackToDefaultTenant();
 
+    /**
+     * Once all the information is set using this builder API, the start method will create the case instance, initialize it according all
+     * the data in the builder and then evaluate the case model to start the case. It will be initialized, evaluated and started in a single
+     * transaction, synchronously, so this method returns once the case model will hit a wait state.
+     *
+     * @return the case instance
+     */
     CaseInstance start();
 
+    /**
+     * Once all the information is set using this builder API, the startAsync method will create the case instance and initialize its data, but
+     * the case model is not yet evaluated, but will be started and evaluated asynchronously in a different transaction.
+     *
+     * @return the case instance as being persisted, but not yet evaluated through the case model
+     */
     CaseInstance startAsync();
 
+    /**
+     * Once all the information is set using this builder API, the startWithForm method will create the case instance and initialize its data by
+     * additionally using the submitted form variables and handling them with the start form provided with the case model (e.g. validation).
+     *
+     * @return the case instance as being persisted, but not yet evaluated through the case model
+     */
     CaseInstance startWithForm();
 
     String getCaseDefinitionId();
@@ -134,6 +196,10 @@ public interface CaseInstanceBuilder {
     Map<String, Object> getTransientVariables();
 
     String getTenantId();
+
+    String getOwner();
+
+    String getAssignee();
     
     String getOverrideDefinitionTenantId();
 

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceBuilder.java
@@ -40,13 +40,13 @@ public interface CaseInstanceBuilder {
     CaseInstanceBuilder caseDefinitionKey(String caseDefinitionKey);
     
     /**
-     * When looking up for a case definition by key it would first look up for a case definition
+     * When looking up for a case definition by key it would first lookup for a case definition
      * within the given parent deployment.
-     * Then it would fall back to the latest case definition with the given key.
+     * Then it would fallback to the latest case definition with the given key.
      * <p>
      * This is typically needed when the CaseInstanceBuilder is called for example
      * from the process engine to start a case instance and it needs to
-     * look up the case definition in the same deployment as the process.
+     * lookup the case definition in the same deployment as the process.
      * Or when starting a case via a case task from the cmmn engine
      */
     CaseInstanceBuilder caseDefinitionParentDeploymentId(String parentDeploymentId);
@@ -146,7 +146,7 @@ public interface CaseInstanceBuilder {
     CaseInstanceBuilder parentId(String parentCaseInstanceId);
 
     /**
-     * If case definition is not found by key in the specified tenant use default tenant search as a fall back
+     * If case definition is not found by key in the specified tenant use default tenant search as a fallback
      *
      * @return modified case instance builder
      */

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceBuilderImpl.java
@@ -35,6 +35,8 @@ public class CaseInstanceBuilderImpl implements CaseInstanceBuilder {
     protected Map<String, Object> variables;
     protected Map<String, Object> transientVariables;
     protected String tenantId;
+    protected String ownerId;
+    protected String assigneeId;
     protected String overrideDefinitionTenantId;
     protected String outcome;
     protected Map<String, Object> startFormVariables;
@@ -141,7 +143,19 @@ public class CaseInstanceBuilderImpl implements CaseInstanceBuilder {
         this.tenantId = tenantId;
         return this;
     }
-    
+
+    @Override
+    public CaseInstanceBuilder owner(String userId) {
+        this.ownerId = userId;
+        return this;
+    }
+
+    @Override
+    public CaseInstanceBuilder assignee(String userId) {
+        this.assigneeId = userId;
+        return this;
+    }
+
     @Override
     public CaseInstanceBuilder overrideCaseDefinitionTenantId(String tenantId) {
         this.overrideDefinitionTenantId = tenantId;
@@ -261,7 +275,17 @@ public class CaseInstanceBuilderImpl implements CaseInstanceBuilder {
     public String getTenantId() {
         return tenantId;
     }
-    
+
+    @Override
+    public String getOwner() {
+        return ownerId;
+    }
+
+    @Override
+    public String getAssignee() {
+        return assigneeId;
+    }
+
     @Override
     public String getOverrideDefinitionTenantId() {
         return overrideDefinitionTenantId;

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceHelperImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceHelperImpl.java
@@ -42,6 +42,7 @@ import org.flowable.cmmn.engine.impl.util.CmmnLoggingSessionUtil;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
 import org.flowable.cmmn.engine.impl.util.EntityLinkUtil;
 import org.flowable.cmmn.engine.impl.util.EventInstanceCmmnUtil;
+import org.flowable.cmmn.engine.impl.util.IdentityLinkUtil;
 import org.flowable.cmmn.engine.impl.util.JobUtil;
 import org.flowable.cmmn.engine.interceptor.StartCaseInstanceAfterContext;
 import org.flowable.cmmn.engine.interceptor.StartCaseInstanceBeforeContext;
@@ -66,6 +67,7 @@ import org.flowable.form.api.FormFieldHandler;
 import org.flowable.form.api.FormInfo;
 import org.flowable.form.api.FormRepositoryService;
 import org.flowable.form.api.FormService;
+import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.job.service.JobService;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.variable.api.history.HistoricVariableInstance;
@@ -272,7 +274,8 @@ public class CaseInstanceHelperImpl implements CaseInstanceHelper {
                 caseInstanceBuilder.getBusinessStatus(), caseInstanceBuilder.getName(), caseInstanceBuilder.getCallbackId(),
                 caseInstanceBuilder.getCallbackType(), caseInstanceBuilder.getReferenceId(), caseInstanceBuilder.getReferenceType(),
                 caseInstanceBuilder.getParentId(), caseInstanceBuilder.getVariables(), caseInstanceBuilder.getTransientVariables(),
-                caseInstanceBuilder.getTenantId(), caseModel.getInitiatorVariableName(), caseModel, caseDefinition, cmmnModel,
+                caseInstanceBuilder.getTenantId(), caseInstanceBuilder.getOwner(), caseInstanceBuilder.getAssignee(),
+                caseModel.getInitiatorVariableName(), caseModel, caseDefinition, cmmnModel,
                 caseInstanceBuilder.getOverrideDefinitionTenantId(), caseInstanceBuilder.getPredefinedCaseInstanceId());
 
         if (cmmnEngineConfiguration.getStartCaseInstanceInterceptor() != null) {
@@ -474,6 +477,16 @@ public class CaseInstanceHelperImpl implements CaseInstanceHelper {
         
         caseInstanceEntityManager.insert(caseInstanceEntity);
         caseInstanceEntity.setSatisfiedSentryPartInstances(new ArrayList<>(1));
+
+        // initialize owner / assignee, if provided
+        if (StringUtils.isNotEmpty(instanceBeforeContext.getOwnerId())) {
+            IdentityLinkUtil.createCaseInstanceIdentityLink(caseInstanceEntity, instanceBeforeContext.getOwnerId(), null,
+                IdentityLinkType.OWNER, cmmnEngineConfiguration);
+        }
+        if (StringUtils.isNotEmpty(instanceBeforeContext.getAssigneeId())) {
+            IdentityLinkUtil.createCaseInstanceIdentityLink(caseInstanceEntity, instanceBeforeContext.getAssigneeId(), null,
+                IdentityLinkType.ASSIGNEE, cmmnEngineConfiguration);
+        }
 
         return caseInstanceEntity;
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/interceptor/StartCaseInstanceBeforeContext.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/interceptor/StartCaseInstanceBeforeContext.java
@@ -27,6 +27,8 @@ public class StartCaseInstanceBeforeContext extends AbstractStartCaseInstanceBef
     protected String parentId;
     protected Map<String, Object> transientVariables;
     protected String tenantId;
+    protected String ownerId;
+    protected String assigneeId;
     protected String initiatorVariableName;
     protected String overrideDefinitionTenantId;
     protected String predefinedCaseInstanceId;
@@ -37,7 +39,7 @@ public class StartCaseInstanceBeforeContext extends AbstractStartCaseInstanceBef
 
     public StartCaseInstanceBeforeContext(String businessKey, String businessStatus, String caseInstanceName, String callbackId, String callbackType,
             String referenceId, String referenceType, String parentId, Map<String, Object> variables,
-            Map<String, Object> transientVariables, String tenantId,
+            Map<String, Object> transientVariables, String tenantId, String ownerId, String assigneeId,
             String initiatorVariableName, Case caseModel, CaseDefinition caseDefinition, CmmnModel cmmnModel,
             String overrideDefinitionTenantId, String predefinedCaseInstanceId) {
 
@@ -50,6 +52,8 @@ public class StartCaseInstanceBeforeContext extends AbstractStartCaseInstanceBef
         this.parentId = parentId;
         this.transientVariables = transientVariables;
         this.tenantId = tenantId;
+        this.ownerId = ownerId;
+        this.assigneeId = assigneeId;
         this.initiatorVariableName = initiatorVariableName;
         this.overrideDefinitionTenantId = overrideDefinitionTenantId;
         this.predefinedCaseInstanceId = predefinedCaseInstanceId;
@@ -105,6 +109,14 @@ public class StartCaseInstanceBeforeContext extends AbstractStartCaseInstanceBef
 
     public String getTenantId() {
         return tenantId;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public String getAssigneeId() {
+        return assigneeId;
     }
 
     public void setTenantId(String tenantId) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/interceptor/StartCaseInstanceBeforeContext.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/interceptor/StartCaseInstanceBeforeContext.java
@@ -111,16 +111,24 @@ public class StartCaseInstanceBeforeContext extends AbstractStartCaseInstanceBef
         return tenantId;
     }
 
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
     public String getOwnerId() {
         return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
     }
 
     public String getAssigneeId() {
         return assigneeId;
     }
 
-    public void setTenantId(String tenantId) {
-        this.tenantId = tenantId;
+    public void setAssigneeId(String assigneeId) {
+        this.assigneeId = assigneeId;
     }
 
     public String getInitiatorVariableName() {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StartCaseWithIdentityLinksTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/StartCaseWithIdentityLinksTest.java
@@ -1,0 +1,184 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.flowable.cmmn.engine.test.impl.CmmnHistoryTestHelper;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.identitylink.api.IdentityLink;
+import org.flowable.identitylink.api.IdentityLinkInfo;
+import org.flowable.identitylink.api.IdentityLinkType;
+import org.flowable.identitylink.api.history.HistoricIdentityLink;
+import org.junit.Test;
+
+/**
+ * Testing the case builder API with the owner / assignee functionality at case start.
+ *
+ * @author Micha Kiener
+ */
+public class StartCaseWithIdentityLinksTest extends FlowableCmmnTestCase {
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+    public void testSetOwnerThroughCaseBuilder() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .owner("someUserId")
+                .start();
+
+        List<IdentityLink> identityLinks = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                IdentityLink::getScopeType)
+            .containsExactly(
+                tuple(IdentityLinkType.OWNER, "someUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+            );
+
+        if (CmmnHistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, cmmnEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                    HistoricIdentityLink::getScopeType)
+                .containsExactlyInAnyOrder(
+                    tuple(IdentityLinkType.OWNER, "someUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+                );
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+    public void testSetAssigneeThroughCaseBuilder() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .assignee("someUserId")
+                .start();
+
+        List<IdentityLink> identityLinks = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                IdentityLink::getScopeType)
+            .containsExactly(
+                tuple(IdentityLinkType.ASSIGNEE, "someUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+            );
+
+        if (CmmnHistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, cmmnEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                    HistoricIdentityLink::getScopeType)
+                .containsExactlyInAnyOrder(
+                    tuple(IdentityLinkType.ASSIGNEE, "someUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+                );
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+    public void testSetOwnerAndAssigneeThroughCaseBuilder() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .owner("firstUserId")
+                .assignee("secondUserId")
+                .start();
+
+        List<IdentityLink> identityLinks = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                IdentityLink::getScopeType)
+            .containsExactlyInAnyOrder(
+                tuple(IdentityLinkType.OWNER, "firstUserId", null, caseInstance.getId(), ScopeTypes.CMMN),
+                tuple(IdentityLinkType.ASSIGNEE, "secondUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+            );
+
+        if (CmmnHistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, cmmnEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                    HistoricIdentityLink::getScopeType)
+                .containsExactlyInAnyOrder(
+                    tuple(IdentityLinkType.OWNER, "firstUserId", null, caseInstance.getId(), ScopeTypes.CMMN),
+                    tuple(IdentityLinkType.ASSIGNEE, "secondUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+                );
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+    public void testSetOwnerAndAssigneeThroughCaseBuilderAsync() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .owner("firstUserId")
+                .assignee("secondUserId")
+                .startAsync();
+
+        // even if the case is started async, the identity links must already have been created, just the case model itself will be
+        // evaluated async, therefore the identity links must be present immediately, not async
+        List<IdentityLink> identityLinks = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                IdentityLink::getScopeType)
+            .containsExactlyInAnyOrder(
+                tuple(IdentityLinkType.OWNER, "firstUserId", null, caseInstance.getId(), ScopeTypes.CMMN),
+                tuple(IdentityLinkType.ASSIGNEE, "secondUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+            );
+
+        if (CmmnHistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, cmmnEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                    HistoricIdentityLink::getScopeType)
+                .containsExactlyInAnyOrder(
+                    tuple(IdentityLinkType.OWNER, "firstUserId", null, caseInstance.getId(), ScopeTypes.CMMN),
+                    tuple(IdentityLinkType.ASSIGNEE, "secondUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+                );
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn")
+    public void testSetOwnerAndAssigneeThroughCaseBuilderWithForm() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneTaskCase")
+                .owner("firstUserId")
+                .assignee("secondUserId")
+                .startWithForm();
+
+        List<IdentityLink> identityLinks = cmmnRuntimeService.getIdentityLinksForCaseInstance(caseInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                IdentityLink::getScopeType)
+            .containsExactlyInAnyOrder(
+                tuple(IdentityLinkType.OWNER, "firstUserId", null, caseInstance.getId(), ScopeTypes.CMMN),
+                tuple(IdentityLinkType.ASSIGNEE, "secondUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+            );
+
+        if (CmmnHistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, cmmnEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getScopeId,
+                    HistoricIdentityLink::getScopeType)
+                .containsExactlyInAnyOrder(
+                    tuple(IdentityLinkType.OWNER, "firstUserId", null, caseInstance.getId(), ScopeTypes.CMMN),
+                    tuple(IdentityLinkType.ASSIGNEE, "secondUserId", null, caseInstance.getId(), ScopeTypes.CMMN)
+                );
+        }
+    }
+}


### PR DESCRIPTION
Adding support within the case builder API to set the owner and / or assignee at case start time to be in sync with the runtime service allowing to set / change and remove owner and assignee directly.

#### Check List:
* Unit tests: YES
* Documentation: NO
