### PR TITLE
Chore: remove @Test from Junit3 tests

### DIFF
--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/history/HistoricTaskInstanceQueryResourceTest.java
@@ -33,7 +33,6 @@ import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.rest.service.BaseSpringRestTestCase;
 import org.flowable.cmmn.rest.service.api.CmmnRestUrls;
 import org.flowable.task.api.Task;
-import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -282,7 +281,6 @@ public class HistoricTaskInstanceQueryResourceTest extends BaseSpringRestTestCas
         assertResultsPresentInPostDataResponse(url, requestNode, task.getId());
     }
 
-    @Test
     public void testQueryTaskByCategory() throws Exception {
         Task t1 = taskService.newTask();
         t1.setName("t1");

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/management/JobCollectionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/management/JobCollectionResourceTest.java
@@ -25,7 +25,6 @@ import org.flowable.cmmn.engine.test.impl.CmmnJobTestHelper;
 import org.flowable.cmmn.rest.service.BaseSpringRestTestCase;
 import org.flowable.cmmn.rest.service.api.CmmnRestUrls;
 import org.flowable.job.api.Job;
-import org.junit.Test;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -122,7 +121,6 @@ public class JobCollectionResourceTest extends BaseSpringRestTestCase {
     /**
      * Test moving a bulk of dead letter jobs
      */
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/management/timerEventListenerCase.cmmn" })
     public void testExecuteBulkDeadLetterMove() throws Exception {
         CaseInstance caseInstance = runtimeService.createCaseInstanceBuilder().caseDefinitionKey("testTimerExpression").start();

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/repository/CaseDefinitionIdentityLinksResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/repository/CaseDefinitionIdentityLinksResourceTest.java
@@ -29,7 +29,6 @@ import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.rest.service.BaseSpringRestTestCase;
 import org.flowable.cmmn.rest.service.api.CmmnRestUrls;
 import org.flowable.identitylink.api.IdentityLink;
-import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -46,7 +45,6 @@ public class CaseDefinitionIdentityLinksResourceTest extends BaseSpringRestTestC
     /**
      * Test getting identitylinks for a case definition.
      */
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/oneHumanTaskCase.cmmn" })
     public void testGetIdentityLinksForProcessDefinition() throws Exception {
 
@@ -80,7 +78,6 @@ public class CaseDefinitionIdentityLinksResourceTest extends BaseSpringRestTestC
                         + "]");
     }
 
-    @Test
     public void testGetIdentityLinksForUnexistingCaseDefinition() throws Exception {
         HttpGet httpGet = new HttpGet(
                 SERVER_URL_PREFIX + CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_CASE_DEFINITION_IDENTITYLINKS_COLLECTION, "unexisting"));
@@ -88,7 +85,6 @@ public class CaseDefinitionIdentityLinksResourceTest extends BaseSpringRestTestC
         closeResponse(response);
     }
 
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/oneHumanTaskCase.cmmn" })
     public void testAddCandidateStarterToCaseDefinition() throws Exception {
         CaseDefinition caseDefinition = repositoryService.createCaseDefinitionQuery().singleResult();
@@ -146,7 +142,6 @@ public class CaseDefinitionIdentityLinksResourceTest extends BaseSpringRestTestC
         repositoryService.deleteCandidateStarterUser(caseDefinition.getId(), "admin");
     }
 
-    @Test
     public void testAddCandidateStarterToUnexistingCaseDefinition() throws Exception {
         // Create user candidate
         ObjectNode requestNode = objectMapper.createObjectNode();
@@ -159,7 +154,6 @@ public class CaseDefinitionIdentityLinksResourceTest extends BaseSpringRestTestC
         closeResponse(response);
     }
 
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/oneHumanTaskCaseWithStarters.cmmn" })
     public void testGetCandidateStarterFromCaseDefinition() throws Exception {
         CaseDefinition caseDefinition = repositoryService.createCaseDefinitionQuery().singleResult();
@@ -199,7 +193,6 @@ public class CaseDefinitionIdentityLinksResourceTest extends BaseSpringRestTestC
                         + "}");
     }
 
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/oneHumanTaskCase.cmmn" })
     public void testDeleteCandidateStarterFromCaseDefinition() throws Exception {
         CaseDefinition caseDefinition = repositoryService.createCaseDefinitionQuery().singleResult();
@@ -229,7 +222,6 @@ public class CaseDefinitionIdentityLinksResourceTest extends BaseSpringRestTestC
         assertThat(remainingLinks).isEmpty();
     }
 
