### PR TITLE
Allow registration of custom my batis mappers through any engine configuration

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/resources/mappers/CustomMybatisBpmnXmlMapper.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/resources/mappers/CustomMybatisBpmnXmlMapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.flowable.CustomMybatisBpmnMapper">
+
+    <select id="customSelectProcessDefinitionDeploymentIdByKey" parameterType="String" resultType="String">
+        SELECT DEPLOYMENT_ID_ FROM ACT_RE_PROCDEF WHERE KEY_ = #{value}
+    </select>
+
+</mapper>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/resources/mappers/CustomMybatisCmmnXmlMapper.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/resources/mappers/CustomMybatisCmmnXmlMapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.flowable.CustomMybatisCmmnMapper">
+
+    <select id="customSelectCaseDefinitionDeploymentIdByKey" parameterType="String" resultType="String">
+        SELECT DEPLOYMENT_ID_ FROM ACT_CMMN_CASEDEF WHERE KEY_ = #{value}
+    </select>
+
+</mapper>


### PR DESCRIPTION

Prior to this change a custom my batis mapper was supposed to be added to the lead engine. However, with this we can now easily register custom mappers with any engine and they will be automatically registered with the lead engine.

#### Check List:
* Unit tests: YES 
* Documentation:  NA
