### PR TITLE
Upgrade to Spring Boot 3.0.5

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -100,27 +100,27 @@ org.apache.httpcomponents       httpclient                  4.5.13          Apac
 org.apache.httpcomponents       httpcore                    4.4.15          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.13          Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
-org.apache.groovy               groovy                      4.0.7           The Apache Software License, Version 2.0
-org.apache.groovy               groovy-jsr223               4.0.7           The Apache Software License, Version 2.0
+org.apache.groovy               groovy                      4.0.10          The Apache Software License, Version 2.0
+org.apache.groovy               groovy-jsr223               4.0.10          The Apache Software License, Version 2.0
 org.liquibase                   liquibase-core              4.5.0           Apache License, Version 2.0
 org.mybatis                     mybatis                     3.5.11          The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              3.0.0           The Apache Software License, Version 2.0
 org.mvel                        mvel2                       2.2.6.Final     The Apache Software License, Version 2.0
-org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
-org.slf4j                       slf4j-api                   1.7.36          MIT License
-org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.5           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.5           The Apache Software License, Version 2.0
+org.slf4j                       jcl-over-slf4j              2.0.7           MIT License
+org.slf4j                       slf4j-api                   2.0.7           MIT License
+org.slf4j                       slf4j-log4j12               2.0.7           MIT License
+org.springframework             spring-beans                6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-context              6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.0.7           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.0.7           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      6.0.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        6.0.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      6.0.2           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,18 +14,18 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>3.0.3</spring.boot.version>
-		<spring.framework.version>6.0.5</spring.framework.version>
+		<spring.boot.version>3.0.5</spring.boot.version>
+		<spring.framework.version>6.0.7</spring.framework.version>
 		<spring.security.version>6.0.2</spring.security.version>
-		<spring.amqp.version>3.0.2</spring.amqp.version>
-		<spring.kafka.version>3.0.3</spring.kafka.version>
+		<spring.amqp.version>3.0.3</spring.amqp.version>
+		<spring.kafka.version>3.0.5</spring.kafka.version>
 		<reactor-netty.version>1.1.1</reactor-netty.version>
 		<jackson.version>2.14.2</jackson.version>
 		<jakarta-jms.version>3.1.0</jakarta-jms.version>
         <camel.version>3.19.0</camel.version>
 		<cxf.version>3.5.4</cxf.version>
-		<slf4j.version>2.0.6</slf4j.version>
-		<groovy.version>4.0.7</groovy.version>
+		<slf4j.version>2.0.7</slf4j.version>
+		<groovy.version>4.0.10</groovy.version>
 		<jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
 
 		<junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Release Notes:

version 3.0.4: https://github.com/spring-projects/spring-boot/releases/tag/v3.0.4
version 3.0.5: https://github.com/spring-projects/spring-boot/releases/tag/v3.0.5