### PR TITLE
adding option to have an inbound event filter in the default event inbound pipeline

### DIFF
--- a/modules/flowable-event-registry-api/src/main/java/org/flowable/eventregistry/api/InboundEventFilter.java
+++ b/modules/flowable-event-registry-api/src/main/java/org/flowable/eventregistry/api/InboundEventFilter.java
@@ -1,0 +1,40 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.eventregistry.api;
+
+/**
+ * This interface must be implemented by a custom filtering bean to hook into the default inbound event processing
+ * pipeline in order to have a very effective way to filter out events which should not be processed any further and
+ * thus preventing expensive processing time like DB lookups and the full consumer invocation.
+ *
+ * @param <T> the type of the expected payload (e.g. a JsonNode)
+ *
+ * @author Micha Kiener
+ */
+@FunctionalInterface
+public interface InboundEventFilter<T> {
+
+    /**
+     * Returns true, if the event should be further processed or false, if the event can be ignored and will not be processed
+     * any further and the pipeline will stop afterwards.
+     *
+     * @param payload the payload  of the event
+     * @return true, if the event should continue to be processed, false, if the pipeline will ignore the event and stop any
+     *      further processing
+     */
+    boolean filter(T payload);
+
+    default boolean filter(FlowableEventInfo<T> event) {
+        return filter(event.getPayload());
+    }
+}

--- a/modules/flowable-event-registry-api/src/main/java/org/flowable/eventregistry/api/model/InboundChannelModelBuilder.java
+++ b/modules/flowable-event-registry-api/src/main/java/org/flowable/eventregistry/api/model/InboundChannelModelBuilder.java
@@ -215,6 +215,12 @@ public interface InboundChannelModelBuilder {
         InboundEventKeyXmlDetectorBuilder xmlDeserializer();
 
         /**
+         * Uses a delegate expression to filter the events before further processing.
+         * The expression needs to resolve to a bean implementing the {@link org.flowable.eventregistry.api.InboundEventFilter} interface.
+         */
+        InboundEventProcessingPipelineBuilder delegateExpressionEventFilter(String delegateExpression);
+
+        /**
          * Uses a delegate expression to deserialize the event.
          */
         InboundEventKeyDetectorBuilder delegateExpressionDeserializer(String delegateExpression);

--- a/modules/flowable-event-registry-json-converter/src/test/java/org/flowable/eventregistry/converter/channel/JmsInboundChannelJsonConverterTest.java
+++ b/modules/flowable-event-registry-json-converter/src/test/java/org/flowable/eventregistry/converter/channel/JmsInboundChannelJsonConverterTest.java
@@ -53,6 +53,8 @@ class JmsInboundChannelJsonConverterTest extends AbstractChannelConverterTest {
                 assertThat(model.getDestination()).isEqualTo("customer");
                 assertThat(model.getDeserializerType()).isEqualTo("json");
 
+                assertThat(model.getEventFilterDelegateExpression()).isEqualTo("testEventFilterExpression");
+
                 ChannelEventKeyDetection eventKeyDetection = model.getChannelEventKeyDetection();
                 assertThat(eventKeyDetection).isNotNull();
                 assertThat(eventKeyDetection.getFixedValue()).isNull();

--- a/modules/flowable-event-registry-json-converter/src/test/java/org/flowable/eventregistry/converter/channel/KafkaInboundChannelJsonConverterTest.java
+++ b/modules/flowable-event-registry-json-converter/src/test/java/org/flowable/eventregistry/converter/channel/KafkaInboundChannelJsonConverterTest.java
@@ -52,6 +52,8 @@ class KafkaInboundChannelJsonConverterTest extends AbstractChannelConverterTest 
 
                 assertThat(model.getDeserializerType()).isEqualTo("json");
 
+                assertThat(model.getEventFilterDelegateExpression()).isEqualTo("testEventFilterExpression");
+
                 ChannelEventKeyDetection eventKeyDetection = model.getChannelEventKeyDetection();
                 assertThat(eventKeyDetection).isNotNull();
                 assertThat(eventKeyDetection.getFixedValue()).isNull();

--- a/modules/flowable-event-registry-json-converter/src/test/java/org/flowable/eventregistry/converter/channel/RabbitInboundChannelJsonConverterTest.java
+++ b/modules/flowable-event-registry-json-converter/src/test/java/org/flowable/eventregistry/converter/channel/RabbitInboundChannelJsonConverterTest.java
@@ -52,6 +52,8 @@ class RabbitInboundChannelJsonConverterTest extends AbstractChannelConverterTest
 
                 assertThat(model.getDeserializerType()).isEqualTo("json");
 
+                assertThat(model.getEventFilterDelegateExpression()).isEqualTo("testEventFilterExpression");
+
                 ChannelEventKeyDetection eventKeyDetection = model.getChannelEventKeyDetection();
                 assertThat(eventKeyDetection).isNotNull();
                 assertThat(eventKeyDetection.getFixedValue()).isNull();

--- a/modules/flowable-event-registry-json-converter/src/test/resources/org/flowable/eventregistry/converter/channel/simpleJmsInboundChannel.json
+++ b/modules/flowable-event-registry-json-converter/src/test/resources/org/flowable/eventregistry/converter/channel/simpleJmsInboundChannel.json
@@ -10,6 +10,7 @@
   "subscription": "testSubscription",
   "concurrency": "3",
   "deserializerType": "json",
+  "eventFilterDelegateExpression": "testEventFilterExpression",
   "channelEventKeyDetection": {
     "jsonField": "eventKey"
   }

--- a/modules/flowable-event-registry-json-converter/src/test/resources/org/flowable/eventregistry/converter/channel/simpleKafkaInboundChannel.json
+++ b/modules/flowable-event-registry-json-converter/src/test/resources/org/flowable/eventregistry/converter/channel/simpleKafkaInboundChannel.json
@@ -21,6 +21,8 @@
     }
   ],
 
