### PR TITLE
Add variable instance id to VariableEvents

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEventBuilder.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableEventBuilder.java
@@ -405,7 +405,7 @@ public class FlowableEventBuilder {
     }
 
     public static FlowableVariableEvent createVariableEvent(FlowableEngineEventType type, String variableName, Object variableValue, VariableType variableType, String taskId, String executionId,
-            String processInstanceId, String processDefinitionId) {
+            String processInstanceId, String processDefinitionId, String variableInstanceId) {
         FlowableVariableEventImpl newEvent = new FlowableVariableEventImpl(type);
         newEvent.setVariableName(variableName);
         newEvent.setVariableValue(variableValue);
@@ -414,6 +414,7 @@ public class FlowableEventBuilder {
         newEvent.setExecutionId(executionId);
         newEvent.setProcessDefinitionId(processDefinitionId);
         newEvent.setProcessInstanceId(processInstanceId);
+        newEvent.setVariableInstanceId(variableInstanceId);
         return newEvent;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableVariableEventImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/delegate/event/impl/FlowableVariableEventImpl.java
@@ -27,6 +27,7 @@ public class FlowableVariableEventImpl extends FlowableProcessEventImpl implemen
     protected Object variableValue;
     protected VariableType variableType;
     protected String taskId;
+    protected String variableInstanceId;
 
     public FlowableVariableEventImpl(FlowableEngineEventType type) {
         super(type);
@@ -68,4 +69,12 @@ public class FlowableVariableEventImpl extends FlowableProcessEventImpl implemen
         this.taskId = taskId;
     }
 
+    @Override
+    public String getVariableInstanceId() {
+        return variableInstanceId;
+    }
+
+    public void setVariableInstanceId(String variableInstanceId) {
+        this.variableInstanceId = variableInstanceId;
+    }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/EventUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/EventUtil.java
@@ -40,7 +40,9 @@ public class EventUtil {
                 variableInstance.getTaskId(),
                 variableInstance.getExecutionId(),
                 variableInstance.getProcessInstanceId(),
-                processDefinitionId);
+                processDefinitionId,
+                variableInstance.getId()
+        );
     }
 
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/event/VariableEventsTest.java
@@ -62,6 +62,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("testVariable");
         assertThat(event.getVariableValue()).isEqualTo("The value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
         listener.clearEventsReceived();
 
         // Update variable
@@ -75,6 +76,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("testVariable");
         assertThat(event.getVariableValue()).isEqualTo("Updated value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
         listener.clearEventsReceived();
 
         // Delete variable
@@ -90,6 +92,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getVariableName()).isEqualTo("testVariable");
         // deleted variable value is always null
         assertThat(event.getVariableValue()).isNull();
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
         listener.clearEventsReceived();
 
         // Create, update and delete multiple variables
@@ -158,6 +161,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("testVariable");
         assertThat(event.getVariableValue()).isEqualTo("The value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
         listener.clearEventsReceived();
     }
 
@@ -267,6 +271,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("variable");
         assertThat(event.getVariableValue()).isEqualTo(123);
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         // Check update event
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
@@ -277,6 +282,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("variable");
         assertThat(event.getVariableValue()).isEqualTo(456);
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         // Check delete event
         event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
@@ -286,6 +292,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("variable");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
         // deleted values are always null
         assertThat(event.getVariableValue()).isNull();
     }
@@ -315,6 +322,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isEqualTo(task.getId());
         assertThat(event.getVariableName()).isEqualTo("testVariable");
         assertThat(event.getVariableValue()).isEqualTo("The value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
@@ -323,6 +331,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isEqualTo(task.getId());
         assertThat(event.getVariableName()).isEqualTo("testVariable");
         assertThat(event.getVariableValue()).isEqualTo("Updated value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
@@ -331,6 +340,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
         assertThat(event.getTaskId()).isEqualTo(task.getId());
         assertThat(event.getVariableName()).isEqualTo("testVariable");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
         // deleted values are always null
         assertThat(event.getVariableValue()).isNull();
         listener.clearEventsReceived();
@@ -358,6 +368,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isEqualTo(task.getId());
         assertThat(event.getVariableName()).isEqualTo("variable");
         assertThat(event.getVariableValue()).isEqualTo(123);
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         // Check update event
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
@@ -367,6 +378,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isEqualTo(task.getId());
         assertThat(event.getVariableName()).isEqualTo("variable");
         assertThat(event.getVariableValue()).isEqualTo(456);
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         // Check delete event
         event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
@@ -376,6 +388,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getProcessInstanceId()).isEqualTo(processInstance.getId());
         assertThat(event.getTaskId()).isEqualTo(task.getId());
         assertThat(event.getVariableName()).isEqualTo("variable");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
         // deleted variable value is always null
         assertThat(event.getVariableValue()).isNull();
     }
