### PR TITLE
Add ability to store completer of HumanTasks and UserTasks in a variable

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
@@ -228,6 +228,7 @@ public interface BpmnXMLConstants {
     public static final String ATTRIBUTE_TASK_USER_PRIORITY = "priority";
     public static final String ATTRIBUTE_TASK_USER_SKIP_EXPRESSION = "skipExpression";
     public static final String ATTRIBUTE_TASK_ID_VARIABLE_NAME = "taskIdVariableName";
+    public static final String ATTRIBUTE_TASK_COMPLETER_VARIABLE_NAME = "taskCompleterVariableName";
 
     public static final String ATTRIBUTE_TASK_RULE_VARIABLES_INPUT = "ruleVariablesInput";
     public static final String ATTRIBUTE_TASK_RULE_RESULT_VARIABLE = "resultVariable";
@@ -341,7 +342,7 @@ public interface BpmnXMLConstants {
     public static final String ELEMENT_EVENT_CORRELATION_PARAMETER = "eventCorrelationParameter";
     public static final String ELEMENT_EVENT_IN_PARAMETER = "eventInParameter";
     public static final String ELEMENT_EVENT_OUT_PARAMETER = "eventOutParameter";
-    
+
     public static final String ELEMENT_EVENT_VARIABLELISTENERDEFINITION = "variableListenerEventDefinition";
     public static final String ATTRIBUTE_VARIABLE_NAME = "variableName";
     public static final String ATTRIBUTE_VARIABLE_CHANGE_TYPE = "variableChangeType";

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/UserTaskXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/UserTaskXMLConverter.java
@@ -57,7 +57,8 @@ public class UserTaskXMLConverter extends BaseBpmnXMLConverter {
             new ExtensionAttribute(ATTRIBUTE_FORM_FIELD_VALIDATION),
             new ExtensionAttribute(ATTRIBUTE_TASK_SERVICE_EXTENSIONID),
             new ExtensionAttribute(ATTRIBUTE_TASK_USER_SKIP_EXPRESSION),
-            new ExtensionAttribute(ATTRIBUTE_TASK_ID_VARIABLE_NAME));
+            new ExtensionAttribute(ATTRIBUTE_TASK_ID_VARIABLE_NAME),
+            new ExtensionAttribute(ATTRIBUTE_TASK_COMPLETER_VARIABLE_NAME));
 
     public UserTaskXMLConverter() {
         HumanPerformerParser humanPerformerParser = new HumanPerformerParser();
@@ -102,6 +103,7 @@ public class UserTaskXMLConverter extends BaseBpmnXMLConverter {
         userTask.setOwner(BpmnXMLUtil.getAttributeValue(ATTRIBUTE_TASK_USER_OWNER, xtr));
         userTask.setPriority(BpmnXMLUtil.getAttributeValue(ATTRIBUTE_TASK_USER_PRIORITY, xtr));
         userTask.setTaskIdVariableName(BpmnXMLUtil.getAttributeValue(ATTRIBUTE_TASK_ID_VARIABLE_NAME, xtr));
+        userTask.setTaskCompleterVariableName(BpmnXMLUtil.getAttributeValue(ATTRIBUTE_TASK_COMPLETER_VARIABLE_NAME, xtr));
 
         String sameDeploymentAttribute = BpmnXMLUtil.getAttributeValue(ATTRIBUTE_SAME_DEPLOYMENT, xtr);
         if (ATTRIBUTE_VALUE_FALSE.equalsIgnoreCase(sameDeploymentAttribute)) {
@@ -161,6 +163,9 @@ public class UserTaskXMLConverter extends BaseBpmnXMLConverter {
         }
         if (userTask.getTaskIdVariableName() != null) {
             writeQualifiedAttribute(ATTRIBUTE_TASK_ID_VARIABLE_NAME, userTask.getTaskIdVariableName(), xtw);
+        }
+        if (userTask.getTaskCompleterVariableName() != null) {
+            writeQualifiedAttribute(ATTRIBUTE_TASK_COMPLETER_VARIABLE_NAME, userTask.getTaskCompleterVariableName(), xtw);
         }
         // write custom attributes
         BpmnXMLUtil.writeCustomAttributes(userTask.getAttributes().values(), xtw, defaultElementAttributes,

--- a/modules/flowable-bpmn-converter/src/main/resources/org/flowable/impl/bpmn/parser/flowable-bpmn-extensions.xsd
+++ b/modules/flowable-bpmn-converter/src/main/resources/org/flowable/impl/bpmn/parser/flowable-bpmn-extensions.xsd
@@ -927,7 +927,7 @@
   <attribute name="taskCompleterVariableName" type="string" default="">
     <annotation>
       <documentation>
-        Allows to specify a variable name on a user task where the completer's user ID will be stored.
+        Optional variable name on a user task where the completer's user ID will be stored.
       </documentation>
     </annotation>
   </attribute>

--- a/modules/flowable-bpmn-converter/src/main/resources/org/flowable/impl/bpmn/parser/flowable-bpmn-extensions.xsd
+++ b/modules/flowable-bpmn-converter/src/main/resources/org/flowable/impl/bpmn/parser/flowable-bpmn-extensions.xsd
@@ -923,4 +923,12 @@
       </documentation>
     </annotation>
   </attribute>
+
+  <attribute name="taskCompleterVariableName" type="string" default="">
+    <annotation>
+      <documentation>
+        Allows to specify a variable name on a user task where the completer's user ID will be stored.
+      </documentation>
+    </annotation>
+  </attribute>
 </schema>

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/UserTaskConverterTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/UserTaskConverterTest.java
@@ -41,6 +41,7 @@ class UserTaskConverterTest {
                     assertThat(userTask.isSameDeployment()).isTrue();
                     assertThat(userTask.getPriority()).isEqualTo("40");
                     assertThat(userTask.getTaskIdVariableName()).isEqualTo("myTaskId");
+                    assertThat(userTask.getTaskCompleterVariableName()).isEqualTo("completer");
                     assertThat(userTask.getDueDate()).isEqualTo("2012-11-01");
 
                     assertThat(userTask.getBusinessCalendarName()).isEqualTo("customCalendarName");
@@ -86,7 +87,7 @@ class UserTaskConverterTest {
                                     FlowableListener::getCustomPropertiesResolverImplementation)
                             .containsExactly(tuple("end", "before-commit", "org.test.TestResolverClass"));
                 });
-        
+
         assertThat(model.getEdgeInfo("flow2")).isNotNull();
         BpmnDiEdge edgeInfo = model.getEdgeInfo("flow2");
         assertThat(edgeInfo.getSourceDockerInfo().getX()).isEqualTo(50.0);
@@ -94,7 +95,7 @@ class UserTaskConverterTest {
         assertThat(edgeInfo.getTargetDockerInfo().getX()).isEqualTo(40.0);
         assertThat(edgeInfo.getTargetDockerInfo().getY()).isEqualTo(30.0);
         assertThat(edgeInfo.getWaypoints()).hasSize(2);
-        
+
         assertThat(model.getEdgeInfo("flow1")).isNull();
     }
 

--- a/modules/flowable-bpmn-converter/src/test/resources/usertaskmodel.bpmn
+++ b/modules/flowable-bpmn-converter/src/test/resources/usertaskmodel.bpmn
@@ -14,7 +14,7 @@
     <sequenceFlow id="flow1" sourceRef="startEvent" targetRef="usertask"></sequenceFlow>
     <startEvent id="startEvent"></startEvent>
     <sequenceFlow id="flow2" sourceRef="usertask" targetRef="endEvent"></sequenceFlow>
-    <userTask id="usertask" name="User task" flowable:category="Test Category" flowable:async="true" flowable:exclusive="false" flowable:assignee="kermit" flowable:candidateUsers="kermit,fozzie" flowable:candidateGroups="management,sales" flowable:dueDate="2012-11-01" flowable:businessCalendarName="customCalendarName" flowable:formKey="testKey" flowable:priority="40" flowable:taskIdVariableName="myTaskId">
+    <userTask id="usertask" name="User task" flowable:category="Test Category" flowable:async="true" flowable:exclusive="false" flowable:assignee="kermit" flowable:candidateUsers="kermit,fozzie" flowable:candidateGroups="management,sales" flowable:dueDate="2012-11-01" flowable:businessCalendarName="customCalendarName" flowable:formKey="testKey" flowable:priority="40" flowable:taskIdVariableName="myTaskId" flowable:taskCompleterVariableName="completer">
       <extensionElements>
         <flowable:customResource name="businessAdministrator">
          <resourceAssignmentExpression>

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/UserTask.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/UserTask.java
@@ -40,6 +40,7 @@ public class UserTask extends Task {
     protected String skipExpression;
     protected String validateFormFields;
     protected String taskIdVariableName;
+    protected String taskCompleterVariableName;
 
     protected Map<String, Set<String>> customUserIdentityLinks = new HashMap<>();
     protected Map<String, Set<String>> customGroupIdentityLinks = new HashMap<>();
@@ -224,6 +225,14 @@ public class UserTask extends Task {
         this.taskIdVariableName = taskIdVariableName;
     }
 
+    public String getTaskCompleterVariableName() {
+        return taskCompleterVariableName;
+    }
+
+    public void setTaskCompleterVariableName(String taskCompleterVariableName) {
+        this.taskCompleterVariableName = taskCompleterVariableName;
+    }
+
     @Override
     public UserTask clone() {
         UserTask clone = new UserTask();
@@ -241,6 +250,7 @@ public class UserTask extends Task {
         setPriority(otherElement.getPriority());
         setCategory(otherElement.getCategory());
         setTaskIdVariableName(otherElement.getTaskIdVariableName());
+        setTaskCompleterVariableName(otherElement.getTaskCompleterVariableName());
         setExtensionId(otherElement.getExtensionId());
         setSkipExpression(otherElement.getSkipExpression());
         setValidateFormFields(otherElement.getValidateFormFields());

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConstants.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConstants.java
@@ -195,6 +195,7 @@ public interface CmmnXmlConstants {
     String ATTRIBUTE_DUE_DATE = "dueDate";
     String ATTRIBUTE_CATEGORY = "category";
     String ATTRIBUTE_TASK_ID_VARIABLE_NAME = "taskIdVariableName";
+    String ATTRIBUTE_TASK_COMPLETER_VARIABLE_NAME = "taskCompleterVariableName";
 
     String ATTRIBUTE_REPETITION_COUNTER_VARIABLE_NAME = "counterVariable";
     String ATTRIBUTE_REPETITION_MAX_INSTANCE_COUNT_NAME = "maxInstanceCount";

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/HumanTaskXmlConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/HumanTaskXmlConverter.java
@@ -49,6 +49,7 @@ public class HumanTaskXmlConverter extends TaskXmlConverter {
         task.setDueDate(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE, CmmnXmlConstants.ATTRIBUTE_DUE_DATE));
         task.setCategory(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE, CmmnXmlConstants.ATTRIBUTE_CATEGORY));
         task.setTaskIdVariableName(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE, CmmnXmlConstants.ATTRIBUTE_TASK_ID_VARIABLE_NAME));
+        task.setTaskCompleterVariableName(xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE, CmmnXmlConstants.ATTRIBUTE_TASK_COMPLETER_VARIABLE_NAME));
 
         String candidateUsersString = xtr.getAttributeValue(CmmnXmlConstants.FLOWABLE_EXTENSIONS_NAMESPACE, CmmnXmlConstants.ATTRIBUTE_CANDIDATE_USERS);
         if (StringUtils.isNotEmpty(candidateUsersString)) {

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/HumanTaskExport.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/HumanTaskExport.java
@@ -84,6 +84,10 @@ public class HumanTaskExport extends AbstractPlanItemDefinitionExport<HumanTask>
         if (StringUtils.isNotEmpty(humanTask.getTaskIdVariableName())) {
             xtw.writeAttribute(FLOWABLE_EXTENSIONS_PREFIX, FLOWABLE_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_ID_VARIABLE_NAME, humanTask.getTaskIdVariableName());
         }
+
+        if (StringUtils.isNotEmpty(humanTask.getTaskCompleterVariableName())) {
+            xtw.writeAttribute(FLOWABLE_EXTENSIONS_PREFIX, FLOWABLE_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_COMPLETER_VARIABLE_NAME, humanTask.getTaskCompleterVariableName());
+        }
     }
 
     @Override

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/HumanTaskVariableCompleterCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/HumanTaskVariableCompleterCmmnXmlConverterTest.java
@@ -1,0 +1,39 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.test.cmmn.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.flowable.cmmn.model.CmmnModel;
+import org.flowable.cmmn.model.HumanTask;
+import org.flowable.cmmn.model.PlanItemDefinition;
+import org.flowable.test.cmmn.converter.util.CmmnXmlConverterTest;
+
+/**
+ * @author Matthias Stöckli
+ */
+public class HumanTaskVariableCompleterCmmnXmlConverterTest {
+
+    @CmmnXmlConverterTest("org/flowable/test/cmmn/converter/humanTaskCompleterVariableName.cmmn")
+    public void validateModel(CmmnModel cmmnModel) {
+        assertThat(cmmnModel).isNotNull();
+
+        PlanItemDefinition itemDefinition = cmmnModel.findPlanItemDefinition("task1");
+
+        assertThat(itemDefinition)
+                .isInstanceOfSatisfying(HumanTask.class, task -> {
+                    assertThat(task.getTaskCompleterVariableName()).isEqualTo("completer");
+                });
+    }
+
+}

--- a/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/humanTaskCompleterVariableName.cmmn
+++ b/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/humanTaskCompleterVariableName.cmmn
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:flowable="http://flowable.org/cmmn" targetNamespace="http://flowable.org/cmmn">
+    <case id="humanTaskVariableNameCase" name="Human Task Variable Case">
+        <casePlanModel id="mainPlanModel" name="Case plan model">
+            <planItem id="planItem1" name="Task 1" definitionRef="task1"/>
+            <humanTask id="task1" name="Task 1" flowable:taskCompleterVariableName="completer"/>
+        </casePlanModel>
+    </case>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
@@ -421,9 +421,13 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
             }
         } else if (PlanItemTransition.COMPLETE.equals(transition)) {
             if (humanTask.getTaskCompleterVariableName() != null) {
-                String taskCompleterVariableName = humanTask.getTaskCompleterVariableName();
+
+                ExpressionManager expressionManager = CommandContextUtil.getExpressionManager(commandContext);
+                Expression expression = expressionManager.createExpression(humanTask.getTaskCompleterVariableName());
+                String completerVariableName = (String) expression.getValue(planItemInstance);
                 String completer = Authentication.getAuthenticatedUserId();
-                planItemInstance.setVariable(taskCompleterVariableName, completer);
+
+                planItemInstance.setVariable(completerVariableName, completer);
             }
         }
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
@@ -44,6 +44,7 @@ import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.assignment.CandidateUtil;
 import org.flowable.common.engine.impl.el.ExpressionManager;
+import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.common.engine.impl.logging.CmmnLoggingSessionConstants;
 import org.flowable.common.engine.impl.logging.LoggingSessionUtil;
@@ -261,7 +262,7 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
 
     protected void handleFormKey(PlanItemInstanceEntity planItemInstanceEntity, ExpressionManager expressionManager,
             TaskEntity taskEntity, CreateHumanTaskBeforeContext beforeContext) {
-        
+
         if (StringUtils.isNotEmpty(beforeContext.getFormKey())) {
             Object formKey = expressionManager.createExpression(beforeContext.getFormKey()).getValue(planItemInstanceEntity);
             if (formKey != null) {
@@ -417,6 +418,12 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
             List<TaskEntity> taskEntities = taskService.findTasksBySubScopeIdScopeType(planItemInstance.getId(), ScopeTypes.CMMN);
             for (TaskEntity taskEntity : taskEntities) {
                 TaskHelper.deleteTask(taskEntity, "cmmn-state-transition-" + transition, false, true, cmmnEngineConfiguration);
+            }
+        } else if (PlanItemTransition.COMPLETE.equals(transition)) {
+            if (humanTask.getTaskCompleterVariableName() != null) {
+                String taskCompleterVariableName = humanTask.getTaskCompleterVariableName();
+                String completer = Authentication.getAuthenticatedUserId();
+                planItemInstance.setVariable(taskCompleterVariableName, completer);
             }
         }
     }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/HumanTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/HumanTaskTest.java
@@ -426,6 +426,7 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
 
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("myCase")
+                .variable("dynamicVariable", "myDynamicVariable")
                 .start();
 
         // Normal string
@@ -440,8 +441,16 @@ public class HumanTaskTest extends FlowableCmmnTestCase {
         Task secondTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskDefinitionKey("task2").singleResult();
         assertThat(secondTask).isNotNull();
         cmmnTaskService.complete(secondTask.getId());
-        Object completerTask2 = cmmnRuntimeService.getVariable(caseInstance.getId(), "completerTask2");
+        String completerTask2 = (String)cmmnRuntimeService.getVariable(caseInstance.getId(), "completerTask2");
         assertThat(completerTask2).isNull();
+
+        // Expression
+        Authentication.setAuthenticatedUserId("DynamicDoe");
+        Task thirdTask = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).taskDefinitionKey("task3").singleResult();
+        assertThat(thirdTask).isNotNull();
+        cmmnTaskService.complete(thirdTask.getId());
+        String completerTask3 = (String)cmmnRuntimeService.getVariable(caseInstance.getId(), "myDynamicVariable");
+        assertThat(completerTask3).isEqualTo("DynamicDoe");
     }
 
 }

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/HumanTaskTest.testHumanTaskCompleterVariableName.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/HumanTaskTest.testHumanTaskCompleterVariableName.cmmn
@@ -12,10 +12,13 @@
 
             <planItem id="planItem1" name="Task One" definitionRef="task1" />
             <planItem id="planItem2" name="Task Two" definitionRef="task2" />
+            <planItem id="planItem3" name="Task Three" definitionRef="task3" />
+            <planItem id="planItem4" name="Dummy Task" definitionRef="task4" />
 
             <humanTask id="task1" name="Task One" flowable:taskCompleterVariableName="completerTask1" />
             <humanTask id="task2" name="Task Two" flowable:taskCompleterVariableName="completerTask2" />
-
+            <humanTask id="task3" name="Task Three" flowable:taskCompleterVariableName="${dynamicVariable}" />
+            <humanTask id="task4" name="Dummy Task" />
         </casePlanModel>
     </case>
 

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/HumanTaskTest.testHumanTaskCompleterVariableName.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/runtime/HumanTaskTest.testHumanTaskCompleterVariableName.cmmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL"
+    xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC"
+    xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI"
+    xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:flowable="http://flowable.org/cmmn"
+    targetNamespace="http://flowable.org/cmmn">
+
+    <case id="myCase" flowable:initiatorVariableName="var1">
+        <casePlanModel id="myPlanModel" name="My CasePlanModel">
+
+            <planItem id="planItem1" name="Task One" definitionRef="task1" />
+            <planItem id="planItem2" name="Task Two" definitionRef="task2" />
+
+            <humanTask id="task1" name="Task One" flowable:taskCompleterVariableName="completerTask1" />
+            <humanTask id="task2" name="Task Two" flowable:taskCompleterVariableName="completerTask2" />
+
+        </casePlanModel>
+    </case>
+
+</definitions>

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/HumanTask.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/HumanTask.java
@@ -29,6 +29,7 @@ public class HumanTask extends Task {
     protected String dueDate;
     protected String category;
     protected String taskIdVariableName;
+    protected String taskCompleterVariableName;
     protected List<String> candidateUsers = new ArrayList<>();
     protected List<String> candidateGroups = new ArrayList<>();
     protected List<FlowableListener> taskListeners = new ArrayList<>();
@@ -105,6 +106,14 @@ public class HumanTask extends Task {
         this.taskIdVariableName = taskIdVariableName;
     }
 
+    public String getTaskCompleterVariableName() {
+        return taskCompleterVariableName;
+    }
+
+    public void setTaskCompleterVariableName(String taskCompleterVariableName) {
+        this.taskCompleterVariableName = taskCompleterVariableName;
+    }
+
     public List<String> getCandidateUsers() {
         return candidateUsers;
     }
@@ -147,6 +156,7 @@ public class HumanTask extends Task {
         setPriority(otherElement.getPriority());
         setCategory(otherElement.getCategory());
         setTaskIdVariableName(otherElement.getTaskIdVariableName());
+        setTaskCompleterVariableName(otherElement.getTaskCompleterVariableName());
 
         setCandidateGroups(new ArrayList<>(otherElement.getCandidateGroups()));
         setCandidateUsers(new ArrayList<>(otherElement.getCandidateUsers()));

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java
@@ -18,7 +18,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.UserTask;
 import org.flowable.common.engine.api.FlowableException;
+import org.flowable.common.engine.api.delegate.Expression;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
 import org.flowable.common.engine.api.scope.ScopeTypes;
@@ -124,6 +127,13 @@ public class TaskHelper {
 
         logUserTaskCompleted(taskEntity);
 
+        if (taskEntity.getExecutionId() != null) {
+            ExecutionEntity execution = CommandContextUtil.getExecutionEntityManager().findById(taskEntity.getExecutionId());
+            if (execution != null) {
+                storeTaskCompleter(taskEntity, execution, processEngineConfiguration);
+            }
+        }
+
         FlowableEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();
         if (eventDispatcher != null && eventDispatcher.isEnabled()) {
             if (variables != null) {
@@ -184,6 +194,26 @@ public class TaskHelper {
             taskLogEntryBuilder.data(data.toString());
             taskLogEntryBuilder.type(HistoricTaskLogEntryType.USER_TASK_COMPLETED.name());
             taskServiceConfiguration.getInternalHistoryTaskManager().recordHistoryUserTaskLog(taskLogEntryBuilder);
+        }
+    }
+
+    protected static void storeTaskCompleter(TaskEntity taskEntity, ExecutionEntity execution, ProcessEngineConfigurationImpl processEngineConfiguration) {
+        if (taskEntity.getProcessDefinitionId() != null) {
+            org.flowable.bpmn.model.Process process = ProcessDefinitionUtil.getProcess(taskEntity.getProcessDefinitionId());
+            FlowElement flowElement = process.getFlowElement(taskEntity.getTaskDefinitionKey(), true);
+            if (flowElement instanceof UserTask) {
+                UserTask userTask = (UserTask) flowElement;
+                String taskCompleterVariableName = userTask.getTaskCompleterVariableName();
+                if (StringUtils.isNotEmpty(taskCompleterVariableName)) {
+                    ExpressionManager expressionManager = processEngineConfiguration.getExpressionManager();
+                    Expression expression = expressionManager.createExpression(userTask.getTaskCompleterVariableName());
+                    String completerVariableName = (String) expression.getValue(execution);
+                    String completer = Authentication.getAuthenticatedUserId();
+                    if (StringUtils.isNotEmpty(completerVariableName)) {
+                        execution.setVariable(completerVariableName, completer);
+                    }
+                }
+            }
         }
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java
@@ -199,8 +199,7 @@ public class TaskHelper {
 
     protected static void storeTaskCompleter(TaskEntity taskEntity, ExecutionEntity execution, ProcessEngineConfigurationImpl processEngineConfiguration) {
         if (taskEntity.getProcessDefinitionId() != null) {
-            org.flowable.bpmn.model.Process process = ProcessDefinitionUtil.getProcess(taskEntity.getProcessDefinitionId());
-            FlowElement flowElement = process.getFlowElement(taskEntity.getTaskDefinitionKey(), true);
+            FlowElement flowElement = execution.getCurrentFlowElement();
             if (flowElement instanceof UserTask) {
                 UserTask userTask = (UserTask) flowElement;
                 String taskCompleterVariableName = userTask.getTaskCompleterVariableName();

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/usertask/UserTaskTest.userTaskCompleterVariableName.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/usertask/UserTaskTest.userTaskCompleterVariableName.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:flowable="http://flowable.org/bpmn"
+	xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+	xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema"
+	expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://activiti.org/bpmn20">
+	<process id="userTaskCompleterVariableName">
+		<documentation>This is a process for testing purposes</documentation>
+
+		<startEvent id="theStart" />
+		<sequenceFlow id="flow1" sourceRef="theStart" targetRef="parallelGateway1" />
+		<parallelGateway id="parallelGateway1" />
+		<sequenceFlow id="flow2" sourceRef="parallelGateway1" targetRef="task1" />
+		<sequenceFlow id="flow3" sourceRef="parallelGateway1" targetRef="task2" />
+		<sequenceFlow id="flow4" sourceRef="parallelGateway1" targetRef="task3" />
+		<userTask id="task1" name="Task 1" flowable:taskCompleterVariableName="completerTask1" />
+		<userTask id="task2" name="Task 2" flowable:taskCompleterVariableName="${'completerTask2'}" />
+		<userTask id="task3" name="Task 3" flowable:taskCompleterVariableName="completerTask3" />
+		<sequenceFlow id="flow5" sourceRef="task1" targetRef="parallelGateway2" />
+		<sequenceFlow id="flow6" sourceRef="task2" targetRef="parallelGateway2" />
+		<sequenceFlow id="flow7" sourceRef="task3" targetRef="parallelGateway2" />
+		<parallelGateway id="parallelGateway2" />
+		<sequenceFlow id="flow8" sourceRef="parallelGateway2" targetRef="task4" />
+		<userTask id="task4" name="Task 4" />
+		<sequenceFlow id="flow9" sourceRef="task4" targetRef="theEnd" />
+		<endEvent id="theEnd" />
+
+	</process>
+</definitions>


### PR DESCRIPTION
When modeling processes, it is often useful to know the user who completed a task. For instance when modeling reviews, we often want to reassign a task back to the original completer of a task.
Potentially, we could also add an additional flag which allows us to store this variable locally (i.e. as a task variable) which may useful in some cases. 