+  "eventFilterDelegateExpression": "testEventFilterExpression",
+
   "deserializerType": "json",
   "channelEventKeyDetection": {
     "jsonField": "eventKey"

--- a/modules/flowable-event-registry-json-converter/src/test/resources/org/flowable/eventregistry/converter/channel/simpleRabbitInboundChannel.json
+++ b/modules/flowable-event-registry-json-converter/src/test/resources/org/flowable/eventregistry/converter/channel/simpleRabbitInboundChannel.json
@@ -18,6 +18,8 @@
   "executor": "rabbitTaskExecutor",
   "ackMode": "NONE",
 
+  "eventFilterDelegateExpression": "testEventFilterExpression",
+
   "deserializerType": "json",
   "channelEventKeyDetection": {
     "jsonField": "eventKey"

--- a/modules/flowable-event-registry-model/src/main/java/org/flowable/eventregistry/model/InboundChannelModel.java
+++ b/modules/flowable-event-registry-model/src/main/java/org/flowable/eventregistry/model/InboundChannelModel.java
@@ -23,6 +23,7 @@ public class InboundChannelModel extends ChannelModel {
 
     protected String contextExtractorDelegateExpression;
     protected String deserializerDelegateExpression;
+    protected String eventFilterDelegateExpression;
     protected String payloadExtractorDelegateExpression;
     protected String headerExtractorDelegateExpression;
     protected String eventTransformerDelegateExpression;
@@ -46,6 +47,14 @@ public class InboundChannelModel extends ChannelModel {
 
     public void setDeserializerType(String deserializerType) {
         this.deserializerType = deserializerType;
+    }
+
+    public String getEventFilterDelegateExpression() {
+        return eventFilterDelegateExpression;
+    }
+
+    public void setEventFilterDelegateExpression(String eventFilterDelegateExpression) {
+        this.eventFilterDelegateExpression = eventFilterDelegateExpression;
     }
 
     public String getContextExtractorDelegateExpression() {

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/model/InboundChannelDefinitionBuilderImpl.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/model/InboundChannelDefinitionBuilderImpl.java
@@ -341,6 +341,12 @@ public class InboundChannelDefinitionBuilderImpl implements InboundChannelModelB
         }
 
         @Override
+        public InboundEventProcessingPipelineBuilder delegateExpressionEventFilter(String delegateExpression) {
+            channelModel.setEventFilterDelegateExpression(delegateExpression);
+            return this;
+        }
+
+        @Override
         public InboundEventKeyDetectorBuilder delegateExpressionDeserializer(String delegateExpression) {
             channelModel.setDeserializerType("expression");
             channelModel.setDeserializerDelegateExpression(delegateExpression);

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/pipeline/DefaultInboundEventProcessingPipeline.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/pipeline/DefaultInboundEventProcessingPipeline.java
@@ -13,6 +13,7 @@
 package org.flowable.eventregistry.impl.pipeline;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
 import org.flowable.eventregistry.api.EventRegistryEvent;
@@ -20,6 +21,7 @@ import org.flowable.eventregistry.api.EventRepositoryService;
 import org.flowable.eventregistry.api.FlowableEventInfo;
 import org.flowable.eventregistry.api.InboundEvent;
 import org.flowable.eventregistry.api.InboundEventDeserializer;
+import org.flowable.eventregistry.api.InboundEventFilter;
 import org.flowable.eventregistry.api.InboundEventKeyDetector;
 import org.flowable.eventregistry.api.InboundEventPayloadExtractor;
 import org.flowable.eventregistry.api.InboundEventProcessingPipeline;
@@ -44,6 +46,7 @@ public class DefaultInboundEventProcessingPipeline<T> implements InboundEventPro
 
     protected EventRepositoryService eventRepositoryService;
     protected InboundEventDeserializer<T> inboundEventDeserializer;
+    protected InboundEventFilter<T> inboundEventFilter;
     protected InboundEventKeyDetector<T> inboundEventKeyDetector;
     protected InboundEventTenantDetector<T> inboundEventTenantDetector;
     protected InboundEventPayloadExtractor<T> inboundEventPayloadExtractor;
@@ -51,6 +54,7 @@ public class DefaultInboundEventProcessingPipeline<T> implements InboundEventPro
 
     public DefaultInboundEventProcessingPipeline(EventRepositoryService eventRepositoryService,
             InboundEventDeserializer<T> inboundEventDeserializer,
+            InboundEventFilter<T> inboundEventFilter,
             InboundEventKeyDetector<T> inboundEventKeyDetector,
             InboundEventTenantDetector<T> inboundEventTenantDetector,
             InboundEventPayloadExtractor<T> inboundEventPayloadExtractor,
@@ -58,6 +62,7 @@ public class DefaultInboundEventProcessingPipeline<T> implements InboundEventPro
         
         this.eventRepositoryService = eventRepositoryService;
         this.inboundEventDeserializer = inboundEventDeserializer;
+        this.inboundEventFilter = inboundEventFilter;
         this.inboundEventKeyDetector = inboundEventKeyDetector;
         this.inboundEventTenantDetector = inboundEventTenantDetector;
         this.inboundEventPayloadExtractor = inboundEventPayloadExtractor;
@@ -75,7 +80,14 @@ public class DefaultInboundEventProcessingPipeline<T> implements InboundEventPro
         T deserializedBody = deserialize(inboundEvent.getBody());
 
         FlowableEventInfo<T> event = new FlowableEventInfoImpl<>(inboundEvent, deserializedBody, inboundChannel);
-        
+
+        // if there is a custom filter in place, invoke it to filter the event for further processing or to abort the pipeline
+        if (inboundEventFilter != null) {
+            if (!inboundEventFilter.filter(event)) {
+                return Collections.emptyList();
+            }
+        }
+
         String eventKey = detectEventDefinitionKey(event);
 
         boolean multiTenant = false;

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/pipeline/InboundChannelModelProcessor.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/pipeline/InboundChannelModelProcessor.java
@@ -24,6 +24,7 @@ import org.flowable.eventregistry.api.ChannelModelProcessor;
 import org.flowable.eventregistry.api.EventRegistry;
 import org.flowable.eventregistry.api.EventRepositoryService;
 import org.flowable.eventregistry.api.InboundEventDeserializer;
+import org.flowable.eventregistry.api.InboundEventFilter;
 import org.flowable.eventregistry.api.InboundEventKeyDetector;
 import org.flowable.eventregistry.api.InboundEventPayloadExtractor;
 import org.flowable.eventregistry.api.InboundEventProcessingPipeline;
@@ -128,6 +129,12 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
             eventDeserializer = resolveExpression(channelModel.getDeserializerDelegateExpression(), InboundEventDeserializer.class);
         }
 
+        // by default, there is not filtering of events in place
+        InboundEventFilter<JsonNode> eventFilter = null;
+        if (StringUtils.isNotEmpty(channelModel.getEventFilterDelegateExpression())) {
+            eventFilter = resolveExpression(channelModel.getEventFilterDelegateExpression(), InboundEventFilter.class);
+        }
+
         InboundEventTenantDetector<JsonNode> eventTenantDetector = null; // By default no multi-tenancy is applied
 
         InboundEventPayloadExtractor<JsonNode> eventPayloadExtractor = createInboundEventPayloadExtractor(channelModel, JsonFieldToMapPayloadExtractor::new);
@@ -177,7 +184,7 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
             }
         }
 
-        return new DefaultInboundEventProcessingPipeline<>(eventRepositoryService, eventDeserializer,
+        return new DefaultInboundEventProcessingPipeline<>(eventRepositoryService, eventDeserializer, eventFilter,
                 eventKeyDetector, eventTenantDetector, eventPayloadExtractor, eventTransformer);
     }
 
@@ -190,6 +197,12 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
         } else {
             //noinspection unchecked
             eventDeserializer = resolveExpression(channelModel.getDeserializerDelegateExpression(), InboundEventDeserializer.class);
+        }
+
+        // by default, there is not filtering of events in place
+        InboundEventFilter<Document> eventFilter = null;
+        if (StringUtils.isNotEmpty(channelModel.getEventFilterDelegateExpression())) {
+            eventFilter = resolveExpression(channelModel.getEventFilterDelegateExpression(), InboundEventFilter.class);
         }
 
         InboundEventTenantDetector<Document> eventTenantDetector = null; // By default no multi-tenancy is applied
@@ -239,7 +252,7 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
             }
         }
 
