### PR TITLE
Mirror functionality done by JobExecutor when triggerIfNeeded is exec…

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncJobCategoryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncJobCategoryTest.java
@@ -1,0 +1,219 @@
+package org.flowable.cmmn.test.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.engine.test.FlowableCmmnTestCase;
+import org.flowable.cmmn.engine.test.impl.CmmnJobTestHelper;
+import org.flowable.common.engine.api.FlowableException;
+import org.flowable.task.api.Task;
+import org.junit.Test;
+
+/**
+ * @author Fabio Filippelli
+ */
+public class AsyncJobCategoryTest extends FlowableCmmnTestCase {
+
+    private final static String CASE_DEF_KEY = "testAsyncServiceTask";
+    private final static String MATCHING_CATEGORY = "cmmnCategory";
+    private final static String NON_MATCHING_CATEGORY = "nonMatchingCategory";
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/async/AsyncTaskTest.testAsyncServiceTaskWithCategory.cmmn")
+    public void testNonMatchingCategory_asyncExecutorOff() {
+        try {
+            cmmnEngineConfiguration.setAsyncExecutorActivate(false);
+            cmmnEngineConfiguration.getAsyncExecutor().shutdown();
+            cmmnEngineConfiguration.addEnabledJobCategory(NON_MATCHING_CATEGORY);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(cmmnEngineConfiguration.getEnabledJobCategories());
+
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(CASE_DEF_KEY).start();
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            cmmnTaskService.complete(task.getId());
+
+            assertThatThrownBy(() -> CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true))
+                    .isInstanceOf(FlowableException.class);
+
+            // job is not executed because of different job category value
+            assertThat(cmmnManagementService.createJobQuery().count()).isEqualTo(1);
+
+            cmmnEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(MATCHING_CATEGORY);
+            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true);
+
+            // the job is done
+            assertThat(cmmnManagementService.createJobQuery().count()).isZero();
+        } finally {
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/async/AsyncTaskTest.testAsyncServiceTaskWithCategory.cmmn")
+    public void testNonMatchingCategory_asyncExecutorOn() {
+        try {
+            cmmnEngineConfiguration.getAsyncExecutor().start();
+            cmmnEngineConfiguration.setAsyncExecutorActivate(true);
+            cmmnEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(NON_MATCHING_CATEGORY);
+
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(CASE_DEF_KEY).start();
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            cmmnTaskService.complete(task.getId());
+
+            assertThatThrownBy(() -> CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true))
+                    .isInstanceOf(FlowableException.class);
+
+            // job is not executed because of different job category value
+            assertThat(cmmnManagementService.createJobQuery().count()).isEqualTo(1);
+
+            cmmnEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(MATCHING_CATEGORY);
+            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true);
+
+            // the job is done
+            assertThat(cmmnManagementService.createJobQuery().count()).isZero();
+        } finally {
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/async/AsyncTaskTest.testAsyncServiceTaskWithCategory.cmmn")
+    public void testMatchingCategory_asyncExecutorOff() {
+        try {
+            cmmnEngineConfiguration.setAsyncExecutorActivate(false);
+            cmmnEngineConfiguration.getAsyncExecutor().shutdown();
+            cmmnEngineConfiguration.addEnabledJobCategory(MATCHING_CATEGORY);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(cmmnEngineConfiguration.getEnabledJobCategories());
+
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(CASE_DEF_KEY).start();
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            cmmnTaskService.complete(task.getId());
+
+            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true);
+
+            // the job is done
+            assertThat(cmmnManagementService.createJobQuery().count()).isZero();
+        } finally {
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/async/AsyncTaskTest.testAsyncServiceTaskWithCategory.cmmn")
+    public void testMatchingCategory_asyncExecutorOn() {
+        try {
+            cmmnEngineConfiguration.getAsyncExecutor().start();
+            cmmnEngineConfiguration.setAsyncExecutorActivate(true);
+            cmmnEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(MATCHING_CATEGORY);
+
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(CASE_DEF_KEY).start();
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            cmmnTaskService.complete(task.getId());
+
+            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true);
+
+            // the job is done
+            assertThat(cmmnManagementService.createJobQuery().count()).isZero();
+        } finally {
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/async/AsyncTaskTest.testAsyncServiceTask.cmmn")
+    public void testEmptyJobCategory_asyncExecutorOff() {
+        try {
+            cmmnEngineConfiguration.setAsyncExecutorActivate(false);
+            cmmnEngineConfiguration.getAsyncExecutor().shutdown();
+            cmmnEngineConfiguration.addEnabledJobCategory(NON_MATCHING_CATEGORY);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(cmmnEngineConfiguration.getEnabledJobCategories());
+
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(CASE_DEF_KEY).start();
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            cmmnTaskService.complete(task.getId());
+
+            assertThatThrownBy(() -> CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true))
+                    .isInstanceOf(FlowableException.class);
+
+            // the job is not done
+            assertThat(cmmnManagementService.createJobQuery().count()).isEqualTo(1);
+        } finally {
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/async/AsyncTaskTest.testAsyncServiceTask.cmmn")
+    public void testEmptyJobCategory_asyncExecutorOn() {
+        try {
+            cmmnEngineConfiguration.getAsyncExecutor().start();
+            cmmnEngineConfiguration.setAsyncExecutorActivate(true);
+            cmmnEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(MATCHING_CATEGORY);
+
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(CASE_DEF_KEY).start();
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            cmmnTaskService.complete(task.getId());
+
+            assertThatThrownBy(() -> CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true))
+                    .isInstanceOf(FlowableException.class);
+
+            // the job is not done
+            assertThat(cmmnManagementService.createJobQuery().count()).isEqualTo(1);
+        } finally {
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/async/AsyncTaskTest.testAsyncServiceTaskWithCategory.cmmn")
+    public void testEmptyEnabledCategory_asyncExecutorOff() {
+        try {
+            cmmnEngineConfiguration.setAsyncExecutorActivate(false);
+            cmmnEngineConfiguration.getAsyncExecutor().shutdown();
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(cmmnEngineConfiguration.getEnabledJobCategories());
+
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(CASE_DEF_KEY).start();
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            cmmnTaskService.complete(task.getId());
+
+            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true);
+
+            // the job is done
+            assertThat(cmmnManagementService.createJobQuery().count()).isZero();
+        } finally {
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/async/AsyncTaskTest.testAsyncServiceTaskWithCategory.cmmn")
+    public void testEmptyEnabledCategory_asyncExecutorOn() {
+        try {
+            cmmnEngineConfiguration.getAsyncExecutor().start();
+            cmmnEngineConfiguration.setAsyncExecutorActivate(true);
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey(CASE_DEF_KEY).start();
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            cmmnTaskService.complete(task.getId());
+
+            CmmnJobTestHelper.waitForJobExecutorToProcessAllJobs(cmmnEngineConfiguration, 4000L, 200L, true);
+
+            // the job is done
+            assertThat(cmmnManagementService.createJobQuery().count()).isZero();
+        } finally {
+            cmmnEngineConfiguration.setEnabledJobCategories(null);
+            cmmnEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+}

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncJobCategoryTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/async/AsyncJobCategoryTest.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.cmmn.test.async;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncJobCategoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncJobCategoryTest.java
@@ -1,0 +1,200 @@
+package org.flowable.engine.test.bpmn.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.flowable.common.engine.api.FlowableException;
+import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.test.Deployment;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Fabio Filippelli
+ */
+public class AsyncJobCategoryTest extends PluggableFlowableTestCase {
+
+    private final static String PROCESS_DEF_KEY = "asyncTask";
+    private final static String MATCHING_CATEGORY = "testCategory";
+    private final static String NON_MATCHING_CATEGORY = "nonMatchingCategory";
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTaskWithJobCategory.bpmn20.xml")
+    public void testNonMatchingCategory_asyncExecutorOff() {
+        try {
+            processEngineConfiguration.setAsyncExecutorActivate(false);
+            processEngineConfiguration.getAsyncExecutor().shutdown();
+            processEngineConfiguration.addEnabledJobCategory(NON_MATCHING_CATEGORY);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(processEngineConfiguration.getEnabledJobCategories());
+
+            runtimeService.startProcessInstanceByKey(PROCESS_DEF_KEY);
+
+            assertThatThrownBy(() -> waitForJobExecutorToProcessAllJobs(4000L, 200L))
+                    .isInstanceOf(FlowableException.class);
+
+            // job is not executed because of different job category value
+            assertThat(managementService.createJobQuery().count()).isEqualTo(1);
+
+            processEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(MATCHING_CATEGORY);
+            waitForJobExecutorToProcessAllJobs(4000L, 200L);
+
+            // the job is done
+            assertThat(managementService.createJobQuery().count()).isZero();
+        } finally {
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTaskWithJobCategory.bpmn20.xml")
+    public void testNonMatchingCategory_asyncExecutorOn() {
+        try {
+            processEngineConfiguration.getAsyncExecutor().start();
+            processEngineConfiguration.setAsyncExecutorActivate(true);
+            processEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(NON_MATCHING_CATEGORY);
+
+            runtimeService.startProcessInstanceByKey(PROCESS_DEF_KEY);
+
+            assertThatThrownBy(() -> waitForJobExecutorToProcessAllJobs(4000L, 200L))
+                    .isInstanceOf(FlowableException.class);
+
+            // job is not executed because of different job category value
+            assertThat(managementService.createJobQuery().count()).isEqualTo(1);
+
+            processEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(MATCHING_CATEGORY);
+            waitForJobExecutorToProcessAllJobs(4000L, 200L);
+
+            // the job is done
+            assertThat(managementService.createJobQuery().count()).isZero();
+        } finally {
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTaskWithJobCategory.bpmn20.xml")
+    public void testMatchingCategory_asyncExecutorOff() {
+        try {
+            processEngineConfiguration.setAsyncExecutorActivate(false);
+            processEngineConfiguration.getAsyncExecutor().shutdown();
+            processEngineConfiguration.addEnabledJobCategory(MATCHING_CATEGORY);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(processEngineConfiguration.getEnabledJobCategories());
+
+            runtimeService.startProcessInstanceByKey(PROCESS_DEF_KEY);
+
+            waitForJobExecutorToProcessAllJobs(4000L, 200L);
+
+            // the job is done
+            assertThat(managementService.createJobQuery().count()).isZero();
+        } finally {
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTaskWithJobCategory.bpmn20.xml")
+    public void testMatchingCategory_asyncExecutorOn() {
+        try {
+            processEngineConfiguration.getAsyncExecutor().start();
+            processEngineConfiguration.setAsyncExecutorActivate(true);
+            processEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(MATCHING_CATEGORY);
+
+            runtimeService.startProcessInstanceByKey(PROCESS_DEF_KEY);
+
+            waitForJobExecutorToProcessAllJobs(4000L, 200L);
+
+            // the job is done
+            assertThat(managementService.createJobQuery().count()).isZero();
+        } finally {
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTask.bpmn20.xml")
+    public void testEmptyJobCategory_asyncExecutorOff() {
+        try {
+            processEngineConfiguration.setAsyncExecutorActivate(false);
+            processEngineConfiguration.getAsyncExecutor().shutdown();
+            processEngineConfiguration.addEnabledJobCategory(NON_MATCHING_CATEGORY);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(processEngineConfiguration.getEnabledJobCategories());
+
+            runtimeService.startProcessInstanceByKey(PROCESS_DEF_KEY);
+
+            assertThatThrownBy(() -> waitForJobExecutorToProcessAllJobs(4000L, 200L))
+                    .isInstanceOf(FlowableException.class);
+
+            // the job is not done
+            assertThat(managementService.createJobQuery().count()).isEqualTo(1);
+        } finally {
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTask.bpmn20.xml")
+    public void testEmptyJobCategory_asyncExecutorOn() {
+        try {
+            processEngineConfiguration.getAsyncExecutor().start();
+            processEngineConfiguration.setAsyncExecutorActivate(true);
+            processEngineConfiguration.getJobServiceConfiguration().addEnabledJobCategory(MATCHING_CATEGORY);
+
+            runtimeService.startProcessInstanceByKey(PROCESS_DEF_KEY);
+
+            assertThatThrownBy(() -> waitForJobExecutorToProcessAllJobs(4000L, 200L))
+                    .isInstanceOf(FlowableException.class);
+
+            // the job is not done
+            assertThat(managementService.createJobQuery().count()).isEqualTo(1);
+        } finally {
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTaskWithJobCategory.bpmn20.xml")
+    public void testEmptyEnabledCategory_asyncExecutorOff() {
+        try {
+            processEngineConfiguration.setAsyncExecutorActivate(false);
+            processEngineConfiguration.getAsyncExecutor().shutdown();
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(processEngineConfiguration.getEnabledJobCategories());
+
+            runtimeService.startProcessInstanceByKey(PROCESS_DEF_KEY);
+
+            waitForJobExecutorToProcessAllJobs(4000L, 200L);
+
+            // the job is done
+            assertThat(managementService.createJobQuery().count()).isZero();
+        } finally {
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/async/AsyncTaskTest.testAsyncTaskWithJobCategory.bpmn20.xml")
+    public void testEmptyEnabledCategory_asyncExecutorOn() {
+        try {
+            processEngineConfiguration.getAsyncExecutor().start();
+            processEngineConfiguration.setAsyncExecutorActivate(true);
+            processEngineConfiguration.setEnabledJobCategories(null);
+
+            runtimeService.startProcessInstanceByKey(PROCESS_DEF_KEY);
+
+            waitForJobExecutorToProcessAllJobs(4000L, 200L);
+
+            // the job is done
+            assertThat(managementService.createJobQuery().count()).isZero();
+        } finally {
+            processEngineConfiguration.setEnabledJobCategories(null);
+            processEngineConfiguration.getJobServiceConfiguration().setEnabledJobCategories(null);
+        }
+    }
+
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncJobCategoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/async/AsyncJobCategoryTest.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.engine.test.bpmn.async;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AbstractAsyncExecutor.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/AbstractAsyncExecutor.java
@@ -155,12 +155,12 @@ public abstract class AbstractAsyncExecutor implements AsyncExecutor {
         while (!temporaryJobQueue.isEmpty()) {
             JobInfo job = temporaryJobQueue.pop();
             JobEntityImpl jobEntity = (JobEntityImpl) job;
-            if(jobServiceConfiguration.getEnabledJobCategories() != null && !jobServiceConfiguration.getEnabledJobCategories().isEmpty()) {
-                if(StringUtils.isEmpty(jobEntity.getCategory())) {
+            if (jobServiceConfiguration.getEnabledJobCategories() != null && !jobServiceConfiguration.getEnabledJobCategories().isEmpty()) {
+                if (StringUtils.isEmpty(jobEntity.getCategory())) {
                     temporaryJobQueue.remove(job);
                     continue;
                 }
-                if(!jobServiceConfiguration.getEnabledJobCategories().contains(jobEntity.getCategory())) {
+                if (!jobServiceConfiguration.getEnabledJobCategories().contains(jobEntity.getCategory())) {
                     temporaryJobQueue.remove(job);
                     continue;
                 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultJobManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultJobManager.java
@@ -95,14 +95,14 @@ public class DefaultJobManager implements JobManager {
     protected void triggerExecutorIfNeeded(JobEntity jobEntity) {
         // When the async executor is activated, the job is directly passed on to the async executor thread
         if (isAsyncExecutorActive()) {
-            if (StringUtils.isNotEmpty(jobEntity.getCategory())) {
-                if (jobServiceConfiguration.getEnabledJobCategories() != null && 
-                        !jobServiceConfiguration.getEnabledJobCategories().contains(jobEntity.getCategory())) {
-                    
+            if(jobServiceConfiguration.getEnabledJobCategories() != null && !jobServiceConfiguration.getEnabledJobCategories().isEmpty()) {
+                if(StringUtils.isEmpty(jobEntity.getCategory())) {
+                    return;
+                }
+                if(!jobServiceConfiguration.getEnabledJobCategories().contains(jobEntity.getCategory())) {
                     return;
                 }
             }
-            
             hintAsyncExecutor(jobEntity);
         }
     }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultJobManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/asyncexecutor/DefaultJobManager.java
@@ -95,11 +95,11 @@ public class DefaultJobManager implements JobManager {
     protected void triggerExecutorIfNeeded(JobEntity jobEntity) {
         // When the async executor is activated, the job is directly passed on to the async executor thread
         if (isAsyncExecutorActive()) {
-            if(jobServiceConfiguration.getEnabledJobCategories() != null && !jobServiceConfiguration.getEnabledJobCategories().isEmpty()) {
-                if(StringUtils.isEmpty(jobEntity.getCategory())) {
+            if (jobServiceConfiguration.getEnabledJobCategories() != null && !jobServiceConfiguration.getEnabledJobCategories().isEmpty()) {
+                if (StringUtils.isEmpty(jobEntity.getCategory())) {
                     return;
                 }
-                if(!jobServiceConfiguration.getEnabledJobCategories().contains(jobEntity.getCategory())) {
+                if (!jobServiceConfiguration.getEnabledJobCategories().contains(jobEntity.getCategory())) {
                     return;
                 }
             }


### PR DESCRIPTION
…uted:

- always execute all jobs if no enabledCategory is defined
- only execute a job without category if there is no enabledCategories defined
- only execute jobs where the jobCategory match the enabledCategories
- added tests with asyncExecutor on and off

Mirror functionality done by JobExecutor when triggerIfNeeded is executed:
- only execute a job without category if there is no enabledCategories defined
- only execute jobs where the jobCategory match the enabledCategories

#### Check List:
* Unit tests: YES
* Documentation: NO
