### PR TITLE
Upgrade to Spring Boot 2.7.16 for flowable6.x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>1.8</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>2.7.15</spring.boot.version>
+		<spring.boot.version>2.7.16</spring.boot.version>
 		<spring.framework.version>5.3.30</spring.framework.version>
-		<spring.amqp.version>2.4.15</spring.amqp.version>
+		<spring.amqp.version>2.4.16</spring.amqp.version>
 		<spring.security.version>5.8.7</spring.security.version>
 		<spring.kafka.version>2.9.9</spring.kafka.version>
 		<reactor-netty.version>1.0.35</reactor-netty.version>


### PR DESCRIPTION
Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v2.7.16
