### PR TITLE
Chore: fix parameter name to match Javadoc

### DIFF
--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/HistoricCaseInstanceMigrationBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/HistoricCaseInstanceMigrationBuilder.java
@@ -24,7 +24,7 @@ public interface HistoricCaseInstanceMigrationBuilder {
      * @return Returns the builder
      * @see HistoricCaseInstanceMigrationDocument
      */
-    HistoricCaseInstanceMigrationBuilder fromHistoricCaseInstanceMigrationDocument(HistoricCaseInstanceMigrationDocument caseInstanceMigrationDocument);
+    HistoricCaseInstanceMigrationBuilder fromHistoricCaseInstanceMigrationDocument(HistoricCaseInstanceMigrationDocument historicCaseInstanceMigrationDocument);
 
     /**
      * Specifies the case definition to migrate to, using the case definition id


### PR DESCRIPTION
When `flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/HistoricCaseInstanceMigrationBuilder.java` was created from `flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/CaseInstanceMigrationBuilder.java`, the Javadoc parameter name was changed to `historicCaseInstanceMigrationDocument` but the method signature was not.   This fixes that oversight.   Now the Javadoc can find the parameter.
