### PR TITLE
Changed AbstractScriptEvaluator to take string as script

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/ScriptInfoParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/ScriptInfoParser.java
@@ -54,7 +54,7 @@ public class ScriptInfoParser extends BaseChildElementParser {
             String elementText = xtr.getElementText();
 
             if (StringUtils.isNotEmpty(elementText)) {
-                script.setScript(elementText);
+                script.setScript(StringUtils.trim(elementText));
             }
             if (parentElement instanceof HasScriptInfo) {
                 ((HasScriptInfo) parentElement).setScriptInfo(script);

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/EventListenerConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/EventListenerConverterTest.java
@@ -86,7 +86,7 @@ class EventListenerConverterTest {
         assertThat(scriptTaskListenerType.getImplementationType()).isEqualTo("script");
         assertThat(scriptTaskListenerType.getImplementation()).isNull();
         assertThat(scriptTaskListenerType.getScriptInfo()).isNotNull();
-        assertThat(scriptTaskListenerType.getScriptInfo().getScript()).contains(" task.setVariable('scriptTaskListenerType', \"Type\");");
+        assertThat(scriptTaskListenerType.getScriptInfo().getScript()).contains("task.setVariable('scriptTaskListenerType', \"Type\");");
         assertThat(scriptTaskListenerType.getScriptInfo().getLanguage()).isEqualTo("groovy");
         assertThat(scriptTaskListenerType.getScriptInfo().getResultVariable()).isEqualTo("scriptTypeResult");
     }
@@ -105,7 +105,7 @@ class EventListenerConverterTest {
         assertThat(scriptListenerType.getImplementationType()).isEqualTo("script");
         assertThat(scriptListenerType.getImplementation()).isNull();
         assertThat(scriptListenerType.getScriptInfo()).isNotNull();
-        assertThat(scriptListenerType.getScriptInfo().getScript()).contains(" task.setVariable('scriptTaskListenerType', \"Type\");");
+        assertThat(scriptListenerType.getScriptInfo().getScript()).contains("task.setVariable('scriptTaskListenerType', \"Type\");");
         assertThat(scriptListenerType.getScriptInfo().getLanguage()).isEqualTo("groovy");
         assertThat(scriptListenerType.getScriptInfo().getResultVariable()).isEqualTo("scriptTypeResult");
     }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/AbstractScriptEvaluator.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/scripting/AbstractScriptEvaluator.java
@@ -42,7 +42,7 @@ public abstract class AbstractScriptEvaluator {
      * <p/>
      * Must not be or evaluate to <code>null</code> to null.
      */
-    protected Expression script;
+    protected String script;
 
     /**
      * The name of the result variable to store the result of the script evaluation in the
@@ -53,7 +53,7 @@ public abstract class AbstractScriptEvaluator {
     public AbstractScriptEvaluator() {
     }
 
-    public AbstractScriptEvaluator(Expression language, Expression script) {
+    public AbstractScriptEvaluator(Expression language, String script) {
         this.script = script;
         this.language = language;
     }
@@ -71,13 +71,9 @@ public abstract class AbstractScriptEvaluator {
         if (language == null) {
             throw new FlowableIllegalStateException("'language' evaluated to null for listener of type 'script'");
         }
-        String script = Objects.toString(this.script.getValue(variableContainer), null);
-        if (script == null) {
-            throw new FlowableIllegalStateException("Script content is null or evaluated to null for listener of type 'script'");
-        }
         ScriptEngineRequest.Builder builder = ScriptEngineRequest.builder();
 
-        return builder.language(language).script(script).variableContainer(variableContainer);
+        return builder.language(language).script(getScript()).variableContainer(variableContainer);
     }
 
     protected Object evaluateScriptRequest(ScriptEngineRequest.Builder requestBuilder) {
@@ -100,18 +96,31 @@ public abstract class AbstractScriptEvaluator {
 
     protected void validateParameters() {
         if (script == null) {
-            throw new IllegalArgumentException("The field 'script' should be set on the TaskListener");
+            throw new FlowableIllegalStateException("The field 'script' should be set on " + getClass().getSimpleName());
         }
 
         if (language == null) {
-            throw new IllegalArgumentException("The field 'language' should be set on the TaskListener");
+            throw new FlowableIllegalStateException("The field 'language' should be set on " + getClass().getSimpleName());
         }
     }
 
     protected abstract ScriptingEngines getScriptingEngines();
 
-    public void setScript(Expression script) {
+    public void setScript(String script) {
         this.script = script;
+    }
+
+    /**
+     * Sets the script as Expression for backwards compatibility.
+     * Requires to for 'field' injection of scripts.
+     * Expression is not evaluated
+     */
+    public void setScript(Expression script) {
+        this.script = script.getExpressionText();
+    }
+
+    public String getScript() {
+        return script;
     }
 
     public void setLanguage(Expression language) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/http/DefaultBpmnHttpActivityDelegate.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/http/DefaultBpmnHttpActivityDelegate.java
@@ -201,8 +201,7 @@ public class DefaultBpmnHttpActivityDelegate extends BaseHttpActivityDelegate im
     }
 
     protected ScriptHttpHandler createScriptHttpHandler(ExpressionManager expressionManager, ScriptInfo scriptInfo) {
-        ScriptHttpHandler scriptHttpHandler = new ScriptHttpHandler(createExpression(expressionManager, scriptInfo.getLanguage()),
-                createExpression(expressionManager, scriptInfo.getScript()));
+        ScriptHttpHandler scriptHttpHandler = new ScriptHttpHandler(createExpression(expressionManager, scriptInfo.getLanguage()), scriptInfo.getScript());
         if (scriptInfo.getResultVariable() != null) {
             scriptHttpHandler.setResultVariable(createExpression(expressionManager, scriptInfo.getResultVariable()));
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/http/handler/ScriptHttpHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/http/handler/ScriptHttpHandler.java
@@ -30,9 +30,8 @@ import org.flowable.variable.api.delegate.VariableScope;
  */
 public class ScriptHttpHandler extends AbstractScriptEvaluator implements HttpRequestHandler, HttpResponseHandler {
 
-    public ScriptHttpHandler(Expression language, Expression script) {
-        this.script = script;
-        this.language = language;
+    public ScriptHttpHandler(Expression language, String script) {
+        super(language, script);
     }
 
     @Override

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTypeExecutionListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTypeExecutionListener.java
@@ -24,7 +24,7 @@ public class ScriptTypeExecutionListener extends AbstractScriptEvaluator impleme
 
     private static final long serialVersionUID = 1L;
 
-    public ScriptTypeExecutionListener(Expression language, Expression script) {
+    public ScriptTypeExecutionListener(Expression language, String script) {
         super(language, script);
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTypeTaskListener.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/listener/ScriptTypeTaskListener.java
@@ -30,7 +30,7 @@ public class ScriptTypeTaskListener extends AbstractScriptEvaluator implements T
 
     private static final long serialVersionUID = -8915149072830499057L;
 
-    public ScriptTypeTaskListener(Expression language, Expression script) {
+    public ScriptTypeTaskListener(Expression language, String script) {
         this.script = script;
         this.language = language;
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/DefaultListenerFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/factory/DefaultListenerFactory.java
@@ -110,7 +110,7 @@ public class DefaultListenerFactory extends AbstractBehaviorFactory implements L
         if (listener.getScriptInfo() != null) {
             ScriptTypeTaskListener scriptListener = new ScriptTypeTaskListener(
                     createExpression(listener.getScriptInfo().getLanguage()),
-                    createExpression(listener.getScriptInfo().getScript()));
+                    listener.getScriptInfo().getScript());
             Optional.ofNullable(listener.getScriptInfo().getResultVariable())
                     .ifPresent(resultVar -> scriptListener.setResultVariable(createExpression(resultVar)));
             return scriptListener;
@@ -144,7 +144,7 @@ public class DefaultListenerFactory extends AbstractBehaviorFactory implements L
         if (listener.getScriptInfo() != null) {
             ScriptTypeExecutionListener scriptListener = new ScriptTypeExecutionListener(
                     createExpression(listener.getScriptInfo().getLanguage()),
-                    createExpression(listener.getScriptInfo().getScript()));
+                    listener.getScriptInfo().getScript());
             Optional.ofNullable(listener.getScriptInfo().getResultVariable())
                     .ifPresent(resultVar -> scriptListener.setResultVariable(createExpression(resultVar)));
             return scriptListener;

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.java
@@ -511,7 +511,6 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
     public void testThrowBpmnErrorCatchBoundaryEventSubProcessMultiInstanceParallelStart() {
         {
             // SubProcess ExecutionListener
-            Map<String, Object> vars = new HashMap<>();
             ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("subProcessErrorHandling")
                     .transientVariable("throwErrorSubProcessStartListener", "EXECUTION_LISTENER_BPMN_ERROR")
                     .transientVariable("elements", Arrays.asList("1", "2", "3"))
@@ -551,7 +550,6 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
     public void testThrowBpmnErrorCatchBoundaryEventSubProcessMultiInstanceParallelStartAsync() {
         {
             // SubProcess ExecutionListener
-            Map<String, Object> vars = new HashMap<>();
             ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("subProcessErrorHandling")
                     .transientVariable("throwErrorSubProcessStartListener", "EXECUTION_LISTENER_BPMN_ERROR")
                     .transientVariable("elements", Arrays.asList("1", "2", "3"))
@@ -595,7 +593,6 @@ public class ExecutionListenerTest extends PluggableFlowableTestCase {
     public void testThrowBpmnErrorCatchBoundaryEventSubProcessMultiInstanceParallelEndAsync() {
         {
             // SubProcess ExecutionListener
-            Map<String, Object> vars = new HashMap<>();
             ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("subProcessErrorHandling")
                     .variable("throwErrorSubProcessEndListener", "EXECUTION_LISTENER_BPMN_ERROR")
                     .variable("elements", Arrays.asList("1", "2", "3"))

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptTypeExecutionListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/executionlistener/ScriptTypeExecutionListenerTest.java
@@ -43,6 +43,7 @@ public class ScriptTypeExecutionListenerTest extends PluggableFlowableTestCase {
                     .extracting(HistoricVariableInstance::getVariableName, HistoricVariableInstance::getValue)
                     .containsExactlyInAnyOrder(
                             tuple("varSetInScript", "yes"),
+                            tuple("groovyScriptSyntaxString", "This is a FOO and this is a BAR"),
                             tuple("myVar", "BAR")
                     );
         }

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/ScriptTaskListenerTest.java
@@ -66,7 +66,7 @@ public class ScriptTaskListenerTest extends PluggableFlowableTestCase {
     }
 
     /**
-     * Tests error trace enhacement by {@link org.flowable.engine.impl.scripting.ProcessEngineScriptTraceEnhancer} and
+     * Tests error trace enhancement by {@link org.flowable.engine.impl.scripting.ProcessEngineScriptTraceEnhancer} and
      * {@link org.flowable.engine.impl.bpmn.listener.ScriptTaskListener}
      */
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/tasklistener/TaskListenerTest.java
@@ -328,7 +328,7 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     public void testInvalidTypeEventListener() {
         assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess3"))
                 .isInstanceOf(FlowableIllegalStateException.class)
-                .hasMessageContaining("Script content is null or evaluated to null for listener of type 'script'");
+                .hasMessageContaining("The field 'script' should be set on ScriptTypeTaskListener");
     }
 
     @Test
@@ -336,7 +336,6 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
     public void testTaskListenerTypeScript() {
         Map<String, Object> vars = new HashMap<>();
         vars.put("scriptLanguageAsExpression", "groovy");
-        vars.put("scriptPayloadAsExpression", "def foo = \"usertask2ReturnVal\"; return foo");
         vars.put("resultVarAsExpression", "task2ScriptListenerResult");
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerTypeScriptProcess", vars);
         org.flowable.task.api.Task task = taskService.createTaskQuery().singleResult();
@@ -361,6 +360,9 @@ public class TaskListenerTest extends PluggableFlowableTestCase {
 
         Object scriptVar = runtimeService.getVariable(processInstance.getId(), "scriptVar");
         assertThat(scriptVar).as("Could not find the 'scriptVar' variable in variable scope").isEqualTo("scriptVarValue");
+
+        Object groovyExpressionSyntaxString = runtimeService.getVariable(processInstance.getId(), "groovyExpressionSyntaxString");
+        assertThat(groovyExpressionSyntaxString).as("Expected groovy expression syntax evaluated").isEqualTo("This is a FOO and this is a BAR");
 
         // Expect evaluation of script supports expressions for language, payload and resultVariable
         Object task2ScriptListenerResult = runtimeService.getVariable(processInstance.getId(), "task2ScriptListenerResult");

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.testThrowBpmnErrorCatchBoundaryEventSubProcessMultiInstanceSequential.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/executionlistener/ExecutionListenerTest.testThrowBpmnErrorCatchBoundaryEventSubProcessMultiInstanceSequential.bpmn20.xml
@@ -14,9 +14,9 @@
                             if(execution.getVariable('throwErrorSubProcessStartListener') != null && execution.getVariable('element') == null)
                                 throw new org.flowable.engine.delegate.BpmnError(execution.getVariable('throwErrorSubProcessStartListener'));
                              else
-                                 execution.setVariable("startProcessListener_"+execution.getVariable('element'), 'executed');
+                                 execution.setVariable("startProcessListener_${execution.getVariable('element')}", 'executed');
 
-                                  execution.getVariable("executionStack")?.add("startProcessListener_"+execution.getVariable('element'));
+                                  execution.getVariable("executionStack")?.add("startProcessListener_${execution.getVariable('element')}");
                             ]]>
                     </flowable:script>
                 </flowable:executionListener>
@@ -26,9 +26,9 @@
                             if(execution.getVariable('throwErrorSubProcessEndListener') != null && execution.getVariable('element') == null)
                                 throw new org.flowable.engine.delegate.BpmnError(execution.getVariable('throwErrorSubProcessEndListener'));
                              else
-                                 execution.setVariable("endProcessListener_"+execution.getVariable('element'), 'executed');
+                                 execution.setVariable("endProcessListener_${execution.getVariable('element')}", 'executed');
 
-                                execution.getVariable("executionStack")?.add("endProcessListener_"+execution.getVariable('element'));
+                                execution.getVariable("executionStack")?.add("endProcessListener_${execution.getVariable('element')}");
                             ]]>
                     </flowable:script>
                 </flowable:executionListener>
@@ -43,9 +43,9 @@
                             if(execution.getVariable('throwErrorSubProcessTaskStartListener') != null && "2".equals(execution.getVariable('element')))
                                 throw new org.flowable.engine.delegate.BpmnError(execution.getVariable('throwErrorSubProcessTaskStartListener'));
                              else
-                                 execution.setVariable("startListener_element_${element}", 'executed');
+                                 execution.setVariable("startListener_element_${execution.getVariable('element')}", 'executed');
 
-                                execution.getVariable("executionStack")?.add("startListener_element_"+execution.getVariable('element'));
+                                execution.getVariable("executionStack")?.add("startListener_element_${execution.getVariable('element')}");
                             ]]>
                         </flowable:script>
                     </flowable:executionListener>
@@ -55,9 +55,9 @@
                             if(execution.getVariable('throwErrorSubProcessTaskEndListener') != null && "2".equals(execution.getVariable('element')))
                                 throw new org.flowable.engine.delegate.BpmnError(execution.getVariable('throwErrorSubProcessTaskEndListener'));
                              else
-                                 execution.setVariable('endListener_element_${element}', 'executed');
+                                 execution.setVariable("endListener_element_${execution.getVariable('element')}", 'executed');
 
-                             execution.getVariable("executionStack")?.add("endListener_element_"+execution.getVariable('element'));
+                             execution.getVariable("executionStack")?.add("endListener_element_${execution.getVariable('element')}");
                             ]]>
                         </flowable:script>
                     </flowable:executionListener>
@@ -65,9 +65,9 @@
                 <script>
                     <![CDATA[
                     def element = execution.getVariable('element');
-                    execution.setVariable("element_${element}", "executed");
+                    execution.setVariable("element_${execution.getVariable('element')}", "executed");
 
-                    execution.getVariable("executionStack")?.add("element_"+execution.getVariable('element'));
+                    execution.getVariable("executionStack")?.add("element_${execution.getVariable('element')}");
                 ]]>
                 </script>
             </scriptTask>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/executionlistener/ScriptTypeExecutionListenerTest.testExecutionListener.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/executionlistener/ScriptTypeExecutionListenerTest.testExecutionListener.bpmn20.xml
@@ -13,8 +13,9 @@
                     <activiti:script language="groovy" resultVariable="myVar">
                         <![CDATA[
                         def bar = "BAR"; // local variable
-                        foo = "FOO"; // pushes variable to execution context
+                        String groovyScriptSyntaxString = "This is a FOO and this is a ${bar}"; // pushes variable to execution context
                         execution.setVariable('varSetInScript', 'yes'); // test access to execution instance
+                        execution.setVariable('groovyScriptSyntaxString', groovyScriptSyntaxString); // test access to execution instance
                         bar // implicit return value
                         ]]>
                     </activiti:script>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/executionlistener/ScriptTypeExecutionListenerTest.testThrowNonFlowableException.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/executionlistener/ScriptTypeExecutionListenerTest.testThrowNonFlowableException.bpmn20.xml
@@ -8,9 +8,8 @@
         <sequenceFlow id="flow1" name="" sourceRef="startevent1" targetRef="endevent1">
             <extensionElements>
                 <flowable:executionListener event="take" type="script">
-                    <flowable:script language="JavaScript" resultVariable="myVar">
-                            var MyError = Packages.java.lang.RuntimeException;
-                            throw new MyError("Illegal argument in listener");
+                    <flowable:script language="JavaScript" resultVariable="myVar"><![CDATA[var MyError = Packages.java.lang.RuntimeException;
+                            throw new MyError("Illegal argument in listener");]]>
                     </flowable:script>
                 </flowable:executionListener>
             </extensionElements>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/tasklistener/TaskListenerTypeScript.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/tasklistener/TaskListenerTypeScript.bpmn20.xml
@@ -11,12 +11,17 @@
             <extensionElements>
                 <flowable:taskListener event="create" type="script">
                     <flowable:script language="groovy" resultVariable="scriptResultVariable">
+                        <![CDATA[
                         def localVariable = "User Task 2 name defined in script";
-                        task.setVariable('scriptVar', "scriptVarValue"); // pushes variable to execution context
+                        def bar = "BAR";
+                        task.setVariable("scriptVar", "scriptVarValue"); // pushes variable to execution context
+                        String groovyScriptSyntaxString = "This is a FOO and this is a ${bar}";
+                        task.setVariable("groovyExpressionSyntaxString", groovyScriptSyntaxString);
                         task.setOwner("kermit"); // test access to task instance
                         task.setVariable("scriptLanguageAsExpression", "groovy");
                         taskService.saveTask(task);
-                        localVariable // implicit return
+                        localVariable; // implicit return
+                        ]]>
                     </flowable:script>
                 </flowable:taskListener>
             </extensionElements>
@@ -28,7 +33,7 @@
             <extensionElements>
                 <flowable:taskListener event="create" type="script">
                     <flowable:script language="${scriptLanguageAsExpression}" resultVariable="${resultVarAsExpression}">
-                        ${scriptPayloadAsExpression}
+                        def foo = "usertask2ReturnVal"; return foo
                     </flowable:script>
                 </flowable:taskListener>
             </extensionElements>

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -229,6 +229,11 @@
             <artifactId>reactor-netty</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithScriptRequestHandlerGroovy.bpmn20.xml
+++ b/modules/flowable-http/src/test/resources/org/flowable/http/bpmn/HttpServiceTaskTest.testGetWithScriptRequestHandlerGroovy.bpmn20.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+  <process id="simpleGetOnly" name="Simple HTTP Get process">
+    <serviceTask id="httpGet" name="HTTP Get" flowable:type="http">
+      <extensionElements>
+        <flowable:field name="requestMethod">
+          <flowable:string><![CDATA[POST]]></flowable:string>
+        </flowable:field>
+        <flowable:field name="requestUrl">
+          <flowable:string><![CDATA[http://localhost:1111/bla]]></flowable:string>
+        </flowable:field>
+        <flowable:httpRequestHandler type="script">
+          <flowable:script language="groovy" resultVariable="scriptRequestHandlerResult">
+            var originalUrl = httpRequest.getUrl();
+            httpRequest.getHttpHeaders().add('Content-Type', 'application/json');
+            httpRequest.setUrl("http://localhost:9798/test");
+            String headers = "Headers: ${httpRequest.getHttpHeaders().formatAsString()}";
+            execution.setVariable("requestHeaders", headers);
+            httpRequest.setMethod("GET");
+            execution.setVariable("originalUrl", originalUrl);
+            originalUrl;
+          </flowable:script>
+        </flowable:httpRequestHandler>
+      </extensionElements>
+    </serviceTask>
+    <startEvent id="theStart" name="Start"></startEvent>
+    <endEvent id="theEnd" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="httpGet"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="httpGet" targetRef="theEnd"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/flowable-secure-javascript/src/main/java/org/flowable/scripting/secure/listener/SecureJavascriptTaskListener.java
+++ b/modules/flowable-secure-javascript/src/main/java/org/flowable/scripting/secure/listener/SecureJavascriptTaskListener.java
@@ -26,7 +26,7 @@ public class SecureJavascriptTaskListener extends ScriptTaskListener {
     public void notify(DelegateTask delegateTask) {
         validateParameters();
         if (SecureJavascriptTaskParseHandler.LANGUAGE_JAVASCRIPT.equalsIgnoreCase(language.getValue(delegateTask).toString())) {
-            Object result = SecureJavascriptUtil.evaluateScript(delegateTask, script.getExpressionText());
+            Object result = SecureJavascriptUtil.evaluateScript(delegateTask, getScript());
             if (resultVariable != null) {
                 delegateTask.setVariable(resultVariable.getExpressionText(), result);
             }


### PR DESCRIPTION
Please note that the expression evaluation might fail, in case the script language supports expressions too in its syntax, like groovy. Therefore, it is recommended to set the script as string.