### PR TITLE
feature: request body for HTTP DELETE

### DIFF
--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/ApacheHttpComponentsFlowableHttpClient.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/ApacheHttpComponentsFlowableHttpClient.java
@@ -32,7 +32,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPatch;
@@ -178,7 +177,9 @@ public class ApacheHttpComponentsFlowableHttpClient implements FlowableHttpClien
                     break;
                 }
                 case "DELETE": {
-                    request = new HttpDelete(uri);
+                    HttpDeleteWithBody delete = new HttpDeleteWithBody(uri);
+                    setRequestEntity(requestInfo, delete);
+                    request = delete;
                     break;
                 }
                 default: {
@@ -375,6 +376,24 @@ public class ApacheHttpComponentsFlowableHttpClient implements FlowableHttpClien
             } catch (IOException ex) {
                 throw new FlowableException("IO exception occurred", ex);
             }
+        }
+    }
+    
+    /**
+     * A HttpDelete alternative that extends {@link HttpEntityEnclosingRequestBase} to allow DELETE with a request body
+     * 
+     * @author ikaakkola
+     */
+    protected static class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
+
+        public HttpDeleteWithBody(URI uri) {
+            super();
+            setURI(uri);
+        }
+
+        @Override
+        public String getMethod() {
+            return "DELETE";
         }
     }
 }

--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/client5/ApacheHttpComponents5FlowableHttpClient.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/client5/ApacheHttpComponents5FlowableHttpClient.java
@@ -170,6 +170,7 @@ public class ApacheHttpComponents5FlowableHttpClient implements FlowableAsyncHtt
                 }
                 case "DELETE": {
                     request = AsyncRequestBuilder.delete(uri);
+                    setRequestEntity(requestInfo,request);
                     break;
                 }
                 default: {

--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/client5/ApacheHttpComponents5FlowableHttpClient.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/client5/ApacheHttpComponents5FlowableHttpClient.java
@@ -170,7 +170,7 @@ public class ApacheHttpComponents5FlowableHttpClient implements FlowableAsyncHtt
                 }
                 case "DELETE": {
                     request = AsyncRequestBuilder.delete(uri);
-                    setRequestEntity(requestInfo,request);
+                    setRequestEntity(requestInfo, request);
                     break;
                 }
                 default: {

--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/spring/reactive/SpringWebClientFlowableHttpClient.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/spring/reactive/SpringWebClientFlowableHttpClient.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.MultipartBodyBuilder;
@@ -131,7 +132,9 @@ public class SpringWebClientFlowableHttpClient implements FlowableAsyncHttpClien
                     break;
                 }
                 case "DELETE": {
-                    headersSpec = webClient.delete().uri(uri);
+                    WebClient.RequestBodySpec delete = webClient.method(HttpMethod.DELETE).uri(uri);
+                    setRequestEntity(requestInfo, delete);
+                    headersSpec = delete;
                     break;
                 }
                 default: {

--- a/modules/flowable-http/src/test/java/org/flowable/http/FlowableHttpClientArgumentProvider.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/FlowableHttpClientArgumentProvider.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import org.flowable.http.common.impl.HttpClientConfig;
 import org.flowable.http.common.impl.apache.ApacheHttpComponentsFlowableHttpClient;
+import org.flowable.http.common.impl.apache.client5.ApacheHttpComponents5FlowableHttpClient;
 import org.flowable.http.common.impl.spring.reactive.SpringWebClientFlowableHttpClient;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -32,7 +33,8 @@ public class FlowableHttpClientArgumentProvider implements ArgumentsProvider {
         HttpClientConfig config = createClientConfig();
         return Stream.of(
                 Arguments.of(new SpringWebClientFlowableHttpClient(config)),
-                Arguments.of(new ApacheHttpComponentsFlowableHttpClient(config))
+                Arguments.of(new ApacheHttpComponentsFlowableHttpClient(config)),
+                Arguments.of(new ApacheHttpComponents5FlowableHttpClient(config))
         );
     }
 

--- a/modules/flowable-http/src/test/java/org/flowable/http/FlowableHttpClientTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/FlowableHttpClientTest.java
@@ -157,4 +157,41 @@ class FlowableHttpClientTest {
                 .containsExactly("application/json");
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(FlowableHttpClientArgumentProvider.class)
+    void deleteWithoutBody(FlowableHttpClient httpClient) {
+        HttpRequest request = new HttpRequest();
+        request.setUrl("http://localhost:9798/api/test");
+        request.setMethod("DELETE");
+        HttpResponse response = httpClient.prepareRequest(request).call();
+        assertThatJson(response.getBody())
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  url: 'http://localhost:9798/api/test',"
+                        + "  body: \"\""
+                        + "}");
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getHttpHeaders().get("Content-Type"))
+                .containsExactly("application/json");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FlowableHttpClientArgumentProvider.class)
+    void deleteWithBody(FlowableHttpClient httpClient) {
+        HttpRequest request = new HttpRequest();
+        request.setUrl("http://localhost:9798/api/test");
+        request.setMethod("DELETE");
+        request.setBody("{ body: 'kermit' }");
+        HttpResponse response = httpClient.prepareRequest(request).call();
+        assertThatJson(response.getBody())
+                .when(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo("{"
+                        + "  url: 'http://localhost:9798/api/test',"
+                        + "  body: \"{ body: 'kermit' }\""
+                        + "}");
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getHttpHeaders().get("Content-Type"))
+                .containsExactly("application/json");
+    }
+
 }


### PR DESCRIPTION
Added support for optional request body to the DELETE operation.

Added tests for http DELETE requests with and without body

#### Check List:
* Unit tests: YES
* Documentation: NA
