### PR TITLE
Upgrade to Spring Security 5.8.7

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -148,10 +148,10 @@ org.springframework             spring-aop                  5.3.30          The 
 org.springframework             spring-core                 5.3.30          The Apache Software License, Version 2.0
 org.springframework             spring-expression           5.3.30          The Apache Software License, Version 2.0
 org.springframework             spring-orm                  5.3.30          The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      5.8.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        5.8.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      5.8.2           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         5.8.2           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      5.8.7           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        5.8.7           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      5.8.7           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         5.8.7           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<spring.amqp.version>2.4.15</spring.amqp.version>
 		<spring.security.version>5.8.7</spring.security.version>
 		<spring.kafka.version>2.9.9</spring.kafka.version>
-		<reactor-netty.version>1.0.28</reactor-netty.version>
+		<reactor-netty.version>1.0.35</reactor-netty.version>
 		<jackson.version>2.13.5</jackson.version>
 		<jakarta-jms.version>2.0.3</jakarta-jms.version>
 		<mule.version>3.8.0</mule.version>
@@ -1011,7 +1011,7 @@
 			<dependency>
 				<groupId>org.hsqldb</groupId>
 				<artifactId>hsqldb</artifactId>
-				<version>2.7.1</version>
+				<version>2.7.2</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<spring.boot.version>2.7.15</spring.boot.version>
 		<spring.framework.version>5.3.30</spring.framework.version>
 		<spring.amqp.version>2.4.15</spring.amqp.version>
-		<spring.security.version>5.8.2</spring.security.version>
+		<spring.security.version>5.8.7</spring.security.version>
 		<spring.kafka.version>2.9.9</spring.kafka.version>
 		<reactor-netty.version>1.0.28</reactor-netty.version>
 		<jackson.version>2.13.5</jackson.version>


### PR DESCRIPTION
Fixes [CVE-2023-34042](https://spring.io/security/cve-2023-34042).

Release Notes:
5.8.3 https://github.com/spring-projects/spring-security/releases/tag/5.8.3
5.8.4 https://github.com/spring-projects/spring-security/releases/tag/5.8.4
5.8.5 https://github.com/spring-projects/spring-security/releases/tag/5.8.5
5.8.6 https://github.com/spring-projects/spring-security/releases/tag/5.8.6
5.8.7 https://github.com/spring-projects/spring-security/releases/tag/5.8.7
