### PR TITLE
Support manual event subscription based case event-registry start 

### DIFF
--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnRuntimeService.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnRuntimeService.java
@@ -467,7 +467,7 @@ public interface CmmnRuntimeService {
     CaseInstanceStartEventSubscriptionModificationBuilder createCaseInstanceStartEventSubscriptionModificationBuilder();
 
     /**
-     * Creates a new event subscription deletion builder delete one or more previously registered case start event subscriptions based
+     * Creates a new event subscription deletion builder to delete one or more previously registered case start event subscriptions based
      * on a particular case definition and with an optional combination of correlation parameter values.
      *
      * @return the subscription deletion builder

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnRuntimeService.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/CmmnRuntimeService.java
@@ -18,6 +18,9 @@ import java.util.Map;
 
 import org.flowable.cmmn.api.runtime.CaseInstanceBuilder;
 import org.flowable.cmmn.api.runtime.CaseInstanceQuery;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionBuilder;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionDeletionBuilder;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionModificationBuilder;
 import org.flowable.cmmn.api.runtime.ChangePlanItemStateBuilder;
 import org.flowable.cmmn.api.runtime.GenericEventListenerInstanceQuery;
 import org.flowable.cmmn.api.runtime.MilestoneInstanceQuery;
@@ -313,12 +316,12 @@ public interface CmmnRuntimeService {
      * @param identityLinkType
      *            type of identity, cannot be null.
      * @throws FlowableObjectNotFoundException
-     *             when the process instance or group doesn't exist.
+     *             when the case instance or group doesn't exist.
      */
     void addGroupIdentityLink(String caseInstanceId, String groupId, String identityLinkType);
 
     /**
-     * Removes the association between a user and a process instance for the given identityLinkType.
+     * Removes the association between a user and a case instance for the given identityLinkType.
      * 
      * @param caseInstanceId
      *            id of the case instance, cannot be null.
@@ -332,7 +335,7 @@ public interface CmmnRuntimeService {
     void deleteUserIdentityLink(String caseInstanceId, String userId, String identityLinkType);
 
     /**
-     * Removes the association between a group and a process instance for the given identityLinkType.
+     * Removes the association between a group and a case instance for the given identityLinkType.
      * 
      * @param caseInstanceId
      *            id of the case instance, cannot be null.
@@ -381,7 +384,7 @@ public interface CmmnRuntimeService {
     FormInfo getStartFormModel(String caseDefinitionId, String caseInstanceId);
     
     /**
-     * Create a {@link ChangePlanItemStateBuilder}, that allows to set various options for changing the state of a process instance.
+     * Create a {@link ChangePlanItemStateBuilder}, that allows to set various options for changing the state of a case instance.
      */
     ChangePlanItemStateBuilder createChangePlanItemStateBuilder();
 
@@ -442,4 +445,32 @@ public interface CmmnRuntimeService {
      *     when the given event is not suitable for dispatching.
      */
     void dispatchEvent(FlowableEvent event);
+    
+    /**
+     * Creates a new event subscription builder to register a subscription to start a new case instance based on an event with a particular set of
+     * correlation parameter values. In order for this to work, the case definition needs to have an event-registry based start event with a
+     * dynamic, manual subscription based behavior and the registered correlation parameter values within the builder need to be based on
+     * actual correlation parameter definitions within the event model the start event is based on.
+     * Register one or more correlation parameter value with in the builder before invoking the
+     * {@link CaseInstanceStartEventSubscriptionBuilder#subscribe()} method to create and register the subscription.
+     *
+     * @return the subscription builder
+     */
+    CaseInstanceStartEventSubscriptionBuilder createCaseInstanceStartEventSubscriptionBuilder();
+
+    /**
+     * Creates a new event subscription modification builder to modify one or more previously registered case start event subscriptions based
+     * on a particular case definition and with an optional combination of correlation parameter values.
+     *
+     * @return the subscription modification builder
+     */
+    CaseInstanceStartEventSubscriptionModificationBuilder createCaseInstanceStartEventSubscriptionModificationBuilder();
+
+    /**
+     * Creates a new event subscription deletion builder delete one or more previously registered case start event subscriptions based
+     * on a particular case definition and with an optional combination of correlation parameter values.
+     *
+     * @return the subscription deletion builder
+     */
+    CaseInstanceStartEventSubscriptionDeletionBuilder createCaseInstanceStartEventSubscriptionDeletionBuilder();
 }

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceStartEventSubscriptionBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceStartEventSubscriptionBuilder.java
@@ -1,0 +1,86 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.api.runtime;
+
+import java.util.Map;
+
+import org.flowable.eventsubscription.api.EventSubscription;
+
+/**
+ * A builder API to create an event subscription to start an event-based case instance whenever an event with a very specific
+ * combination of correlation values occurs.
+ * You can model an event-based start for a case model to create a new case instance whenever that event happens, but not, if
+ * it should only start a case on a particular combination of correlation values.
+ *
+ * In order for this to work, you need a case definition with an event registry start, configured with the manual, correlation based
+ * subscription behavior.
+ *
+ * @author Micha Kiener
+ */
+public interface CaseInstanceStartEventSubscriptionBuilder {
+
+    /**
+     * Set the case definition to be started using a manually added subscription by its key. By default, always the latest version is
+     * used to start a new case instance, unless you use {@link #doNotUpdateToLatestVersionAutomatically()} to mark the builder to stick to
+     * exactly the current version of the case definition and don't update it, if a new version would be deployed later on.
+     * This method is mandatory and will throw an exception when trying to register a subscription where the case definition key was not set or
+     * is null.
+     *
+     * @param caseDefinitionKey the key of the case definition to be started a new instance of when the subscription has a match at runtime
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionBuilder caseDefinitionKey(String caseDefinitionKey);
+
+    /**
+     * Mark the subscription to not use the latest case definition automatically, should there be a new version deployed after the subscription
+     * was created. This means, adding the subscription will always stick to the current version of the case definition, and it will NOT be updated
+     * automatically should there be a new version deployed later on. By default, when this method is not invoked on the builder, the subscription will
+     * be updated automatically to the latest version when a new version of the case definition is deployed.
+     * The subscription can still be updated to the latest version by manually migrating it to whatever version you want.
+     *
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionBuilder doNotUpdateToLatestVersionAutomatically();
+
+    /**
+     * Adds a specific correlation parameter value for the subscription, which means this value needs to exactly match the event
+     * payload in order to trigger the case start (along with all registered correlation parameter values of course).
+     *
+     * @param parameterName the name of the correlation parameter
+     * @param parameterValue the value of the correlation parameter
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionBuilder addCorrelationParameterValue(String parameterName, Object parameterValue);
+
+    /**
+     * Registers a list of correlation parameter values for the subscription. The result is the same as registering
+     * them one after the other.
+     *
+     * @param parameters the map of correlation parameter values to be registered for the subscription
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionBuilder addCorrelationParameterValues(Map<String, Object> parameters);
+
+    /**
+     * Set the tenant id for the subscription.
+     *
+     * @param tenantId the id of the tenant
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionBuilder tenantId(String tenantId);
+
+    /**
+     * Creates the event subscription with the registered combination of correlation parameter values and saves it.
+     */
+    EventSubscription subscribe();
+}

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceStartEventSubscriptionDeletionBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceStartEventSubscriptionDeletionBuilder.java
@@ -1,0 +1,68 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.api.runtime;
+
+import java.util.Map;
+
+import org.flowable.cmmn.api.CmmnRuntimeService;
+
+/**
+ * A builder API to delete a manually created case start event subscription which was created and registered using the
+ * {@link CmmnRuntimeService#createCaseInstanceStartEventSubscriptionBuilder()} builder API.
+ * With this API you can delete one or more such subscriptions based on the correlation parameter values and event type.
+ *
+ * @author Micha Kiener
+ */
+public interface CaseInstanceStartEventSubscriptionDeletionBuilder {
+
+    /**
+     * Set the case definition using its specific id the manually created subscription is based on. This is mandatory and must be provided.
+     *
+     * @param caseDefinitionId the id of the case definition the subscription is based on (an exact version of it)
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionDeletionBuilder caseDefinitionId(String caseDefinitionId);
+    
+    /**
+     * Set the tenant id in case you are running in a multi tenant environment and the event model needs to be retrieved from a specific tenant.
+     *
+     * @param tenantId the id of the tenant the subscription is created for
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionDeletionBuilder tenantId(String tenantId);
+
+    /**
+     * Adds a specific correlation parameter value for the subscription to be deleted. If you register the same correlation parameter values
+     * as when creating and registering the event subscription, only that particular one will be deleted with this builder.
+     * If you want to delete all manually created subscriptions, don't register any correlation parameter values, which would result in all matching
+     * the provided case definition and event-registry start event will be deleted.
+     *
+     * @param parameterName the name of the correlation parameter
+     * @param parameterValue the value of the correlation parameter
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionDeletionBuilder addCorrelationParameterValue(String parameterName, Object parameterValue);
+
+    /**
+     * Registers a list of correlation parameter values for the subscription(s) to be deleted.
+     *
+     * @param parameters the map of correlation parameter values to be registered for the subscription
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionDeletionBuilder addCorrelationParameterValues(Map<String, Object> parameters);
+
+    /**
+     * Deletes all the matching event subscriptions.
+     */
+    void deleteSubscriptions();
+}

--- a/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceStartEventSubscriptionModificationBuilder.java
+++ b/modules/flowable-cmmn-api/src/main/java/org/flowable/cmmn/api/runtime/CaseInstanceStartEventSubscriptionModificationBuilder.java
@@ -1,0 +1,76 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.api.runtime;
+
+import java.util.Map;
+
+import org.flowable.cmmn.api.CmmnRuntimeService;
+
+/**
+ * A builder API to modify a manually created case start event subscription which was created and registered using the
+ * {@link CmmnRuntimeService#createCaseInstanceStartEventSubscriptionBuilder()} builder API.
+ * With this API you can modify one or more such subscriptions like migrating to a specific version of a case definition (if you choose to not automatically
+ * migrate then to the latest version upon deployment of a new version).
+ *
+ * @author Micha Kiener
+ */
+public interface CaseInstanceStartEventSubscriptionModificationBuilder {
+
+    /**
+     * Set the case definition using its specific id the manually created subscription is based on. This is mandatory and must be provided.
+     *
+     * @param caseDefinitionId the id of the case definition the subscription is based on (an exact version of it)
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionModificationBuilder caseDefinitionId(String caseDefinitionId);
+    
+    /**
+     * Set the tenant id in case you are running in a multi tenant environment and the event model needs to be retrieved from a specific tenant.
+     *
+     * @param tenantId the id of the tenant the subscription is created for
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionModificationBuilder tenantId(String tenantId);
+
+    /**
+     * Adds a specific correlation parameter value for the subscription to be modified. If you register the same correlation parameter values as when creating
+     * and registering the event subscription, only that particular one will be modified with this builder.
+     * If you want to modify all manually created subscriptions, don't register any correlation parameter values, which would result in all matching
+     * the provided case definition and event-registry start event will be modified.
+     *
+     * @param parameterName the name of the correlation parameter
+     * @param parameterValue the value of the correlation parameter
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionModificationBuilder addCorrelationParameterValue(String parameterName, Object parameterValue);
+
+    /**
+     * Registers a list of correlation parameter values for the subscription(s) to be modified.
+     *
+     * @param parameters the map of correlation parameter values to be registered for the subscription
+     * @return the builder to be used for method chaining
+     */
+    CaseInstanceStartEventSubscriptionModificationBuilder addCorrelationParameterValues(Map<String, Object> parameters);
+
+    /**
+     * Migrate all the matching event subscriptions to the latest case definition, which should be done if you want to manually upgrade the subscriptions
+     * to the latest version of the case definition.
+     */
+    void migrateToLatestCaseDefinition();
+
+    /**
+     * Migrate all matching event subscriptions to the specific case definition.
+     * @param caseDefinitionId the id of the case definition to migrate to
+     */
+    void migrateToCaseDefinition(String caseDefinitionId);
+}

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConstants.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConstants.java
@@ -221,6 +221,7 @@ public interface CmmnXmlConstants {
     String ELEMENT_EVENT_OUT_PARAMETER = "eventOutParameter";
     String START_EVENT_CORRELATION_CONFIGURATION = "startEventCorrelationConfiguration";
     String START_EVENT_CORRELATION_STORE_AS_UNIQUE_REFERENCE_ID = "storeAsUniqueReferenceId";
+    String START_EVENT_CORRELATION_MANUAL = "manualSubscription";
 
     String ELEMENT_VARIABLE_AGGREGATION = "variableAggregation";
     String ATTRIBUTE_VARIABLE_AGGREGATION_VARIABLE = "variable";

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AbstractCaseStartEventSubscriptionCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AbstractCaseStartEventSubscriptionCmd.java
@@ -98,7 +98,7 @@ public class AbstractCaseStartEventSubscriptionCmd {
                     
                 } else {
                     throw new FlowableObjectNotFoundException("Case definition with key '" + caseDefinitionKey +
-                        "' and tenantId '"+ tenantId +"' was not found", CaseDefinition.class);
+                        "' and tenantId '" + tenantId + "' was not found.", CaseDefinition.class);
                 }
             }
         }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AbstractCaseStartEventSubscriptionCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/AbstractCaseStartEventSubscriptionCmd.java
