### PR TITLE
support owner and assignee within process builder API

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceAsyncCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceAsyncCmd.java
@@ -44,7 +44,7 @@ public class StartProcessInstanceAsyncCmd extends StartProcessInstanceCmd {
         processInstanceHelper = processEngineConfiguration.getProcessInstanceHelper();
         ExecutionEntity processInstance = (ExecutionEntity) processInstanceHelper.createProcessInstance(processDefinition, businessKey, businessStatus,
                 processInstanceName, overrideDefinitionTenantId, predefinedProcessInstanceId, variables, transientVariables, callbackId, callbackType,
-                referenceId, referenceType, stageInstanceId, false);
+                referenceId, referenceType, ownerId, assigneeId, stageInstanceId, false);
         ExecutionEntity execution = processInstance.getExecutions().get(0);
         Process process = ProcessDefinitionUtil.getProcess(processInstance.getProcessDefinitionId());
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceByMessageCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceByMessageCmd.java
@@ -45,19 +45,30 @@ public class StartProcessInstanceByMessageCmd implements Command<ProcessInstance
     protected String referenceId;
     protected String referenceType;
     protected String tenantId;
+    protected String ownerId;
+    protected String assigneeId;
 
     public StartProcessInstanceByMessageCmd(String messageName, String businessKey, Map<String, Object> processVariables, String tenantId) {
+        this(messageName, businessKey, processVariables, tenantId, null, null);
+    }
+
+    public StartProcessInstanceByMessageCmd(String messageName, String businessKey, Map<String, Object> processVariables, String tenantId,
+        String ownerId, String assigneeId) {
         this.messageName = messageName;
         this.businessKey = businessKey;
         this.processVariables = processVariables;
         this.tenantId = tenantId;
+        this.ownerId = ownerId;
+        this.assigneeId = assigneeId;
     }
 
     public StartProcessInstanceByMessageCmd(ProcessInstanceBuilderImpl processInstanceBuilder) {
         this(processInstanceBuilder.getMessageName(),
                 processInstanceBuilder.getBusinessKey(),
                 processInstanceBuilder.getVariables(),
-                processInstanceBuilder.getTenantId());
+                processInstanceBuilder.getTenantId(),
+                processInstanceBuilder.getOwnerId(),
+                processInstanceBuilder.getAssigneeId());
         this.transientVariables = processInstanceBuilder.getTransientVariables();
         this.callbackId = processInstanceBuilder.getCallbackId();
         this.callbackType = processInstanceBuilder.getCallbackType();
@@ -95,7 +106,8 @@ public class StartProcessInstanceByMessageCmd implements Command<ProcessInstance
 
         ProcessInstanceHelper processInstanceHelper = processEngineConfiguration.getProcessInstanceHelper();
         ProcessInstance processInstance = processInstanceHelper.createAndStartProcessInstanceByMessage(processDefinition,
-                messageName, businessKey, businessStatus, processVariables, transientVariables, callbackId, callbackType, referenceId, referenceType);
+                messageName, businessKey, businessStatus, processVariables, transientVariables, callbackId, callbackType, referenceId, referenceType,
+                ownerId, assigneeId);
 
         return processInstance;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/StartProcessInstanceCmd.java
@@ -68,6 +68,8 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
     protected String callbackType;
     protected String referenceId;
     protected String referenceType;
+    protected String ownerId;
+    protected String assigneeId;
     protected String stageInstanceId;
     protected Map<String, Object> startFormVariables;
     protected String outcome;
@@ -105,6 +107,8 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
         this.callbackType = processInstanceBuilder.getCallbackType();
         this.referenceId = processInstanceBuilder.getReferenceId();
         this.referenceType = processInstanceBuilder.getReferenceType();
+        this.ownerId = processInstanceBuilder.getOwnerId();
+        this.assigneeId = processInstanceBuilder.getAssigneeId();
         this.stageInstanceId = processInstanceBuilder.getStageInstanceId();
         this.startFormVariables = processInstanceBuilder.getStartFormVariables();
         this.outcome = processInstanceBuilder.getOutcome();
@@ -238,7 +242,7 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
     protected ProcessInstance startProcessInstance(ProcessDefinition processDefinition) {
         return processInstanceHelper.createProcessInstance(processDefinition, businessKey, businessStatus, processInstanceName,
             overrideDefinitionTenantId, predefinedProcessInstanceId, variables, transientVariables,
-            callbackId, callbackType, referenceId, referenceType, stageInstanceId, true);
+            callbackId, callbackType, referenceId, referenceType, ownerId, assigneeId, stageInstanceId, true);
     }
 
     protected boolean hasStartFormData() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SubmitStartFormCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SubmitStartFormCmd.java
