### PR TITLE
Replace AdoptOpenJDK info with Eclipse Adoptium

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The distribution contains most of the sources as jar files. The source code of F
 
 ### JDK 8+
 
-Flowable runs on a JDK higher than or equal to version 8. Use the JDK packaged with your Linux distribution or go to https://adoptopenjdk.net and click on button "Latest release". There are installation instructions on that page as well. To verify that your installation was successful, run "java -version" on the command line.  That should print the installed version of your JDK.
+Flowable runs on a JDK higher than or equal to version 8. Use the JDK packaged with your Linux distribution or go to [adoptium.net](https://adoptium.net/) and click on the *Latest LTS Release* button. There are installation instructions on that page as well. To verify that your installation was successful, run `java -version` on the command line. That should print the installed version of your JDK.
 
 ### Contributing
 


### PR DESCRIPTION
AdoptOpenJDK was succeeded by Eclipse Adoptium in July 2021.

https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/

#### Check List:
* Unit tests: NA
* Documentation: NA