@@ -1,0 +1,155 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.cmmn.api.CmmnRepositoryService;
+import org.flowable.cmmn.api.repository.CaseDefinition;
+import org.flowable.cmmn.converter.CmmnXmlConstants;
+import org.flowable.cmmn.engine.CmmnEngineConfiguration;
+import org.flowable.cmmn.engine.impl.persistence.entity.CaseDefinitionEntityManager;
+import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.cmmn.model.Case;
+import org.flowable.cmmn.model.CmmnModel;
+import org.flowable.cmmn.model.ExtensionElement;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.FlowableObjectNotFoundException;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.eventregistry.model.EventModel;
+import org.flowable.eventregistry.model.EventPayload;
+import org.flowable.eventsubscription.service.EventSubscriptionService;
+
+/**
+ * An abstract command with various common methods for the creation and modification of case start event subscriptions.
+ *
+ * @author Micha Kiener
+ */
+public class AbstractCaseStartEventSubscriptionCmd {
+
+    protected String generateCorrelationConfiguration(String eventDefinitionKey, String tenantId, Map<String, Object> correlationParameterValues, CommandContext commandContext) {
+        EventModel eventModel = getEventModel(eventDefinitionKey, tenantId, commandContext);
+        Map<String, Object> correlationParameters = new HashMap<>();
+        for (Map.Entry<String, Object> correlationValue : correlationParameterValues.entrySet()) {
+            // make sure the correlation parameter value is based on a valid, defined correlation parameter within the event model
+            checkEventModelCorrelationParameter(eventModel, correlationValue.getKey());
+            correlationParameters.put(correlationValue.getKey(), correlationValue.getValue());
+        }
+
+        return CommandContextUtil.getEventRegistry().generateKey(correlationParameters);
+    }
+
+    protected void checkEventModelCorrelationParameter(EventModel eventModel, String correlationParameterName) {
+        Collection<EventPayload> correlationParameters = eventModel.getCorrelationParameters();
+        for (EventPayload correlationParameter : correlationParameters) {
+            if (correlationParameter.getName().equals(correlationParameterName)) {
+                return;
+            }
+        }
+        throw new FlowableIllegalArgumentException("There is no correlation parameter with name '" + correlationParameterName + "' defined in event model "
+            + "with key '" + eventModel.getKey() + "'. You can only subscribe for an event with a combination of valid correlation parameters.");
+    }
+
+    protected CaseDefinition getLatestCaseDefinitionByKey(String caseDefinitionKey, String tenantId, CommandContext commandContext) {
+        CaseDefinitionEntityManager caseDefinitionEntityManager = CommandContextUtil.getCaseDefinitionEntityManager(commandContext);
+        CaseDefinition caseDefinition = null;
+        if (caseDefinitionKey != null && (tenantId == null || CmmnEngineConfiguration.NO_TENANT_ID.equals(tenantId))) {
+            caseDefinition = caseDefinitionEntityManager.findLatestCaseDefinitionByKey(caseDefinitionKey);
+
+            if (caseDefinition == null) {
+                throw new FlowableObjectNotFoundException("No case definition found for key '" + caseDefinitionKey + "'", CaseDefinition.class);
+            }
+
+        } else if (caseDefinitionKey != null && tenantId != null && !CmmnEngineConfiguration.NO_TENANT_ID.equals(tenantId)) {
+
+            caseDefinition = caseDefinitionEntityManager.findLatestCaseDefinitionByKeyAndTenantId(caseDefinitionKey, tenantId);
+
+            if (caseDefinition == null) {
+                CmmnEngineConfiguration caseEngineConfiguration = CommandContextUtil.getCmmnEngineConfiguration(commandContext);
+                if (caseEngineConfiguration.isFallbackToDefaultTenant()) {
+                    String defaultTenant = caseEngineConfiguration.getDefaultTenantProvider().getDefaultTenant(tenantId, ScopeTypes.BPMN, caseDefinitionKey);
+                    if (StringUtils.isNotEmpty(defaultTenant)) {
+                        caseDefinition = caseDefinitionEntityManager.findLatestCaseDefinitionByKeyAndTenantId(caseDefinitionKey, defaultTenant);
+                        
+                    } else {
+                        caseDefinition = caseDefinitionEntityManager.findLatestCaseDefinitionByKey(caseDefinitionKey);
+                    }
+                    
+                    if (caseDefinition == null) {
+                        throw new FlowableObjectNotFoundException("No case definition found for key '" + caseDefinitionKey +
+                            "'. Fallback to default tenant was also applied.", CaseDefinition.class);
+                    }
+                    
+                } else {
+                    throw new FlowableObjectNotFoundException("Case definition with key '" + caseDefinitionKey +
+                        "' and tenantId '"+ tenantId +"' was not found", CaseDefinition.class);
+                }
+            }
+        }
+        
+        if (caseDefinition == null) {
+            throw new FlowableIllegalArgumentException("No deployed case definition found for key '" + caseDefinitionKey + "'.");
+        }
+        
+        return caseDefinition;
+    }
+
+    protected CaseDefinition getCaseDefinitionById(String caseDefinitionId, CommandContext commandContext) {
+        CmmnRepositoryService repositoryService = CommandContextUtil.getCmmnEngineConfiguration(commandContext).getCmmnRepositoryService();
+
+        CaseDefinition caseDefinition = repositoryService.createCaseDefinitionQuery()
+            .caseDefinitionId(caseDefinitionId)
+            .singleResult();
+
+        if (caseDefinition == null) {
+            throw new FlowableIllegalArgumentException("No deployed case definition found for id '" + caseDefinitionId + "'.");
+        }
+        return caseDefinition;
+    }
+
+    protected Case getCase(String caseDefinitionId, CommandContext commandContext) {
+        CmmnRepositoryService repositoryService = CommandContextUtil.getCmmnEngineConfiguration(commandContext).getCmmnRepositoryService();
+        CmmnModel cmmnModel = repositoryService.getCmmnModel(caseDefinitionId);
+        return cmmnModel.getPrimaryCase();
+    }
+
+    protected EventModel getEventModel(String eventDefinitionKey, String tenantId, CommandContext commandContext) {
+        EventModel eventModel = CommandContextUtil.getEventRepositoryService(commandContext).getEventModelByKey(eventDefinitionKey, tenantId);
+        if (eventModel == null) {
+            throw new FlowableIllegalArgumentException("Could not find event model with key '" + eventDefinitionKey + "'.");
+        }
+        return eventModel;
+    }
+
+    protected String getStartCorrelationConfiguration(String caseDefinitionId, CommandContext commandContext) {
+        CmmnModel cmmnModel = CommandContextUtil.getCmmnEngineConfiguration(commandContext).getCmmnRepositoryService().getCmmnModel(caseDefinitionId);
+        if (cmmnModel != null) {
+            List<ExtensionElement> correlationCfgExtensions = cmmnModel.getPrimaryCase().getExtensionElements()
+                .getOrDefault(CmmnXmlConstants.START_EVENT_CORRELATION_CONFIGURATION, Collections.emptyList());
+            if (!correlationCfgExtensions.isEmpty()) {
+                return correlationCfgExtensions.get(0).getElementText();
+            }
+        }
+        return null;
+    }
+
+    protected EventSubscriptionService getEventSubscriptionService(CommandContext commandContext) {
+        return CommandContextUtil.getCmmnEngineConfiguration(commandContext).getEventSubscriptionServiceConfiguration().getEventSubscriptionService();
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/DeleteCaseInstanceStartEventSubscriptionCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/DeleteCaseInstanceStartEventSubscriptionCmd.java
@@ -1,0 +1,58 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.flowable.cmmn.converter.CmmnXmlConstants;
+import org.flowable.cmmn.engine.impl.runtime.CaseInstanceStartEventSubscriptionDeletionBuilderImpl;
+import org.flowable.cmmn.model.Case;
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+
+/**
+ * This command either modifies event subscriptions with a case start event and optional correlation parameter values.
+ *
+ * @author Micha Kiener
+ */
+public class DeleteCaseInstanceStartEventSubscriptionCmd extends AbstractCaseStartEventSubscriptionCmd implements Command<Void>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    protected final CaseInstanceStartEventSubscriptionDeletionBuilderImpl builder;
+
+    public DeleteCaseInstanceStartEventSubscriptionCmd(CaseInstanceStartEventSubscriptionDeletionBuilderImpl builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        Case caze = getCase(builder.getCaseDefinitionId(), commandContext);
+        String eventDefinitionKey = caze.getStartEventType();
+        String startCorrelationConfiguration = getStartCorrelationConfiguration(builder.getCaseDefinitionId(), commandContext);
+
+        if (eventDefinitionKey != null && Objects.equals(startCorrelationConfiguration, CmmnXmlConstants.START_EVENT_CORRELATION_MANUAL)) {
+            String correlationKey = null;
+
+            if (builder.hasCorrelationParameterValues()) {
+                correlationKey = generateCorrelationConfiguration(eventDefinitionKey, builder.getTenantId(),
+                        builder.getCorrelationParameterValues(), commandContext);
+            }
+
+            getEventSubscriptionService(commandContext).deleteEventSubscriptionsForScopeDefinitionAndScopeStartEvent(builder.getCaseDefinitionId(),
+                eventDefinitionKey, correlationKey);
+        }
+
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/DeleteCaseInstanceStartEventSubscriptionCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/DeleteCaseInstanceStartEventSubscriptionCmd.java
@@ -22,7 +22,7 @@ import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 
 /**
- * This command either modifies event subscriptions with a case start event and optional correlation parameter values.
+ * This command deletes event subscriptions with a case start event and optional correlation parameter values.
  *
  * @author Micha Kiener
  */

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/ModifyCaseInstanceStartEventSubscriptionCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/ModifyCaseInstanceStartEventSubscriptionCmd.java
@@ -1,0 +1,77 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.flowable.cmmn.api.repository.CaseDefinition;
+import org.flowable.cmmn.converter.CmmnXmlConstants;
+import org.flowable.cmmn.engine.impl.runtime.CaseInstanceStartEventSubscriptionModificationBuilderImpl;
+import org.flowable.cmmn.model.Case;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+
+/**
+ * This command either modifies event subscriptions with a case start event and optional correlation parameter values.
+ *
+ * @author Micha Kiener
+ */
+public class ModifyCaseInstanceStartEventSubscriptionCmd extends AbstractCaseStartEventSubscriptionCmd implements Command<Void>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final CaseInstanceStartEventSubscriptionModificationBuilderImpl builder;
+
+    public ModifyCaseInstanceStartEventSubscriptionCmd(CaseInstanceStartEventSubscriptionModificationBuilderImpl builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        CaseDefinition newCaseDefinition;
+        if (builder.hasNewCaseDefinitionId()) {
+            newCaseDefinition = getCaseDefinitionById(builder.getNewCaseDefinitionId(), commandContext);
+        } else {
+            // no explicit case definition provided, so use latest one
+            CaseDefinition caseDefinition = getCaseDefinitionById(builder.getCaseDefinitionId(), commandContext);
+            newCaseDefinition = getLatestCaseDefinitionByKey(caseDefinition.getKey(), caseDefinition.getTenantId(), commandContext);
+        }
+
+        if (newCaseDefinition == null) {
+            throw new FlowableIllegalArgumentException("Cannot find case definition with id " + (builder.hasNewCaseDefinitionId() ?
+                builder.getNewCaseDefinitionId() :
+                builder.getCaseDefinitionId()));
+        }
+
+        Case caze = getCase(newCaseDefinition.getId(), commandContext);
+
+        String eventDefinitionKey = caze.getStartEventType();
+        String startCorrelationConfiguration = getStartCorrelationConfiguration(newCaseDefinition.getId(), commandContext);
+
+        if (eventDefinitionKey != null && Objects.equals(startCorrelationConfiguration, CmmnXmlConstants.START_EVENT_CORRELATION_MANUAL)) {
+            String correlationKey = null;
+
+            if (builder.hasCorrelationParameterValues()) {
+                correlationKey = generateCorrelationConfiguration(eventDefinitionKey, builder.getTenantId(),
+                        builder.getCorrelationParameterValues(), commandContext);
+            }
+
+            getEventSubscriptionService(commandContext).updateEventSubscriptionScopeDefinitionId(builder.getCaseDefinitionId(), newCaseDefinition.getId(),
+                eventDefinitionKey, null, correlationKey);
+        }
+
+        return null;
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RegisterCaseInstanceStartEventSubscriptionCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/RegisterCaseInstanceStartEventSubscriptionCmd.java
@@ -1,0 +1,94 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.cmd;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.flowable.cmmn.api.repository.CaseDefinition;
+import org.flowable.cmmn.converter.CmmnXmlConstants;
+import org.flowable.cmmn.engine.CmmnEngineConfiguration;
+import org.flowable.cmmn.engine.impl.runtime.CaseInstanceStartEventSubscriptionBuilderImpl;
+import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.cmmn.model.Case;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.common.engine.impl.interceptor.Command;
+import org.flowable.common.engine.impl.interceptor.CommandContext;
+import org.flowable.eventsubscription.api.EventSubscription;
+import org.flowable.eventsubscription.api.EventSubscriptionBuilder;
+import org.flowable.eventsubscription.service.EventSubscriptionService;
+
+/**
+ * This command creates and registers a new case start event subscription based on the provided builder information.
+ *
+ * @author Micha Kiener
+ */
+public class RegisterCaseInstanceStartEventSubscriptionCmd extends AbstractCaseStartEventSubscriptionCmd implements Command<EventSubscription>,
+    Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final CaseInstanceStartEventSubscriptionBuilderImpl builder;
+
+    public RegisterCaseInstanceStartEventSubscriptionCmd(CaseInstanceStartEventSubscriptionBuilderImpl builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public EventSubscription execute(CommandContext commandContext) {
+        CaseDefinition caseDefinition = getLatestCaseDefinitionByKey(builder.getCaseDefinitionKey(), builder.getTenantId(), commandContext);
+        Case caze = getCase(caseDefinition.getId(), commandContext);
+
+        EventSubscription eventSubscription = null;
+        String eventDefinitionKey = caze.getStartEventType();
+        String startCorrelationConfiguration = getStartCorrelationConfiguration(caseDefinition.getId(), commandContext);
+
+        if (eventDefinitionKey != null && Objects.equals(startCorrelationConfiguration, CmmnXmlConstants.START_EVENT_CORRELATION_MANUAL)) {
+            String correlationKey = generateCorrelationConfiguration(eventDefinitionKey, builder.getTenantId(), builder.getCorrelationParameterValues(), commandContext);
+
+            eventSubscription = insertEventRegistryEvent(eventDefinitionKey, builder.isDoNotUpdateToLatestVersionAutomatically(), caseDefinition,
+                correlationKey, commandContext);
+        }
+
+        if (eventSubscription == null) {
+            throw new FlowableIllegalArgumentException("The case definition with id '" + caseDefinition.getId()
+                + "' does not have an event-registry based start event with a manual subscription behavior.");
+        }
+
+        return eventSubscription;
+    }
+
+    protected EventSubscription insertEventRegistryEvent(String eventDefinitionKey, boolean doNotUpdateToLatestVersionAutomatically,
+        CaseDefinition caseDefinition, String correlationKey, CommandContext commandContext) {
+        
+        CmmnEngineConfiguration caseEngineConfiguration = CommandContextUtil.getCmmnEngineConfiguration(commandContext);
+        EventSubscriptionService eventSubscriptionService = caseEngineConfiguration.getEventSubscriptionServiceConfiguration().getEventSubscriptionService();
+        EventSubscriptionBuilder eventSubscriptionBuilder = eventSubscriptionService.createEventSubscriptionBuilder()
+                .eventType(eventDefinitionKey)
+                .scopeDefinitionId(caseDefinition.getId())
+                .scopeType(ScopeTypes.CMMN)
+                .configuration(correlationKey);
+
+        if (caseDefinition.getTenantId() != null) {
+            eventSubscriptionBuilder.tenantId(caseDefinition.getTenantId());
+        }
+
+        // if we need to update the case definition to the latest version upon new deployment, also set the definition key, not just the case definition id
+        if (!doNotUpdateToLatestVersionAutomatically) {
+            eventSubscriptionBuilder.scopeDefinitionKey(caseDefinition.getKey());
+        }
+
+        return eventSubscriptionBuilder.create();
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceStartEventSubscriptionBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceStartEventSubscriptionBuilderImpl.java
@@ -1,0 +1,102 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionBuilder;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.eventsubscription.api.EventSubscription;
+
+/**
+ * A default implementation for the case start event subscription builder.
+ *
+ * @author Micha Kiener
+ */
+public class CaseInstanceStartEventSubscriptionBuilderImpl implements CaseInstanceStartEventSubscriptionBuilder {
+    protected final CmmnRuntimeServiceImpl cmmnRuntimeService;
+    protected String caseDefinitionKey;
+    protected String tenantId;
+    protected final Map<String, Object> correlationParameterValues = new HashMap<>();
+    protected boolean doNotUpdateToLatestVersionAutomatically;
+
+    public CaseInstanceStartEventSubscriptionBuilderImpl(CmmnRuntimeServiceImpl cmmnRuntimeService) {
+        this.cmmnRuntimeService = cmmnRuntimeService;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionBuilder caseDefinitionKey(String caseDefinitionKey) {
+        this.caseDefinitionKey = caseDefinitionKey;
+        return this;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionBuilder doNotUpdateToLatestVersionAutomatically() {
+        this.doNotUpdateToLatestVersionAutomatically = true;
+        return this;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionBuilder addCorrelationParameterValue(String parameterName, Object parameterValue) {
+        correlationParameterValues.put(parameterName, parameterValue);
+        return this;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionBuilder addCorrelationParameterValues(Map<String, Object> parameters) {
+        correlationParameterValues.putAll(parameters);
+        return this;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionBuilder tenantId(String tenantId) {
+        this.tenantId = tenantId;
+        return this;
+    }
+
+    public String getCaseDefinitionKey() {
+        return caseDefinitionKey;
+    }
+
+    public Map<String, Object> getCorrelationParameterValues() {
+        return correlationParameterValues;
+    }
+
+    public boolean isDoNotUpdateToLatestVersionAutomatically() {
+        return doNotUpdateToLatestVersionAutomatically;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @Override
+    public EventSubscription subscribe() {
+        checkValidInformation();
+        return cmmnRuntimeService.registerCaseInstanceStartEventSubscription(this);
+    }
+
+    protected void checkValidInformation() {
+        if (StringUtils.isEmpty(caseDefinitionKey)) {
+            throw new FlowableIllegalArgumentException("The case definition must be provided using the key for the subscription to be registered.");
+        }
+
+        if (correlationParameterValues.isEmpty()) {
+            throw new FlowableIllegalArgumentException(
+                "At least one correlation parameter value must be provided for a dynamic case start event subscription, "
+                    + "otherwise the case would get started on all events, regardless their correlation parameter values.");
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceStartEventSubscriptionDeletionBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceStartEventSubscriptionDeletionBuilderImpl.java
@@ -1,0 +1,89 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionDeletionBuilder;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+
+/**
+ * The implementation for a case start event subscription deletion builder.
+ *
+ * @author Micha Kiener
+ */
+public class CaseInstanceStartEventSubscriptionDeletionBuilderImpl implements CaseInstanceStartEventSubscriptionDeletionBuilder {
+    
+    protected final CmmnRuntimeServiceImpl cmmnRuntimeService;
+    protected String caseDefinitionId;
+    protected String tenantId;
+    protected final Map<String, Object> correlationParameterValues = new HashMap<>();
+
+    public CaseInstanceStartEventSubscriptionDeletionBuilderImpl(CmmnRuntimeServiceImpl runtimeService) {
+        this.cmmnRuntimeService = runtimeService;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionDeletionBuilder caseDefinitionId(String caseDefinitionId) {
+        this.caseDefinitionId = caseDefinitionId;
+        return this;
+    }
+    
+    @Override
+    public CaseInstanceStartEventSubscriptionDeletionBuilder tenantId(String tenantId) {
+        this.tenantId = tenantId;
+        return this;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionDeletionBuilder addCorrelationParameterValue(String parameterName, Object parameterValue) {
+        correlationParameterValues.put(parameterName, parameterValue);
+        return this;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionDeletionBuilder addCorrelationParameterValues(Map<String, Object> parameters) {
+        correlationParameterValues.putAll(parameters);
+        return this;
+    }
+
+    public String getCaseDefinitionId() {
+        return caseDefinitionId;
+    }
+    
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public boolean hasCorrelationParameterValues() {
+        return correlationParameterValues.size() > 0;
+    }
+
+    public Map<String, Object> getCorrelationParameterValues() {
+        return correlationParameterValues;
+    }
+
+    @Override
+    public void deleteSubscriptions() {
+        checkValidInformation();
+        cmmnRuntimeService.deleteCaseInstanceStartEventSubscriptions(this);
+    }
+
+    protected void checkValidInformation() {
+        if (StringUtils.isEmpty(caseDefinitionId)) {
+            throw new FlowableIllegalArgumentException("The case definition must be provided using the exact id of the version the subscription was registered for.");
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceStartEventSubscriptionModificationBuilderImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CaseInstanceStartEventSubscriptionModificationBuilderImpl.java
@@ -1,0 +1,104 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.engine.impl.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionModificationBuilder;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+
+/**
+ * The implementation for a case start event subscription modification builder.
+ *
+ * @author Micha Kiener
+ */
+public class CaseInstanceStartEventSubscriptionModificationBuilderImpl implements CaseInstanceStartEventSubscriptionModificationBuilder {
+    protected final CmmnRuntimeServiceImpl cmmnRuntimeService;
+    protected String caseDefinitionId;
+    protected String newCaseDefinitionId;
+    protected String tenantId;
+    protected final Map<String, Object> correlationParameterValues = new HashMap<>();
+
+    public CaseInstanceStartEventSubscriptionModificationBuilderImpl(CmmnRuntimeServiceImpl cmmnRuntimeService) {
+        this.cmmnRuntimeService = cmmnRuntimeService;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionModificationBuilder caseDefinitionId(String caseDefinitionId) {
+        this.caseDefinitionId = caseDefinitionId;
+        return this;
+    }
+    
+    @Override
+    public CaseInstanceStartEventSubscriptionModificationBuilder tenantId(String tenantId) {
+        this.tenantId = tenantId;
+        return this;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionModificationBuilder addCorrelationParameterValue(String parameterName, Object parameterValue) {
+        correlationParameterValues.put(parameterName, parameterValue);
+        return this;
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionModificationBuilder addCorrelationParameterValues(Map<String, Object> parameters) {
+        correlationParameterValues.putAll(parameters);
+        return this;
+    }
+
+    public String getCaseDefinitionId() {
+        return caseDefinitionId;
+    }
+
+    public boolean hasNewCaseDefinitionId() {
+        return StringUtils.isNotBlank(newCaseDefinitionId);
+    }
+
+    public String getNewCaseDefinitionId() {
+        return newCaseDefinitionId;
+    }
+    
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public boolean hasCorrelationParameterValues() {
+        return correlationParameterValues.size() > 0;
+    }
+
+    public Map<String, Object> getCorrelationParameterValues() {
+        return correlationParameterValues;
+    }
+
+    @Override
+    public void migrateToLatestCaseDefinition() {
+        checkValidInformation();
+        cmmnRuntimeService.migrateCaseInstanceStartEventSubscriptionsToCaseDefinitionVersion(this);
+    }
+
+    @Override
+    public void migrateToCaseDefinition(String caseDefinitionId) {
+        this.newCaseDefinitionId = caseDefinitionId;
+        checkValidInformation();
+        cmmnRuntimeService.migrateCaseInstanceStartEventSubscriptionsToCaseDefinitionVersion(this);
+    }
+
+    protected void checkValidInformation() {
+        if (StringUtils.isEmpty(caseDefinitionId)) {
+            throw new FlowableIllegalArgumentException("The case definition must be provided using the exact id of the version the subscription was registered for.");
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CmmnRuntimeServiceImpl.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/runtime/CmmnRuntimeServiceImpl.java
@@ -22,6 +22,9 @@ import org.flowable.cmmn.api.StageResponse;
 import org.flowable.cmmn.api.runtime.CaseInstance;
 import org.flowable.cmmn.api.runtime.CaseInstanceBuilder;
 import org.flowable.cmmn.api.runtime.CaseInstanceQuery;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionBuilder;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionDeletionBuilder;
+import org.flowable.cmmn.api.runtime.CaseInstanceStartEventSubscriptionModificationBuilder;
 import org.flowable.cmmn.api.runtime.ChangePlanItemStateBuilder;
 import org.flowable.cmmn.api.runtime.GenericEventListenerInstanceQuery;
 import org.flowable.cmmn.api.runtime.MilestoneInstanceQuery;
@@ -39,6 +42,7 @@ import org.flowable.cmmn.engine.impl.cmd.ChangePlanItemStateCmd;
 import org.flowable.cmmn.engine.impl.cmd.CompleteCaseInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.CompleteStagePlanItemInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.DeleteCaseInstanceCmd;
+import org.flowable.cmmn.engine.impl.cmd.DeleteCaseInstanceStartEventSubscriptionCmd;
 import org.flowable.cmmn.engine.impl.cmd.DeleteIdentityLinkForCaseInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.DisablePlanItemInstanceCmd;
 import org.flowable.cmmn.engine.impl.cmd.DispatchEventCommand;
@@ -61,6 +65,8 @@ import org.flowable.cmmn.engine.impl.cmd.GetVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.GetVariablesCmd;
 import org.flowable.cmmn.engine.impl.cmd.HasCaseInstanceVariableCmd;
 import org.flowable.cmmn.engine.impl.cmd.HasPlanItemInstanceVariableCmd;
+import org.flowable.cmmn.engine.impl.cmd.ModifyCaseInstanceStartEventSubscriptionCmd;
+import org.flowable.cmmn.engine.impl.cmd.RegisterCaseInstanceStartEventSubscriptionCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveCaseInstanceAssigneeCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveCaseInstanceOwnerCmd;
 import org.flowable.cmmn.engine.impl.cmd.RemoveEventListenerCommand;
@@ -88,6 +94,7 @@ import org.flowable.common.engine.api.delegate.event.FlowableEvent;
 import org.flowable.common.engine.api.delegate.event.FlowableEventListener;
 import org.flowable.common.engine.impl.service.CommonEngineServiceImpl;
 import org.flowable.entitylink.api.EntityLink;
+import org.flowable.eventsubscription.api.EventSubscription;
 import org.flowable.eventsubscription.api.EventSubscriptionQuery;
 import org.flowable.eventsubscription.service.impl.EventSubscriptionQueryImpl;
 import org.flowable.form.api.FormInfo;
@@ -455,4 +462,30 @@ public class CmmnRuntimeServiceImpl extends CommonEngineServiceImpl<CmmnEngineCo
         commandExecutor.execute(new DispatchEventCommand(event));
     }
 
+    @Override
+    public CaseInstanceStartEventSubscriptionBuilder createCaseInstanceStartEventSubscriptionBuilder() {
+        return new CaseInstanceStartEventSubscriptionBuilderImpl(this);
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionModificationBuilder createCaseInstanceStartEventSubscriptionModificationBuilder() {
+        return new CaseInstanceStartEventSubscriptionModificationBuilderImpl(this);
+    }
+
+    @Override
+    public CaseInstanceStartEventSubscriptionDeletionBuilder createCaseInstanceStartEventSubscriptionDeletionBuilder() {
+        return new CaseInstanceStartEventSubscriptionDeletionBuilderImpl(this);
+    }
+
+    public EventSubscription registerCaseInstanceStartEventSubscription(CaseInstanceStartEventSubscriptionBuilderImpl builder) {
+        return commandExecutor.execute(new RegisterCaseInstanceStartEventSubscriptionCmd(builder));
+    }
+
+    public void migrateCaseInstanceStartEventSubscriptionsToCaseDefinitionVersion(CaseInstanceStartEventSubscriptionModificationBuilderImpl builder) {
+        commandExecutor.execute(new ModifyCaseInstanceStartEventSubscriptionCmd(builder));
+    }
+
+    public void deleteCaseInstanceStartEventSubscriptions(CaseInstanceStartEventSubscriptionDeletionBuilderImpl builder) {
+        commandExecutor.execute(new DeleteCaseInstanceStartEventSubscriptionCmd(builder));
+    }
 }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.java
@@ -1,0 +1,830 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.eventregistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.groups.Tuple;
+import org.flowable.cmmn.api.repository.CaseDefinition;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.eventregistry.api.EventDeployment;
+import org.flowable.eventregistry.api.EventRepositoryService;
+import org.flowable.eventsubscription.api.EventSubscription;
+import org.flowable.task.api.Task;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * Various tests for event-registry based case starts, both static and dynamic and the handling of the event subscriptions.
+ *
+ * @author Micha Kiener
+ */
+public class DynamicCaseStartEventRegistryDeploymentTest extends FlowableEventRegistryCmmnTestCase {
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryStaticStartTestCase.cmmn"
+    })
+    public void testStaticEventRegistryCaseStart() {
+        sendEvent("kermit", "start");
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey)
+                .containsExactlyInAnyOrder("eventRegistryStaticStartTestCase");
+
+        Task task = cmmnTaskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+
+        cmmnTaskService.complete(task.getId());
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartWithoutManualSubscription() {
+        sendEvent("kermit", "start");
+
+        // there must be no running case instance as we didn't create a manual subscription yet
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryStaticStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartWithoutCaseDefinition() {
+        FlowableIllegalArgumentException exception = Assertions.assertThrowsExactly(FlowableIllegalArgumentException.class, () -> {
+            // manually register start subscription, but with different correlation than the actual event being sent
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+                .addCorrelationParameterValue("customer", "test")
+                .addCorrelationParameterValue("action", "start")
+                .subscribe();
+        });
+
+        assertThat(exception.getMessage()).isEqualTo("The case definition must be provided using the key for the subscription to be registered.");
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryStaticStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartWithIllegalManualSubscriptionForWrongStartEvent() {
+        FlowableIllegalArgumentException exception = Assertions.assertThrowsExactly(FlowableIllegalArgumentException.class, () -> {
+            // manually register start subscription, but with different correlation than the actual event being sent
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+                .caseDefinitionKey("eventRegistryStaticStartTestCase")
+                .addCorrelationParameterValue("customer", "test")
+                .addCorrelationParameterValue("action", "start")
+                .subscribe();
+        });
+
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("eventRegistryStaticStartTestCase").latestVersion().singleResult();
+
+        assertThat(exception.getMessage()).isEqualTo("The case definition with id '" + caseDefinition.getId() + "' does not have an event-registry based start event with a manual subscription behavior.");
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartWithNonMatchingManualSubscription() {
+        // manually register start subscription, but with different correlation than the actual event being sent
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "test")
+            .addCorrelationParameterValue("action", "start")
+            .subscribe();
+
+        sendEvent("kermit", "start");
+
+        // there must be no running case instance as we didn't create a manual subscription yet
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartWithIllegalManualSubscriptionForWrongCorrelation() {
+        FlowableIllegalArgumentException exception = Assertions.assertThrowsExactly(FlowableIllegalArgumentException.class, () -> {
+            // manually register start subscription, but with different correlation than the actual event being sent
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+                .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+                .addCorrelationParameterValue("invalidCorrelationParameter", "test")
+                .addCorrelationParameterValue("action", "start")
+                .subscribe();
+        });
+
+        assertThat(exception.getMessage()).isEqualTo("There is no correlation parameter with name 'invalidCorrelationParameter' defined in event model with key 'simpleTest'. You can only subscribe for an event with a combination of valid correlation parameters.");
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartWithMatchingManualSubscription() {
+        // manually register start subscription, matching the event correlation sent later
+        EventSubscription eventSubscription = cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "kermit")
+            .addCorrelationParameterValue("action", "start")
+            .subscribe();
+
+        assertThat(eventSubscription).isNotNull().extracting(EventSubscription::getScopeDefinitionKey).isEqualTo("eventRegistryDynamicStartTestCase");
+
+        sendEvent("kermit", "start");
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey)
+                .containsExactlyInAnyOrder("eventRegistryDynamicStartTestCase");
+
+        Task task = cmmnTaskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+
+        cmmnTaskService.complete(task.getId());
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartWithMatchingManualSubscriptionVersion2() {
+        // manually register start subscription, matching the event correlation sent later
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValues(Map.of("customer", "kermit", "action", "start"))
+            .subscribe();
+
+        sendEvent("kermit", "start");
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey)
+                .containsExactlyInAnyOrder("eventRegistryDynamicStartTestCase");
+
+        Task task = cmmnTaskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+
+        cmmnTaskService.complete(task.getId());
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryStaticStartTestCase.cmmn"
+    })
+    public void testStaticEventRegistryCaseStartAfterRedeployment() {
+        sendEvent("kermit", "start");
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey)
+                .containsExactlyInAnyOrder("eventRegistryStaticStartTestCase");
+
+        Task task = cmmnTaskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+
+        cmmnTaskService.complete(task.getId());
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+        // redeploy the case definition (which removes and re-adds the static start subscription)
+        CaseDefinition caseDefinition = deployCaseDefinition("eventRegistryStaticStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryStaticStartTestCase.cmmn");
+
+        try {
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(caseDefinition.getId());
+
+            task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+        } finally {
+            deleteDeployment(caseDefinition.getDeploymentId());
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartAfterRedeployment() {
+        // manually register start subscription, matching the event correlation sent later
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "kermit")
+            .addCorrelationParameterValue("action", "start")
+            .subscribe();
+
+        sendEvent("kermit", "start");
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey)
+                .containsExactlyInAnyOrder("eventRegistryDynamicStartTestCase");
+
+        Task task = cmmnTaskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+
+        cmmnTaskService.complete(task.getId());
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+        // the scope definition key must be present in the subscription
+        assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+            .extracting(EventSubscription::getScopeDefinitionKey)
+            .containsExactlyInAnyOrder("eventRegistryDynamicStartTestCase");
+
+        // redeploy the case definition (which must not remove the subscriptions, but rather update them to the newest version)
+        CaseDefinition caseDefinition = deployCaseDefinition("eventRegistryDynamicStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn");
+
+        try {
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", caseDefinition.getId()));
+
+            task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+        } finally {
+            deleteDeployment(caseDefinition.getDeploymentId());
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartAfterRedeploymentWithoutAutoUpdate() {
+        // manually register start subscription, matching the event correlation sent later
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "kermit")
+            .addCorrelationParameterValue("action", "start")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+        sendEvent("kermit", "start");
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey)
+                .containsExactlyInAnyOrder("eventRegistryDynamicStartTestCase");
+
+        Task task = cmmnTaskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+
+        cmmnTaskService.complete(task.getId());
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+        // the scope definition key must not be present in the event subscription
+        assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+            .extracting(EventSubscription::getScopeDefinitionKey).containsOnlyNulls();
+
+        // search the first case definition as we don't have auto-update in the subscription
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase").latestVersion().singleResult();
+
+        // redeploy the case definition (which must not remove the subscriptions, but rather update them to the newest version)
+        CaseDefinition latestCaseDefinition = deployCaseDefinition("eventRegistryDynamicStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn");
+
+        try {
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", caseDefinition.getId()));
+
+            task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+        } finally {
+            deleteDeployment(latestCaseDefinition.getDeploymentId());
+        }
+    }
+
+    @Test
+    public void testSubscriptionDeletionAfterUndeploy() {
+        CaseDefinition caseDefinition = deployCaseDefinition("eventRegistryDynamicStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn");
+
+        try {
+            // manually register start subscriptions
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+                .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+                .addCorrelationParameterValue("customer", "kermit")
+                .addCorrelationParameterValue("action", "start")
+                .subscribe();
+
+            Map<String, Object> correlationParameters = new HashMap<>();
+            correlationParameters.put("customer", "kermit");
+            correlationParameters.put("action", "start");
+            String correlationConfig1 = getEventRegistry().generateKey(correlationParameters);
+
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+                .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+                .addCorrelationParameterValue("customer", "frog")
+                .addCorrelationParameterValue("action", "end")
+                .subscribe();
+
+            correlationParameters.put("customer", "frog");
+            correlationParameters.put("action", "end");
+            String correlationConfig2 = getEventRegistry().generateKey(correlationParameters);
+
+            assertThat(cmmnRuntimeService.createEventSubscriptionQuery().scopeDefinitionId(caseDefinition.getId()).list())
+                .extracting(EventSubscription::getScopeDefinitionId, EventSubscription::getConfiguration)
+                .containsExactlyInAnyOrder(
+                    Tuple.tuple(caseDefinition.getId(), correlationConfig1),
+                    Tuple.tuple(caseDefinition.getId(), correlationConfig2));
+        } finally {
+            deleteDeployment(caseDefinition.getDeploymentId());
+        }
+
+        // now the subscriptions also need to be deleted, after the case definition was undeployed
+        assertThat(cmmnRuntimeService.createEventSubscriptionQuery().scopeDefinitionId(caseDefinition.getId()).list()).isEmpty();
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartAfterSubscriptionMigration() {
+        // manually register start subscription, matching the event correlation sent later
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "kermit")
+            .addCorrelationParameterValue("action", "start")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "frog")
+            .addCorrelationParameterValue("action", "end")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+        // search the first case definition as we don't have auto-update in the subscriptions
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase").latestVersion().singleResult();
+
+        assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+            .extracting(EventSubscription::getScopeDefinitionId)
+            .containsExactlyInAnyOrder(caseDefinition.getId(), caseDefinition.getId());
+
+        // redeploy the case definition (which must not remove or update the existing subscriptions)
+        CaseDefinition newCaseDefinition = deployCaseDefinition("eventRegistryDynamicStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn");
+
+        try {
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", caseDefinition.getId()));
+
+            Task task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+            // now migrate to the latest case definition manually
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionModificationBuilder()
+                .caseDefinitionId(caseDefinition.getId())
+                .migrateToLatestCaseDefinition();
+
+            assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+                .extracting(EventSubscription::getScopeDefinitionId)
+                .containsExactlyInAnyOrder(newCaseDefinition.getId(), newCaseDefinition.getId());
+
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", newCaseDefinition.getId()));
+
+            task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+        } finally {
+            deleteDeployment(newCaseDefinition.getDeploymentId());
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartAfterSingleSubscriptionMigration() {
+        // manually register start subscription, matching the event correlation sent later
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "kermit")
+            .addCorrelationParameterValue("action", "start")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "frog")
+            .addCorrelationParameterValue("action", "end")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+
+        Map<String, Object> correlationParameters = new HashMap<>();
+        correlationParameters.put("customer", "kermit");
+        correlationParameters.put("action", "start");
+        String correlationConfig1 = getEventRegistry().generateKey(correlationParameters);
+
+        correlationParameters.put("customer", "frog");
+        correlationParameters.put("action", "end");
+        String correlationConfig2 = getEventRegistry().generateKey(correlationParameters);
+
+        // search the first case definition as we don't have auto-update in the subscriptions
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase").latestVersion().singleResult();
+
+        assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+            .extracting(EventSubscription::getScopeDefinitionId, EventSubscription::getConfiguration)
+            .containsExactlyInAnyOrder(
+                Tuple.tuple(caseDefinition.getId(), correlationConfig1),
+                Tuple.tuple(caseDefinition.getId(), correlationConfig2));
+
+        // redeploy the case definition (which must not remove or update the existing subscriptions)
+        CaseDefinition newCaseDefinition = deployCaseDefinition("eventRegistryDynamicStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn");
+
+        try {
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", caseDefinition.getId()));
+
+            Task task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+            // now migrate to the latest case definition manually
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionModificationBuilder()
+                .caseDefinitionId(caseDefinition.getId())
+                .addCorrelationParameterValues(Map.of("customer", "kermit", "action", "start"))
+                .migrateToLatestCaseDefinition();
+
+            assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+                .extracting(EventSubscription::getScopeDefinitionId, EventSubscription::getConfiguration)
+                .containsExactlyInAnyOrder(
+                    Tuple.tuple(caseDefinition.getId(), correlationConfig2),
+                    Tuple.tuple(newCaseDefinition.getId(), correlationConfig1));
+
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", newCaseDefinition.getId()));
+
+            task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+        } finally {
+            deleteDeployment(newCaseDefinition.getDeploymentId());
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartAfterSingleSubscriptionMigrationToSpecificVersion() {
+        // manually register start subscription, matching the event correlation sent later
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "kermit")
+            .addCorrelationParameterValue("action", "start")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "frog")
+            .addCorrelationParameterValue("action", "end")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+
+        Map<String, Object> correlationParameters = new HashMap<>();
+        correlationParameters.put("customer", "kermit");
+        correlationParameters.put("action", "start");
+        String correlationConfig1 = getEventRegistry().generateKey(correlationParameters);
+
+        correlationParameters.put("customer", "frog");
+        correlationParameters.put("action", "end");
+        String correlationConfig2 = getEventRegistry().generateKey(correlationParameters);
+
+        // search the first case definition as we don't have auto-update in the subscriptions
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase").latestVersion().singleResult();
+
+        assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+            .extracting(EventSubscription::getScopeDefinitionId, EventSubscription::getConfiguration)
+            .containsExactlyInAnyOrder(
+                Tuple.tuple(caseDefinition.getId(), correlationConfig1),
+                Tuple.tuple(caseDefinition.getId(), correlationConfig2));
+
+        // redeploy the case definition (which must not remove or update the existing subscriptions)
+        CaseDefinition newCaseDefinition = deployCaseDefinition("eventRegistryDynamicStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn");
+
+        try {
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", caseDefinition.getId()));
+
+            Task task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+            // now migrate to the latest case definition manually
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionModificationBuilder()
+                .caseDefinitionId(caseDefinition.getId())
+                .addCorrelationParameterValues(Map.of("customer", "kermit", "action", "start"))
+                .migrateToCaseDefinition(newCaseDefinition.getId());
+
+            assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+                .extracting(EventSubscription::getScopeDefinitionId, EventSubscription::getConfiguration)
+                .containsExactlyInAnyOrder(
+                    Tuple.tuple(caseDefinition.getId(), correlationConfig2),
+                    Tuple.tuple(newCaseDefinition.getId(), correlationConfig1));
+
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", newCaseDefinition.getId()));
+
+            task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+        } finally {
+            deleteDeployment(newCaseDefinition.getDeploymentId());
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartAfterSingleSubscriptionDeletion() {
+        // manually register start subscription, matching the event correlation sent later
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "kermit")
+            .addCorrelationParameterValue("action", "start")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "frog")
+            .addCorrelationParameterValue("action", "end")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+
+        Map<String, Object> correlationParameters = new HashMap<>();
+        correlationParameters.put("customer", "kermit");
+        correlationParameters.put("action", "start");
+        String correlationConfig1 = getEventRegistry().generateKey(correlationParameters);
+
+        correlationParameters.put("customer", "frog");
+        correlationParameters.put("action", "end");
+        String correlationConfig2 = getEventRegistry().generateKey(correlationParameters);
+
+        // search the first case definition as we don't have auto-update in the subscriptions
+        CaseDefinition caseDefinition =cmmnRepositoryService.createCaseDefinitionQuery()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase").latestVersion().singleResult();
+
+        assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+            .extracting(EventSubscription::getScopeDefinitionId, EventSubscription::getConfiguration)
+            .containsExactlyInAnyOrder(
+                Tuple.tuple(caseDefinition.getId(), correlationConfig1),
+                Tuple.tuple(caseDefinition.getId(), correlationConfig2));
+
+        // redeploy the case definition (which must not remove or update the existing subscriptions)
+        CaseDefinition newCaseDefinition = deployCaseDefinition("eventRegistryDynamicStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn");
+
+        try {
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", caseDefinition.getId()));
+
+            Task task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+            // now migrate to the latest case definition manually
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionDeletionBuilder()
+                .caseDefinitionId(caseDefinition.getId())
+                .addCorrelationParameterValues(Map.of("customer", "kermit", "action", "start"))
+                .deleteSubscriptions();
+
+            assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+                .extracting(EventSubscription::getScopeDefinitionId, EventSubscription::getConfiguration)
+                .containsExactlyInAnyOrder(Tuple.tuple(caseDefinition.getId(), correlationConfig2));
+
+            sendEvent("kermit", "start");
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+            sendEvent("frog", "end");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", caseDefinition.getId()));
+
+            task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+        } finally {
+            deleteDeployment(newCaseDefinition.getDeploymentId());
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn"
+    })
+    public void testDynamicEventRegistryCaseStartAfterAllSubscriptionDeletion() {
+        // manually register start subscription, matching the event correlation sent later
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "kermit")
+            .addCorrelationParameterValue("action", "start")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+        cmmnRuntimeService.createCaseInstanceStartEventSubscriptionBuilder()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase")
+            .addCorrelationParameterValue("customer", "frog")
+            .addCorrelationParameterValue("action", "end")
+            .doNotUpdateToLatestVersionAutomatically()
+            .subscribe();
+
+
+        Map<String, Object> correlationParameters = new HashMap<>();
+        correlationParameters.put("customer", "kermit");
+        correlationParameters.put("action", "start");
+        String correlationConfig1 = getEventRegistry().generateKey(correlationParameters);
+
+        correlationParameters.put("customer", "frog");
+        correlationParameters.put("action", "end");
+        String correlationConfig2 = getEventRegistry().generateKey(correlationParameters);
+
+        // search the first case definition as we don't have auto-update in the subscriptions
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery()
+            .caseDefinitionKey("eventRegistryDynamicStartTestCase").latestVersion().singleResult();
+
+        assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list())
+            .extracting(EventSubscription::getScopeDefinitionId, EventSubscription::getConfiguration)
+            .containsExactlyInAnyOrder(
+                Tuple.tuple(caseDefinition.getId(), correlationConfig1),
+                Tuple.tuple(caseDefinition.getId(), correlationConfig2));
+
+        // redeploy the case definition (which must not remove or update the existing subscriptions)
+        CaseDefinition newCaseDefinition = deployCaseDefinition("eventRegistryDynamicStartTestCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn");
+
+        try {
+            sendEvent("kermit", "start");
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .extracting(CaseInstance::getCaseDefinitionKey, CaseInstance::getCaseDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventRegistryDynamicStartTestCase", caseDefinition.getId()));
+
+            Task task = cmmnTaskService.createTaskQuery().singleResult();
+            assertThat(task).isNotNull();
+
+            cmmnTaskService.complete(task.getId());
+
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+            // now migrate to the latest case definition manually
+            cmmnRuntimeService.createCaseInstanceStartEventSubscriptionDeletionBuilder()
+                .caseDefinitionId(caseDefinition.getId())
+                .deleteSubscriptions();
+
+            assertThat(cmmnRuntimeService.createEventSubscriptionQuery().eventType("simpleTest").list()).isEmpty();
+
+            sendEvent("kermit", "start");
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+
+            sendEvent("frog", "end");
+            assertThat(cmmnRuntimeService.createCaseInstanceQuery().list()).isEmpty();
+        } finally {
+            deleteDeployment(newCaseDefinition.getDeploymentId());
+        }
+    }
+
+    protected CaseInstance sendEvent(String customerId, String action) {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+            .caseDefinitionKey("sendTestEventCase")
+            .variable("customerId", customerId)
+            .variable("customerName", "Kermit the Frog")
+            .variable("eventKey", "simpleTest")
+            .variable("action", action)
+            .start();
+
+        return caseInstance;
+    }
+
+    @Before
+    public void deployEventDefinitionAndSendEventCaseDefinition() {
+        EventRepositoryService eventRepositoryService = getEventRepositoryService();
+        eventRepositoryService.createDeployment()
+            .name("SimpleEvent")
+            .addClasspathResource("org/flowable/cmmn/test/eventregistry/SendInternalEventTaskTest.simple.event")
+            .deploy();
+
+        deployCaseDefinition("sendTestEventCase.cmmn",
+            "org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.sendTestEventCase.cmmn");
+    }
+
+    @After
+    public void deleteEventAndCaseDeployment() {
+        EventRepositoryService eventRepositoryService = getEventRepositoryService();
+        List<EventDeployment> deployments = eventRepositoryService.createDeploymentQuery().list();
+        for (EventDeployment eventDeployment : deployments) {
+            eventRepositoryService.deleteDeployment(eventDeployment.getId());
+        }
+
+        CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().caseDefinitionKey("sendTestEventCase").singleResult();
+        if (caseDefinition != null) {
+            deleteDeployment(caseDefinition.getDeploymentId());
+        }
+    }
+}

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryDynamicStartTestCase.cmmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn" design:palette="flowable-engage-case-palette">
+  <case id="eventRegistryDynamicStartTestCase" name="Event Registry Dynamic Start Test Case" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <extensionElements>
+      <flowable:eventType><![CDATA[simpleTest]]></flowable:eventType>
+      <flowable:startEventCorrelationConfiguration><![CDATA[manualSubscription]]></flowable:startEventCorrelationConfiguration>
+      <flowable:eventOutParameter source="customer" target="customer"></flowable:eventOutParameter>
+      <flowable:eventOutParameter source="name" target="name"></flowable:eventOutParameter>
+      <flowable:eventOutParameter source="action" target="action"></flowable:eventOutParameter>
+    </extensionElements>
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItemcmmnTask_1" name="Test Task" definitionRef="cmmnTask_1"></planItem>
+      <humanTask id="cmmnTask_1" name="Test Task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_eventRegistryDynamicStartTestCase">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="400.0" width="400.0" x="270.0" y="120.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnTask_1" cmmnElementRef="planItemcmmnTask_1">
+        <dc:Bounds height="80.0" width="100.0" x="324.0" y="178.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryStaticStartTestCase.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.eventRegistryStaticStartTestCase.cmmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn" design:palette="flowable-engage-case-palette">
+  <case id="eventRegistryStaticStartTestCase" name="Event Registry Static Start Test Case" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <extensionElements>
+      <flowable:eventType><![CDATA[simpleTest]]></flowable:eventType>
+      <flowable:startEventCorrelationConfiguration><![CDATA[startNewInstance]]></flowable:startEventCorrelationConfiguration>
+      <flowable:eventOutParameter source="customer" target="customer"></flowable:eventOutParameter>
+      <flowable:eventOutParameter source="name" target="name"></flowable:eventOutParameter>
+      <flowable:eventOutParameter source="action" target="action"></flowable:eventOutParameter>
+    </extensionElements>
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItemcmmnTask_1" name="Test Task" definitionRef="cmmnTask_1"></planItem>
+      <humanTask id="cmmnTask_1" name="Test Task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </humanTask>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_eventRegistryStaticStartTestCase">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="400.0" width="400.0" x="270.0" y="120.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnTask_1" cmmnElementRef="planItemcmmnTask_1">
+        <dc:Bounds height="80.0" width="100.0" x="330.0" y="181.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.sendTestEventCase.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventregistry/DynamicCaseStartEventRegistryDeploymentTest.sendTestEventCase.cmmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn" design:palette="flowable-engage-case-palette">
+  <case id="sendTestEventCase" name="Send Test Event Case" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItemcmmnTask_1" name="Send event task" definitionRef="cmmnTask_1"></planItem>
+      <task id="cmmnTask_1" name="Send event task" flowable:type="send-event">
+        <extensionElements>
+          <flowable:eventType><![CDATA[simpleTest]]></flowable:eventType>
+          <flowable:eventInParameter source="${customerId}" target="customer"></flowable:eventInParameter>
+          <flowable:eventInParameter source="${customerName}" target="name"></flowable:eventInParameter>
+          <flowable:eventInParameter source="${action}" target="action"></flowable:eventInParameter>
+          <flowable:eventInParameter source="${eventKey}" target="eventKey"></flowable:eventInParameter>
+          <flowable:systemChannel></flowable:systemChannel>
+          <design:stencilid><![CDATA[SendEventTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </task>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_sendTestEventCase">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="679.0" width="830.0" x="270.0" y="120.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnTask_1" cmmnElementRef="planItemcmmnTask_1">
+        <dc:Bounds height="80.0" width="100.0" x="355.0" y="190.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/EventSubscriptionService.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/EventSubscriptionService.java
@@ -74,7 +74,9 @@ public interface EventSubscriptionService {
     void updateEventSubscriptionTenantId(String oldTenantId, String newTenantId);
 
     void updateEventSubscriptionProcessDefinitionId(String oldProcessDefinitionId, String newProcessDefinitionId, String eventType, String activityId, String scopeDefinitionKey, String configuration);
-    
+
+    void updateEventSubscriptionScopeDefinitionId(String oldScopeDefinitionId, String newScopeDefinitionId, String eventType, String scopeDefinitionKey, String configuration);
+
     void updateEventSubscription(EventSubscriptionEntity eventSubscription);
 
     boolean lockEventSubscription(String eventSubscriptionId);
@@ -94,5 +96,7 @@ public interface EventSubscriptionService {
     void deleteEventSubscriptionsForScopeDefinitionIdAndTypeAndNullScopeId(String scopeDefinitionId, String scopeType);
 
     void deleteEventSubscriptionsForProcessDefinitionAndProcessStartEvent(String processDefinitionId, String eventType, String activityId, String configuration);
-    
+
+    void deleteEventSubscriptionsForScopeDefinitionAndScopeStartEvent(String scopeDefinitionId, String eventType, String configuration);
+
 }

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/EventSubscriptionServiceImpl.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/EventSubscriptionServiceImpl.java
@@ -150,6 +150,11 @@ public class EventSubscriptionServiceImpl extends CommonServiceImpl<EventSubscri
     }
 
     @Override
+    public void updateEventSubscriptionScopeDefinitionId(String oldScopeDefinitionId, String newScopeDefinitionId, String eventType, String scopeDefinitionKey, String configuration) {
+        getEventSubscriptionEntityManager().updateEventSubscriptionScopeDefinitionId(oldScopeDefinitionId, newScopeDefinitionId, eventType, scopeDefinitionKey, configuration);
+    }
+
+    @Override
     public void updateEventSubscription(EventSubscriptionEntity eventSubscription) {
         getEventSubscriptionEntityManager().update(eventSubscription);
     }
@@ -197,6 +202,11 @@ public class EventSubscriptionServiceImpl extends CommonServiceImpl<EventSubscri
     @Override
     public void deleteEventSubscriptionsForProcessDefinitionAndProcessStartEvent(String processDefinitionId, String eventType, String activityId, String configuration) {
         getEventSubscriptionEntityManager().deleteEventSubscriptionsForProcessDefinitionAndProcessStartEvent(processDefinitionId, eventType, activityId, configuration);
+    }
+
+    @Override
+    public void deleteEventSubscriptionsForScopeDefinitionAndScopeStartEvent(String scopeDefinitionId, String eventType, String configuration) {
+        getEventSubscriptionEntityManager().deleteEventSubscriptionsForScopeDefinitionAndScopeStartEvent(scopeDefinitionId, eventType, configuration);
     }
 
     public EventSubscription createEventSubscription(EventSubscriptionBuilder builder) {

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManager.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManager.java
@@ -44,6 +44,8 @@ public interface EventSubscriptionEntityManager extends EntityManager<EventSubsc
 
     void updateEventSubscriptionProcessDefinitionId(String oldProcessDefinitionId, String newProcessDefinitionId, String eventType, String activityId, String scopeDefinitionKey, String configuration);
 
+    void updateEventSubscriptionScopeDefinitionId(String oldScopeDefinitionId, String newScopeDefinitionId, String eventType, String scopeDefinitionKey, String configuration);
+
     boolean lockEventSubscription(String eventSubscriptionId);
 
     void unlockEventSubscription(String eventSubscriptionId);
@@ -61,6 +63,8 @@ public interface EventSubscriptionEntityManager extends EntityManager<EventSubsc
     void deleteEventSubscriptionsForScopeDefinitionIdAndTypeAndNullScopeId(String scopeDefinitionId, String scopeType);
 
     void deleteEventSubscriptionsForProcessDefinitionAndProcessStartEvent(String processDefinitionId, String eventType, String activityId, String configuration);
+
+    void deleteEventSubscriptionsForScopeDefinitionAndScopeStartEvent(String scopeDefinitionId, String eventType, String configuration);
 
     /* Find (generic) */
 

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManagerImpl.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManagerImpl.java
@@ -203,6 +203,11 @@ public class EventSubscriptionEntityManagerImpl
     }
 
     @Override
+    public void updateEventSubscriptionScopeDefinitionId(String oldScopeDefinitionId, String newScopeDefinitionId, String eventType, String scopeDefinitionKey, String configuration) {
+        dataManager.updateEventSubscriptionScopeDefinitionId(oldScopeDefinitionId, newScopeDefinitionId, eventType, scopeDefinitionKey, configuration);
+    }
+
+    @Override
     public boolean lockEventSubscription(String eventSubscriptionId) {
         EventSubscriptionServiceConfiguration serviceConfiguration = getServiceConfiguration();
 
@@ -250,6 +255,11 @@ public class EventSubscriptionEntityManagerImpl
     @Override
     public void deleteEventSubscriptionsForProcessDefinitionAndProcessStartEvent(String processDefinitionId, String eventType, String activityId, String configuration) {
         dataManager.deleteEventSubscriptionsForProcessDefinitionAndProcessStartEvent(processDefinitionId, eventType, activityId, configuration);
+    }
+
+    @Override
+    public void deleteEventSubscriptionsForScopeDefinitionAndScopeStartEvent(String scopeDefinitionId, String eventType, String configuration) {
+        dataManager.deleteEventSubscriptionsForScopeDefinitionAndScopeStartEvent(scopeDefinitionId, eventType, configuration);
     }
 
     protected SignalEventSubscriptionEntity insertSignalEvent(EventSubscriptionBuilder eventSubscriptionBuilder) {

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/EventSubscriptionDataManager.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/EventSubscriptionDataManager.java
@@ -75,6 +75,8 @@ public interface EventSubscriptionDataManager extends DataManager<EventSubscript
 
     void updateEventSubscriptionProcessDefinitionId(String oldProcessDefinitionId, String newProcessDefinitionId, String eventType, String activityId, String scopeDefinitionKey, String configuration);
 
+    void updateEventSubscriptionScopeDefinitionId(String oldScopeDefinitionId, String newScopeDefinitionId, String eventType, String scopeDefinitionKey, String configuration);
+
     boolean updateEventSubscriptionLockTime(String eventSubscriptionId, Date lockDate, String lockOwner, Date currentTime);
 
     void clearEventSubscriptionLockTime(String eventSubscriptionId);
@@ -90,5 +92,7 @@ public interface EventSubscriptionDataManager extends DataManager<EventSubscript
     void deleteEventSubscriptionsForScopeDefinitionIdAndTypeAndNullScopeId(String scopeDefinitionId, String scopeType);
 
     void deleteEventSubscriptionsForProcessDefinitionAndProcessStartEvent(String processDefinitionId, String eventType, String activityId, String configuration);
+
+    void deleteEventSubscriptionsForScopeDefinitionAndScopeStartEvent(String scopeDefinitionId, String eventType, String configuration);
 
 }

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsByScopeDefinitionIdAndScopeStartEventMatcher.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsByScopeDefinitionIdAndScopeStartEventMatcher.java
@@ -1,0 +1,43 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.flowable.common.engine.impl.persistence.cache.CachedEntityMatcherAdapter;
+import org.flowable.eventsubscription.service.impl.persistence.entity.EventSubscriptionEntity;
+
+/**
+ * A matcher for event subscriptions with a case start event and specific case definition id and optional configuration (correlation parameter values).
+ *
+ * @author Micha Kiener
+ */
+public class EventSubscriptionsByScopeDefinitionIdAndScopeStartEventMatcher extends CachedEntityMatcherAdapter<EventSubscriptionEntity> {
+
+    @Override
+    public boolean isRetained(EventSubscriptionEntity eventSubscriptionEntity, Object parameter) {
+        Map<String, String> params = (Map<String, String>) parameter;
+
+        String scopeDefinitionId = params.get("scopeDefinitionId");
+        String eventType = params.get("eventType");
+        String activityId = params.get("activityId");
+        String configuration = params.get("configuration");
+
+        return Objects.equals(scopeDefinitionId, eventSubscriptionEntity.getScopeDefinitionId())
+            && Objects.equals(eventType, eventSubscriptionEntity.getEventType())
+            && Objects.equals(activityId, eventSubscriptionEntity.getActivityId())
+            && (configuration == null || Objects.equals(configuration, eventSubscriptionEntity.getConfiguration()));
+    }
+
+}

--- a/modules/flowable-eventsubscription-service/src/main/resources/org/flowable/eventsubscription/service/db/mapping/entity/EventSubscription.xml
+++ b/modules/flowable-eventsubscription-service/src/main/resources/org/flowable/eventsubscription/service/db/mapping/entity/EventSubscription.xml
@@ -1098,6 +1098,19 @@
     <if test="configuration != null">
         and CONFIGURATION_ = #{configuration, jdbcType=VARCHAR}
     </if>
+   </update> <!-- process definition id update -->
+
+   <update id="updateManualScopeStartEventSubscriptionWithScopeDefinitionId" parameterType="map">
+    update ${prefix}ACT_RU_EVENT_SUBSCR
+    set SCOPE_DEFINITION_ID_ = #{newScopeDefinitionId, jdbcType=VARCHAR}
+    where SCOPE_DEFINITION_ID_ = #{oldScopeDefinitionId, jdbcType=VARCHAR}
+    and EVENT_TYPE_ = #{eventType, jdbcType=VARCHAR}
+    <if test="scopeDefinitionKey != null">
+        and SCOPE_DEFINITION_KEY_ = #{scopeDefinitionKey, jdbcType=VARCHAR}
+    </if>
+    <if test="configuration != null">
+        and CONFIGURATION_ = #{configuration, jdbcType=VARCHAR}
+    </if>
    </update>
 
   <update id="updateEventSubscriptionLockTime" parameterType="java.util.Map">
@@ -1167,6 +1180,15 @@
     PROC_DEF_ID_ = #{processDefinitionId, jdbcType=VARCHAR}
     and EVENT_TYPE_ = #{eventType, jdbcType=VARCHAR}
     and ACTIVITY_ID_ = #{activityId, jdbcType=VARCHAR}
+    <if test="configuration != null">
+        and CONFIGURATION_ = #{configuration, jdbcType=VARCHAR}
+    </if>
+  </delete>
+
+  <delete id="deleteManualScopeStartEventSubscriptions" parameterType="map">
+    delete from ${prefix}ACT_RU_EVENT_SUBSCR where
+    SCOPE_DEFINITION_ID_ = #{scopeDefinitionId, jdbcType=VARCHAR}
+    and EVENT_TYPE_ = #{eventType, jdbcType=VARCHAR}
     <if test="configuration != null">
         and CONFIGURATION_ = #{configuration, jdbcType=VARCHAR}
     </if>


### PR DESCRIPTION
Add support for dynamic, manually created event subscriptions with any combination of correlation parameter values for an event-registry based case start.

Check List:
Unit tests: YES
Documentation: NO
