### PR TITLE
fix: NPE fix when signal not found from model

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/SignalEventDefinitionParseHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/SignalEventDefinitionParseHandler.java
@@ -33,10 +33,7 @@ public class SignalEventDefinitionParseHandler extends AbstractBpmnParseHandler<
     @Override
     protected void executeParse(BpmnParse bpmnParse, SignalEventDefinition signalDefinition) {
 
-        Signal signal = null;
-        if (bpmnParse.getBpmnModel().containsSignalId(signalDefinition.getSignalRef())) {
-            signal = bpmnParse.getBpmnModel().getSignal(signalDefinition.getSignalRef());
-        }
+        Signal signal = bpmnParse.getBpmnModel().getSignal(signalDefinition.getSignalRef());
 
         if (bpmnParse.getCurrentFlowElement() instanceof IntermediateCatchEvent) {
             IntermediateCatchEvent intermediateCatchEvent = (IntermediateCatchEvent) bpmnParse.getCurrentFlowElement();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/StartEventParseHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/parser/handler/StartEventParseHandler.java
@@ -55,10 +55,7 @@ public class StartEventParseHandler extends AbstractActivityBpmnParseHandler<Sta
 
                 } else if (eventDefinition instanceof SignalEventDefinition) {
                     SignalEventDefinition signalDefinition = (SignalEventDefinition) eventDefinition;
-                    Signal signal = null;
-                    if (bpmnParse.getBpmnModel().containsSignalId(signalDefinition.getSignalRef())) {
-                        signal = bpmnParse.getBpmnModel().getSignal(signalDefinition.getSignalRef());
-                    }
+                    Signal signal = bpmnParse.getBpmnModel().getSignal(signalDefinition.getSignalRef());
 
                     element.setBehavior(bpmnParse.getActivityBehaviorFactory().createEventSubProcessSignalStartEventActivityBehavior(
                             element, signalDefinition, signal));

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -1196,9 +1196,8 @@ public abstract class AbstractDynamicStateManager {
                     if (eventDefinition instanceof SignalEventDefinition && (eventSubscriptions == null || eventSubscriptions.isEmpty())) {
                         SignalEventDefinition signalEventDefinition = (SignalEventDefinition) eventDefinition;
                         BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(eventSubProcessExecution.getProcessDefinitionId());
-                        Signal signal = null;
-                        if (bpmnModel.containsSignalId(signalEventDefinition.getSignalRef())) {
-                            signal = bpmnModel.getSignal(signalEventDefinition.getSignalRef());
+                        Signal signal = bpmnModel.getSignal(signalEventDefinition.getSignalRef());
+                        if (signal != null) {
                             signalEventDefinition.setSignalRef(signal.getName());
                         }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessInstanceHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessInstanceHelper.java
@@ -12,13 +12,13 @@
  */
 package org.flowable.engine.impl.util;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.constants.BpmnXMLConstants;
 import org.flowable.bpmn.model.BpmnModel;
@@ -64,8 +64,6 @@ import org.flowable.eventsubscription.service.impl.persistence.entity.MessageEve
 import org.flowable.eventsubscription.service.impl.persistence.entity.SignalEventSubscriptionEntity;
 import org.flowable.identitylink.api.IdentityLinkType;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tijs Rademakers
@@ -436,9 +434,8 @@ public class ProcessInstanceHelper {
         
         SignalEventDefinition signalEventDefinition = (SignalEventDefinition) eventDefinition;
         BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(parentExecution.getProcessDefinitionId());
-        Signal signal = null;
-        if (bpmnModel.containsSignalId(signalEventDefinition.getSignalRef())) {
-            signal = bpmnModel.getSignal(signalEventDefinition.getSignalRef());
+        Signal signal = bpmnModel.getSignal(signalEventDefinition.getSignalRef());
+        if (signal != null) {
             signalEventDefinition.setSignalRef(signal.getName());
         }
 
@@ -544,5 +541,5 @@ public class ProcessInstanceHelper {
             }
         }
     }
-    
+
 }


### PR DESCRIPTION
In some rare cases the BpmnModel can change between the call to "containsSignalId" and the call to get the signal, causing an NPE if the signal was no longer available on the model.

Due to the way containsSignalId is implemented, the call to it is entirely unnecessary in these cases.
