### PR TITLE
Upgrade to Spring Security 6.1.4

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -119,10 +119,10 @@ org.springframework             spring-aop                  6.0.12           The
 org.springframework             spring-core                 6.0.12           The Apache Software License, Version 2.0
 org.springframework             spring-expression           6.0.12           The Apache Software License, Version 2.0
 org.springframework             spring-orm                  6.0.12           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      6.1.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        6.1.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      6.1.3           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         6.1.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      6.1.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        6.1.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      6.1.4           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         6.1.4           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>3.1.3</spring.boot.version>
 		<spring.framework.version>6.0.12</spring.framework.version>
-		<spring.security.version>6.1.3</spring.security.version>
+		<spring.security.version>6.1.4</spring.security.version>
 		<spring.amqp.version>3.0.8</spring.amqp.version>
 		<spring.kafka.version>3.0.10</spring.kafka.version>
 		<spring.ldap.version>3.1.1</spring.ldap.version>


### PR DESCRIPTION
Fixes [CVE-2023-34042](https://spring.io/security/cve-2023-34042).

Release Notes: https://github.com/spring-projects/spring-security/releases/tag/6.1.4
