### PR TITLE
Upgrade to Spring Boot 2.7.15 for 6.x track

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -101,7 +101,7 @@ com.fasterxml.jackson.core      jackson-core                2.13.5          The 
 com.fasterxml.jackson.core      jackson-databind            2.13.5          The Apache Software License, Version 2.0
 com.fasterxml.jackson.datatype  jackson-datatype-joda       2.13.5          The Apache Software License, Version 2.0
 com.google.guava                guava                       31.0.1-jre      The Apache Software License, Version 2.0
-com.h2database                  h2                          2.1.214         The H2 License, Version 1.0
+com.h2database                  h2                          2.2.220         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0
 com.sun.mail                    javax.mail                  1.6.2           CDDL/GPLv2+CE
 commons-beanutils               commons-beanutils           1.8.3           The Apache Software License, Version 2.0
@@ -122,7 +122,7 @@ javax.annotation                jsr250-api                  1.0             COMM
 joda-time                       joda-time                   2.10.13         Apache 2
 log4j                           log4j                       1.2.17          The Apache Software License, Version 2.0
 org.apache.commons              commons-email               1.5             Apache License, Version 2.0
-org.apache.commons              commons-lang3               3.12.0          The Apache Software License, Version 2.0
+org.apache.commons              commons-lang3               3.13.0          The Apache Software License, Version 2.0
 org.apache.httpcomponents       httpclient                  4.5.13          Apache License, Version 2.0
 org.apache.httpcomponents       httpcore                    4.4.15          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.13          Apache License, Version 2.0
@@ -136,18 +136,18 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              1.7.36          MIT License
 org.slf4j                       slf4j-api                   1.7.36          MIT License
 org.slf4j                       slf4j-log4j12               1.7.36          MIT License
-org.springframework             spring-beans                5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-context              5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-context-support      5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-tx                   5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-web                  5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-aop                  5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-core                 5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-expression           5.3.25          The Apache Software License, Version 2.0
-org.springframework             spring-orm                  5.3.25          The Apache Software License, Version 2.0
+org.springframework             spring-beans                5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-context              5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-context-support      5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-tx                   5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-web                  5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-aop                  5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-core                 5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-expression           5.3.29          The Apache Software License, Version 2.0
+org.springframework             spring-orm                  5.3.29          The Apache Software License, Version 2.0
 org.springframework.security    spring-security-config      5.8.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-core        5.8.2           The Apache Software License, Version 2.0
 org.springframework.security    spring-security-crypto      5.8.2           The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,23 +14,23 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.7.8</spring.boot.version>
-		<spring.framework.version>5.3.25</spring.framework.version>
-		<spring.amqp.version>2.4.9</spring.amqp.version>
+		<spring.boot.version>2.7.15</spring.boot.version>
+		<spring.framework.version>5.3.29</spring.framework.version>
+		<spring.amqp.version>2.4.15</spring.amqp.version>
 		<spring.security.version>5.8.2</spring.security.version>
 		<spring.kafka.version>2.9.9</spring.kafka.version>
 		<reactor-netty.version>1.0.28</reactor-netty.version>
 		<jackson.version>2.13.5</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
-    <camel.version>3.14.0</camel.version>
+    	<camel.version>3.14.0</camel.version>
 		<cxf.version>3.4.2</cxf.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<groovy.version>4.0.3</groovy.version>
 		<jib-maven-plugin.version>2.6.0</jib-maven-plugin.version>
 
 		<junit.version>4.13.2</junit.version>
-		<junit.jupiter.version>5.9.2</junit.jupiter.version>
+		<junit.jupiter.version>5.9.3</junit.jupiter.version>
 		<hikari.version>4.0.3</hikari.version>
 		<maven.deploy.plugin.version>3.1.0</maven.deploy.plugin.version>
 		<maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
@@ -86,7 +86,7 @@
 			<dependency>
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
-				<version>2.1.214</version>
+				<version>2.2.220</version>
 			</dependency>
 			<!-- Logging -->
 			<dependency>
@@ -112,7 +112,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.0</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
@@ -232,7 +232,7 @@
 			<dependency>
 				<groupId>com.mysql</groupId>
 				<artifactId>mysql-connector-j</artifactId>
-				<version>8.0.31</version>
+				<version>8.0.33</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mariadb.jdbc</groupId>
@@ -242,7 +242,7 @@
 			<dependency>
 				<groupId>com.ibm.db2</groupId>
 				<artifactId>jcc</artifactId>
-				<version>11.5.7.0</version>
+				<version>11.5.8.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.flowable</groupId>
@@ -1206,7 +1206,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M5</version>
+				<version>3.1.2</version>
 				<configuration>
 					<failIfNoTests>false</failIfNoTests>
 					<trimStackTrace>false</trimStackTrace>


### PR DESCRIPTION
Spring Boot is significantly out of date; it is currently at 2.7.9.  Below is the release date and release notes for the various versions that bring the project up to version 2.7.15.

<pre>
Date of Release        Release Notes
============           ==============
Feb 23                 https://github.com/spring-projects/spring-boot/releases/tag/v2.7.9

Mar 23                 https://github.com/spring-projects/spring-boot/releases/tag/v2.7.10

Apr 20                 https://github.com/spring-projects/spring-boot/releases/tag/v2.7.11

May 18                 https://github.com/spring-projects/spring-boot/releases/tag/v2.7.12

Jun 22                 https://github.com/spring-projects/spring-boot/releases/tag/v2.7.13

Jul 20                 https://github.com/spring-projects/spring-boot/releases/tag/v2.7.14

Aug 24                 https://github.com/spring-projects/spring-boot/releases/tag/v2.7.15
</pre>

I attempted to make all the dependent jar changes (and a few others that I know about).   The only one I **DID NOT**  update was to MariaDB 3.1.4.   I seem to remember that the project had some issues with updating that jar previously.

After making the changes to the `pom.xml` file I ran `mvn clean test` without error.