### PR TITLE
EventSubProcess for error treatment should not be searched in children

### DIFF
--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/FlowElementsContainer.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/FlowElementsContainer.java
@@ -20,6 +20,10 @@ import java.util.Map;
  */
 public interface FlowElementsContainer {
 
+
+    //Custom PROTOOLS:
+    FlowElement getFlowElement(String flowElementId, boolean searchRecursive);
+
     FlowElement getFlowElement(String id);
 
     Collection<FlowElement> getFlowElements();

--- a/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/SubProcess.java
+++ b/modules/flowable-bpmn-model/src/main/java/org/flowable/bpmn/model/SubProcess.java
@@ -33,6 +33,26 @@ public class SubProcess extends Activity implements FlowElementsContainer {
     protected List<Artifact> artifactList = new ArrayList<>();
     protected List<ValuedDataObject> dataObjects = new ArrayList<>();
 
+
+    //Custom PROTOOLS:
+    @Override
+    public FlowElement getFlowElement(String flowElementId, boolean searchRecursive) {
+        if (searchRecursive) {
+            return flowElementMap.get(flowElementId);
+        } else {
+            return findFlowElementInList(flowElementId);
+        }
+    }
+    protected FlowElement findFlowElementInList(String flowElementId) {
+        for (FlowElement f : flowElementList) {
+            if (f.getId() != null && f.getId().equals(flowElementId)) {
+                return f;
+            }
+        }
+        return null;
+    }
+    //END CUSTOM
+
     @Override
     public FlowElement getFlowElement(String id) {
         FlowElement foundElement = null;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ErrorPropagation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ErrorPropagation.java
@@ -160,7 +160,7 @@ public class ErrorPropagation {
                             String refActivityId = refId.substring(0, refId.indexOf('#'));
                             String refProcessDefinitionId = refId.substring(refId.indexOf('#') + 1);
                             if (parentExecution.getProcessDefinitionId().equals(refProcessDefinitionId) &&
-                                            currentContainer.getFlowElement(refActivityId) != null) {
+                                            currentContainer.getFlowElement(refActivityId,false) != null) {
 
                                 matchingEvent = getCatchEventFromList(events, parentExecution);
                                 String errorCode = getErrorCodeFromErrorEventDefinition(matchingEvent);


### PR DESCRIPTION
#3754 : this patch will prevent searching within children subprocesses when searching for the correct event processing subprocesses