### PR TITLE
fix: do not attempt to delete entity if not found

### DIFF
--- a/ide-settings/eclipse/Preferences-Java-CodeStyle-OrganizeImports.importorder
+++ b/ide-settings/eclipse/Preferences-Java-CodeStyle-OrganizeImports.importorder
@@ -1,0 +1,9 @@
+#Organize Import Order
+#Tue Nov 15 14:50:24 EET 2022
+0=\#
+1=java
+2=javax
+3=org
+4=com
+5=liquibase
+6=

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/AbstractDataManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/AbstractDataManager.java
@@ -90,7 +90,9 @@ public abstract class AbstractDataManager<EntityImpl extends Entity> implements 
     @Override
     public void delete(String id) {
         EntityImpl entity = findById(id);
-        delete(entity);
+        if (entity != null) {
+            delete(entity);
+        }
     }
 
     @Override

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/persistence/entity/AbstractEntityManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/persistence/entity/AbstractEntityManager.java
@@ -92,7 +92,9 @@ public abstract class AbstractEntityManager<EntityImpl extends Entity, DM extend
     @Override
     public void delete(String id) {
         EntityImpl entity = findById(id);
-        delete(entity);
+        if (entity != null) {
+            delete(entity);
+        }
     }
 
     @Override


### PR DESCRIPTION
When deleting an entity with ID, it is entirely possible that the entity does not exist. In such cases, do not attempt to delete it as that will cause a NPE in DbSqlSession.
