### PR TITLE
Chore: Upgrade to Spring Security 5.7.4 and dependencies

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.23          The 
 org.springframework             spring-core                 5.3.23          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.23          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.23          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.7.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.7.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.7.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.7.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.7.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.7.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.7.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.7.4           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,10 @@
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.7.4</spring.boot.version>
 		<spring.framework.version>5.3.23</spring.framework.version>
-		<spring.security.version>5.7.3</spring.security.version>
+		<spring.security.version>5.7.4</spring.security.version>
 		<spring.amqp.version>2.4.7</spring.amqp.version>
 		<spring.kafka.version>2.8.9</spring.kafka.version>
-		<reactor-netty.version>1.0.20</reactor-netty.version>
+		<reactor-netty.version>1.0.24</reactor-netty.version>
 		<jackson.version>2.13.4</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>


### PR DESCRIPTION
See Release Notes at: https://github.com/spring-projects/spring-security/releases/tag/5.7.4
