### PR TITLE
Upgrade to Spring Security 6.1.5 and Spring Framework 6.0.13

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -107,22 +107,22 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              2.0.9           MIT License
 org.slf4j                       slf4j-api                   2.0.9           MIT License
 org.slf4j                       slf4j-log4j12               2.0.9           MIT License
-org.springframework             spring-beans                6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.12           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      6.1.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        6.1.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      6.1.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         6.1.4           The Apache Software License, Version 2.0
+org.springframework             spring-beans                6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-context              6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.0.13           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      6.1.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        6.1.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      6.1.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         6.1.5           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
 		<spring.boot.version>3.1.4</spring.boot.version>
-		<spring.framework.version>6.0.12</spring.framework.version>
-		<spring.security.version>6.1.4</spring.security.version>
+		<spring.framework.version>6.0.13</spring.framework.version>
+		<spring.security.version>6.1.5</spring.security.version>
 		<spring.amqp.version>3.0.9</spring.amqp.version>
 		<spring.kafka.version>3.0.10</spring.kafka.version>
 		<spring.ldap.version>3.1.1</spring.ldap.version>
@@ -161,7 +161,7 @@
 			<dependency>
 				<groupId>jakarta.xml.bind</groupId>
 				<artifactId>jakarta.xml.bind-api</artifactId>
-				<version>4.0.0</version>
+				<version>4.0.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.glassfish.jaxb</groupId>


### PR DESCRIPTION
Spring Security:

Release Notes:  https://github.com/spring-projects/spring-security/releases/tag/6.1.5

Spring Framework:
Includes 34 fixes and documentation improvements of which 7 are fixes for regressions. There are no Flowable related dependency updates.

Release Notes: https://github.com/spring-projects/spring-framework/releases/tag/v6.0.13