### PR TITLE
fix(sec): upgrade com.mysql:mysql-connector-j to 8.0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
 			<dependency>
 				<groupId>com.mysql</groupId>
 				<artifactId>mysql-connector-j</artifactId>
-				<version>8.0.32</version>
+				<version>8.0.33</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mariadb.jdbc</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.mysql:mysql-connector-j 8.0.32
- [CVE-2023-21971](https://www.oscs1024.com/hd/CVE-2023-21971)


### What did I do？
Upgrade com.mysql:mysql-connector-j from 8.0.32 to 8.0.33 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS