### PR TITLE
fix: add getHandlerTypes() for the different Job Queries

### DIFF
--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/DeadLetterJobQueryImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/DeadLetterJobQueryImpl.java
@@ -127,6 +127,7 @@ public class DeadLetterJobQueryImpl extends AbstractQuery<DeadLetterJobQuery, Jo
         return this;
     }
 
+    @Override
     public DeadLetterJobQueryImpl processDefinitionKey(String processDefinitionKey) {
         if (processDefinitionKey == null) {
             throw new FlowableIllegalArgumentException("Provided process definition key is null");
@@ -464,6 +465,10 @@ public class DeadLetterJobQueryImpl extends AbstractQuery<DeadLetterJobQuery, Jo
 
     public String getHandlerType() {
         return handlerType;
+    }
+
+    public Collection<String> getHandlerTypes() {
+        return handlerTypes;
     }
 
     public boolean getExecutable() {

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/ExternalWorkerJobQueryImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/ExternalWorkerJobQueryImpl.java
@@ -450,6 +450,10 @@ public class ExternalWorkerJobQueryImpl extends AbstractQuery<ExternalWorkerJobQ
         return this.handlerType;
     }
 
+    public Collection<String> getHandlerTypes() {
+        return handlerTypes;
+    } 
+
     public Date getNow() {
         return jobServiceConfiguration.getClock().getCurrentTime();
     }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/HistoryJobQueryImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/HistoryJobQueryImpl.java
@@ -198,6 +198,10 @@ public class HistoryJobQueryImpl extends AbstractQuery<HistoryJobQuery, HistoryJ
         return this.handlerType;
     }
 
+    public Collection<String> getHandlerTypes() {
+        return handlerTypes;
+    }
+
     public Date getNow() {
         return jobServiceConfiguration.getClock().getCurrentTime();
     }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/SuspendedJobQueryImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/SuspendedJobQueryImpl.java
@@ -505,6 +505,10 @@ public class SuspendedJobQueryImpl extends AbstractQuery<SuspendedJobQuery, Job>
         return handlerType;
     }
 
+    public Collection<String> getHandlerTypes() {
+        return handlerTypes;
+    }
+
     public boolean getRetriesLeft() {
         return retriesLeft;
     }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/TimerJobQueryImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/TimerJobQueryImpl.java
@@ -442,6 +442,10 @@ public class TimerJobQueryImpl extends AbstractQuery<TimerJobQuery, Job> impleme
         return handlerType;
     }
 
+    public Collection<String> getHandlerTypes() {
+        return handlerTypes;
+    }
+
     public boolean getExecutable() {
         return executable;
     }


### PR DESCRIPTION
getHandlerTypes should be implemented by all the different job queries, not just the default JobQueryImpl

#### Check List:
* Unit tests: NA
* Documentation: NA
