### PR TITLE
Upgrade to Spring Security 6.0.3 and Spring Framework 6.0.8

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -109,22 +109,22 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              2.0.7           MIT License
 org.slf4j                       slf4j-api                   2.0.7           MIT License
 org.slf4j                       slf4j-log4j12               2.0.7           MIT License
-org.springframework             spring-beans                6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.7           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.7           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      6.0.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        6.0.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      6.0.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         6.0.2           The Apache Software License, Version 2.0
+org.springframework             spring-beans                6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-context              6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.0.8           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      6.0.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        6.0.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      6.0.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         6.0.3           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>3.0.5</spring.boot.version>
-		<spring.framework.version>6.0.7</spring.framework.version>
-		<spring.security.version>6.0.2</spring.security.version>
+		<spring.framework.version>6.0.8</spring.framework.version>
+		<spring.security.version>6.0.3</spring.security.version>
 		<spring.amqp.version>3.0.3</spring.amqp.version>
 		<spring.kafka.version>3.0.5</spring.kafka.version>
-		<reactor-netty.version>1.1.1</reactor-netty.version>
+		<reactor-netty.version>1.1.6</reactor-netty.version>
 		<jackson.version>2.14.2</jackson.version>
 		<jakarta-jms.version>3.1.0</jakarta-jms.version>
         <camel.version>3.19.0</camel.version>
@@ -467,7 +467,7 @@
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
-				<version>3.23.1</version>
+				<version>3.24.2</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Spring Security release notes: https://github.com/spring-projects/spring-security/releases/tag/6.0.3
Spring Framework release notes: https://github.com/spring-projects/spring-framework/releases/tag/v6.0.8

The Security update fixes the following CVE:
[cve-2023-20862: Empty SecurityContext Is Not Properly Saved Upon Logout](https://spring.io/security/cve-2023-20862)

The Framework updates fixes the following CVE:
[cve-2023-20863: Spring Expression DoS Vulnerability](https://spring.io/security/cve-2023-20863)
