### PR TITLE
Chore: mismatch of logging placeholders and arguments

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -594,7 +594,7 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Multi-instance '{}' {}. Details: loopCounter={}, nrOrCompletedInstances={},nrOfActiveInstances={},nrOfInstances={}",
                     execution.getCurrentFlowElement() != null ? execution.getCurrentFlowElement().getId() : "", custom, loopCounter,
-                    nrOfCompletedInstances, nrOfActiveInstances, nrOfInstances, execution);
+                    nrOfCompletedInstances, nrOfActiveInstances, nrOfInstances);
         }
     }
 


### PR DESCRIPTION
As part of https://github.com/flowable/flowable-engine/pull/3481 the variable, `execution` was added to the debug message but no placeholder was added.

It would appear that the `id` of the `execution` is logged.   

The output of `execution` would be the default `toString()` and would provide little or no additional information thus the decision to remove it to make the number of placeholders match the number of arguments.

