### PR TITLE
The status of multiple instance tasks leads to the deletion of resour…

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/EndExecutionOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/EndExecutionOperation.java
@@ -260,6 +260,15 @@ public class EndExecutionOperation extends AbstractOperation {
             for (ExecutionEntity childExecutionEntity : childExecutions) {
                 if (!isInEventSubProcess(childExecutionEntity) && childExecutionEntity.isActive() && !childExecutionEntity.isEnded()) {
                     activeSiblings = true;
+                    break;
+                }
+                if (childExecutionEntity.isMultiInstanceRoot()){
+                    for (ExecutionEntity childMultiExecutionEntity : childExecutionEntity.getExecutions()){
+                        if (!isInEventSubProcess(childMultiExecutionEntity) && childMultiExecutionEntity.isActive() && !childMultiExecutionEntity.isEnded()) {
+                            activeSiblings = true;
+                            break;
+                        }
+                    }
                 }
             }
             


### PR DESCRIPTION
…ces.(#3792)

After tracking the code, I found that the reason might lie in the fact that when `childExecutionEntity` is of multiple instance type, `childExecutionEntity.isActive()=false`. Additionally, the IS_ACTIVE_ field is set to 0 in the ACT_RU_EXECUTION table even when the sub-instance is still being processed. This modification is just a suggestion and it's not certain if there are any other side effects.

#### Check List:
* Unit tests: NA
* Documentation: NA
