### PR TITLE
fix sql syntax error

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/CaseInstance.xml
+++ b/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/CaseInstance.xml
@@ -769,7 +769,7 @@
                                                     </when>
                                                 </choose>
                                                 <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
-                                                    or A_OR${index}.TEXT_ is null
+                                                    or V.TEXT_ is null
                                                 </if>
                                                 )
                                             </if>
@@ -791,7 +791,7 @@
                                                 <include refid="variableOperator"/>
                                                 #{queryVariableValue.longValue}
                                                 <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
-                                                    or A_OR${index}.LONG_ is null
+                                                    or V.LONG_ is null
                                                 </if>
                                                 )
                                             </if>
@@ -800,7 +800,7 @@
                                                 <include refid="variableOperator"/>
                                                 #{queryVariableValue.doubleValue}
                                                 <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
-                                                    or A_OR${index}.DOUBLE_ is null
+                                                    or V.DOUBLE_ is null
                                                 </if>
                                                 )
                                             </if>

--- a/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/HistoricProcessInstance.xml
+++ b/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/HistoricProcessInstance.xml
@@ -658,7 +658,7 @@
                                     <when test="queryVariableValue.operator.equals('LIKE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">${wildcardEscapeClause}</when>
                                 </choose>
                                 <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
-                                    or A_OR${index}.TEXT_ is null
+                                    or V.TEXT_ is null
                                 </if>
                                 )
                             </if>
@@ -678,7 +678,7 @@
                                 <include refid="executionVariableOperator" />
                                 #{queryVariableValue.longValue}
                                 <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
-                                    or A_OR${index}.LONG_ is null
+                                    or V.LONG_ is null
                                 </if>
                                 )
                             </if>
@@ -687,7 +687,7 @@
                                 <include refid="executionVariableOperator" />
                                 #{queryVariableValue.doubleValue}
                                 <if test="queryVariableValue.operator.equals('NOT_EQUALS') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE')">
-                                    or A_OR${index}.DOUBLE_ is null
+                                    or V.DOUBLE_ is null
                                 </if>
                                 )
                             </if>


### PR DESCRIPTION
Fixes #3474 

There is a wrong alias in these mapper.xml: [CaseInstance.xml](https://github.com/flowable/flowable-engine/blob/main/modules/flowable-cmmn-engine/src/main/resources/org/flowable/cmmn/db/mapping/entity/CaseInstance.xml), [HistoricProcessInstance.xml](https://github.com/flowable/flowable-engine/blob/main/modules/flowable-engine/src/main/resources/org/flowable/db/mapping/entity/HistoricProcessInstance.xml). `A_OR${index}` doesn't exist.
