### PR TITLE
Extend error message in HistoryTestHelper with more context information

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/HistoryTestHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/HistoryTestHelper.java
@@ -95,9 +95,11 @@ public class HistoryTestHelper {
                 if (areJobsAvailable) {
                     List<HistoryJob> historyJobs = managementService.createHistoryJobQuery().list();
                     String jobData = historyJobs.stream()
-                            .map(job -> String.format("Job id=%s, handlerType=%s, retries=%d, exceptionMessage=%s", job.getId(),
-                                    job.getJobHandlerType(), job.getRetries(), job.getExceptionMessage())).collect(
-                                    Collectors.joining("\n"));
+                            .map(job -> String.format(
+                                    "Job id=%s, handlerType=%s, retries=%d, exceptionMessage=%s, handlerConfiguration=%s, advancedJobHandlerConfiguration=%s",
+                                    job.getId(), job.getJobHandlerType(), job.getRetries(), job.getExceptionMessage(), job.getJobHandlerConfiguration(),
+                                    managementService.getHistoryJobHistoryJson(job.getId())))
+                            .collect(Collectors.joining("\n"));
                     throw new FlowableException("time limit of " + maxMillisToWait + " was exceeded. Remaining, unprocessed jobs:\n" + jobData);
                 }
     

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/HistoryTestHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/HistoryTestHelper.java
@@ -13,8 +13,10 @@
 
 package org.flowable.engine.impl.test;
 
+import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.stream.Collectors;
 
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
@@ -22,6 +24,7 @@ import org.flowable.engine.ManagementService;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.test.FlowableRule;
+import org.flowable.job.api.HistoryJob;
 import org.flowable.job.service.impl.asyncexecutor.AsyncExecutor;
 
 /**
@@ -33,7 +36,7 @@ public class HistoryTestHelper {
     public static boolean isHistoryLevelAtLeast(HistoryLevel historyLevel, ProcessEngineConfigurationImpl processEngineConfiguration) {
         return isHistoryLevelAtLeast(historyLevel, processEngineConfiguration, 20000);
     }
-    
+
     public static boolean isHistoryLevelAtLeast(HistoryLevel historyLevel, ProcessEngineConfigurationImpl processEngineConfiguration, long time) {
         if (processEngineConfiguration.getHistoryLevel().isAtLeast(historyLevel)) {
             
@@ -90,7 +93,12 @@ public class HistoryTestHelper {
                     timer.cancel();
                 }
                 if (areJobsAvailable) {
-                    throw new FlowableException("time limit of " + maxMillisToWait + " was exceeded");
+                    List<HistoryJob> historyJobs = managementService.createHistoryJobQuery().list();
+                    String jobData = historyJobs.stream()
+                            .map(job -> String.format("Job id=%s, handlerType=%s, retries=%d, exceptionMessage=%s", job.getId(),
+                                    job.getJobHandlerType(), job.getRetries(), job.getExceptionMessage())).collect(
+                                    Collectors.joining("\n"));
+                    throw new FlowableException("time limit of " + maxMillisToWait + " was exceeded. Remaining, unprocessed jobs:\n" + jobData);
                 }
     
             } finally {


### PR DESCRIPTION
* Makes it a lot clearer why a test failed.

