### PR TITLE
fix(sec): upgrade org.springframework:spring-core to 5.2.19.RELEASE

### DIFF
--- a/modules/flowable-mule/pom.xml
+++ b/modules/flowable-mule/pom.xml
@@ -15,7 +15,7 @@
   
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.mule.version>4.1.9.RELEASE</spring.mule.version>
+    <spring.mule.version>5.2.19.RELEASE</spring.mule.version>
     <spring-security.mule.version>4.0.1.RELEASE</spring-security.mule.version>
     <flowable.artifact>
       org.flowable.mule


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.springframework:spring-core 4.1.9.RELEASE
- [CVE-2021-22060](https://www.oscs1024.com/hd/CVE-2021-22060)
- [CVE-2021-22096](https://www.oscs1024.com/hd/CVE-2021-22096)


### What did I do？
Upgrade org.springframework:spring-core from 4.1.9.RELEASE to 5.2.19.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS