### PR TITLE
other: Eclipse organize imports order

### DIFF
--- a/ide-settings/eclipse/Preferences-Java-CodeStyle-OrganizeImports.importorder
+++ b/ide-settings/eclipse/Preferences-Java-CodeStyle-OrganizeImports.importorder
@@ -1,0 +1,9 @@
+#Organize Import Order
+#Tue Nov 15 14:50:24 EET 2022
+0=\#
+1=java
+2=javax
+3=org
+4=com
+5=liquibase
+6=


### PR DESCRIPTION
Eclipse preferences to order imports in same way as the IntelliJ settings do.

#### Check List:
* Unit tests: NA
* Documentation: NA