-        return new DefaultInboundEventProcessingPipeline<>(eventRepositoryService, eventDeserializer,
+        return new DefaultInboundEventProcessingPipeline<>(eventRepositoryService, eventDeserializer, eventFilter,
             eventKeyDetector, eventTenantDetector, eventPayloadExtractor, eventTransformer);
     }
 
@@ -282,6 +295,12 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
             throw new FlowableException(
                 "The channel deserializer expression for the channel model with key " + channelModel.getKey()
                     + " was empty. The deserializerDelegateExpression has to be provided for a channel with an expression deserializer.");
+        }
+
+        // by default, there is not filtering of events in place
+        InboundEventFilter<?> eventFilter = null;
+        if (StringUtils.isNotEmpty(channelModel.getEventFilterDelegateExpression())) {
+            eventFilter = resolveExpression(channelModel.getEventFilterDelegateExpression(), InboundEventFilter.class);
         }
 
         InboundEventTenantDetector<?> eventTenantDetector = null; // By default no multi-tenancy is applied
@@ -343,7 +362,7 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
         }
 
         //noinspection unchecked
-        return new DefaultInboundEventProcessingPipeline(eventRepositoryService, eventDeserializer,
+        return new DefaultInboundEventProcessingPipeline(eventRepositoryService, eventDeserializer, eventFilter,
             eventKeyDetector, eventTenantDetector, eventPayloadExtractor, eventTransformer);
     }
 


### PR DESCRIPTION
Adding a new option to have an event filter delegate expression within the default inbound event pipeline.

#### Check List:
* Unit tests: YES
* Documentation: NO
