### PR TITLE
Initial Spring Boot AOT Native support

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/deployer/CaseDefinitionDiagramHelper.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/deployer/CaseDefinitionDiagramHelper.java
@@ -78,7 +78,7 @@ public class CaseDefinitionDiagramHelper {
                 && CommandContextUtil.getCmmnEngineConfiguration().isCreateDiagramOnDeploy()) {
 
             // If the 'getProcessDiagramResourceNameFromDeployment' call returns null, it means
-            // no diagram image for the process definition was provided in the deployment resources.
+            // no diagram image for the case definition was provided in the deployment resources.
             return ResourceNameUtil.getCaseDiagramResourceNameFromDeployment(caseDefinition, deployment.getResources()) == null;
         }
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/FlowableBeanFactoryInitializationAotProcessor.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/FlowableBeanFactoryInitializationAotProcessor.java
@@ -1,0 +1,250 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.aot;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.ibatis.javassist.util.proxy.ProxyFactory;
+import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
+import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
+import org.apache.ibatis.type.TypeHandler;
+import org.flowable.bpmn.converter.BpmnXMLConverter;
+import org.flowable.bpmn.model.ImplementationType;
+import org.flowable.bpmn.model.ServiceTask;
+import org.flowable.common.engine.api.query.Query;
+import org.flowable.common.engine.impl.db.ListQueryParameterObject;
+import org.flowable.common.engine.impl.de.odysseus.el.ExpressionFactoryImpl;
+import org.flowable.common.engine.impl.persistence.cache.EntityCacheImpl;
+import org.flowable.common.engine.impl.persistence.entity.ByteArrayRef;
+import org.flowable.common.engine.impl.persistence.entity.Entity;
+import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.TablePageQueryImpl;
+import org.flowable.eventregistry.impl.db.SetChannelDefinitionTypeAndImplementationCustomChange;
+import org.flowable.variable.api.types.VariableType;
+import org.flowable.variable.service.impl.InternalVariableInstanceQueryImpl;
+import org.flowable.variable.service.impl.QueryVariableValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Josh Long
+ * @author Joram Barrez
+ */
+class FlowableBeanFactoryInitializationAotProcessor implements BeanFactoryInitializationAotProcessor {
+
+    private final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    FlowableBeanFactoryInitializationAotProcessor() {
+    }
+
+
+    private Set<Resource> processResources() {
+        return resources("processes/**/*.bpmn20.xml");
+    }
+
+    private Set<Resource> flowablePersistenceResources() throws Exception {
+
+        var resources = new HashSet<Resource>();
+        resources.addAll(resources("org/flowable/**/*.sql", "org/flowable/**/*.xml", "org/flowable/**/*.txt", "org/flowable/**/*.xsd", "org/flowable/**/*.properties"));
+        resources.addAll(processResources());
+
+        for (var e : "xml,yaml,yml".split(","))
+            resources.add(new ClassPathResource("flowable-default." + e));
+
+        resources.addAll(from(this.resolver.getResources("META-INF/services/org.flowable.common.engine.impl.EngineConfigurator")));
+        resources.addAll(from(this.resolver.getResources("org/flowable/common/engine/impl/de/odysseus/el/misc/LocalStrings")));
+        return resources.stream()
+                .filter(Resource::exists)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
+        return (generationContext, beanFactoryInitializationCode) -> {
+            var hints = generationContext.getRuntimeHints();
+            beanFactory.getBeanClassLoader();
+            try {
+
+                var memberCategories = MemberCategory.values();
+
+
+                for (var c : Set.of(ProxyFactory.class, XMLLanguageDriver.class,
+                        org.apache.ibatis.logging.slf4j.Slf4jImpl.class, EntityCacheImpl.class,
+                        RawLanguageDriver.class, org.apache.ibatis.session.Configuration.class, HashSet.class))
+                    hints.reflection().registerType(c, memberCategories);
+
+                var types = new Class[]{
+                        TypeHandler.class,
+                        EntityManager.class,
+                        Entity.class,
+                        Query.class,
+                        VariableType.class,
+                        ListQueryParameterObject.class,
+                        TablePageQueryImpl.class,
+                        SetChannelDefinitionTypeAndImplementationCustomChange.class,
+                        ByteArrayRef.class,
+                        InternalVariableInstanceQueryImpl.class,
+                        QueryVariableValue.class,
+                        ExpressionFactoryImpl.class
+                };
+
+                var packagesSet = new HashSet<String>();
+                packagesSet.add("org.apache.ibatis");
+                packagesSet.add("org.flowable");
+                packagesSet.addAll(AutoConfigurationPackages.get(beanFactory));
+                var packages = packagesSet.toArray(new String[0]);
+
+                for (var t : types) {
+                    hints.reflection().registerType(t, memberCategories);
+                    var subTypes = FlowableSpringAotUtils.getSubTypesOf(t, packages);
+                    for (var s : subTypes) {
+                        if (StringUtils.hasText(s)) {
+                            hints.reflection().registerType(TypeReference.of(s), memberCategories);
+                        }
+                    }
+                }
+
+                var resources = new HashSet<Resource>();
+                resources.addAll(flowablePersistenceResources());
+                resources.addAll("""
+                        flowable-default.properties
+                        flowable-default.xml
+                        flowable-default.yaml
+                        flowable-default.yml
+                           """
+                        .stripIndent()
+                        .stripLeading()
+                        .trim()
+                        .lines()
+                        .map(l -> l.strip().trim())
+                        .filter(l -> !l.isEmpty())
+                        .map(ClassPathResource::new)
+                        .toList());
+
+
+                for (var resource : resources) {
+                    if (resource.exists()) {
+                        hints.resources().registerResource(resource);
+                    }
+                }
+
+
+                // here lay dragons; we're going to attempt to proactively register aot hints for beans referenced within a process definition
+                var processDefinitions = this.processResources();
+                for (var processDefinitionXmlResource : processDefinitions) {
+                    Assert.state(processDefinitionXmlResource.exists(), "the process definition file [" + processDefinitionXmlResource.getFilename() +
+                            "] does not exist");
+
+                    hints.resources().registerResource(processDefinitionXmlResource);
+                    try (var in = processDefinitionXmlResource.getInputStream()) {
+
+                        var bpmnXMLConverter = new BpmnXMLConverter();
+                        var bpmnModel = bpmnXMLConverter.convertToBpmnModel(() -> in, false, false);
+                        var serviceTasks = bpmnModel.getMainProcess().findFlowElementsOfType(ServiceTask.class);
+                        for (var st : serviceTasks) {
+                            if (st.getImplementationType().equals(ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION)) {
+                                var expression = st.getImplementation();
+                                var expressionWithoutDelimiters = expression.substring(2);
+                                expressionWithoutDelimiters = expressionWithoutDelimiters.substring(0, expressionWithoutDelimiters.length() - 1);
+                                var beanName = expressionWithoutDelimiters;
+                                try {
+                                    var beanDefinition = beanFactory.getBeanDefinition(beanName);
+                                    hints.reflection().registerType(TypeReference.of(beanDefinition.getBeanClassName()), MemberCategory.values());
+
+                                    log.debug("registering hint for bean name [" + beanName + "]");
+                                }//
+                                catch (Throwable throwable) {
+                                    log.error("couldn't find bean named [" + beanName + "]");
+                                }
+
+                            }
+                        }
+                    }
+                }
+
+
+            }//
+            catch (Throwable throwable) {
+                throw new RuntimeException(throwable);
+            }
+        };
+    }
+
+
+    private static <T> Set<T> from(T[] t) {
+        return new HashSet<>(Arrays.asList(t));
+    }
+
+    private static Resource newResourceFor(Resource in) {
+        try {
+            var marker = "jar!";
+            var externalFormOfUrl = in.getURL().toExternalForm();
+            if (externalFormOfUrl.contains(marker)) {
+                var rest = externalFormOfUrl.substring(externalFormOfUrl.lastIndexOf(marker) + marker.length());
+                return new ClassPathResource(rest);
+            }//
+            else {
+                // ugh i think this only works for maven? what about gradle?
+                var classesSubstring = "classes/";
+                var locationOfClassesInUrl = externalFormOfUrl.indexOf(classesSubstring);
+                if (locationOfClassesInUrl != -1) {
+                    return new ClassPathResource(externalFormOfUrl.substring(locationOfClassesInUrl + classesSubstring.length()));
+                }
+
+            }
+
+            return in;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    Set<Resource> resources(String... patterns) {
+        return Stream
+                .of(patterns)
+                .map(path -> ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + path)
+                .flatMap(p -> {
+                    try {
+                        return Stream.of(this.resolver.getResources(p));
+                    }//
+                    catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .map(FlowableBeanFactoryInitializationAotProcessor::newResourceFor)
+                .filter(Resource::exists)
+                .collect(Collectors.toSet());
+    }
+
+
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/FlowableMybatisMappersBeanFactoryInitializationAotProcessor.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/FlowableMybatisMappersBeanFactoryInitializationAotProcessor.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.aot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.BeanFactory;
+
+/**
+ *  @author Josh Long
+ */
+class FlowableMybatisMappersBeanFactoryInitializationAotProcessor
+        extends MybatisMappersBeanFactoryInitializationAotProcessor {
+
+    FlowableMybatisMappersBeanFactoryInitializationAotProcessor() {
+
+    }
+
+    @Override
+    protected List<String> getPackagesToScan(BeanFactory b) {
+        var defaults = super.getPackagesToScan(b);
+        var l = new ArrayList<String>();
+        l.add("org.flowable");
+        l.addAll(defaults);
+        return l;
+    }
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/FlowableSpringAotUtils.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/FlowableSpringAotUtils.java
@@ -1,0 +1,85 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.aot;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+
+/**
+ * @author Josh Long
+ */
+final class FlowableSpringAotUtils {
+
+	private static final Logger log = LoggerFactory.getLogger(FlowableSpringAotUtils.class);
+
+	private FlowableSpringAotUtils() {
+	}
+
+	static Resource newResourceFor(Resource in) {
+		try {
+			var marker = "jar!";
+			var p = in.getURL().toExternalForm();
+			var rest = p.substring(p.lastIndexOf(marker) + marker.length());
+			return new ClassPathResource(rest);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	static boolean isSerializable(Class<?> clazz) {
+		return Serializable.class.isAssignableFrom(clazz);
+	}
+
+	static <T> void debug(String message, Collection<T> tCollection) {
+		log.debug(message + System.lineSeparator());
+		for (var t : tCollection)
+			log.debug('\t' + t.toString());
+		log.debug(System.lineSeparator());
+	}
+
+	static String packageToPath(String packageName) {
+		var sb = new StringBuilder();
+		for (var c : packageName.toCharArray())
+			sb.append(c == '.' ? '/' : c);
+		return sb.toString();
+	}
+
+
+	static Set<String> getSubTypesOf(Class<?> clzzName, String... packages) {
+		var set = new HashSet<String>();
+
+		for (var p : packages) {
+			var classPathScanningCandidateComponentProvider = new ClassPathScanningCandidateComponentProvider(false);
+
+			classPathScanningCandidateComponentProvider.addIncludeFilter(new AssignableTypeFilter(clzzName));
+
+			var results = classPathScanningCandidateComponentProvider.findCandidateComponents(p);
+			for (var r : results)
+				set.add(r.getBeanClassName());
+		}
+
+		return set;
+
+	}
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/MybatisApplicationSpecificBeanFactoryInitializationAotProcessor.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/MybatisApplicationSpecificBeanFactoryInitializationAotProcessor.java
@@ -1,0 +1,169 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.aot;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.apache.ibatis.annotations.DeleteProvider;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.UpdateProvider;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Register hints based upon the structure of a particular user's Spring Boot application
+ * packages and {@link org.springframework.beans.factory.BeanFactory}
+ *
+ * @author Josh Long
+ */
+class MybatisApplicationSpecificBeanFactoryInitializationAotProcessor implements BeanFactoryInitializationAotProcessor {
+
+	private final PathMatchingResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
+
+	MybatisApplicationSpecificBeanFactoryInitializationAotProcessor() {
+	}
+
+	private Collection<Resource> attemptToRegisterXmlResourcesForBasePackage(
+			ConfigurableListableBeanFactory beanFactory) throws Exception {
+		var set = new HashSet<Resource>();
+		for (var packageName : AutoConfigurationPackages.get(beanFactory)) {
+			Assert.hasText(packageName, "the package name must not be empty!");
+			var path = FlowableSpringAotUtils.packageToPath(packageName);
+			for (var resolvedXmlResource : this.resourcePatternResolver
+				.getResources(ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + path + "/**/*.xml")) {
+				var fqn = resolvedXmlResource.getURI().toString();
+				if (resolvedXmlResource.exists()) {
+					var np = fqn.substring(fqn.indexOf(path));
+					var npr = new ClassPathResource(np);
+					set.add(npr);
+				}
+			}
+		}
+		return set;
+	}
+
+	@Override
+	public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
+
+		if (!ClassUtils.isPresent("org.mybatis.spring.mapper.MapperFactoryBean", beanFactory.getBeanClassLoader()))
+			return null;
+
+		try {
+			var classesToRegister = new HashSet<Class<?>>();
+			var proxiesToRegister = new HashSet<Class<?>>();
+			var resourcesToRegister = new HashSet<Resource>();
+			resourcesToRegister.addAll(attemptToRegisterXmlResourcesForBasePackage(beanFactory));
+
+			// Flowable doesn't use mapper classes
+//			var beanNames = beanFactory.getBeanNamesForType(MapperFactoryBean.class);
+//			for (var beanName : beanNames) {
+//				var beanDefinition = beanFactory.getBeanDefinition(beanName.substring(1));
+//				var mapperInterface = beanDefinition.getPropertyValues().getPropertyValue("mapperInterface");
+//				if (mapperInterface != null && mapperInterface.getValue() != null) {
+//					var mapperInterfaceType = (Class<?>) mapperInterface.getValue();
+//					if (mapperInterfaceType != null) {
+//						proxiesToRegister.add(mapperInterfaceType);
+//						resourcesToRegister
+//							.add(new ClassPathResource(mapperInterfaceType.getName().replace('.', '/').concat(".xml")));
+//						registerReflectionTypeIfNecessary(mapperInterfaceType, classesToRegister);
+//						registerMapperRelationships(mapperInterfaceType, classesToRegister);
+//					}
+//				}
+//			}
+
+			return (generationContext, beanFactoryInitializationCode) -> {
+				var mcs = MemberCategory.values();
+				var runtimeHints = generationContext.getRuntimeHints();
+				FlowableSpringAotUtils.debug("proxies", proxiesToRegister);
+				FlowableSpringAotUtils.debug("classes for reflection", classesToRegister);
+				FlowableSpringAotUtils.debug("resources", resourcesToRegister);
+				for (var c : proxiesToRegister) {
+					runtimeHints.proxies().registerJdkProxy(c);
+					runtimeHints.reflection().registerType(c, mcs);
+				}
+				for (var c : classesToRegister) {
+					runtimeHints.reflection().registerType(c, mcs);
+					if (FlowableSpringAotUtils.isSerializable(c))
+						runtimeHints.serialization().registerType(TypeReference.of(c.getName()));
+				}
+				for (var r : resourcesToRegister) {
+					if (r.exists()) {
+						runtimeHints.resources().registerResource(r);
+					}
+				}
+			};
+		} //
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@SafeVarargs
+	private <T extends Annotation> void registerSqlProviderTypes(Method method, Set<Class<?>> registry,
+			Class<T> annotationType, Function<T, Class<?>>... providerTypeResolvers) {
+		for (T annotation : method.getAnnotationsByType(annotationType)) {
+			for (Function<T, Class<?>> providerTypeResolver : providerTypeResolvers) {
+				registerReflectionTypeIfNecessary(providerTypeResolver.apply(annotation), registry);
+			}
+		}
+	}
+
+	private void registerReflectionTypeIfNecessary(Class<?> type, Set<Class<?>> registry) {
+		if (!type.isPrimitive() && !type.getName().startsWith("java")) {
+			registry.add(type);
+		}
+	}
+
+	private void registerMapperRelationships(Class<?> mapperInterfaceType, Set<Class<?>> registry) {
+		var methods = ReflectionUtils.getAllDeclaredMethods(mapperInterfaceType);
+		for (var method : methods) {
+			if (method.getDeclaringClass() != Object.class) {
+
+				ReflectionUtils.makeAccessible(method);
+
+				registerSqlProviderTypes(method, registry, SelectProvider.class, SelectProvider::value,
+						SelectProvider::type);
+				registerSqlProviderTypes(method, registry, InsertProvider.class, InsertProvider::value,
+						InsertProvider::type);
+				registerSqlProviderTypes(method, registry, UpdateProvider.class, UpdateProvider::value,
+						UpdateProvider::type);
+				registerSqlProviderTypes(method, registry, DeleteProvider.class, DeleteProvider::value,
+						DeleteProvider::type);
+
+				var returnType = MybatisMapperTypeUtils.resolveReturnClass(mapperInterfaceType, method);
+				registerReflectionTypeIfNecessary(returnType, registry);
+
+				MybatisMapperTypeUtils.resolveParameterClasses(mapperInterfaceType, method)
+					.forEach(x -> registerReflectionTypeIfNecessary(x, registry));
+			}
+		}
+	}
+
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/MybatisGlobalBeanFactoryInitializationAotProcessor.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/MybatisGlobalBeanFactoryInitializationAotProcessor.java
@@ -1,0 +1,262 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.aot;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.RandomAccess;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.apache.ibatis.annotations.CacheNamespace;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.DeleteProvider;
+import org.apache.ibatis.annotations.Flush;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.Many;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.One;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Property;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.Update;
+import org.apache.ibatis.annotations.UpdateProvider;
+import org.apache.ibatis.builder.CacheRefResolver;
+import org.apache.ibatis.builder.ResultMapResolver;
+import org.apache.ibatis.builder.annotation.MapperAnnotationBuilder;
+import org.apache.ibatis.builder.annotation.MethodResolver;
+import org.apache.ibatis.builder.annotation.ProviderContext;
+import org.apache.ibatis.builder.annotation.ProviderMethodResolver;
+import org.apache.ibatis.cache.Cache;
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.cache.NullCacheKey;
+import org.apache.ibatis.cache.decorators.BlockingCache;
+import org.apache.ibatis.cache.decorators.FifoCache;
+import org.apache.ibatis.cache.decorators.LoggingCache;
+import org.apache.ibatis.cache.decorators.LruCache;
+import org.apache.ibatis.cache.decorators.SerializedCache;
+import org.apache.ibatis.cache.decorators.SynchronizedCache;
+import org.apache.ibatis.cache.decorators.TransactionalCache;
+import org.apache.ibatis.cache.decorators.WeakCache;
+import org.apache.ibatis.cache.impl.PerpetualCache;
+import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.javassist.util.proxy.ProxyFactory;
+import org.apache.ibatis.javassist.util.proxy.RuntimeSupport;
+import org.apache.ibatis.logging.Log;
+import org.apache.ibatis.logging.LogFactory;
+import org.apache.ibatis.logging.commons.JakartaCommonsLoggingImpl;
+import org.apache.ibatis.logging.jdbc.BaseJdbcLogger;
+import org.apache.ibatis.logging.jdbc.ConnectionLogger;
+import org.apache.ibatis.logging.jdbc.PreparedStatementLogger;
+import org.apache.ibatis.logging.jdbc.ResultSetLogger;
+import org.apache.ibatis.logging.jdbc.StatementLogger;
+import org.apache.ibatis.logging.jdk14.Jdk14LoggingImpl;
+import org.apache.ibatis.logging.log4j.Log4jImpl;
+import org.apache.ibatis.logging.log4j2.Log4j2AbstractLoggerImpl;
+import org.apache.ibatis.logging.log4j2.Log4j2Impl;
+import org.apache.ibatis.logging.log4j2.Log4j2LoggerImpl;
+import org.apache.ibatis.logging.nologging.NoLoggingImpl;
+import org.apache.ibatis.logging.slf4j.Slf4jImpl;
+import org.apache.ibatis.logging.stdout.StdOutImpl;
+import org.apache.ibatis.mapping.ResultFlag;
+import org.apache.ibatis.parsing.XNode;
+import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
+import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.logging.slf4j.SLF4JLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+/**
+ * Register invariant hints for Mybatis that are presumed the same for all applications
+ *
+ * @author Josh Long
+ */
+class MybatisGlobalBeanFactoryInitializationAotProcessor implements BeanFactoryInitializationAotProcessor {
+
+	private final PathMatchingResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
+
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+	MybatisGlobalBeanFactoryInitializationAotProcessor() {
+	}
+
+	private void registerProxies(RuntimeHints hints) {
+		var proxies = Set.of(Set.of(Connection.class.getName()), Set.of(SqlSession.class.getName()),
+				Set.of(PreparedStatement.class.getName(), CallableStatement.class.getName()),
+				Set.of(ParameterizedType.class.getName(),
+						"org.springframework.core.SerializableTypeWrapper$SerializableTypeProxy",
+						Serializable.class.getName()),
+				Set.of(TypeVariable.class.getName(),
+						"org.springframework.core.SerializableTypeWrapper$SerializableTypeProxy",
+						Serializable.class.getName()),
+				Set.of(WildcardType.class.getName(),
+						"org.springframework.core.SerializableTypeWrapper$SerializableTypeProxy",
+						Serializable.class.getName()));
+		FlowableSpringAotUtils.debug("global proxies", proxies);
+		for (var p : proxies) {
+			var parts = p.stream().map(TypeReference::of).toArray(TypeReference[]::new);
+			hints.proxies().registerJdkProxy(parts);
+		}
+	}
+
+	private static Resource newResourceFor(Resource in) {
+		try {
+			var marker = "jar!";
+			var p = in.getURL().toExternalForm();
+			var rest = p.substring(p.lastIndexOf(marker) + marker.length());
+			return new ClassPathResource(rest);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void registerResources(RuntimeHints hints) throws IOException {
+
+		var resources = new HashSet<Resource>();
+		var config = Stream
+			.of("org/apache/ibatis/builder/xml/*.dtd", "org/apache/ibatis/builder/xml/*.xsd",
+					"org/mybatis/spring/config/*.xsd")
+			.map(p -> ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + p)
+			.flatMap(p -> {
+				try {
+					return Stream.of(this.resourcePatternResolver.getResources(p));
+				}
+				catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			})
+			.map(MybatisGlobalBeanFactoryInitializationAotProcessor::newResourceFor)
+			.filter(Resource::exists)
+			.toList();
+
+		resources.addAll(config);
+
+		FlowableSpringAotUtils.debug("resources", resources);
+		for (var r : resources)
+			hints.resources().registerResource(r);
+	}
+
+	private void registerGlobalTypeHints(RuntimeHints hints) {
+
+		var caches = Set.of(Cache.class, LruCache.class, BlockingCache.class, SerializedCache.class, FifoCache.class,
+				NullCacheKey.class, PerpetualCache.class, CacheKey.class, WeakCache.class, TransactionalCache.class,
+				SynchronizedCache.class, LoggingCache.class);
+
+		var collections = Set.of(AbstractList.class, List.class, RandomAccess.class, Cloneable.class, Collection.class,
+				TreeSet.class, SortedSet.class, Iterator.class, ArrayList.class, HashSet.class, Set.class, Map.class);
+
+		var loggers = Set.of(Log4jImpl.class, Log4j2Impl.class, Log4j2LoggerImpl.class, Log4j2AbstractLoggerImpl.class,
+				NoLoggingImpl.class, SLF4JLogger.class, StdOutImpl.class, BaseJdbcLogger.class, ConnectionLogger.class,
+				PreparedStatementLogger.class, ResultSetLogger.class, StatementLogger.class, Jdk14LoggingImpl.class,
+				JakartaCommonsLoggingImpl.class, Slf4jImpl.class);
+
+		var annotations = Set.of(Select.class, Update.class, Insert.class, Delete.class, SelectProvider.class,
+				UpdateProvider.class, InsertProvider.class, CacheNamespace.class, Flush.class, DeleteProvider.class,
+				Options.class, Options.FlushCachePolicy.class, Many.class, Mapper.class, One.class, Property.class,
+				Result.class, Results.class);
+
+		var memberCategories = MemberCategory.values();
+
+		var classesForReflection = new HashSet<Class<?>>();
+
+		classesForReflection.addAll(caches);
+		classesForReflection.addAll(annotations);
+		classesForReflection.addAll(loggers);
+		classesForReflection.addAll(collections);
+
+		// Original version:
+//		classesForReflection.addAll(Set.of(Serializable.class, SpringBootVFS.class, PerpetualCache.class, Cursor.class,
+//				Optional.class, LruCache.class, MethodHandles.class, Date.class, HashMap.class, CacheRefResolver.class,
+//				XNode.class, ResultFlag.class, ResultMapResolver.class, MapperScannerConfigurer.class,
+//				MethodResolver.class, ProviderMethodResolver.class, ProviderContext.class,
+//				MapperAnnotationBuilder.class, Logger.class, LogFactory.class, RuntimeSupport.class, Log.class,
+//				SqlSessionTemplate.class, SqlSessionFactory.class, SqlSessionFactoryBean.class, ProxyFactory.class,
+//				XMLLanguageDriver.class, RawLanguageDriver.class, Configuration.class, String.class, int.class,
+//				Number.class, Integer.class, long.class, Long.class, short.class, Short.class, byte.class, Byte.class,
+//				float.class, Float.class, boolean.class, Boolean.class, double.class, Double.class));
+
+		classesForReflection.addAll(Set.of(Serializable.class, PerpetualCache.class, Cursor.class,
+				Optional.class, LruCache.class, MethodHandles.class, Date.class, HashMap.class, CacheRefResolver.class,
+				XNode.class, ResultFlag.class, ResultMapResolver.class,
+				MethodResolver.class, ProviderMethodResolver.class, ProviderContext.class,
+				MapperAnnotationBuilder.class, Logger.class, LogFactory.class, RuntimeSupport.class, Log.class,
+				SqlSessionFactory.class, ProxyFactory.class,
+				XMLLanguageDriver.class, RawLanguageDriver.class, Configuration.class, String.class, int.class,
+				Number.class, Integer.class, long.class, Long.class, short.class, Short.class, byte.class, Byte.class,
+				float.class, Float.class, boolean.class, Boolean.class, double.class, Double.class));
+
+		FlowableSpringAotUtils.debug("global types for reflection", classesForReflection);
+
+		for (var c : classesForReflection) {
+			hints.reflection().registerType(c, memberCategories);
+			if (FlowableSpringAotUtils.isSerializable(c)) {
+				hints.serialization().registerType(TypeReference.of(c.getName()));
+				if (log.isDebugEnabled())
+					log.debug("the type " + c.getName() + " is serializable");
+			}
+		}
+	}
+
+	@Override
+	public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
+		return (generationContext, beanFactoryInitializationCode) -> {
+			try {
+				var hints = generationContext.getRuntimeHints();
+				registerResources(hints);
+				registerGlobalTypeHints(hints);
+				registerProxies(hints);
+			} //
+			catch (Throwable throwable) {
+				throw new RuntimeException(throwable);
+			}
+		};
+	}
+
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/MybatisMapperTypeUtils.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/MybatisMapperTypeUtils.java
@@ -1,0 +1,63 @@
+/*
+ *    Copyright 2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.flowable.spring.aot;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.ibatis.reflection.TypeParameterResolver;
+
+/**
+ * @author Josh Long
+ */
+final class MybatisMapperTypeUtils {
+
+
+	static Class<?> resolveReturnClass(Class<?> mapperInterface, Method method) {
+		var resolvedReturnType = TypeParameterResolver.resolveReturnType(method, mapperInterface);
+		return typeToClass(resolvedReturnType, method.getReturnType());
+	}
+
+	static Set<Class<?>> resolveParameterClasses(Class<?> mapperInterface, Method method) {
+		return Stream.of(TypeParameterResolver.resolveParamTypes(method, mapperInterface))
+			.map(x -> typeToClass(x, x instanceof Class ? (Class<?>) x : Object.class))
+			.collect(Collectors.toSet());
+	}
+
+	private static Class<?> typeToClass(Type src, Class<?> fallback) {
+		var result = (Class<?>) null;
+		if (src instanceof Class<?> c) {
+			result = c.isArray() ? c.getComponentType() : c;
+		}
+		else if (src instanceof ParameterizedType parameterizedType) {
+			var index = (parameterizedType.getRawType() instanceof Class
+					&& Map.class.isAssignableFrom((Class<?>) parameterizedType.getRawType())
+					&& parameterizedType.getActualTypeArguments().length > 1) ? 1 : 0;
+			var actualType = parameterizedType.getActualTypeArguments()[index];
+			result = typeToClass(actualType, fallback);
+		}
+		if (result == null) {
+			result = fallback;
+		}
+		return result;
+	}
+
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/MybatisMappersBeanFactoryInitializationAotProcessor.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/aot/MybatisMappersBeanFactoryInitializationAotProcessor.java
@@ -1,0 +1,133 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.aot;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.util.FileCopyUtils;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+/**
+ * Discovers any {@literal  mappings.xml} and reads them in to then register the
+ * referenced {@literal .xml} files as resource hints.
+ *
+ * @author Josh Long
+ */
+class MybatisMappersBeanFactoryInitializationAotProcessor implements BeanFactoryInitializationAotProcessor {
+
+	private final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+	MybatisMappersBeanFactoryInitializationAotProcessor() {
+	}
+
+	private Set<Resource> persistenceResources(String rootPackage) throws Exception {
+		var folderFromPackage = FlowableSpringAotUtils.packageToPath(rootPackage);
+		var patterns = Stream//
+			.of(folderFromPackage + "/**/mappings.xml")//
+			.map(path -> ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + path)//
+			.flatMap(p -> {
+				try {
+					return Stream.of(this.resolver.getResources(p));
+				} //
+				catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			})//
+			.map(FlowableSpringAotUtils::newResourceFor)
+			.toList();
+
+		var resources = new HashSet<Resource>();
+		for (var p : patterns) {
+			var mappers = mappers(p);
+			resources.add(p);
+			resources.addAll(mappers);
+		}
+		return resources.stream().filter(Resource::exists).collect(Collectors.toSet());
+	}
+
+	protected List<String> getPackagesToScan (BeanFactory b){
+		return  AutoConfigurationPackages.get(b) ;
+	}
+
+	@Override
+	public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
+		try {
+			var packages =  getPackagesToScan(beanFactory);
+			var resources = new HashSet<Resource>();
+			for (var pkg : packages) {
+				resources.addAll(persistenceResources(pkg));
+			}
+			return (generationContext, beanFactoryInitializationCode) -> {
+				for (var r : resources)
+					if (r.exists())
+						generationContext.getRuntimeHints().resources().registerResource(r);
+			};
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Set<Resource> mappers(Resource mapping) throws Exception {
+		var resources = new HashSet<Resource>();
+		try (var in = new InputStreamReader(mapping.getInputStream())) {
+			var xml = FileCopyUtils.copyToString(in);
+			resources.addAll(mapperResources(xml));
+		}
+		resources.add(mapping);
+		return resources;
+
+	}
+
+	private Set<Resource> mapperResources(String xml) {
+		try {
+			var set = new HashSet<Resource>();
+			var dbf = DocumentBuilderFactory.newInstance();
+			var db = dbf.newDocumentBuilder();
+			var is = new InputSource(new StringReader(xml));
+			var doc = db.parse(is);
+			var mappersElement = (Element) doc.getElementsByTagName("mappers").item(0);
+			var mapperList = mappersElement.getElementsByTagName("mapper");
+			for (var i = 0; i < mapperList.getLength(); i++) {
+				var mapperElement = (Element) mapperList.item(i);
+				var resourceValue = mapperElement.getAttribute("resource");
+				set.add(new ClassPathResource(resourceValue));
+			}
+			return set;
+		} //
+		catch (Throwable throwable) {
+			throw new RuntimeException(throwable);
+		}
+
+	}
+
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/spring/aot.factories
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,5 @@
+org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=\
+org.flowable.spring.aot.FlowableBeanFactoryInitializationAotProcessor,\
+org.flowable.spring.aot.FlowableMybatisMappersBeanFactoryInitializationAotProcessor,\
+org.flowable.spring.aot.MybatisGlobalBeanFactoryInitializationAotProcessor,\
+org.flowable.spring.aot.MybatisApplicationSpecificBeanFactoryInitializationAotProcessor

--- a/modules/flowable-spring-common/src/main/java/org/flowable/common/spring/CommonAutoDeploymentStrategy.java
+++ b/modules/flowable-spring-common/src/main/java/org/flowable/common/spring/CommonAutoDeploymentStrategy.java
@@ -13,7 +13,6 @@
 
 package org.flowable.common.spring;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 
@@ -123,7 +122,7 @@ public abstract class CommonAutoDeploymentStrategy<E> implements AutoDeploymentS
         } else {
             try {
                 resourceName = resource.getFile().getAbsolutePath();
-            } catch (IOException e) {
+            } catch (Exception e) { // Catching any exception here, as e.g. Graal will throw an UnsupportedException instead of an IOException
                 resourceName = resource.getFilename();
             }
         }


### PR DESCRIPTION
This PR adds initial support for Flowable + Spring Boot using the Spring Boot AOT Native image engine. 
Using the aot.properties approach, the new processors will only kick in when building native images (they won't interfere with 'regular' projects). 

Current scope of classes/resources that are added to the native image build:

- Flowable classes
- Mybatis classes that rely on reflection
- Mybatis mapper XML files
- BPMN/CMMN/DMN resources

Original code by @joshlong and further continued in a pair programming hacking session.