### PR TITLE
Upgrade to Spring Framework 6.0.10

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -109,18 +109,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              2.0.7           MIT License
 org.slf4j                       slf4j-api                   2.0.7           MIT License
 org.slf4j                       slf4j-log4j12               2.0.7           MIT License
-org.springframework             spring-beans                6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.9           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.9           The Apache Software License, Version 2.0
+org.springframework             spring-beans                6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-context              6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.0.10          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.0.10          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      6.0.3           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        6.0.3           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      6.0.3           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>3.0.7</spring.boot.version>
-		<spring.framework.version>6.0.9</spring.framework.version>
+		<spring.framework.version>6.0.10</spring.framework.version>
 		<spring.security.version>6.0.3</spring.security.version>
 		<spring.amqp.version>3.0.3</spring.amqp.version>
 		<spring.kafka.version>3.0.5</spring.kafka.version>


### PR DESCRIPTION
Spring Framework 6.0.10 ships with [new features, fixes and documentation improvements](https://github.com/spring-projects/spring-framework/releases/tag/v6.0.10), including [7 fixes for regressions](https://github.com/spring-projects/spring-framework/issues?q=is%3Aclosed+milestone%3A6.0.10+label%3A%22type%3A+regression%22).

Release Notes: https://github.com/spring-projects/spring-framework/releases/tag/v6.0.10
