### PR TITLE
Fixed LiquibaseBasedSchemaManager handling of create schema update

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/LiquibaseBasedSchemaManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/LiquibaseBasedSchemaManager.java
@@ -68,7 +68,10 @@ public abstract class LiquibaseBasedSchemaManager implements SchemaManager {
 
     public void initSchema(String databaseSchemaUpdate) {
         try {
-            if (AbstractEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)) {
+            if (AbstractEngineConfiguration.DB_SCHEMA_UPDATE_CREATE.equals(databaseSchemaUpdate)) {
+                runForLiquibase(this::schemaCreate);
+            }
+            else if (AbstractEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)) {
                 runForLiquibase(this::schemaCreate);
 
             } else if (AbstractEngineConfiguration.DB_SCHEMA_UPDATE_DROP_CREATE.equals(databaseSchemaUpdate)) {


### PR DESCRIPTION
The LiquibaseBasedSchemaManager does not handle the "create" schema update option.

If the database schema update approach is set for the process engine by passing ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE to the SpringProcessEngineConfiguration instance, then this is applied to the DmnEngineConfiguration by the DmnEngineConfigurator. The LiquibaseBasedSchemaManager does not handle this schema update option so the DMN database tables are not created.

This change fixes the LiquibaseBasedSchemaManager's handling of create schema update option.

Closes #3771 