### PR TITLE
Upgrade to Spring Security 5.8.2 for flowable6.x branch

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -96,10 +96,10 @@ Quartz
 This software includes unchanged copies of the following libraries:
 
 aopalliance                     aopalliance                 1.0             Public Domain
-com.fasterxml.jackson.core      jackson-annotations         2.13.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-core                2.13.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-databind            2.13.4          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-joda       2.13.4          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-annotations         2.13.5          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-core                2.13.5          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-databind            2.13.5          The Apache Software License, Version 2.0
+com.fasterxml.jackson.datatype  jackson-datatype-joda       2.13.5          The Apache Software License, Version 2.0
 com.google.guava                guava                       31.0.1-jre      The Apache Software License, Version 2.0
 com.h2database                  h2                          2.1.214         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.25          The 
 org.springframework             spring-core                 5.3.25          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.25          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.25          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.8.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.8.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.8.1           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.8.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.8.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.8.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.8.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.8.2           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>2.7.6</spring.boot.version>
 		<spring.framework.version>5.3.25</spring.framework.version>
-		<spring.security.version>5.8.1</spring.security.version>
+		<spring.security.version>5.8.2</spring.security.version>
 		<spring.amqp.version>2.4.8</spring.amqp.version>
 		<spring.kafka.version>2.8.11</spring.kafka.version>
-		<reactor-netty.version>1.0.25</reactor-netty.version>
-		<jackson.version>2.13.4.20221013</jackson.version>
+		<reactor-netty.version>1.0.28</reactor-netty.version>
+		<jackson.version>2.13.5</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
         <camel.version>3.14.0</camel.version>
@@ -30,7 +30,7 @@
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 
 		<junit.version>4.13.2</junit.version>
-		<junit.jupiter.version>5.8.2</junit.jupiter.version>
+		<junit.jupiter.version>5.9.2</junit.jupiter.version>
 		<hikari.version>4.0.3</hikari.version>
 		<maven.deploy.plugin.version>3.1.0</maven.deploy.plugin.version>
 		<maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
@@ -800,7 +800,7 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.6.14.Final</version>
+				<version>5.6.15.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>


### PR DESCRIPTION
Release Notes:  https://github.com/spring-projects/spring-security/releases/tag/5.8.2