-    @Test
     public void testDeleteCandidateStarterFromUnexistingCaseDefinition() throws Exception {
         HttpDelete httpDelete = new HttpDelete(
                 SERVER_URL_PREFIX + CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_CASE_DEFINITION_IDENTITYLINK, "unexisting", "groups", "admin"));
@@ -237,7 +229,6 @@ public class CaseDefinitionIdentityLinksResourceTest extends BaseSpringRestTestC
         closeResponse(response);
     }
 
-    @Test
     public void testGetCandidateStarterFromUnexistingCaseDefinition() throws Exception {
         HttpGet httpGet = new HttpGet(
                 SERVER_URL_PREFIX + CmmnRestUrls.createRelativeResourceUrl(CmmnRestUrls.URL_CASE_DEFINITION_IDENTITYLINK, "unexisting", "groups", "admin"));

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/CaseInstanceCollectionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/CaseInstanceCollectionResourceTest.java
@@ -46,7 +46,6 @@ import org.flowable.form.api.FormInfo;
 import org.flowable.form.api.FormRepositoryService;
 import org.flowable.form.api.FormService;
 import org.flowable.task.api.Task;
-import org.junit.Test;
 import org.mockito.Mock;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -740,7 +739,6 @@ public class CaseInstanceCollectionResourceTest extends BaseSpringRestTestCase {
     /**
      * Test  bulk deletion of case instances.
      */
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/oneHumanTaskCase.cmmn" })
     public void testBulkDeleteCaseInstances() throws Exception {
         CaseInstance caseInstance1 = runtimeService.createCaseInstanceBuilder().caseDefinitionKey("oneHumanTaskCase").start();
@@ -763,7 +761,6 @@ public class CaseInstanceCollectionResourceTest extends BaseSpringRestTestCase {
     /**
      * Test  bulk deletion of case instances.
      */
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/oneHumanTaskCase.cmmn" })
     public void testInvalidBulkDeleteCaseInstances() throws Exception {
         CaseInstance caseInstance1 = runtimeService.createCaseInstanceBuilder().caseDefinitionKey("oneHumanTaskCase").start();
@@ -793,7 +790,6 @@ public class CaseInstanceCollectionResourceTest extends BaseSpringRestTestCase {
     /**
      * Test bulk termination of case instances.
      */
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/oneHumanTaskCase.cmmn" })
     public void testBulkTerminateCaseInstances() throws Exception {
         CaseInstance caseInstance1 = runtimeService.createCaseInstanceBuilder().caseDefinitionKey("oneHumanTaskCase").start();
@@ -817,7 +813,6 @@ public class CaseInstanceCollectionResourceTest extends BaseSpringRestTestCase {
     /**
      * Test bulk termination of case instances.
      */
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/repository/oneHumanTaskCase.cmmn" })
     public void testInvalidBulkTerminateCaseInstances() throws Exception {
         CaseInstance caseInstance1 = runtimeService.createCaseInstanceBuilder().caseDefinitionKey("oneHumanTaskCase").start();

--- a/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/EventSubscriptionResourceTest.java
+++ b/modules/flowable-cmmn-rest/src/test/java/org/flowable/cmmn/rest/service/api/runtime/EventSubscriptionResourceTest.java
@@ -27,7 +27,6 @@ import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.rest.service.BaseSpringRestTestCase;
 import org.flowable.cmmn.rest.service.api.CmmnRestUrls;
 import org.flowable.eventsubscription.api.EventSubscription;
-import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -36,7 +35,6 @@ import net.javacrumbs.jsonunit.core.Option;
 
 public class EventSubscriptionResourceTest extends BaseSpringRestTestCase {
 
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/runtime/signalEventListener.cmmn" })
     public void testQueryEventSubscriptions() throws Exception {
         Calendar hourAgo = Calendar.getInstance();
@@ -91,7 +89,6 @@ public class EventSubscriptionResourceTest extends BaseSpringRestTestCase {
         assertResultsPresentInDataResponse(url, eventSubscription.getId());
     }
 
-    @Test
     @CmmnDeployment(resources = { "org/flowable/cmmn/rest/service/api/runtime/signalEventListener.cmmn" })
     public void testGetEventSubscription() throws Exception {
         runtimeService.createCaseInstanceBuilder().caseDefinitionKey("testSimpleEnableTask").start();


### PR DESCRIPTION
The `@Test` annotation is not used in JUnit3 tests: 
<pre>
 public class MyTest extends TestCase {
      @Test
      public void testFoo() { }
 }
</pre>
should be 
<pre>
 public class MyTest extends TestCase {
      public void testFoo() { }
 }
</pre>

