### PR TITLE
Chore: Upgrade to SpringBoot 2.7.4 and dependencies

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -96,12 +96,12 @@ Quartz
 This software includes unchanged copies of the following libraries:
 
 aopalliance                     aopalliance                 1.0             Public Domain
-com.fasterxml.jackson.core      jackson-annotations         2.13.1          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-core                2.13.1          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-databind            2.13.1          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-joda       2.13.1          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-annotations         2.13.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-core                2.13.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-databind            2.13.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.datatype  jackson-datatype-joda       2.13.4          The Apache Software License, Version 2.0
 com.google.guava                guava                       31.0.1-jre      The Apache Software License, Version 2.0
-com.h2database                  h2                          1.4.200         The H2 License, Version 1.0
+com.h2database                  h2                          2.1.214         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0
 com.sun.mail                    javax.mail                  1.6.2           CDDL/GPLv2+CE
 commons-beanutils               commons-beanutils           1.8.3           The Apache Software License, Version 2.0
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
 org.slf4j                       slf4j-api                   1.7.36          MIT License
 org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.22          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.22          The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.23          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.23          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.7.3           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.7.3           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.7.3           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.7.3</spring.boot.version>
-		<spring.framework.version>5.3.22</spring.framework.version>
+		<spring.framework.version>5.3.23</spring.framework.version>
 		<spring.security.version>5.7.3</spring.security.version>
-		<spring.amqp.version>2.4.6</spring.amqp.version>
-		<spring.kafka.version>2.8.7</spring.kafka.version>
+		<spring.amqp.version>2.4.7</spring.amqp.version>
+		<spring.kafka.version>2.8.9</spring.kafka.version>
 		<reactor-netty.version>1.0.20</reactor-netty.version>
-		<jackson.version>2.13.3</jackson.version>
+		<jackson.version>2.13.4</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>3.14.0</camel.version>
@@ -795,7 +795,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.6.10.Final</version>
+				<version>5.6.11.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>


### PR DESCRIPTION
Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.4

This PR replaces the update to the SpringFramework https://github.com/flowable/flowable-engine/pull/3465
