### PR TITLE
Upgrade to Spring Framework 5.3.24 and Spring Security 5.8.0

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -136,22 +136,22 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
 org.slf4j                       slf4j-api                   1.7.36          MIT License
 org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.23          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.23          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.7.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.7.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.7.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.7.5           The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.24          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.24          The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.8.0           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.8.0           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.8.0           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.8.0           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.7.5</spring.boot.version>
-		<spring.framework.version>5.3.23</spring.framework.version>
-		<spring.security.version>5.7.5</spring.security.version>
+		<spring.framework.version>5.3.24</spring.framework.version>
+		<spring.security.version>5.8.0</spring.security.version>
 		<spring.amqp.version>2.4.7</spring.amqp.version>
 		<spring.kafka.version>2.8.10</spring.kafka.version>
-		<reactor-netty.version>1.0.20</reactor-netty.version>
+		<reactor-netty.version>1.0.25</reactor-netty.version>
 		<jackson.version>2.13.4.20221013</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
@@ -800,7 +800,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.6.12.Final</version>
+				<version>5.6.14.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>
@@ -1011,7 +1011,7 @@
 			<dependency>
 				<groupId>org.hsqldb</groupId>
 				<artifactId>hsqldb</artifactId>
-				<version>2.3.2</version>
+				<version>2.7.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Spring Security Release Notes: https://github.com/spring-projects/spring-security/releases/tag/5.8.0
Spring Framework Release Notes: https://github.com/spring-projects/spring-framework/releases/tag/v5.3.24

Ran: `mvn clean test` without issue locally

Note that the biggest change is in the versioning of **hsqldb**: from 2.3.2 to 2.7.1

This PR supersedes https://github.com/flowable/flowable-engine/pull/3529