### PR TITLE
Upgrade to Spring Boot 3.0.7

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -70,10 +70,10 @@ Quartz
 This software includes unchanged copies of the following libraries:
 
 aopalliance                     aopalliance                 1.0             Public Domain
-com.fasterxml.jackson.core      jackson-annotations         2.14.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-core                2.14.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-databind            2.14.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-joda       2.14.2          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-annotations         2.14.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-core                2.14.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-databind            2.14.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.datatype  jackson-datatype-joda       2.14.3          The Apache Software License, Version 2.0
 com.google.guava                guava                       31.0.1-jre      The Apache Software License, Version 2.0
 com.h2database                  h2                          2.1.214         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0
@@ -101,7 +101,7 @@ org.apache.httpcomponents       httpcore                    4.4.15          Apac
 org.apache.httpcomponents       httpmime                    4.5.13          Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
 org.apache.groovy               groovy                      4.0.10          The Apache Software License, Version 2.0
-org.apache.groovy               groovy-jsr223               4.0.10          The Apache Software License, Version 2.0
+org.apache.groovy               groovy-jsr223               4.0.12          The Apache Software License, Version 2.0
 org.liquibase                   liquibase-core              4.5.0           Apache License, Version 2.0
 org.mybatis                     mybatis                     3.5.11          The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              3.0.0           The Apache Software License, Version 2.0
@@ -109,18 +109,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              2.0.7           MIT License
 org.slf4j                       slf4j-api                   2.0.7           MIT License
 org.slf4j                       slf4j-log4j12               2.0.7           MIT License
-org.springframework             spring-beans                6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.8           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.8           The Apache Software License, Version 2.0
+org.springframework             spring-beans                6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-context              6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.0.9           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      6.0.3           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        6.0.3           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      6.0.3           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,22 +14,22 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>3.0.5</spring.boot.version>
-		<spring.framework.version>6.0.8</spring.framework.version>
+		<spring.boot.version>3.0.7</spring.boot.version>
+		<spring.framework.version>6.0.9</spring.framework.version>
 		<spring.security.version>6.0.3</spring.security.version>
 		<spring.amqp.version>3.0.3</spring.amqp.version>
 		<spring.kafka.version>3.0.5</spring.kafka.version>
 		<reactor-netty.version>1.1.6</reactor-netty.version>
-		<jackson.version>2.14.2</jackson.version>
+		<jackson.version>2.14.3</jackson.version>
 		<jakarta-jms.version>3.1.0</jakarta-jms.version>
         <camel.version>3.19.0</camel.version>
 		<cxf.version>3.5.4</cxf.version>
 		<slf4j.version>2.0.7</slf4j.version>
-		<groovy.version>4.0.10</groovy.version>
+		<groovy.version>4.0.12</groovy.version>
 		<jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
 
 		<junit.version>4.13.2</junit.version>
-		<junit.jupiter.version>5.9.2</junit.jupiter.version>
+		<junit.jupiter.version>5.9.3</junit.jupiter.version>
 		<hikari.version>4.0.3</hikari.version>
 		<maven.deploy.plugin.version>3.0.0</maven.deploy.plugin.version>
 		<maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>


### PR DESCRIPTION
This release includes a fix for [CVE-2023-20883: Spring Boot Welcome Page DoS Vulnerability](http://spring.io/security/cve-2023-20883).

Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v3.0.7


Supersedes https://github.com/flowable/flowable-engine/pull/3651

