### PR TITLE
Migration: Allow to configure a pre/post expression which is executed…

### DIFF
--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/CaseInstanceMigrationBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/CaseInstanceMigrationBuilder.java
@@ -135,6 +135,22 @@ public interface CaseInstanceMigrationBuilder {
     CaseInstanceMigrationBuilder addChangePlanItemIdWithDefinitionIdMapping(ChangePlanItemIdWithDefinitionIdMapping mapping);
 
     /**
+     * Specifies an expression which is executed before the migration starts.
+     *
+     * @param preUpgradeExpression the expression e.g. ${mySpringBean.doSomething()}
+     * @return Returns the builder
+     */
+    CaseInstanceMigrationBuilder withPreUpgradeExpression(String preUpgradeExpression);
+
+    /**
+     * Specifies an expression which is executed after the migration is finished.
+     *
+     * @param postUpgradeExpression the expression e.g. ${mySpringBean.doSomething()}
+     * @return Returns the builder
+     */
+    CaseInstanceMigrationBuilder withPostUpgradeExpression(String postUpgradeExpression);
+
+    /**
      * Specifies a case instance variable that will also be available during the case migration
      *
      * @param variableName Name of the variable

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/CaseInstanceMigrationDocument.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/CaseInstanceMigrationDocument.java
@@ -43,6 +43,10 @@ public interface CaseInstanceMigrationDocument {
     
     List<ChangePlanItemIdWithDefinitionIdMapping> getChangePlanItemIdWithDefinitionIdMappings();
 
+    String getPreUpgradeExpression();
+
+    String getPostUpgradeExpression();
+
     Map<String, Map<String, Object>> getPlanItemLocalVariables();
 
     Map<String, Object> getCaseInstanceVariables();

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/CaseInstanceMigrationDocumentBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/migration/CaseInstanceMigrationDocumentBuilder.java
@@ -55,6 +55,10 @@ public interface CaseInstanceMigrationDocumentBuilder {
 
     CaseInstanceMigrationDocumentBuilder addCaseInstanceVariables(Map<String, Object> caseInstanceVariables);
 
+    CaseInstanceMigrationDocumentBuilder preUpgradeExpression(String preUpgradeExpression);
+
+    CaseInstanceMigrationDocumentBuilder postUpgradeExpression(String postUpgradeExpression);
+
     CaseInstanceMigrationDocument build();
 
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationBuilderImpl.java
@@ -123,6 +123,18 @@ public class CaseInstanceMigrationBuilderImpl implements CaseInstanceMigrationBu
     }
 
     @Override
+    public CaseInstanceMigrationBuilder withPreUpgradeExpression(String preUpgradeExpression) {
+        this.caseInstanceMigrationDocumentDocumentBuilder.preUpgradeExpression(preUpgradeExpression);
+        return this;
+    }
+
+    @Override
+    public CaseInstanceMigrationBuilder withPostUpgradeExpression(String postUpgradeExpression) {
+        this.caseInstanceMigrationDocumentDocumentBuilder.postUpgradeExpression(postUpgradeExpression);
+        return this;
+    }
+
+    @Override
     public CaseInstanceMigrationBuilder withCaseInstanceVariable(String variableName, Object variableValue) {
         this.caseInstanceMigrationDocumentDocumentBuilder.addCaseInstanceVariable(variableName, variableValue);
         return this;
@@ -138,6 +150,8 @@ public class CaseInstanceMigrationBuilderImpl implements CaseInstanceMigrationBu
     public CaseInstanceMigrationDocument getCaseInstanceMigrationDocument() {
         return this.caseInstanceMigrationDocumentDocumentBuilder.build();
     }
+
+
 
     @Override
     public void migrate(String caseInstanceId) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationDocumentBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationDocumentBuilderImpl.java
@@ -43,6 +43,8 @@ public class CaseInstanceMigrationDocumentBuilderImpl implements CaseInstanceMig
     protected List<WaitingForRepetitionPlanItemDefinitionMapping> waitingForRepetitionPlanItemDefinitionMappings = new ArrayList<>();
     protected List<RemoveWaitingForRepetitionPlanItemDefinitionMapping> removeWaitingForRepetitionPlanItemDefinitionMappings = new ArrayList<>();
     protected List<ChangePlanItemIdMapping> changePlanItemIdMappings = new ArrayList<>();
+    protected String preUpgradeExpression;
+    protected String postUpgradeExpression;
     protected List<ChangePlanItemIdWithDefinitionIdMapping> changePlanItemIdWithDefinitionIdMappings = new ArrayList<>();
     protected Map<String, Object> caseInstanceVariables = new HashMap<>();
 
@@ -150,6 +152,18 @@ public class CaseInstanceMigrationDocumentBuilderImpl implements CaseInstanceMig
     }
 
     @Override
+    public CaseInstanceMigrationDocumentBuilder preUpgradeExpression(String preUpgradeExpression) {
+        this.preUpgradeExpression = preUpgradeExpression;
+        return this;
+    }
+
+    @Override
+    public CaseInstanceMigrationDocumentBuilder postUpgradeExpression(String postUpgradeExpression) {
+        this.postUpgradeExpression = postUpgradeExpression;
+        return this;
+    }
+
+    @Override
     public CaseInstanceMigrationDocument build() {
         CaseInstanceMigrationDocumentImpl caseInstanceMigrationDocument = new CaseInstanceMigrationDocumentImpl();
         caseInstanceMigrationDocument.setMigrateToCaseDefinitionId(this.migrateToCaseDefinitionId);
@@ -162,6 +176,8 @@ public class CaseInstanceMigrationDocumentBuilderImpl implements CaseInstanceMig
         caseInstanceMigrationDocument.setChangePlanItemIdMappings(this.changePlanItemIdMappings);
         caseInstanceMigrationDocument.setChangePlanItemIdWithDefinitionIdMappings(this.changePlanItemIdWithDefinitionIdMappings);
         caseInstanceMigrationDocument.setCaseInstanceVariables(this.caseInstanceVariables);
+        caseInstanceMigrationDocument.setPreUpgradeExpression(this.preUpgradeExpression);
+        caseInstanceMigrationDocument.setPostUpgradeExpression(this.postUpgradeExpression);
         return caseInstanceMigrationDocument;
     }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationDocumentConstants.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationDocumentConstants.java
@@ -36,6 +36,8 @@ public interface CaseInstanceMigrationDocumentConstants {
     String REMOVE_WAITING_FOR_REPETITION_PLAN_ITEM_DEFINITIONS_JSON_SECTION = "removeWaitingForRepetitionPlanItemDefinitions";
     String CHANGE_PLAN_ITEM_IDS_JSON_SECTION = "changePlanItemIds";
     String CHANGE_PLAN_ITEM_IDS_WITH_DEFINITION_ID_JSON_SECTION = "changePlanItemIdsWithDefinitionId";
+    String PRE_UPGRADE_EXPRESSION_KEY_JSON_PROPERTY = "preUpgradeExpression";
+    String POST_UPGRADE_EXPRESSION_KEY_JSON_PROPERTY = "postUpgradeExpression";
     String LOCAL_VARIABLES_JSON_SECTION = "localVariables";
     String CASE_INSTANCE_VARIABLES_JSON_SECTION = "caseInstanceVariables";
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationDocumentConverter.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationDocumentConverter.java
@@ -99,6 +99,14 @@ public class CaseInstanceMigrationDocumentConverter implements CaseInstanceMigra
         if (changePlanItemIdWithDefinitionIdMappingNodes != null && !changePlanItemIdWithDefinitionIdMappingNodes.isNull()) {
             documentNode.set(CHANGE_PLAN_ITEM_IDS_WITH_DEFINITION_ID_JSON_SECTION, changePlanItemIdWithDefinitionIdMappingNodes);
         }
+
+        if (caseInstanceMigrationDocument.getPreUpgradeExpression() != null) {
+            documentNode.put(PRE_UPGRADE_EXPRESSION_KEY_JSON_PROPERTY, caseInstanceMigrationDocument.getPreUpgradeExpression());
+        }
+
+        if (caseInstanceMigrationDocument.getPostUpgradeExpression() != null) {
+            documentNode.put(POST_UPGRADE_EXPRESSION_KEY_JSON_PROPERTY, caseInstanceMigrationDocument.getPostUpgradeExpression());
+        }
         
         JsonNode caseInstanceVariablesNode = convertToJsonCaseInstanceVariables(caseInstanceMigrationDocument, objectMapper);
         if (caseInstanceVariablesNode != null && !caseInstanceVariablesNode.isNull()) {
@@ -292,6 +300,13 @@ public class CaseInstanceMigrationDocumentConverter implements CaseInstanceMigra
                 Map<String, Object> caseInstanceVariables = convertFromJsonNodeToObject(caseInstanceVariablesNode, objectMapper);
                 documentBuilder.addCaseInstanceVariables(caseInstanceVariables);
             }
+
+            String preUpgradeExpression = getJsonProperty(PRE_UPGRADE_EXPRESSION_KEY_JSON_PROPERTY, rootNode);
+            documentBuilder.preUpgradeExpression(preUpgradeExpression);
+
+            String postUpgradeExpression = getJsonProperty(POST_UPGRADE_EXPRESSION_KEY_JSON_PROPERTY, rootNode);
+            documentBuilder.postUpgradeExpression(postUpgradeExpression);
+
             return documentBuilder.build();
 
         } catch (IOException e) {

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationDocumentImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationDocumentImpl.java
@@ -43,6 +43,8 @@ public class CaseInstanceMigrationDocumentImpl implements CaseInstanceMigrationD
     protected List<RemoveWaitingForRepetitionPlanItemDefinitionMapping> removeWaitingForRepetitionPlanItemDefinitionMappings = new ArrayList<>();
     protected List<ChangePlanItemIdMapping> changePlanItemIdMappings = new ArrayList<>();
     protected List<ChangePlanItemIdWithDefinitionIdMapping> changePlanItemIdWithDefinitionIdMappings = new ArrayList<>();
+    protected String preUpgradeExpression;
+    protected String postUpgradeExpression;
     protected Map<String, Object> caseInstanceVariables = new HashMap<>();
     protected Map<String, Map<String, Object>> planItemLocalVariables = new HashMap<>();
 
@@ -95,6 +97,14 @@ public class CaseInstanceMigrationDocumentImpl implements CaseInstanceMigrationD
 
     public void setCaseInstanceVariables(Map<String, Object> caseInstanceVariables) {
         this.caseInstanceVariables = caseInstanceVariables;
+    }
+
+    public void setPreUpgradeExpression(String preUpgradeExpression) {
+        this.preUpgradeExpression = preUpgradeExpression;
+    }
+
+    public void setPostUpgradeExpression(String postUpgradeExpression) {
+        this.postUpgradeExpression = postUpgradeExpression;
     }
 
     @Override
@@ -150,6 +160,16 @@ public class CaseInstanceMigrationDocumentImpl implements CaseInstanceMigrationD
     @Override
     public List<ChangePlanItemIdWithDefinitionIdMapping> getChangePlanItemIdWithDefinitionIdMappings() {
         return changePlanItemIdWithDefinitionIdMappings;
+    }
+
+    @Override
+    public String getPreUpgradeExpression() {
+        return preUpgradeExpression;
+    }
+
+    @Override
+    public String getPostUpgradeExpression() {
+        return postUpgradeExpression;
     }
 
     @Override

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationManagerImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/migration/CaseInstanceMigrationManagerImpl.java
@@ -256,6 +256,10 @@ public class CaseInstanceMigrationManagerImpl extends AbstractCmmnDynamicStateMa
 
     protected void doMigrateCaseInstance(CaseInstanceEntity caseInstance, CaseDefinition caseDefinitionToMigrateTo, CaseInstanceMigrationDocument document, CommandContext commandContext) {
         LOGGER.debug("Start migration of case instance with Id:'{}' to case definition identified by {}", caseInstance.getId(), printCaseDefinitionIdentifierMessage(document));
+        if (document.getPreUpgradeExpression() != null && !document.getPreUpgradeExpression().isEmpty()) {
+            cmmnEngineConfiguration.getExpressionManager().createExpression(document.getPreUpgradeExpression()).getValue(caseInstance);
+        }
+
         ChangePlanItemStateBuilderImpl changePlanItemStateBuilder = prepareChangeStateBuilder(caseInstance, caseDefinitionToMigrateTo, document, commandContext);
 
         LOGGER.debug("Updating case definition reference of case root execution with id:'{}' to '{}'", caseInstance.getId(), caseDefinitionToMigrateTo.getId());
@@ -292,6 +296,10 @@ public class CaseInstanceMigrationManagerImpl extends AbstractCmmnDynamicStateMa
             for (CaseInstanceMigrationCallback caseInstanceMigrationCallback : migrationCallbacks) {
                 caseInstanceMigrationCallback.caseInstanceMigrated(caseInstance, caseDefinitionToMigrateTo, document);
             }
+        }
+
+        if (document.getPostUpgradeExpression() != null && !document.getPostUpgradeExpression().isEmpty()) {
+            cmmnEngineConfiguration.getExpressionManager().createExpression(document.getPostUpgradeExpression()).getValue(caseInstance);
         }
     }
     

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/migration/CaseInstanceMigrationTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/migration/CaseInstanceMigrationTest.java
@@ -4242,6 +4242,56 @@ public class CaseInstanceMigrationTest extends AbstractCaseMigrationTest {
         }
     }
 
+    @Test
+    void withPreUpgradeExpression() {
+        // Arrange
+        CaseDefinition definition1 = deployCaseDefinition("test1", "org/flowable/cmmn/test/migration/one-task.cmmn.xml");
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testCase").start();
+        CaseDefinition definition2 = deployCaseDefinition("test1", "org/flowable/cmmn/test/migration/one-task.cmmn.xml");
+
+        // Act
+        cmmnMigrationService.createCaseInstanceMigrationBuilder()
+                .migrateToCaseDefinition(definition2.getId())
+                .withPreUpgradeExpression("${variableContainer.setVariable('preUpgradeExpressionExecuted', true)}")
+                .migrate(caseInstance.getId());
+
+        // Assert
+        CaseInstance caseInstanceAfterMigration = cmmnRuntimeService.createCaseInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .includeCaseVariables()
+                .singleResult();
+        assertThat(caseInstanceAfterMigration.getCaseDefinitionId()).isEqualTo(definition2.getId());
+        assertThat(caseInstanceAfterMigration.getCaseDefinitionVersion()).isEqualTo(2);
+        assertThat(caseInstanceAfterMigration.getCaseDefinitionDeploymentId()).isEqualTo(definition2.getDeploymentId());
+
+        assertThat((Boolean) caseInstanceAfterMigration.getCaseVariables().getOrDefault("preUpgradeExpressionExecuted", false)).isTrue();
+    }
+
+    @Test
+    void withPostUpgradeExpression() {
+        // Arrange
+        CaseDefinition definition1 = deployCaseDefinition("test1", "org/flowable/cmmn/test/migration/one-task.cmmn.xml");
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("testCase").start();
+        CaseDefinition definition2 = deployCaseDefinition("test1", "org/flowable/cmmn/test/migration/one-task.cmmn.xml");
+
+        // Act
+        cmmnMigrationService.createCaseInstanceMigrationBuilder()
+                .migrateToCaseDefinition(definition2.getId())
+                .withPostUpgradeExpression("${variableContainer.setVariable('postUpgradeExpressionExecuted', true)}")
+                .migrate(caseInstance.getId());
+
+        // Assert
+        CaseInstance caseInstanceAfterMigration = cmmnRuntimeService.createCaseInstanceQuery()
+                .caseInstanceId(caseInstance.getId())
+                .includeCaseVariables()
+                .singleResult();
+        assertThat(caseInstanceAfterMigration.getCaseDefinitionId()).isEqualTo(definition2.getId());
+        assertThat(caseInstanceAfterMigration.getCaseDefinitionVersion()).isEqualTo(2);
+        assertThat(caseInstanceAfterMigration.getCaseDefinitionDeploymentId()).isEqualTo(definition2.getDeploymentId());
+
+        assertThat((Boolean) caseInstanceAfterMigration.getCaseVariables().getOrDefault("postUpgradeExpressionExecuted", false)).isTrue();
+    }
+
     // with sentries
     // with stages
     // with new expected case variables


### PR DESCRIPTION
For process migration we allow the users to define expressions which are triggered before/after the migration, this possibilty is missing currently for case migration. There is already an option to register a custom CaseInstanceMigrationCallback, but this callback service would be executed for every case migration. Often the migration looks different from case to case.
