### PR TITLE
Upgrade to Spring Boot 3.1.5, Security 6.1.5 and Spring Framework 6.0.13

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -69,10 +69,10 @@ Quartz
 This software includes unchanged copies of the following libraries:
 
 aopalliance                     aopalliance                 1.0             Public Domain
-com.fasterxml.jackson.core      jackson-annotations         2.15.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-core                2.15.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.core      jackson-databind            2.15.2          The Apache Software License, Version 2.0
-com.fasterxml.jackson.datatype  jackson-datatype-joda       2.15.2          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-annotations         2.15.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-core                2.15.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.core      jackson-databind            2.15.3          The Apache Software License, Version 2.0
+com.fasterxml.jackson.datatype  jackson-datatype-joda       2.15.3          The Apache Software License, Version 2.0
 com.google.guava                guava                       31.0.1-jre      The Apache Software License, Version 2.0
 com.h2database                  h2                          2.1.214         The H2 License, Version 1.0
 com.fasterxml.uuid              java-uuid-generator         3.3.0           The Apache Software License, Version 2.0
@@ -107,22 +107,22 @@ org.mvel                        mvel2                       2.2.6.Final     The 
 org.slf4j                       jcl-over-slf4j              2.0.9           MIT License
 org.slf4j                       slf4j-api                   2.0.9           MIT License
 org.slf4j                       slf4j-log4j12               2.0.9           MIT License
-org.springframework             spring-beans                6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.12           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.12           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      6.1.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        6.1.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      6.1.4           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         6.1.4           The Apache Software License, Version 2.0
+org.springframework             spring-beans                6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-context              6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.0.13           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.0.13           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      6.1.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        6.1.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      6.1.5           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         6.1.5           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,14 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>3.1.4</spring.boot.version>
-		<spring.framework.version>6.0.12</spring.framework.version>
-		<spring.security.version>6.1.4</spring.security.version>
-		<spring.amqp.version>3.0.9</spring.amqp.version>
-		<spring.kafka.version>3.0.10</spring.kafka.version>
+		<spring.boot.version>3.1.5</spring.boot.version>
+		<spring.framework.version>6.0.13</spring.framework.version>
+		<spring.security.version>6.1.5</spring.security.version>
+		<spring.amqp.version>3.0.10</spring.amqp.version>
+		<spring.kafka.version>3.0.12</spring.kafka.version>
 		<spring.ldap.version>3.1.1</spring.ldap.version>
 		<reactor-netty.version>1.1.8</reactor-netty.version>
-		<jackson.version>2.15.2</jackson.version>
+		<jackson.version>2.15.3</jackson.version>
 		<jakarta-jms.version>3.1.0</jakarta-jms.version>
         <camel.version>4.0.0</camel.version>
 		<cxf.version>4.0.2</cxf.version>
@@ -161,7 +161,7 @@
 			<dependency>
 				<groupId>jakarta.xml.bind</groupId>
 				<artifactId>jakarta.xml.bind-api</artifactId>
-				<version>4.0.0</version>
+				<version>4.0.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.glassfish.jaxb</groupId>
@@ -270,7 +270,7 @@
 			<dependency>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>6.2.9.Final</version>
+				<version>6.2.13.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>


### PR DESCRIPTION
**Spring Boot:**

Release Notes: https://github.com/spring-projects/spring-boot/releases/tag/v3.1.5

**Spring Security:**

Release Notes:  https://github.com/spring-projects/spring-security/releases/tag/6.1.5

**Spring Framework:**
Includes 34 fixes and documentation improvements of which 7 are fixes for regressions. There are no Flowable related dependency updates.

Release Notes: https://github.com/spring-projects/spring-framework/releases/tag/v6.0.13