### PR TITLE
Chore: Upgrade to Spring Boot 2.7.5 and dependencies

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.23          The 
 org.springframework             spring-core                 5.3.23          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.23          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.23          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.7.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.7.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.7.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.7.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.7.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.7.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.7.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.7.4           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/modules/flowable-app-engine/pom.xml
+++ b/modules/flowable-app-engine/pom.xml
@@ -108,8 +108,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -570,8 +570,8 @@
             <id>mysql</id>
             <dependencies>
                 <dependency>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
+                    <groupId>com.mysql</groupId>
+                    <artifactId>mysql-connector-j</artifactId>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/modules/flowable-cmmn-engine/pom.xml
+++ b/modules/flowable-cmmn-engine/pom.xml
@@ -160,8 +160,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-content-engine/pom.xml
+++ b/modules/flowable-content-engine/pom.xml
@@ -450,8 +450,8 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
+					<groupId>com.mysql</groupId>
+					<artifactId>mysql-connector-j</artifactId>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>

--- a/modules/flowable-dmn-engine/pom.xml
+++ b/modules/flowable-dmn-engine/pom.xml
@@ -501,8 +501,8 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
+					<groupId>com.mysql</groupId>
+					<artifactId>mysql-connector-j</artifactId>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>

--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -213,8 +213,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -1543,8 +1543,8 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
+                    <groupId>com.mysql</groupId>
+                    <artifactId>mysql-connector-j</artifactId>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/modules/flowable-event-registry/pom.xml
+++ b/modules/flowable-event-registry/pom.xml
@@ -475,8 +475,8 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
+                    <groupId>com.mysql</groupId>
+                    <artifactId>mysql-connector-j</artifactId>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/modules/flowable-form-engine/pom.xml
+++ b/modules/flowable-form-engine/pom.xml
@@ -490,8 +490,8 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
+					<groupId>com.mysql</groupId>
+					<artifactId>mysql-connector-j</artifactId>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>

--- a/modules/flowable-idm-engine/pom.xml
+++ b/modules/flowable-idm-engine/pom.xml
@@ -476,8 +476,8 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
+					<groupId>com.mysql</groupId>
+					<artifactId>mysql-connector-j</artifactId>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>

--- a/modules/flowable-ui/flowable-ui-app/pom.xml
+++ b/modules/flowable-ui/flowable-ui-app/pom.xml
@@ -246,8 +246,8 @@
             <id>mysql</id>
             <dependencies>
                 <dependency>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
+                    <groupId>com.mysql</groupId>
+                    <artifactId>mysql-connector-j</artifactId>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/modules/flowable5-compatibility-test/pom.xml
+++ b/modules/flowable5-compatibility-test/pom.xml
@@ -37,8 +37,8 @@
 			<version>6.7.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/modules/flowable5-compatibility-testdata/pom.xml
+++ b/modules/flowable5-compatibility-testdata/pom.xml
@@ -47,8 +47,8 @@
 			<version>5.23.0</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/modules/flowable5-engine/pom.xml
+++ b/modules/flowable5-engine/pom.xml
@@ -98,8 +98,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -929,8 +929,8 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
+					<groupId>com.mysql</groupId>
+					<artifactId>mysql-connector-j</artifactId>
 					<scope>test</scope>
 				</dependency>
 			</dependencies>

--- a/modules/flowable5-test/pom.xml
+++ b/modules/flowable5-test/pom.xml
@@ -106,8 +106,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,13 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.7.4</spring.boot.version>
+		<spring.boot.version>2.7.5</spring.boot.version>
 		<spring.framework.version>5.3.23</spring.framework.version>
-		<spring.security.version>5.7.3</spring.security.version>
+		<spring.security.version>5.7.4</spring.security.version>
 		<spring.amqp.version>2.4.7</spring.amqp.version>
-		<spring.kafka.version>2.8.9</spring.kafka.version>
+		<spring.kafka.version>2.8.10</spring.kafka.version>
 		<reactor-netty.version>1.0.20</reactor-netty.version>
-		<jackson.version>2.13.4</jackson.version>
+		<jackson.version>2.13.4.20221013</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>3.14.0</camel.version>
@@ -230,9 +230,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>mysql</groupId>
-				<artifactId>mysql-connector-java</artifactId>
-				<version>8.0.30</version>
+				<groupId>com.mysql</groupId>
+				<artifactId>mysql-connector-j</artifactId>
+				<version>8.0.31</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mariadb.jdbc</groupId>
@@ -800,7 +800,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.6.11.Final</version>
+				<version>5.6.12.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>
@@ -1980,8 +1980,8 @@
 			<id>mysql</id>
 			<dependencies>
 				<dependency>
-					<groupId>mysql</groupId>
-					<artifactId>mysql-connector-java</artifactId>
+					<groupId>com.mysql</groupId>
+					<artifactId>mysql-connector-j</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>

--- a/qa/dbclean/pom.xml
+++ b/qa/dbclean/pom.xml
@@ -27,9 +27,9 @@
       <version>12.2.0.1</version>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.29</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.0.31</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.jtds</groupId>


### PR DESCRIPTION
Upgrade to Spring Boot 2.7.5 and dependencies.

See Release Notes at: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.5

Note the mysql connector jar has moved its location in Maven (see https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.0.31) and that is the reason for all the mysql changes.

This PR supersedes https://github.com/flowable/flowable-engine/pull/3497 which will be closed.