@@ -58,9 +58,9 @@ public class SubmitStartFormCmd extends NeedsActiveProcessDefinitionCmd<ProcessI
 
         // TODO: backwards compatibility? Only create the process instance and not start it? How?
         if (businessKey != null) {
-            processInstance = (ExecutionEntity) processInstanceHelper.createProcessInstance(processDefinition, businessKey, null, null, null, null);
+            processInstance = (ExecutionEntity) processInstanceHelper.createProcessInstance(processDefinition, businessKey, null, null, null, null, null, null);
         } else {
-            processInstance = (ExecutionEntity) processInstanceHelper.createProcessInstance(processDefinition, null, null, null, null, null);
+            processInstance = (ExecutionEntity) processInstanceHelper.createProcessInstance(processDefinition, null, null, null, null, null, null, null);
         }
 
         CommandContextUtil.getHistoryManager(commandContext).recordFormPropertiesSubmitted(processInstance.getExecutions().get(0), properties, null,

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/event/SignalEventHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/event/SignalEventHandler.java
@@ -63,7 +63,7 @@ public class SignalEventHandler extends AbstractEventHandler {
 
             ProcessInstanceHelper processInstanceHelper = CommandContextUtil.getProcessEngineConfiguration(commandContext).getProcessInstanceHelper();
             processInstanceHelper.createAndStartProcessInstanceWithInitialFlowElement(processDefinition, null, null, null, flowElement, process,
-                    getPayloadAsMap(payload), null, true);
+                    getPayloadAsMap(payload), null, null, null, true);
 
         } else if (eventSubscription.getScopeId() != null && ScopeTypes.CMMN.equals(eventSubscription.getScopeType())) {
             CommandContextUtil.getProcessEngineConfiguration(commandContext).getCaseInstanceService().handleSignalEvent(eventSubscription, getPayloadAsMap(payload));

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/TimerStartEventJobHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/TimerStartEventJobHandler.java
@@ -69,7 +69,7 @@ public class TimerStartEventJobHandler extends TimerEventHandler implements JobH
                     }
                     ProcessInstanceHelper processInstanceHelper = processEngineConfiguration.getProcessInstanceHelper();
                     processInstanceHelper.createAndStartProcessInstanceWithInitialFlowElement(processDefinitionEntity, null, null, null, flowElement, process
-                            , null, null, true);
+                            , null, null, null, null, true);
                 } else {
                     new StartProcessInstanceCmd(processDefinitionEntity.getKey(), null, null, null, job.getTenantId()).execute(commandContext);
                 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/runtime/ProcessInstanceBuilderImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/runtime/ProcessInstanceBuilderImpl.java
@@ -42,6 +42,8 @@ public class ProcessInstanceBuilderImpl implements ProcessInstanceBuilder {
     protected String referenceType;
     protected String stageInstanceId;
     protected String tenantId;
+    protected String ownerId;
+    protected String assigneeId;
     protected String overrideDefinitionTenantId;
     protected String predefinedProcessInstanceId;
     protected Map<String, Object> variables;
@@ -144,6 +146,18 @@ public class ProcessInstanceBuilderImpl implements ProcessInstanceBuilder {
     @Override
     public ProcessInstanceBuilder predefineProcessInstanceId(String processInstanceId) {
         this.predefinedProcessInstanceId = processInstanceId;
+        return this;
+    }
+
+    @Override
+    public ProcessInstanceBuilder owner(String userId) {
+        this.ownerId = userId;
+        return this;
+    }
+
+    @Override
+    public ProcessInstanceBuilder assignee(String userId) {
+        this.assigneeId = userId;
         return this;
     }
 
@@ -307,6 +321,14 @@ public class ProcessInstanceBuilderImpl implements ProcessInstanceBuilder {
 
     public String getPredefinedProcessInstanceId() {
         return predefinedProcessInstanceId;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public String getAssigneeId() {
+        return assigneeId;
     }
 
     public Map<String, Object> getVariables() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessInstanceHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessInstanceHelper.java
@@ -216,10 +216,10 @@ public class ProcessInstanceHelper {
         }
 
         // add owner and assignee identity links, if set
-        if (ownerId != null) {
+        if (startInstanceBeforeContext.getOwnerId() != null) {
             IdentityLinkUtil.createProcessInstanceIdentityLink(processInstance, ownerId, null, IdentityLinkType.OWNER);
         }
-        if (assigneeId != null) {
+        if (startInstanceBeforeContext.getAssigneeId() != null) {
             IdentityLinkUtil.createProcessInstanceIdentityLink(processInstance, assigneeId, null, IdentityLinkType.ASSIGNEE);
         }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/interceptor/StartProcessInstanceBeforeContext.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/interceptor/StartProcessInstanceBeforeContext.java
@@ -25,6 +25,8 @@ public class StartProcessInstanceBeforeContext extends AbstractStartProcessInsta
     protected String referenceId;
     protected String referenceType;
     protected String tenantId;
+    protected String ownerId;
+    protected String assigneeId;
     protected String initiatorVariableName;
     protected String overrideDefinitionTenantId;
     protected String predefinedProcessInstanceId;
@@ -35,7 +37,7 @@ public class StartProcessInstanceBeforeContext extends AbstractStartProcessInsta
         
     public StartProcessInstanceBeforeContext(String businessKey, String businessStatus, String processInstanceName,
             String callbackId, String callbackType, String referenceId, String referenceType,
-            Map<String, Object> variables, Map<String, Object> transientVariables, String tenantId,
+            Map<String, Object> variables, Map<String, Object> transientVariables, String tenantId, String ownerId, String assigneeId,
             String initiatorVariableName, String initialActivityId, FlowElement initialFlowElement, Process process,
             ProcessDefinition processDefinition, String overrideDefinitionTenantId, String predefinedProcessInstanceId) {
         
@@ -47,6 +49,8 @@ public class StartProcessInstanceBeforeContext extends AbstractStartProcessInsta
         this.referenceId = referenceId;
         this.referenceType = referenceType;
         this.tenantId = tenantId;
+        this.ownerId = ownerId;
+        this.assigneeId = assigneeId;
         this.initiatorVariableName = initiatorVariableName;
         this.overrideDefinitionTenantId = overrideDefinitionTenantId;
         this.predefinedProcessInstanceId = predefinedProcessInstanceId;
@@ -90,6 +94,22 @@ public class StartProcessInstanceBeforeContext extends AbstractStartProcessInsta
 
     public void setTenantId(String tenantId) {
         this.tenantId = tenantId;
+    }
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    public String getAssigneeId() {
+        return assigneeId;
+    }
+
+    public void setAssigneeId(String assigneeId) {
+        this.assigneeId = assigneeId;
     }
 
     public String getInitiatorVariableName() {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/ProcessInstanceBuilder.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/runtime/ProcessInstanceBuilder.java
@@ -115,6 +115,20 @@ public interface ProcessInstanceBuilder {
     ProcessInstanceBuilder predefineProcessInstanceId(String processInstanceId);
 
     /**
+     * Set the owner of the process instance to be created to the given user id.
+     * @param userId the id of the user to become the owner of the process instance
+     * @return the process instance builder for method chaining
+     */
+    ProcessInstanceBuilder owner(String userId);
+
+    /**
+     * Set the assignee of the process instance to be created to the given user id.
+     * @param userId the id of the user to become the owner of the process instance
+     * @return the process instance builder for method chaining
+     */
+    ProcessInstanceBuilder assignee(String userId);
+
+    /**
      * Sets the process variables
      */
     ProcessInstanceBuilder variables(Map<String, Object> variables);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceBuilderIdentityLinkTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/ProcessInstanceBuilderIdentityLinkTest.java
@@ -1,0 +1,193 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.test.api.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+
+import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.engine.impl.test.HistoryTestHelper;
+import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.Deployment;
+import org.flowable.identitylink.api.IdentityLink;
+import org.flowable.identitylink.api.IdentityLinkInfo;
+import org.flowable.identitylink.api.IdentityLinkType;
+import org.flowable.identitylink.api.history.HistoricIdentityLink;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Testing the owner and assignee identity link setup methods within the process instance builder API.
+ *
+ * @author Micha Kiener
+ */
+public class ProcessInstanceBuilderIdentityLinkTest extends PluggableFlowableTestCase {
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    public void testProcessInstanceBuilderWithOwner() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+            .processDefinitionKey("oneTaskProcess")
+            .owner("kermit")
+            .start();
+
+        List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(processInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+            .containsExactly(
+                tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId())
+            );
+
+        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+                .containsExactly(
+                    tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId())
+                );
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    public void testProcessInstanceBuilderWithAssignee() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+            .processDefinitionKey("oneTaskProcess")
+            .assignee("kermit")
+            .start();
+
+        List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(processInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+            .containsExactly(
+                tuple(IdentityLinkType.ASSIGNEE, "kermit", null, processInstance.getId())
+            );
+
+        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+                .containsExactly(
+                    tuple(IdentityLinkType.ASSIGNEE, "kermit", null, processInstance.getId())
+                );
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    public void testProcessInstanceBuilderWithOwnerAndAssignee() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+            .processDefinitionKey("oneTaskProcess")
+            .owner("kermit")
+            .assignee("denise")
+            .start();
+
+        List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(processInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+            .containsExactlyInAnyOrder(
+                tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId()),
+                tuple(IdentityLinkType.ASSIGNEE, "denise", null, processInstance.getId())
+            );
+
+        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                    tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId()),
+                    tuple(IdentityLinkType.ASSIGNEE, "denise", null, processInstance.getId())
+                );
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    public void testProcessInstanceBuilderWithOwnerAsync() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+            .processDefinitionKey("oneTaskProcess")
+            .owner("kermit")
+            .startAsync();
+
+        List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(processInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+            .containsExactly(
+                tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId())
+            );
+
+        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+                .containsExactly(
+                    tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId())
+                );
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    public void testProcessInstanceBuilderWithAssigneeAsync() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+            .processDefinitionKey("oneTaskProcess")
+            .assignee("kermit")
+            .startAsync();
+
+        List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(processInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+            .containsExactly(
+                tuple(IdentityLinkType.ASSIGNEE, "kermit", null, processInstance.getId())
+            );
+
+        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+                .containsExactly(
+                    tuple(IdentityLinkType.ASSIGNEE, "kermit", null, processInstance.getId())
+                );
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    public void testProcessInstanceBuilderWithOwnerAndAssigneeAsync() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+            .processDefinitionKey("oneTaskProcess")
+            .owner("kermit")
+            .assignee("denise")
+            .startAsync();
+
+        List<IdentityLink> identityLinks = runtimeService.getIdentityLinksForProcessInstance(processInstance.getId());
+        assertThat(identityLinks)
+            .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+            .containsExactlyInAnyOrder(
+                tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId()),
+                tuple(IdentityLinkType.ASSIGNEE, "denise", null, processInstance.getId())
+            );
+
+        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForProcessInstance(processInstance.getId());
+            assertThat(historicIdentityLinks)
+                .extracting(IdentityLinkInfo::getType, IdentityLinkInfo::getUserId, IdentityLinkInfo::getGroupId, IdentityLinkInfo::getProcessInstanceId)
+                .containsExactlyInAnyOrder(
+                    tuple(IdentityLinkType.OWNER, "kermit", null, processInstance.getId()),
+                    tuple(IdentityLinkType.ASSIGNEE, "denise", null, processInstance.getId())
+                );
+        }
+    }
+}

--- a/modules/flowable-form-engine-configurator/src/test/java/org/flowable/form/engine/test/AbstractFlowableFormEngineConfiguratorTest.java
+++ b/modules/flowable-form-engine-configurator/src/test/java/org/flowable/form/engine/test/AbstractFlowableFormEngineConfiguratorTest.java
@@ -14,6 +14,7 @@ package org.flowable.form.engine.test;
 
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.RepositoryService;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.util.EngineServiceUtil;
 import org.flowable.engine.test.FlowableRule;
 import org.flowable.form.api.FormRepositoryService;
@@ -31,6 +32,7 @@ public class AbstractFlowableFormEngineConfiguratorTest {
     protected static ProcessEngine cachedProcessEngine;
     protected RepositoryService repositoryService;
     protected FormRepositoryService formRepositoryService;
+    protected ProcessEngineConfigurationImpl processEngineConfiguration;
 
     @Before
     public void initProcessEngine() {
@@ -40,6 +42,12 @@ public class AbstractFlowableFormEngineConfiguratorTest {
 
         this.repositoryService = cachedProcessEngine.getRepositoryService();
         this.formRepositoryService = EngineServiceUtil.getFormRepositoryService(cachedProcessEngine.getProcessEngineConfiguration());
+        if (cachedProcessEngine.getProcessEngineConfiguration() instanceof ProcessEngineConfigurationImpl) {
+            this.processEngineConfiguration = (ProcessEngineConfigurationImpl) cachedProcessEngine.getProcessEngineConfiguration();
+        }
     }
 
+    protected ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
+        return processEngineConfiguration;
+    }
 }


### PR DESCRIPTION
Adding support for initial owner and assignee within the process instance builder API to be in sync with the case instance builder API

#### Check List:
* Unit tests: YES
* Documentation: NA
