### PR TITLE
fix(sec): upgrade org.springframework:spring-beans to 5.2.20.RELEASE

### DIFF
--- a/modules/flowable-mule/pom.xml
+++ b/modules/flowable-mule/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.mule.version>4.1.9.RELEASE</spring.mule.version>
+    <spring.mule.version>5.2.20.RELEASE</spring.mule.version>
     <spring-security.mule.version>4.0.1.RELEASE</spring-security.mule.version>
     <flowable.artifact>
       org.flowable.mule
@@ -96,7 +96,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>

--- a/modules/flowable5-mule-test/pom.xml
+++ b/modules/flowable5-mule-test/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.mule.version>3.2.10.RELEASE</spring.mule.version>
+    <spring.mule.version>5.2.20.RELEASE</spring.mule.version>
     <flowable.artifact>
       org.activiti.mule.test
     </flowable.artifact>
@@ -77,7 +77,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<name>Flowable</name>
@@ -15,7 +15,7 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.7.4</spring.boot.version>
-		<spring.framework.version>5.3.23</spring.framework.version>
+		<spring.framework.version>5.2.20.RELEASE</spring.framework.version>
 		<spring.security.version>5.7.3</spring.security.version>
 		<spring.amqp.version>2.4.7</spring.amqp.version>
 		<spring.kafka.version>2.8.9</spring.kafka.version>
@@ -44,15 +44,15 @@
 		<argLine>-Duser.language=en -Dfile.encoding=UTF-8 -XX:+UseParallelGC</argLine>
 
 		<!-- OSGi bundles properties -->
-		<flowable.artifact />
+		<flowable.artifact/>
 		<flowable.osgi.import.flowable.version>version="[$(version;==;${flowable.osgi.version.clean}),$(version;=+;${flowable.osgi.version.clean}))"</flowable.osgi.import.flowable.version>
 		<flowable.osgi.import.strict.version>version="[$(version;===;${flowable.osgi.version.clean}),$(version;==+;${flowable.osgi.version.clean}))"</flowable.osgi.import.strict.version>
 		<flowable.osgi.import.default.version>[$(version;==;$(@)),$(version;+;$(@)))</flowable.osgi.import.default.version>
 		<flowable.osgi.import.defaults>
 		</flowable.osgi.import.defaults>
-		<flowable.osgi.import.before.defaults />
-		<flowable.osgi.import.additional />
-		<flowable.osgi.export.additional />
+		<flowable.osgi.import.before.defaults/>
+		<flowable.osgi.import.additional/>
+		<flowable.osgi.export.additional/>
 		<flowable.osgi.import.pkg>
 			org.flowable.*;${flowable.osgi.import.flowable.version},
 			${flowable.osgi.import.before.defaults},
@@ -60,7 +60,7 @@
 			${flowable.osgi.import.additional},
 			*
 		</flowable.osgi.import.pkg>
-		<flowable.osgi.activator />
+		<flowable.osgi.activator/>
 		<flowable.osgi.failok>false</flowable.osgi.failok>
 		<flowable.osgi.export>${flowable.osgi.export.pkg};${flowable.osgi.version};-noimport:=true</flowable.osgi.export>
 		<!-- <flowable.osgi.export.pkg>!*.impl;${flowable.artifact}*</flowable.osgi.export.pkg>
@@ -69,16 +69,16 @@
 			${flowable.artifact}*,
 			${flowable.osgi.export.additional}
 		</flowable.osgi.export.pkg>
-		<flowable.osgi.private.pkg></flowable.osgi.private.pkg>
+		<flowable.osgi.private.pkg/>
 		<flowable.osgi.version>version=${project.version}</flowable.osgi.version>
 		<flowable.osgi.split.pkg>-split-package:=first</flowable.osgi.split.pkg>
 		<flowable.osgi.import>${flowable.osgi.import.pkg}</flowable.osgi.import>
-		<flowable.osgi.dynamic />
+		<flowable.osgi.dynamic/>
 		<flowable.osgi.symbolic.name>${flowable.artifact}</flowable.osgi.symbolic.name>
 		<flowable.osgi.exclude.dependencies>false</flowable.osgi.exclude.dependencies>
 		<flowable.osgi.remove.headers>Ignore-Package,Include-Resource,Private-Package,Bundle-DocURL</flowable.osgi.remove.headers>
 		<flowable.osgi.include.resource>{maven-resources}</flowable.osgi.include.resource>
-		<flowable.osgi.embed></flowable.osgi.embed>
+		<flowable.osgi.embed/>
 	</properties>
 
 	<dependencyManagement>
@@ -1319,7 +1319,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore/>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-beans 4.1.9.RELEASE
- [CVE-2022-22965](https://www.oscs1024.com/hd/CVE-2022-22965)


### What did I do？
Upgrade org.springframework:spring-beans from 4.1.9.RELEASE to 5.2.20.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS