### PR TITLE
Handle Error in the execution of JavaDelegate

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskJavaDelegateActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ServiceTaskJavaDelegateActivityBehavior.java
@@ -114,6 +114,13 @@ public class ServiceTaskJavaDelegateActivityBehavior extends TaskActivityBehavio
                 }
                 
                 throw e;
+            } catch (Throwable t) {
+                if (processEngineConfiguration.isLoggingSessionEnabled()) {
+                    BpmnLoggingSessionUtil.addErrorLoggingData(LoggingSessionConstants.TYPE_SERVICE_TASK_EXCEPTION,
+                            "Service task with java class " + javaDelegate.getClass().getName() + " threw throwable " + t.getMessage(), t, execution);
+                }
+
+                throw new RuntimeException(t);
             }
             
         } else {

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/jobexecutor/AsyncExecutorTest.JobErrorCheck.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/jobexecutor/AsyncExecutorTest.JobErrorCheck.bpmn20.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" targetNamespace="http://www.activiti.org/test" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="14.0.0">
+    <process id="JobErrorCheck" name="Job Error Check" isExecutable="true">
+        <startEvent id="startevent1" name="Start">
+            <outgoing>Flow_1ygz058</outgoing>
+        </startEvent>
+        <endEvent id="endevent1" name="End" />
+        <serviceTask id="servicetask1" name="Service Task"  activiti:async="true" activiti:class="org.flowable.engine.test.jobexecutor.AsyncExecutorTest$TestErrorJavaDelegate">
+            <incoming>Flow_1ygz058</incoming>
+        </serviceTask>
+        <sequenceFlow id="flow2" sourceRef="servicetask1" targetRef="endevent1" />
+        <sequenceFlow id="Flow_1ygz058" sourceRef="startevent1" targetRef="servicetask1" />
+    </process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_JobErrorCheck">
+        <bpmndi:BPMNPlane id="BPMNPlane_JobErrorCheck" bpmnElement="JobErrorCheck">
+            <bpmndi:BPMNShape id="BPMNShape_startevent1" bpmnElement="startevent1">
+                <omgdc:Bounds x="150" y="90" width="35" height="35" />
+                <bpmndi:BPMNLabel>
+                    <omgdc:Bounds x="156" y="125" width="24" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMNShape_servicetask1" bpmnElement="servicetask1">
+                <omgdc:Bounds x="327" y="80" width="105" height="55" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMNShape_endevent1" bpmnElement="endevent1">
+                <omgdc:Bounds x="502" y="90" width="35" height="35" />
+                <bpmndi:BPMNLabel>
+                    <omgdc:Bounds x="510" y="125" width="20" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMNEdge_flow2" bpmnElement="flow2">
+                <omgdi:waypoint x="432" y="107" />
+                <omgdi:waypoint x="502" y="107" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1ygz058_di" bpmnElement="Flow_1ygz058">
+                <omgdi:waypoint x="185" y="108" />
+                <omgdi:waypoint x="327" y="108" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
Hello everyone,

This pull request is related to this ticket in this forum https://forum.flowable.org/t/oom-error-and-incoherent-datas-in-db/10869.

We are using flowable 6.8.0 and we had an OutOfMemory error in production which leaded to 387 activity instances with 'endTime' set to null and with no related job in database. 

The process instances that were linked to these incoherent activity instances were stucked.

We had to re-create a job manually in database to make the process instances go forward. 

In this PR, we reproduced the case and caught a Throwable to handle this case.

It is quite urgent for us :)

It would be good to create a minor 6.8.1 as well! 

For now we are far from upgrading to 7.0.0.

Thank you very much for your concern.