### PR TITLE
Upgrade to Spring Boot 3.0.4

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -109,18 +109,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
 org.slf4j                       slf4j-api                   1.7.36          MIT License
 org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.5           The Apache Software License, Version 2.0
+org.springframework             spring-beans                6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-context              6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.0.6           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.0.6           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      6.0.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        6.0.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      6.0.2           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>3.0.3</spring.boot.version>
-		<spring.framework.version>6.0.5</spring.framework.version>
+		<spring.boot.version>3.0.4</spring.boot.version>
+		<spring.framework.version>6.0.6</spring.framework.version>
 		<spring.security.version>6.0.2</spring.security.version>
 		<spring.amqp.version>3.0.2</spring.amqp.version>
-		<spring.kafka.version>3.0.3</spring.kafka.version>
+		<spring.kafka.version>3.0.4</spring.kafka.version>
 		<reactor-netty.version>1.1.1</reactor-netty.version>
 		<jackson.version>2.14.2</jackson.version>
 		<jakarta-jms.version>3.1.0</jakarta-jms.version>


### PR DESCRIPTION
Includes update to Spring Framework 6.0.6

Release Notes:  https://github.com/spring-projects/spring-boot/releases/tag/v3.0.4
