### PR TITLE
Allow LocalDate and Instants for user and human task due dates

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/HumanTaskActivityBehavior.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.cmmn.engine.impl.behavior.impl;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -293,8 +296,15 @@ public class HumanTaskActivityBehavior extends TaskActivityBehavior implements P
                         taskEntity.setDueDate(DateTime.parse(dueDateString).toDate());
                     }
 
+                } else if (dueDate instanceof Instant) {
+                    taskEntity.setDueDate(Date.from((Instant) dueDate));
+                } else if (dueDate instanceof LocalDate) {
+                    Date localDueDate = Date.from(((LocalDate) dueDate).atStartOfDay()
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant());
+                    taskEntity.setDueDate(localDueDate);
                 } else {
-                    throw new FlowableIllegalArgumentException("Due date expression does not resolve to a Date or Date string: " + beforeContext.getDueDate());
+                    throw new FlowableIllegalArgumentException("Due date expression does not resolve to a Date, Instant, LocalDate or Date string: " + beforeContext.getDueDate());
                 }
             }
         }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,6 +12,9 @@
  */
 package org.flowable.engine.impl.bpmn.behavior;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -251,10 +254,16 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Ac
                     BusinessCalendar businessCalendar = processEngineConfiguration.getBusinessCalendarManager()
                             .getBusinessCalendar(businessCalendarName);
                     task.setDueDate(businessCalendar.resolveDuedate((String) dueDate));
-
-                } else {
-                    throw new FlowableIllegalArgumentException("Due date expression does not resolve to a Date or Date string: " + activeTaskDueDate);
+                } else if (dueDate instanceof Instant) {
+                    task.setDueDate(Date.from((Instant) dueDate));
+                } else if (dueDate instanceof LocalDate) {
+                    Date localDueDate = Date.from(((LocalDate) dueDate).atStartOfDay()
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant());
+                    task.setDueDate(localDueDate);
                 }
+            } else {
+                throw new FlowableIllegalArgumentException("Due date expression does not resolve to a Date, Instant, LocalDate or Date string: " + beforeContext.getDueDate());
             }
         }
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -261,9 +261,9 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior implements Ac
                             .atZone(ZoneId.systemDefault())
                             .toInstant());
                     task.setDueDate(localDueDate);
+                } else {
+                    throw new FlowableIllegalArgumentException("Due date expression does not resolve to a Date, Instant, LocalDate or Date string: " + beforeContext.getDueDate());
                 }
-            } else {
-                throw new FlowableIllegalArgumentException("Due date expression does not resolve to a Date, Instant, LocalDate or Date string: " + beforeContext.getDueDate());
             }
         }
     }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -16,6 +16,9 @@ package org.flowable.engine.test.bpmn.usertask;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -43,15 +46,26 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
     public void testDueDateExtension() throws Exception {
 
         Date date = new SimpleDateFormat("dd-MM-yyyy hh:mm:ss").parse("06-07-1986 12:10:00");
+        LocalDate localDate = LocalDate.of(1986, 7, 6);
+        Instant instant = date.toInstant();
+
         Map<String, Object> variables = new HashMap<>();
         variables.put("dateVariable", date);
+        variables.put("instantVariable", instant);
+        variables.put("localDateVariable", localDate);
 
         // Start process-instance, passing date that should be used as dueDate
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dueDateExtension", variables);
 
-        org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        org.flowable.task.api.Task dateTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("dateTask").singleResult();
+        org.flowable.task.api.Task localDateTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("localDateTask").singleResult();
+        org.flowable.task.api.Task instantTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("instantTask").singleResult();
 
-        assertThat(task.getDueDate()).isEqualTo(date);
+        assertThat(dateTask.getDueDate()).isEqualTo(date);
+        assertThat(instantTask.getDueDate()).isEqualTo(date);
+
+        Date startOfDay = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        assertThat(localDateTask.getDueDate()).isEqualTo(startOfDay);
     }
 
     @Test

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -14,6 +14,7 @@
 package org.flowable.engine.test.bpmn.usertask;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -24,6 +25,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.impl.calendar.BusinessCalendar;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
@@ -66,6 +68,19 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
 
         Date startOfDay = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
         assertThat(localDateTask.getDueDate()).isEqualTo(startOfDay);
+    }
+
+    @Test
+    @Deployment
+    public void testDueDateExtensionWithUnparseableDate() throws Exception {
+        int notAValidDate = 0;
+
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("dateVariable", notAValidDate);
+
+        assertThrows(FlowableIllegalArgumentException.class, () -> {
+            runtimeService.startProcessInstanceByKey("dueDateExtensionWithUnparseableDate", variables);
+        });
     }
 
     @Test

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.testDueDateExtension.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.testDueDateExtension.bpmn20.xml
@@ -1,19 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="taskAssigneeExample" 
-  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="Examples">
-  
-  <process id="dueDateExtension">
-  
-    <startEvent id="theStart" />
-    
-    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+<definitions id="taskAssigneeExample"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
 
-    <userTask id="theTask" name="my task" activiti:dueDate="${dateVariable}" />
-    
-    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
-    
+  <process id="dueDateExtension">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="parallelSplit" />
+
+    <parallelGateway id="parallelSplit"/>
+
+    <sequenceFlow id="flow2" sourceRef="parallelSplit" targetRef="dateTask" />
+    <sequenceFlow id="flow3" sourceRef="parallelSplit" targetRef="localDateTask" />
+    <sequenceFlow id="flow4" sourceRef="parallelSplit" targetRef="instantTask" />
+
+    <userTask id="dateTask" name="my java.util.Date task" activiti:dueDate="${dateVariable}" />
+    <userTask id="localDateTask" name="my java.time.LocalDate task" activiti:dueDate="${localDateVariable}" />
+    <userTask id="instantTask" name="my java.time.Instant task" activiti:dueDate="${instantVariable}" />
+
+    <parallelGateway id="parallelJoin"/>
+
+    <sequenceFlow id="flow5" sourceRef="dateTask" targetRef="parallelJoin" />
+    <sequenceFlow id="flow6" sourceRef="localDateTask" targetRef="parallelJoin" />
+    <sequenceFlow id="flow7" sourceRef="instantTask" targetRef="parallelJoin" />
+
+
     <endEvent id="theEnd" />
     
   </process>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.testDueDateExtensionWithUnparseableDate.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.testDueDateExtensionWithUnparseableDate.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="taskAssigneeExample"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="dueDateExtensionWithUnparseableDate">
+
+        <startEvent id="theStart" />
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+
+        <userTask id="theTask" name="my task" activiti:dueDate="${dateVariable}" />
+
+        <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+
+        <endEvent id="theEnd" />
+
+    </process>
+
+</definitions>


### PR DESCRIPTION
With these changes, users can now set dynamic LocalDate and Instant due dates in UserTasks and HumanTasks.