### PR TITLE
Upgrade to Spring Security 6.0.2 and Spring Framework 6.0.5

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -70,10 +70,10 @@ Quartz
 This software includes unchanged copies of the following libraries:
 
 aopalliance                     aopalliance                 1.0             Public Domain
-com.fasterxml.jackson.core      jackson-annotations         2.13.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-core                2.13.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-databind            2.13.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-joda       2.13.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-annotations         2.14.2          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-core                2.14.2          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-databind            2.14.2          The Apache Software License, Version 2.0
+com.fasterxml.jackson.datatype  jackson-datatype-joda       2.14.2          The Apache Software License, Version 2.0
 com.google.guava                guava                       31.0.1-jre      The Apache Software License, Version 2.0
 com.h2database                  h2                          2.1.214         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0
@@ -109,22 +109,22 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
 org.slf4j                       slf4j-api                   1.7.36          MIT License
 org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.4          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.4          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      6.0.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        6.0.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      6.0.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         6.0.1           The Apache Software License, Version 2.0
+org.springframework             spring-beans                6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-context              6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.0.5          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.0.5          The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      6.0.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        6.0.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      6.0.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         6.0.2           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>3.0.1</spring.boot.version>
-		<spring.framework.version>6.0.4</spring.framework.version>
-		<spring.security.version>6.0.1</spring.security.version>
+		<spring.framework.version>6.0.5</spring.framework.version>
+		<spring.security.version>6.0.2</spring.security.version>
 		<spring.amqp.version>3.0.0</spring.amqp.version>
 		<spring.kafka.version>3.0.1</spring.kafka.version>
-		<reactor-netty.version>1.1.1</reactor-netty.version>
-		<jackson.version>2.14.1</jackson.version>
+		<reactor-netty.version>1.1.3</reactor-netty.version>
+		<jackson.version>2.14.2</jackson.version>
 		<jakarta-jms.version>3.1.0</jakarta-jms.version>
         <camel.version>3.19.0</camel.version>
 		<cxf.version>3.5.4</cxf.version>
@@ -29,7 +29,7 @@
 		<jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
 
 		<junit.version>4.13.2</junit.version>
-		<junit.jupiter.version>5.9.1</junit.jupiter.version>
+		<junit.jupiter.version>5.9.2</junit.jupiter.version>
 		<hikari.version>4.0.3</hikari.version>
 		<maven.deploy.plugin.version>3.0.0</maven.deploy.plugin.version>
 		<maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>


### PR DESCRIPTION
Spring Security release notes:  https://github.com/spring-projects/spring-security/releases/tag/6.0.2
Spring Framework release notes:  https://github.com/spring-projects/spring-framework/releases/tag/v6.0.5

