### PR TITLE
Chore: replace API marked for removal

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/ExpressionManagerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/ExpressionManagerTest.java
@@ -75,7 +75,7 @@ public class ExpressionManagerTest extends PluggableFlowableTestCase {
     @Deployment(resources = "org/flowable/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")
     public void testFloatJsonVariableSerialization() {
         Map<String, Object> vars = new HashMap<>();
-        vars.put("mapVariable", processEngineConfiguration.getObjectMapper().createObjectNode().put("minFloatVar", new Float(-1.5)));
+        vars.put("mapVariable", processEngineConfiguration.getObjectMapper().createObjectNode().put("minFloatVar", Float.valueOf((float)-1.5)));
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
 
         Expression expression = this.processEngineConfiguration.getExpressionManager().createExpression("#{mapVariable.minFloatVar}");


### PR DESCRIPTION
The constructor `new Float(double value)` has been deprecated since JDK 9 and is marked for removal.  Here is the relevant code in the JDK:

<pre>
    /**
     * Constructs a newly allocated {@code Float} object that
     * represents the argument converted to type {@code float}.
     *
     * @param   value   the value to be represented by the {@code Float}.
     *
     * @deprecated
     * It is rarely appropriate to use this constructor. Instead, use the
     * static factory method {@link #valueOf(float)} method as follows:
     * {@code Float.valueOf((float)value)}.
     */
    @Deprecated(since="9", forRemoval = true)
    public Float(double value) {
        this.value = (float)value;
    }
</pre>