@@ -409,6 +422,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
             assertThat(event.getTaskId()).isEqualTo(newTask.getId());
             assertThat(event.getVariableName()).isEqualTo("testVariable");
             assertThat(event.getVariableValue()).isEqualTo(123);
+            assertThat(event.getVariableInstanceId()).isNotEmpty();
 
             event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
             assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
@@ -418,6 +432,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
             assertThat(event.getTaskId()).isEqualTo(newTask.getId());
             assertThat(event.getVariableName()).isEqualTo("testVariable");
             assertThat(event.getVariableValue()).isEqualTo(456);
+            assertThat(event.getVariableInstanceId()).isNotEmpty();
 
             event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
             assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_DELETED);
@@ -426,6 +441,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
             assertThat(event.getProcessInstanceId()).isNull();
             assertThat(event.getTaskId()).isEqualTo(newTask.getId());
             assertThat(event.getVariableName()).isEqualTo("testVariable");
+            assertThat(event.getVariableInstanceId()).isNotEmpty();
             // deleted variable value is always null
             assertThat(event.getVariableValue()).isNull();
         } finally {
@@ -458,6 +474,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("var2");
         assertThat(event.getVariableValue()).isEqualTo("var2 value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(1);
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
@@ -467,6 +484,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("var2");
         assertThat(event.getVariableValue()).isEqualTo("The value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         listener.clearEventsReceived();
     }
@@ -493,6 +511,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("var1");
         assertThat(event.getVariableValue()).isEqualTo("var1 value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         ExecutionEntity subprocessInstance = (ExecutionEntity) runtimeService.createExecutionQuery()
                 .rootProcessInstanceId(processInstance.getId())
@@ -508,6 +527,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("var3");
         assertThat(event.getVariableValue()).isEqualTo("var3 value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
 
         event = (FlowableVariableEvent) listener.getEventsReceived().get(2);
         assertThat(event.getType()).isEqualTo(FlowableEngineEventType.VARIABLE_UPDATED);
@@ -517,6 +537,7 @@ public class VariableEventsTest extends PluggableFlowableTestCase {
         assertThat(event.getTaskId()).isNull();
         assertThat(event.getVariableName()).isEqualTo("var3");
         assertThat(event.getVariableValue()).isEqualTo("var1 value");
+        assertThat(event.getVariableInstanceId()).isNotEmpty();
     }
 
     @BeforeEach

--- a/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/event/FlowableVariableEvent.java
+++ b/modules/flowable-variable-service-api/src/main/java/org/flowable/variable/api/event/FlowableVariableEvent.java
@@ -44,4 +44,9 @@ public interface FlowableVariableEvent extends FlowableEngineEvent {
      */
     String getTaskId();
 
+    /**
+     * @return the id of the variable instance.
+     */
+    String getVariableInstanceId();
+
 }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/event/impl/FlowableVariableEventBuilder.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/event/impl/FlowableVariableEventBuilder.java
@@ -49,6 +49,7 @@ public class FlowableVariableEventBuilder {
         newEvent.setVariableValue(variableValue);
         newEvent.setVariableType(variableType);
         newEvent.setTaskId(variableInstance.getTaskId());
+        newEvent.setVariableInstanceId(variableInstance.getId());
         if (variableInstance.getScopeType() == null) {
             newEvent.setExecutionId(variableInstance.getExecutionId());
             newEvent.setProcessInstanceId(variableInstance.getProcessInstanceId());

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/event/impl/FlowableVariableEventImpl.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/event/impl/FlowableVariableEventImpl.java
@@ -28,6 +28,7 @@ public class FlowableVariableEventImpl extends FlowableEngineEventImpl implement
     protected Object variableValue;
     protected VariableType variableType;
     protected String taskId;
+    protected String variableInstanceId;
 
     public FlowableVariableEventImpl(FlowableEngineEventType type) {
         super(type);
@@ -69,4 +70,12 @@ public class FlowableVariableEventImpl extends FlowableEngineEventImpl implement
         this.taskId = taskId;
     }
 
+    @Override
+    public String getVariableInstanceId() {
+        return variableInstanceId;
+    }
+
+    public void setVariableInstanceId(String variableInstanceId) {
+        this.variableInstanceId = variableInstanceId;
+    }
 }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
@@ -262,7 +262,7 @@ public class ActivitiEventBuilder {
     }
 
     public static FlowableVariableEvent createVariableEvent(FlowableEngineEventType type, String variableName, Object variableValue, VariableType variableType, String taskId,
-            String executionId, String processInstanceId, String processDefinitionId) {
+            String executionId, String processInstanceId, String processDefinitionId, String variableInstanceId) {
         ActivitiVariableEventImpl newEvent = new ActivitiVariableEventImpl(type);
         newEvent.setVariableName(variableName);
         newEvent.setVariableValue(variableValue);
@@ -271,6 +271,7 @@ public class ActivitiEventBuilder {
         newEvent.setExecutionId(executionId);
         newEvent.setProcessDefinitionId(processDefinitionId);
         newEvent.setProcessInstanceId(processInstanceId);
+        newEvent.setVariableInstanceId(variableInstanceId);
         return newEvent;
     }
 

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiVariableEventImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiVariableEventImpl.java
@@ -30,6 +30,7 @@ public class ActivitiVariableEventImpl extends ActivitiEventImpl implements Flow
     protected String taskId;
     protected String scopeId;
     protected String scopeType;
+    protected String variableInstanceId;
 
     public ActivitiVariableEventImpl(FlowableEngineEventType type) {
         super(type);
@@ -97,5 +98,14 @@ public class ActivitiVariableEventImpl extends ActivitiEventImpl implements Flow
     @Override
     public String getScopeDefinitionId() {
         return ScopeTypes.BPMN.equals(scopeType) ? processDefinitionId : null;
+    }
+
+    @Override
+    public String getVariableInstanceId() {
+        return variableInstanceId;
+    }
+
+    public void setVariableInstanceId(String variableInstanceId) {
+        this.variableInstanceId = variableInstanceId;
     }
 }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -873,7 +873,7 @@ public class DbSqlSession implements Session {
 
     protected static FlowableVariableEvent createVariableDeleteEvent(VariableInstanceEntity variableInstance) {
         return ActivitiEventBuilder.createVariableEvent(FlowableEngineEventType.VARIABLE_DELETED, variableInstance.getName(), null, variableInstance.getType(),
-                variableInstance.getTaskId(), variableInstance.getExecutionId(), variableInstance.getProcessInstanceId(), null);
+                variableInstance.getTaskId(), variableInstance.getExecutionId(), variableInstance.getProcessInstanceId(), null, variableInstance.getId());
     }
 
     protected void flushRegularDeletes(boolean dispatchEvent) {

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -1310,7 +1310,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
             Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                     ActivitiEventBuilder.createVariableEvent(FlowableEngineEventType.VARIABLE_CREATED, variableName, value, result.getType(), result.getTaskId(),
-                            result.getExecutionId(), getProcessInstanceId(), getProcessDefinitionId()),
+                            result.getExecutionId(), getProcessInstanceId(), getProcessDefinitionId(), result.getId()),
                     EngineConfigurationConstants.KEY_PROCESS_ENGINE_CONFIG);
         }
         return result;
@@ -1325,7 +1325,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
             Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                     ActivitiEventBuilder.createVariableEvent(FlowableEngineEventType.VARIABLE_UPDATED, variableInstance.getName(), value, variableInstance.getType(),
-                            variableInstance.getTaskId(), variableInstance.getExecutionId(), getProcessInstanceId(), getProcessDefinitionId()),
+                            variableInstance.getTaskId(), variableInstance.getExecutionId(), getProcessInstanceId(), getProcessDefinitionId(), variableInstance.getId()),
                     EngineConfigurationConstants.KEY_PROCESS_ENGINE_CONFIG);
         }
     }

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
@@ -310,7 +310,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
         if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
             Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                     ActivitiEventBuilder.createVariableEvent(FlowableEngineEventType.VARIABLE_CREATED, variableName, value, result.getType(), result.getTaskId(),
-                            result.getExecutionId(), getProcessInstanceId(), getProcessDefinitionId()),
+                            result.getExecutionId(), getProcessInstanceId(), getProcessDefinitionId(), null),
                     EngineConfigurationConstants.KEY_PROCESS_ENGINE_CONFIG);
         }
         return result;
@@ -325,7 +325,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
         if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
             Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                     ActivitiEventBuilder.createVariableEvent(FlowableEngineEventType.VARIABLE_UPDATED, variableInstance.getName(), value, variableInstance.getType(),
-                            variableInstance.getTaskId(), variableInstance.getExecutionId(), getProcessInstanceId(), getProcessDefinitionId()),
+                            variableInstance.getTaskId(), variableInstance.getExecutionId(), getProcessInstanceId(), getProcessDefinitionId(), variableInstance.getId()),
                     EngineConfigurationConstants.KEY_PROCESS_ENGINE_CONFIG);
         }
     }


### PR DESCRIPTION
This pull request adds the instance ID variable to VariableEvents. This can be helpful if someone wants to modify a variable within a VariableEvent, for example, when the variable has been updated.

