### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/async-history.yml
+++ b/.github/workflows/async-history.yml
@@ -8,6 +8,9 @@ env:
     -B -V --no-transfer-progress
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
+permissions:
+  contents: read
+
 jobs:
   test_async:
     name: Async History ${{ matrix.engineModule }}

--- a/.github/workflows/db2.yml
+++ b/.github/workflows/db2.yml
@@ -11,6 +11,9 @@ env:
     -B -V --no-transfer-progress
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
+permissions:
+  contents: read
+
 jobs:
   test_db2:
     name: DB2 ${{ matrix.db2 }}

--- a/.github/workflows/docker-release-with-latest.yml
+++ b/.github/workflows/docker-release-with-latest.yml
@@ -2,6 +2,9 @@ name: Release Docker Images With Latest
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   release_docker_images_with_latest:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -2,6 +2,9 @@ name: Release Docker Images
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   release_docker_images:
     runs-on: ubuntu-latest

--- a/.github/workflows/flowable5.yml
+++ b/.github/workflows/flowable5.yml
@@ -2,6 +2,9 @@ name: Flowable 5 Build
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test_jdk:
     name: Flowable 5 Tests

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - flowable-helm
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write  # for helm/chart-releaser-action to push chart release and create a release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/java-ea.yml
+++ b/.github/workflows/java-ea.yml
@@ -11,6 +11,9 @@ env:
     -B -V --no-transfer-progress
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
+permissions:
+  contents: read
+
 jobs:
   test_jdkea:
     name: Linux (OpenJDK EA)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ env:
     -B -V --no-transfer-progress
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
+permissions:
+  contents: read
+
 jobs:
   test_jdk:
     name: Linux (JDK ${{ matrix.java }})

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -13,6 +13,9 @@ env:
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
 # We explicitly don't use a container for running the job since there is some connectivity issues to MariaDB if that is done
+permissions:
+  contents: read
+
 jobs:
   test_mariadb:
     name: MariaDB ${{ matrix.mariadb }}

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -13,6 +13,9 @@ env:
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
 # We explicitly don't use a container for running the job since there is some connectivity issues to MySQL if that is done
+permissions:
+  contents: read
+
 jobs:
   test_mysql:
     name: MySQL ${{ matrix.mysql }}

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -11,6 +11,9 @@ env:
     -B -V --no-transfer-progress
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
+permissions:
+  contents: read
+
 jobs:
   test_oracle:
     name: Oracle ${{ matrix.oracle }}

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -12,6 +12,9 @@ env:
     -B -V --no-transfer-progress
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
+permissions:
+  contents: read
+
 jobs:
   test_postgres:
     name: Postgres ${{ matrix.postgres }}

--- a/.github/workflows/sql-server.yml
+++ b/.github/workflows/sql-server.yml
@@ -12,6 +12,9 @@ env:
     -B -V --no-transfer-progress
     -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
+permissions:
+  contents: read
+
 jobs:
   test_mssql:
     name: SQL Server ${{ matrix.mssql }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,9 @@ env:
     -B -V --no-transfer-progress
     -D http.keepAlive=false -D maven.wagon.http.pool=false -D maven.wagon.httpconnectionManager.ttlSeconds=120
 
+permissions:
+  contents: read
+
 jobs:
   windows:
     name: 'Windows'


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/flowable/flowable-engine/actions/runs/3168290252/jobs/5159389916#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- async-history.yml
- db2.yml
- docker-release-with-latest.yml
- docker-release.yml
- flowable5.yml
- helm-release.yml
- java-ea.yml
- main.yml
- mariadb.yml
- mysql.yml
- oracle.yml
- postgres.yml
- sql-server.yml
- windows.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>