### PR TITLE
The property "migrateToProcessDefinitionVersion" is optional, if it i…

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/migration/ProcessInstanceMigrationDocumentBuilderImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/migration/ProcessInstanceMigrationDocumentBuilderImpl.java
@@ -129,7 +129,7 @@ public class ProcessInstanceMigrationDocumentBuilderImpl implements ProcessInsta
             if (migrateToProcessDefinitionKey == null) {
                 throw new FlowableException("Process definition key cannot be null");
             }
-            if (migrateToProcessDefinitionVersion == null || migrateToProcessDefinitionVersion < 0) {
+            if (migrateToProcessDefinitionVersion != null && migrateToProcessDefinitionVersion < 0) {
                 throw new FlowableException("Process definition version must be a positive number");
             }
         }


### PR DESCRIPTION
…s not set it takes the latest process definition (see AbstractDynamicStateManager#resolveProcessDefinition())

* Unit tests: NO
* Documentation: NO

