### PR TITLE
Make sure that Parallel multi instance local variables are properly transformed

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -337,6 +337,13 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
     
     @Override
     public void interrupted(DelegateExecution execution) {
+        if (execution.isMultiInstanceRoot()) {
+            // We are only performing the interrupt logic for multi instance root executions
+            internalInterrupted(execution);
+        }
+    }
+
+    protected void internalInterrupted(DelegateExecution execution) {
         if (hasVariableAggregationDefinitions(execution)) {
             Map<String, VariableAggregationDefinition> aggregationsByTarget = groupAggregationsByTarget(execution, aggregations.getOverviewAggregations(),
                     CommandContextUtil.getProcessEngineConfiguration());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
@@ -399,4 +399,14 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
 
         parentScopeExecution.forceUpdate();
     }
+
+    @Override
+    protected void internalInterrupted(DelegateExecution execution) {
+        // When the activity is interrupted we need to update the number of completed / active instances
+        // to only be primitive values based on their current values
+        setLoopVariable(execution, NUMBER_OF_COMPLETED_INSTANCES, getLoopVariable(execution, NUMBER_OF_COMPLETED_INSTANCES));
+        setLoopVariable(execution, NUMBER_OF_ACTIVE_INSTANCES, getLoopVariable(execution, NUMBER_OF_ACTIVE_INSTANCES));
+
+        super.internalInterrupted(execution);
+    }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -43,6 +43,7 @@ import org.flowable.engine.impl.ExecutionQueryImpl;
 import org.flowable.engine.impl.ProcessInstanceQueryImpl;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.flowable.engine.impl.cmmn.CaseInstanceService;
+import org.flowable.engine.impl.delegate.InterruptibleActivityBehaviour;
 import org.flowable.engine.impl.delegate.SubProcessActivityBehavior;
 import org.flowable.engine.impl.history.HistoryManager;
 import org.flowable.engine.impl.persistence.CountingExecutionEntity;
@@ -483,6 +484,16 @@ public class ExecutionEntityManagerImpl
 
         List<ExecutionEntity> childExecutions = collectChildren(execution.getProcessInstance());
         for (ExecutionEntity subExecutionEntity : childExecutions) {
+            // We are treating the deletion of a process instance similar to an interruption
+            // The reason for that is that there might be variables that have to be persisted differently
+            // i.e. nrOfCompletedInstances / nrOfActiveInstance or variable aggregations
+            FlowElement subExecutionFlowElement = subExecutionEntity.getCurrentFlowElement();
+            if (subExecutionFlowElement instanceof FlowNode) {
+                Object behavior = ((FlowNode) subExecutionFlowElement).getBehavior();
+                if (behavior instanceof InterruptibleActivityBehaviour) {
+                    ((InterruptibleActivityBehaviour) behavior).interrupted(subExecutionEntity);
+                }
+            }
             if (subExecutionEntity.isMultiInstanceRoot()) {
                 for (ExecutionEntity miExecutionEntity : subExecutionEntity.getExecutions()) {
                     if (miExecutionEntity.getSubProcessInstance() != null) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/MybatisHistoricDetailDataManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/MybatisHistoricDetailDataManager.java
@@ -12,10 +12,12 @@
  */
 package org.flowable.engine.impl.persistence.entity.data.impl;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.flowable.common.engine.impl.persistence.cache.CachedEntityMatcher;
 import org.flowable.engine.history.HistoricDetail;
 import org.flowable.engine.impl.HistoricDetailQueryImpl;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -29,11 +31,25 @@ import org.flowable.engine.impl.persistence.entity.HistoricFormPropertyEntity;
 import org.flowable.engine.impl.persistence.entity.HistoricFormPropertyEntityImpl;
 import org.flowable.engine.impl.persistence.entity.data.AbstractProcessDataManager;
 import org.flowable.engine.impl.persistence.entity.data.HistoricDetailDataManager;
+import org.flowable.engine.impl.persistence.entity.data.impl.cachematcher.HistoricDetailsByProcessInstanceIdEntityMatcher;
+import org.flowable.engine.impl.persistence.entity.data.impl.cachematcher.HistoricDetailsByTaskInstanceIdEntityMatcher;
 
 /**
  * @author Joram Barrez
  */
 public class MybatisHistoricDetailDataManager extends AbstractProcessDataManager<HistoricDetailEntity> implements HistoricDetailDataManager {
+
+    private static final List<Class<? extends HistoricDetailEntity>> ENTITY_SUBCLASSES = Arrays.asList(
+            HistoricDetailVariableInstanceUpdateEntityImpl.class,
+            HistoricFormPropertyEntityImpl.class,
+            HistoricDetailAssignmentEntityImpl.class
+    );
+
+    protected CachedEntityMatcher<HistoricDetailEntity> historicDetailsByProcessInstanceIdEntityMatcher
+            = new HistoricDetailsByProcessInstanceIdEntityMatcher();
+
+    protected CachedEntityMatcher<HistoricDetailEntity> historicDetailsByTaskIdEntityMatcher
+            = new HistoricDetailsByTaskInstanceIdEntityMatcher();
 
     public MybatisHistoricDetailDataManager(ProcessEngineConfigurationImpl processEngineConfiguration) {
         super(processEngineConfiguration);
@@ -42,6 +58,11 @@ public class MybatisHistoricDetailDataManager extends AbstractProcessDataManager
     @Override
     public Class<? extends HistoricDetailEntity> getManagedEntityClass() {
         return HistoricDetailEntityImpl.class;
+    }
+
+    @Override
+    public List<Class<? extends HistoricDetailEntity>> getManagedEntitySubClasses() {
+        return ENTITY_SUBCLASSES;
     }
 
     @Override
@@ -68,13 +89,13 @@ public class MybatisHistoricDetailDataManager extends AbstractProcessDataManager
     @Override
     @SuppressWarnings("unchecked")
     public List<HistoricDetailEntity> findHistoricDetailsByProcessInstanceId(String processInstanceId) {
-        return getDbSqlSession().selectList("selectHistoricDetailByProcessInstanceId", processInstanceId);
+        return getList("selectHistoricDetailByProcessInstanceId", processInstanceId, historicDetailsByProcessInstanceIdEntityMatcher);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public List<HistoricDetailEntity> findHistoricDetailsByTaskId(String taskId) {
-        return getDbSqlSession().selectList("selectHistoricDetailByTaskId", taskId);
+        return getList("selectHistoricDetailByTaskId", taskId, historicDetailsByTaskIdEntityMatcher);
     }
 
     @Override

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/HistoricDetailsByProcessInstanceIdEntityMatcher.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/HistoricDetailsByProcessInstanceIdEntityMatcher.java
@@ -1,0 +1,30 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.persistence.entity.data.impl.cachematcher;
+
+import org.flowable.common.engine.impl.persistence.cache.CachedEntityMatcherAdapter;
+import org.flowable.engine.impl.persistence.entity.HistoricDetailEntity;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class HistoricDetailsByProcessInstanceIdEntityMatcher extends CachedEntityMatcherAdapter<HistoricDetailEntity> {
+
+    @Override
+    public boolean isRetained(HistoricDetailEntity entity, Object parameter) {
+        // parameter = process instance execution id
+        return entity.getProcessInstanceId() != null
+                && entity.getProcessInstanceId().equals(parameter);
+    }
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/HistoricDetailsByTaskInstanceIdEntityMatcher.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/data/impl/cachematcher/HistoricDetailsByTaskInstanceIdEntityMatcher.java
@@ -1,0 +1,30 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.impl.persistence.entity.data.impl.cachematcher;
+
+import org.flowable.common.engine.impl.persistence.cache.CachedEntityMatcherAdapter;
+import org.flowable.engine.impl.persistence.entity.HistoricDetailEntity;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class HistoricDetailsByTaskInstanceIdEntityMatcher extends CachedEntityMatcherAdapter<HistoricDetailEntity> {
+
+    @Override
+    public boolean isRetained(HistoricDetailEntity entity, Object parameter) {
+        // parameter = task id
+        return entity.getTaskId() != null
+                && entity.getTaskId().equals(parameter);
+    }
+
+}

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testLoopVariablesWithBoundaryOnSubprocess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testLoopVariablesWithBoundaryOnSubprocess.bpmn20.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:design="http://flowable.org/design" typeLanguage="http://www.w3.org/2001/XMLSchema"
+             expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/processdef" design:palette="flowable-process-palette">
+    <signal id="cancelSubProcess" name="cancelSubProcess" flowable:scope="global"/>
+    <process id="ModelWithSubProcess" name="ModelWithSubProcess" isExecutable="true">
+        <startEvent id="startEvent1"/>
+        <sequenceFlow id="sequenceFlow1" sourceRef="startEvent1" targetRef="subProcess1"/>
+        <subProcess id="subProcess1" name="sub process">
+            <multiInstanceLoopCharacteristics isSequential="false">
+                <loopCardinality>3</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+            <startEvent id="subProcessStart"/>
+            <userTask id="userTask1" name="Task #${loopCounter}"/>
+            <endEvent id="subProcessEnd"/>
+            <sequenceFlow id="sequenceFlow2" sourceRef="subProcessStart" targetRef="userTask1"/>
+            <sequenceFlow id="sequenceFlow3" sourceRef="userTask1" targetRef="subProcessEnd"/>
+        </subProcess>
+        <endEvent id="end1"/>
+        <sequenceFlow id="sequenceFlow4" sourceRef="subProcess1" targetRef="end1"/>
+        <boundaryEvent id="intermediateSignalEventBoundary1" attachedToRef="subProcess1" cancelActivity="true">
+            <signalEventDefinition signalRef="cancelSubProcess"/>
+        </boundaryEvent>
+        <userTask id="formTask2" name="Cancelled Sub Process"/>
+        <sequenceFlow id="sequenceFlow5" sourceRef="intermediateSignalEventBoundary1" targetRef="formTask2"/>
+        <endEvent id="endNoneEvent3"/>
+        <sequenceFlow id="sequenceFlow6" sourceRef="formTask2" targetRef="endNoneEvent3"/>
+    </process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_ModelWithSubProcess">
+        <bpmndi:BPMNPlane bpmnElement="ModelWithSubProcess" id="BPMNPlane_ModelWithSubProcess">
+            <bpmndi:BPMNShape bpmnElement="startEvent1" id="BPMNShape_startEvent1">
+                <omgdc:Bounds height="30.0" width="30.0" x="100.0" y="163.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="subProcess1" id="BPMNShape_subProcess1">
+                <omgdc:Bounds height="228.0" width="357.0" x="233.0" y="64.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="subProcessStart" id="BPMNShape_subProcessStart">
+                <omgdc:Bounds height="30.0" width="30.0" x="263.0" y="164.5"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+                <omgdc:Bounds height="80.0" width="100.0" x="341.0" y="139.5"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="subProcessEnd" id="BPMNShape_subProcessEnd">
+                <omgdc:Bounds height="28.0" width="28.0" x="540.0" y="164.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="end1" id="BPMNShape_end1">
+                <omgdc:Bounds height="28.0" width="28.0" x="638.0" y="164.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="intermediateSignalEventBoundary1" id="BPMNShape_intermediateSignalEventBoundary1">
+                <omgdc:Bounds height="30.0" width="30.0" x="320.0" y="277.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="formTask2" id="BPMNShape_formTask2">
+                <omgdc:Bounds height="80.0" width="100.0" x="285.0" y="391.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="endNoneEvent3" id="BPMNShape_endNoneEvent3">
+                <omgdc:Bounds height="28.0" width="28.0" x="430.0" y="417.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow5" id="BPMNEdge_sequenceFlow5" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0"
+                             flowable:targetDockerX="50.0" flowable:targetDockerY="40.0">
+                <omgdi:waypoint x="335.0" y="306.94999905419866"/>
+                <omgdi:waypoint x="335.0" y="391.0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow6" id="BPMNEdge_sequenceFlow6" flowable:sourceDockerX="50.0" flowable:sourceDockerY="40.0"
+                             flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+                <omgdi:waypoint x="384.94999999981" y="431.0"/>
+                <omgdi:waypoint x="430.0" y="431.0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow3" id="BPMNEdge_sequenceFlow3" flowable:sourceDockerX="50.0" flowable:sourceDockerY="40.0"
+                             flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+                <omgdi:waypoint x="440.95000000000005" y="179.03987730061348"/>
+                <omgdi:waypoint x="540.0005763491032" y="178.12836940443208"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow4" id="BPMNEdge_sequenceFlow4" flowable:sourceDockerX="178.5" flowable:sourceDockerY="114.0"
+                             flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+                <omgdi:waypoint x="589.95" y="178.0"/>
+                <omgdi:waypoint x="638.0" y="178.0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow1" id="BPMNEdge_sequenceFlow1" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0"
+                             flowable:targetDockerX="178.5" flowable:targetDockerY="114.0">
+                <omgdi:waypoint x="129.94999979204067" y="178.0"/>
+                <omgdi:waypoint x="233.0" y="178.0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow2" id="BPMNEdge_sequenceFlow2" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0"
+                             flowable:targetDockerX="50.0" flowable:targetDockerY="40.0">
+                <omgdi:waypoint x="292.9499985690373" y="179.5"/>
+                <omgdi:waypoint x="341.0" y="179.5"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testLoopVariablesWithSubprocessWhenProcessIsDeleted.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/multiinstance/MultiInstanceTest.testLoopVariablesWithSubprocessWhenProcessIsDeleted.bpmn20.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:flowable="http://flowable.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:design="http://flowable.org/design" typeLanguage="http://www.w3.org/2001/XMLSchema"
+             expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.flowable.org/processdef" design:palette="flowable-process-palette">
+    <process id="ModelWithSubProcess" name="ModelWithSubProcess" isExecutable="true">
+        <startEvent id="startEvent1"/>
+        <sequenceFlow id="sequenceFlow1" sourceRef="startEvent1" targetRef="subProcess1"/>
+        <subProcess id="subProcess1" name="sub process">
+            <multiInstanceLoopCharacteristics isSequential="false" flowable:elementVariable="item">
+                <loopCardinality>3</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+            <startEvent id="subProcessStart" flowable:formFieldValidation="true"/>
+            <userTask id="userTask1" name="Task #${loopCounter}"/>
+            <endEvent id="subProcessEnd"/>
+            <sequenceFlow id="sequenceFlow2" sourceRef="subProcessStart" targetRef="userTask1"/>
+            <sequenceFlow id="sequenceFlow3" sourceRef="userTask1" targetRef="subProcessEnd"/>
+        </subProcess>
+        <endEvent id="end1"/>
+        <sequenceFlow id="sequenceFlow4" sourceRef="subProcess1" targetRef="end1"/>
+    </process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_ModelWithSubProcess">
+        <bpmndi:BPMNPlane bpmnElement="ModelWithSubProcess" id="BPMNPlane_ModelWithSubProcess">
+            <bpmndi:BPMNShape bpmnElement="startEvent1" id="BPMNShape_startEvent1">
+                <omgdc:Bounds height="30.0" width="30.0" x="100.0" y="163.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="subProcess1" id="BPMNShape_subProcess1">
+                <omgdc:Bounds height="228.0" width="357.0" x="233.0" y="64.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="subProcessStart" id="BPMNShape_subProcessStart">
+                <omgdc:Bounds height="30.0" width="30.0" x="263.0" y="164.5"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+                <omgdc:Bounds height="80.0" width="100.0" x="341.0" y="139.5"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="subProcessEnd" id="BPMNShape_subProcessEnd">
+                <omgdc:Bounds height="28.0" width="28.0" x="540.0" y="164.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="end1" id="BPMNShape_end1">
+                <omgdc:Bounds height="28.0" width="28.0" x="638.0" y="164.0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow3" id="BPMNEdge_sequenceFlow3" flowable:sourceDockerX="50.0" flowable:sourceDockerY="40.0"
+                             flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+                <omgdi:waypoint x="440.95000000000005" y="179.03987730061348"/>
+                <omgdi:waypoint x="540.0005763491032" y="178.12836940443208"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow4" id="BPMNEdge_sequenceFlow4" flowable:sourceDockerX="178.5" flowable:sourceDockerY="114.0"
+                             flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+                <omgdi:waypoint x="589.95" y="178.0"/>
+                <omgdi:waypoint x="638.0" y="178.0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow1" id="BPMNEdge_sequenceFlow1" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0"
+                             flowable:targetDockerX="178.5" flowable:targetDockerY="114.0">
+                <omgdi:waypoint x="129.94999979204067" y="178.0"/>
+                <omgdi:waypoint x="233.0" y="178.0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow2" id="BPMNEdge_sequenceFlow2" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0"
+                             flowable:targetDockerX="50.0" flowable:targetDockerY="40.0">
+                <omgdi:waypoint x="292.9499985690373" y="179.5"/>
+                <omgdi:waypoint x="341.0" y="179.5"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
When a parallel multi instance execution is interrupted or deleted then we need to transform the temporary runtime variables into permanent historic variables

fixes #3536

#### Check List:
* Unit tests: YES
* Documentation: NA
