### PR TITLE
feat: Reconfigurable DataManagers for some Entity types

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/persistence/entity/AbstractEntityManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/persistence/entity/AbstractEntityManager.java
@@ -23,7 +23,7 @@ import org.flowable.common.engine.impl.persistence.entity.data.DataManager;
  * @author Filip Hrisafov
  */
 public abstract class AbstractEntityManager<EntityImpl extends Entity, DM extends DataManager<EntityImpl>>
-    implements EntityManager<EntityImpl> {
+    implements MutableEntityManager<EntityImpl, DM> {
 
     protected DM dataManager;
     protected String engineType;
@@ -110,6 +110,11 @@ public abstract class AbstractEntityManager<EntityImpl extends Entity, DM extend
         }
     }
 
+    @Override
+    public void setDataManager(DM dataManager) {
+        this.dataManager = dataManager;
+    }
+
     protected void fireEntityDeletedEvent(Entity entity) {
         FlowableEventDispatcher eventDispatcher = getEventDispatcher();
         if (eventDispatcher != null && eventDispatcher.isEnabled()) {
@@ -123,10 +128,6 @@ public abstract class AbstractEntityManager<EntityImpl extends Entity, DM extend
 
     protected DM getDataManager() {
         return dataManager;
-    }
-
-    protected void setDataManager(DM dataManager) {
-        this.dataManager = dataManager;
     }
 
     protected abstract FlowableEventDispatcher getEventDispatcher();

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/persistence/entity/ByteArrayEntityManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/persistence/entity/ByteArrayEntityManager.java
@@ -13,11 +13,12 @@
 package org.flowable.common.engine.impl.persistence.entity;
 
 import java.util.List;
+import org.flowable.common.engine.impl.persistence.entity.data.ByteArrayDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface ByteArrayEntityManager extends EntityManager<ByteArrayEntity> {
+public interface ByteArrayEntityManager extends MutableEntityManager<ByteArrayEntity, ByteArrayDataManager> {
 
     /**
      * Returns all {@link ByteArrayEntity}.
@@ -25,14 +26,14 @@ public interface ByteArrayEntityManager extends EntityManager<ByteArrayEntity> {
     List<ByteArrayEntity> findAll();
 
     /**
-     * Deletes the {@link ByteArrayEntity} with the given id from the database. Important: this operation will NOT do any optimistic locking, to avoid loading the bytes in memory. So use this method
-     * only in conjunction with an entity that has optimistic locking!.
+     * Deletes the {@link ByteArrayEntity} with the given id from the database. Important: this operation will NOT do any optimistic locking, to avoid
+     * loading the bytes in memory. So use this method only in conjunction with an entity that has optimistic locking!.
      */
     void deleteByteArrayById(String byteArrayEntityId);
 
     /**
-     * Deletes the {@link ByteArrayEntity} with the given ids from the database. Important: this operation will NOT do any optimistic locking, to avoid loading the bytes in memory. So use this method
-     * only in conjunction with an entity that has optimistic locking!.
+     * Deletes the {@link ByteArrayEntity} with the given ids from the database. Important: this operation will NOT do any optimistic locking, to
+     * avoid loading the bytes in memory. So use this method only in conjunction with an entity that has optimistic locking!.
      */
     void bulkDeleteByteArraysById(List<String> byteArrayEntityIds);
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/persistence/entity/MutableEntityManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/persistence/entity/MutableEntityManager.java
@@ -12,15 +12,15 @@
  */
 package org.flowable.common.engine.impl.persistence.entity;
 
-import java.util.List;
-import org.flowable.common.engine.impl.persistence.entity.data.PropertyDataManager;
+import org.flowable.common.engine.impl.persistence.entity.data.DataManager;
 
 /**
- * @author Joram Barrez
+ * An {@link EntityManager} that allows the {@link DataManager} of the entity manager implementation to be reconfigured at runtime.
+ * 
+ * @author ikaakkola (Qvantel Finland Oy)
  */
-public interface PropertyEntityManager extends MutableEntityManager<PropertyEntity, PropertyDataManager> {
+public interface MutableEntityManager<EntityImpl extends Entity, DM extends DataManager<EntityImpl>> extends EntityManager<EntityImpl> {
 
-    List<PropertyEntity> findAll();
+    void setDataManager(DM dataManager);
 
-    void directInsertProperty(String name, String value);
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -4011,12 +4010,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setAttachmentDataManager(AttachmentDataManager attachmentDataManager) {
         this.attachmentDataManager = attachmentDataManager;
+        this.attachmentEntityManager.setDataManager(attachmentDataManager);
         return this;
     }
 
     @Override
     public ProcessEngineConfigurationImpl setByteArrayDataManager(ByteArrayDataManager byteArrayDataManager) {
         this.byteArrayDataManager = byteArrayDataManager;
+        this.byteArrayEntityManager.setDataManager(byteArrayDataManager);
         return this;
     }
 
@@ -4026,6 +4027,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setCommentDataManager(CommentDataManager commentDataManager) {
         this.commentDataManager = commentDataManager;
+        this.commentEntityManager.setDataManager(commentDataManager);
         return this;
     }
 
@@ -4035,6 +4037,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setDeploymentDataManager(DeploymentDataManager deploymentDataManager) {
         this.deploymentDataManager = deploymentDataManager;
+        this.deploymentEntityManager.setDataManager(deploymentDataManager);
         return this;
     }
 
@@ -4044,6 +4047,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setEventLogEntryDataManager(EventLogEntryDataManager eventLogEntryDataManager) {
         this.eventLogEntryDataManager = eventLogEntryDataManager;
+        this.eventLogEntryEntityManager.setDataManager(eventLogEntryDataManager);
         return this;
     }
 
@@ -4053,6 +4057,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setExecutionDataManager(ExecutionDataManager executionDataManager) {
         this.executionDataManager = executionDataManager;
+        this.executionEntityManager.setDataManager(executionDataManager);
         return this;
     }
 
@@ -4062,6 +4067,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setActivityInstanceDataManager(ActivityInstanceDataManager activityInstanceDataManager) {
         this.activityInstanceDataManager = activityInstanceDataManager;
+        this.activityInstanceEntityManager.setDataManager(activityInstanceDataManager);
         return this;
     }
 
@@ -4071,6 +4077,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setHistoricActivityInstanceDataManager(HistoricActivityInstanceDataManager historicActivityInstanceDataManager) {
         this.historicActivityInstanceDataManager = historicActivityInstanceDataManager;
+        this.historicActivityInstanceEntityManager.setDataManager(historicActivityInstanceDataManager);
         return this;
     }
 
@@ -4080,6 +4087,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setHistoricDetailDataManager(HistoricDetailDataManager historicDetailDataManager) {
         this.historicDetailDataManager = historicDetailDataManager;
+        this.historicDetailEntityManager.setDataManager(historicDetailDataManager);
         return this;
     }
 
@@ -4089,6 +4097,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setHistoricProcessInstanceDataManager(HistoricProcessInstanceDataManager historicProcessInstanceDataManager) {
         this.historicProcessInstanceDataManager = historicProcessInstanceDataManager;
+        this.historicProcessInstanceEntityManager.setDataManager(historicProcessInstanceDataManager);
         return this;
     }
 
@@ -4098,6 +4107,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setModelDataManager(ModelDataManager modelDataManager) {
         this.modelDataManager = modelDataManager;
+        this.modelEntityManager.setDataManager(modelDataManager);
         return this;
     }
 
@@ -4107,6 +4117,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setProcessDefinitionDataManager(ProcessDefinitionDataManager processDefinitionDataManager) {
         this.processDefinitionDataManager = processDefinitionDataManager;
+        this.processDefinitionEntityManager.setDataManager(processDefinitionDataManager);
         return this;
     }
 
@@ -4116,12 +4127,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setProcessDefinitionInfoDataManager(ProcessDefinitionInfoDataManager processDefinitionInfoDataManager) {
         this.processDefinitionInfoDataManager = processDefinitionInfoDataManager;
+        this.processDefinitionInfoEntityManager.setDataManager(processDefinitionInfoDataManager);
         return this;
     }
 
     @Override
     public ProcessEngineConfigurationImpl setPropertyDataManager(PropertyDataManager propertyDataManager) {
         this.propertyDataManager = propertyDataManager;
+        this.propertyEntityManager.setDataManager(propertyDataManager);
         return this;
     }
 
@@ -4131,6 +4144,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setResourceDataManager(ResourceDataManager resourceDataManager) {
         this.resourceDataManager = resourceDataManager;
+        this.resourceEntityManager.setDataManager(resourceDataManager);
         return this;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ActivityInstanceEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ActivityInstanceEntityManager.java
@@ -15,17 +15,17 @@ package org.flowable.engine.impl.persistence.entity;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
 import org.flowable.bpmn.model.FlowElement;
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.impl.ActivityInstanceQueryImpl;
+import org.flowable.engine.impl.persistence.entity.data.ActivityInstanceDataManager;
 import org.flowable.engine.runtime.ActivityInstance;
 import org.flowable.task.service.impl.persistence.entity.TaskEntity;
 
 /**
  * @author martin.grofcik
  */
-public interface ActivityInstanceEntityManager extends EntityManager<ActivityInstanceEntity> {
+public interface ActivityInstanceEntityManager extends MutableEntityManager<ActivityInstanceEntity,ActivityInstanceDataManager> {
 
     ActivityInstanceEntity findUnfinishedActivityInstance(ExecutionEntity execution);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/CommentEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/CommentEntityManager.java
@@ -14,15 +14,15 @@ package org.flowable.engine.impl.persistence.entity;
 
 import java.util.Collection;
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
+import org.flowable.engine.impl.persistence.entity.data.CommentDataManager;
 import org.flowable.engine.task.Comment;
 import org.flowable.engine.task.Event;
 
 /**
  * @author Joram Barrez
  */
-public interface CommentEntityManager extends EntityManager<CommentEntity> {
+public interface CommentEntityManager extends MutableEntityManager<CommentEntity,CommentDataManager> {
 
     List<Comment> findCommentsByTaskId(String taskId);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/DeploymentEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/DeploymentEntityManager.java
@@ -14,15 +14,15 @@ package org.flowable.engine.impl.persistence.entity;
 
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.impl.DeploymentQueryImpl;
+import org.flowable.engine.impl.persistence.entity.data.DeploymentDataManager;
 import org.flowable.engine.repository.Deployment;
 
 /**
  * @author Joram Barrez
  */
-public interface DeploymentEntityManager extends EntityManager<DeploymentEntity> {
+public interface DeploymentEntityManager extends MutableEntityManager<DeploymentEntity,DeploymentDataManager> {
 
     List<Deployment> findDeploymentsByQueryCriteria(DeploymentQueryImpl deploymentQuery);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/EventLogEntryEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/EventLogEntryEntityManager.java
@@ -13,14 +13,14 @@
 package org.flowable.engine.impl.persistence.entity;
 
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.event.EventLogEntry;
+import org.flowable.engine.impl.persistence.entity.data.EventLogEntryDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface EventLogEntryEntityManager extends EntityManager<EventLogEntryEntity> {
+public interface EventLogEntryEntityManager extends MutableEntityManager<EventLogEntryEntity,EventLogEntryDataManager> {
 
     List<EventLogEntry> findAllEventLogEntries();
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ExecutionEntityManager.java
@@ -16,11 +16,11 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
 import org.flowable.bpmn.model.FlowElement;
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.impl.ExecutionQueryImpl;
 import org.flowable.engine.impl.ProcessInstanceQueryImpl;
+import org.flowable.engine.impl.persistence.entity.data.ExecutionDataManager;
 import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.runtime.Execution;
 import org.flowable.engine.runtime.ProcessInstance;
@@ -28,7 +28,7 @@ import org.flowable.engine.runtime.ProcessInstance;
 /**
  * @author Joram Barrez
  */
-public interface ExecutionEntityManager extends EntityManager<ExecutionEntity> {
+public interface ExecutionEntityManager extends MutableEntityManager<ExecutionEntity,ExecutionDataManager> {
 
     ExecutionEntity createProcessInstanceExecution(ProcessDefinition processDefinition, String predefinedProcessInstanceId,
             String businessKey, String businessStatus, String processInstanceName, String callbackId, String callbackType, String referenceId,

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricActivityInstanceEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricActivityInstanceEntityManager.java
@@ -15,16 +15,16 @@ package org.flowable.engine.impl.persistence.entity;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.impl.HistoricActivityInstanceQueryImpl;
+import org.flowable.engine.impl.persistence.entity.data.HistoricActivityInstanceDataManager;
 import org.flowable.engine.runtime.ActivityInstance;
 
 /**
  * @author Joram Barrez
  */
-public interface HistoricActivityInstanceEntityManager extends EntityManager<HistoricActivityInstanceEntity> {
+public interface HistoricActivityInstanceEntityManager extends MutableEntityManager<HistoricActivityInstanceEntity,HistoricActivityInstanceDataManager> {
 
     HistoricActivityInstanceEntity create(ActivityInstance activityInstance);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricDetailEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricDetailEntityManager.java
@@ -16,16 +16,16 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.history.HistoricDetail;
 import org.flowable.engine.impl.HistoricDetailQueryImpl;
+import org.flowable.engine.impl.persistence.entity.data.HistoricDetailDataManager;
 import org.flowable.variable.service.impl.persistence.entity.VariableInstanceEntity;
 
 /**
  * @author Joram Barrez
  */
-public interface HistoricDetailEntityManager extends EntityManager<HistoricDetailEntity> {
+public interface HistoricDetailEntityManager extends MutableEntityManager<HistoricDetailEntity,HistoricDetailDataManager> {
 
     HistoricFormPropertyEntity insertHistoricFormPropertyEntity(ExecutionEntity execution, String propertyId, String propertyValue, String taskId,
         Date createTime);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricProcessInstanceEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/HistoricProcessInstanceEntityManager.java
@@ -15,15 +15,15 @@ package org.flowable.engine.impl.persistence.entity;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.impl.HistoricProcessInstanceQueryImpl;
+import org.flowable.engine.impl.persistence.entity.data.HistoricProcessInstanceDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface HistoricProcessInstanceEntityManager extends EntityManager<HistoricProcessInstanceEntity> {
+public interface HistoricProcessInstanceEntityManager extends MutableEntityManager<HistoricProcessInstanceEntity,HistoricProcessInstanceDataManager> {
 
     @Override
     HistoricProcessInstanceEntity create();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ModelEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ModelEntityManager.java
@@ -14,15 +14,15 @@ package org.flowable.engine.impl.persistence.entity;
 
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.impl.ModelQueryImpl;
+import org.flowable.engine.impl.persistence.entity.data.ModelDataManager;
 import org.flowable.engine.repository.Model;
 
 /**
  * @author Joram Barrez
  */
-public interface ModelEntityManager extends EntityManager<ModelEntity> {
+public interface ModelEntityManager extends MutableEntityManager<ModelEntity,ModelDataManager> {
 
     void insertEditorSourceForModel(String modelId, byte[] modelSource);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ProcessDefinitionEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ProcessDefinitionEntityManager.java
@@ -14,15 +14,15 @@ package org.flowable.engine.impl.persistence.entity;
 
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.engine.impl.ProcessDefinitionQueryImpl;
+import org.flowable.engine.impl.persistence.entity.data.ProcessDefinitionDataManager;
 import org.flowable.engine.repository.ProcessDefinition;
 
 /**
  * @author Joram Barrez
  */
-public interface ProcessDefinitionEntityManager extends EntityManager<ProcessDefinitionEntity> {
+public interface ProcessDefinitionEntityManager extends MutableEntityManager<ProcessDefinitionEntity,ProcessDefinitionDataManager> {
 
     ProcessDefinitionEntity findLatestProcessDefinitionByKey(String processDefinitionKey);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ProcessDefinitionInfoEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ProcessDefinitionInfoEntityManager.java
@@ -12,12 +12,13 @@
  */
 package org.flowable.engine.impl.persistence.entity;
 
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
+import org.flowable.engine.impl.persistence.entity.data.ProcessDefinitionInfoDataManager;
 
 /**
  * @author Tijs Rademakers
  */
-public interface ProcessDefinitionInfoEntityManager extends EntityManager<ProcessDefinitionInfoEntity> {
+public interface ProcessDefinitionInfoEntityManager extends MutableEntityManager<ProcessDefinitionInfoEntity,ProcessDefinitionInfoDataManager> {
 
     void insertProcessDefinitionInfo(ProcessDefinitionInfoEntity processDefinitionInfo);
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ResourceEntityManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/entity/ResourceEntityManager.java
@@ -13,13 +13,13 @@
 package org.flowable.engine.impl.persistence.entity;
 
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
+import org.flowable.engine.impl.persistence.entity.data.ResourceDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface ResourceEntityManager extends EntityManager<ResourceEntity> {
+public interface ResourceEntityManager extends MutableEntityManager<ResourceEntity,ResourceDataManager> {
 
     List<ResourceEntity> findResourcesByDeploymentId(String deploymentId);
 

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/EventSubscriptionServiceConfiguration.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/EventSubscriptionServiceConfiguration.java
@@ -109,6 +109,7 @@ public class EventSubscriptionServiceConfiguration extends AbstractServiceConfig
 
     public EventSubscriptionServiceConfiguration setEventSubscriptionDataManager(EventSubscriptionDataManager eventSubscriptionDataManager) {
         this.eventSubscriptionDataManager = eventSubscriptionDataManager;
+        this.eventSubscriptionEntityManager.setDataManager(eventSubscriptionDataManager);
         return this;
     }
     

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManager.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManager.java
@@ -13,16 +13,16 @@
 package org.flowable.eventsubscription.service.impl.persistence.entity;
 
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.eventsubscription.api.EventSubscription;
 import org.flowable.eventsubscription.api.EventSubscriptionBuilder;
 import org.flowable.eventsubscription.service.impl.EventSubscriptionQueryImpl;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.EventSubscriptionDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface EventSubscriptionEntityManager extends EntityManager<EventSubscriptionEntity> {
+public interface EventSubscriptionEntityManager extends MutableEntityManager<EventSubscriptionEntity, EventSubscriptionDataManager> {
 
     /* Create entity */
 

--- a/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/IdentityLinkServiceConfiguration.java
+++ b/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/IdentityLinkServiceConfiguration.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.identitylink.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.flowable.common.engine.impl.AbstractServiceConfiguration;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.identitylink.service.impl.HistoricIdentityLinkServiceImpl;
@@ -24,8 +25,6 @@ import org.flowable.identitylink.service.impl.persistence.entity.data.HistoricId
 import org.flowable.identitylink.service.impl.persistence.entity.data.IdentityLinkDataManager;
 import org.flowable.identitylink.service.impl.persistence.entity.data.impl.MybatisHistoricIdentityLinkDataManager;
 import org.flowable.identitylink.service.impl.persistence.entity.data.impl.MybatisIdentityLinkDataManager;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Tijs Rademakers
@@ -136,6 +135,7 @@ public class IdentityLinkServiceConfiguration extends AbstractServiceConfigurati
 
     public IdentityLinkServiceConfiguration setIdentityLinkDataManager(IdentityLinkDataManager identityLinkDataManager) {
         this.identityLinkDataManager = identityLinkDataManager;
+        this.identityLinkEntityManager.setDataManager(identityLinkDataManager);
         return this;
     }
     
@@ -145,6 +145,7 @@ public class IdentityLinkServiceConfiguration extends AbstractServiceConfigurati
 
     public IdentityLinkServiceConfiguration setHistoricIdentityLinkDataManager(HistoricIdentityLinkDataManager historicIdentityLinkDataManager) {
         this.historicIdentityLinkDataManager = historicIdentityLinkDataManager;
+        this.historicIdentityLinkEntityManager.setDataManager(historicIdentityLinkDataManager);
         return this;
     }
 

--- a/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/HistoricIdentityLinkEntityManager.java
+++ b/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/HistoricIdentityLinkEntityManager.java
@@ -14,13 +14,13 @@ package org.flowable.identitylink.service.impl.persistence.entity;
 
 import java.util.Collection;
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
+import org.flowable.identitylink.service.impl.persistence.entity.data.HistoricIdentityLinkDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface HistoricIdentityLinkEntityManager extends EntityManager<HistoricIdentityLinkEntity> {
+public interface HistoricIdentityLinkEntityManager extends MutableEntityManager<HistoricIdentityLinkEntity,HistoricIdentityLinkDataManager> {
 
     List<HistoricIdentityLinkEntity> findHistoricIdentityLinksByTaskId(String taskId);
 

--- a/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/IdentityLinkEntityManager.java
+++ b/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/impl/persistence/entity/IdentityLinkEntityManager.java
@@ -14,14 +14,14 @@ package org.flowable.identitylink.service.impl.persistence.entity;
 
 import java.util.Collection;
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.identitylink.api.history.HistoricIdentityLink;
+import org.flowable.identitylink.service.impl.persistence.entity.data.IdentityLinkDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface IdentityLinkEntityManager extends EntityManager<IdentityLinkEntity> {
+public interface IdentityLinkEntityManager extends MutableEntityManager<IdentityLinkEntity,IdentityLinkDataManager> {
 
     IdentityLinkEntity createIdentityLinkFromHistoricIdentityLink(HistoricIdentityLink historicIdentityLink);
 

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/DeadLetterJobEntityManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/DeadLetterJobEntityManager.java
@@ -13,16 +13,15 @@
 package org.flowable.job.service.impl.persistence.entity;
 
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.DeadLetterJobQueryImpl;
-import org.flowable.job.service.impl.JobQueryImpl;
+import org.flowable.job.service.impl.persistence.entity.data.DeadLetterJobDataManager;
 
 /**
  * @author Tijs Rademakers
  */
-public interface DeadLetterJobEntityManager extends EntityManager<DeadLetterJobEntity> {
+public interface DeadLetterJobEntityManager extends MutableEntityManager<DeadLetterJobEntity,DeadLetterJobDataManager> {
 
     /**
      * Find the deadletter job with the given correlation id.

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/ExternalWorkerJobEntityManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/ExternalWorkerJobEntityManager.java
@@ -13,18 +13,18 @@
 package org.flowable.job.service.impl.persistence.entity;
 
 import java.util.List;
-
 import org.flowable.common.engine.impl.persistence.entity.EntityManager;
 import org.flowable.job.api.ExternalWorkerJob;
 import org.flowable.job.service.impl.ExternalWorkerJobAcquireBuilderImpl;
 import org.flowable.job.service.impl.ExternalWorkerJobQueryImpl;
+import org.flowable.job.service.impl.persistence.entity.data.ExternalWorkerJobDataManager;
 
 /**
  * {@link EntityManager} responsible for the {@link ExternalWorkerJobEntity} class.
  *
  * @author Filip Hrisafov
  */
-public interface ExternalWorkerJobEntityManager extends EntityManager<ExternalWorkerJobEntity>, JobInfoEntityManager<ExternalWorkerJobEntity> {
+public interface ExternalWorkerJobEntityManager extends EntityManager<ExternalWorkerJobEntity>, MutableJobInfoEntityManager<ExternalWorkerJobEntity,ExternalWorkerJobDataManager> {
 
     /**
      * Insert the {@link ExternalWorkerJobEntity}, similar to insert(ExternalWorkerJobEntity), but returns a boolean in case the insert did not go through. This could happen if the execution related to the

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/HistoryJobEntityManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/HistoryJobEntityManager.java
@@ -13,17 +13,17 @@
 package org.flowable.job.service.impl.persistence.entity;
 
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
 import org.flowable.job.api.HistoryJob;
 import org.flowable.job.service.impl.HistoryJobQueryImpl;
+import org.flowable.job.service.impl.persistence.entity.data.HistoryJobDataManager;
 
 /**
  * {@link EntityManager} responsible for the {@link HistoryJobEntity} class.
  *
  * @author Tijs Rademakers
  */
-public interface HistoryJobEntityManager extends EntityManager<HistoryJobEntity>, JobInfoEntityManager<HistoryJobEntity> {
+public interface HistoryJobEntityManager
+                extends MutableJobInfoEntityManager<HistoryJobEntity, HistoryJobDataManager> {
 
     /**
      * Executes a {@link HistoryJobQueryImpl} and returns the matching {@link HistoryJobEntity} instances.
@@ -36,8 +36,8 @@ public interface HistoryJobEntityManager extends EntityManager<HistoryJobEntity>
     long findHistoryJobCountByQueryCriteria(HistoryJobQueryImpl jobQuery);
 
     /**
-     * The default delete method will cascade to the references entities.
-     * This delete doesn't delete the referenced byte array entities (configuration and exception).
+     * The default delete method will cascade to the references entities. This delete doesn't delete the referenced byte array entities (configuration
+     * and exception).
      */
     void deleteNoCascade(HistoryJobEntity historyJobEntity);
 

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/JobEntityManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/JobEntityManager.java
@@ -13,17 +13,16 @@
 package org.flowable.job.service.impl.persistence.entity;
 
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
 import org.flowable.job.api.Job;
 import org.flowable.job.service.impl.JobQueryImpl;
+import org.flowable.job.service.impl.persistence.entity.data.JobDataManager;
 
 /**
  * {@link EntityManager} responsible for the {@link JobEntity} class.
  *
  * @author Joram Barrez
  */
-public interface JobEntityManager extends EntityManager<JobEntity>, JobInfoEntityManager<JobEntity> {
+public interface JobEntityManager extends MutableJobInfoEntityManager<JobEntity,JobDataManager> {
 
     /**
      * Insert the {@link JobEntity}, similar to insert(JobEntity), but returns a boolean in case the insert did not go through. This could happen if the execution related to the
@@ -48,4 +47,5 @@ public interface JobEntityManager extends EntityManager<JobEntity>, JobInfoEntit
     
 
     void deleteJobsByExecutionId(String executionId);
+    
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/JobInfoEntityManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/JobInfoEntityManager.java
@@ -14,10 +14,8 @@ package org.flowable.job.service.impl.persistence.entity;
 
 import java.util.Date;
 import java.util.List;
-
 import org.flowable.common.engine.impl.Page;
 import org.flowable.common.engine.impl.persistence.entity.EntityManager;
-import org.flowable.job.service.impl.cmd.AcquireJobsCmd;
 
 public interface JobInfoEntityManager <T extends JobInfoEntity> extends EntityManager<T> {
 

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/MutableJobInfoEntityManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/MutableJobInfoEntityManager.java
@@ -10,23 +10,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flowable.engine.impl.persistence.entity;
+package org.flowable.job.service.impl.persistence.entity;
 
-import java.util.Collection;
-import java.util.List;
 import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
-import org.flowable.engine.impl.persistence.entity.data.AttachmentDataManager;
+import org.flowable.common.engine.impl.persistence.entity.data.DataManager;
 
 /**
- * @author Joram Barrez
+ * @author ikaakkola (Qvantel Finland Oy)
  */
-public interface AttachmentEntityManager extends MutableEntityManager<AttachmentEntity,AttachmentDataManager> {
+public interface MutableJobInfoEntityManager<T extends JobInfoEntity, DM extends DataManager<T>>
+                extends JobInfoEntityManager<T>, MutableEntityManager<T, DM> {
 
-    List<AttachmentEntity> findAttachmentsByProcessInstanceId(String processInstanceId);
-
-    List<AttachmentEntity> findAttachmentsByTaskId(String taskId);
-
-    void deleteAttachmentsByTaskId(String taskId);
-    
-    void bulkDeleteAttachmentsByTaskId(Collection<String> taskIds);
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/SuspendedJobEntityManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/SuspendedJobEntityManager.java
@@ -13,16 +13,15 @@
 package org.flowable.job.service.impl.persistence.entity;
 
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.job.api.Job;
-import org.flowable.job.service.impl.JobQueryImpl;
 import org.flowable.job.service.impl.SuspendedJobQueryImpl;
+import org.flowable.job.service.impl.persistence.entity.data.SuspendedJobDataManager;
 
 /**
  * @author Tijs Rademakers
  */
-public interface SuspendedJobEntityManager extends EntityManager<SuspendedJobEntity> {
+public interface SuspendedJobEntityManager extends MutableEntityManager<SuspendedJobEntity, SuspendedJobDataManager> {
 
     /**
      * Find the suspended job with the given correlation id.
@@ -53,5 +52,5 @@ public interface SuspendedJobEntityManager extends EntityManager<SuspendedJobEnt
      * Changes the tenantId for all jobs related to a given deployment id.
      */
     void updateJobTenantIdForDeployment(String deploymentId, String newTenantId);
-    
+
 }

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/TimerJobEntityManager.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/TimerJobEntityManager.java
@@ -13,11 +13,9 @@
 package org.flowable.job.service.impl.persistence.entity;
 
 import java.util.List;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
 import org.flowable.job.api.Job;
-import org.flowable.job.service.impl.JobQueryImpl;
 import org.flowable.job.service.impl.TimerJobQueryImpl;
+import org.flowable.job.service.impl.persistence.entity.data.TimerJobDataManager;
 import org.flowable.variable.api.delegate.VariableScope;
 
 /**
@@ -26,7 +24,7 @@ import org.flowable.variable.api.delegate.VariableScope;
  * @author Tijs Rademakers
  * @author Vasile Dirla
  */
-public interface TimerJobEntityManager extends JobInfoEntityManager<TimerJobEntity> {
+public interface TimerJobEntityManager extends MutableJobInfoEntityManager<TimerJobEntity,TimerJobDataManager> {
 
     /**
      * Insert the {@link TimerJobEntity}, similar to insert(TimerJobEntity), but returns a boolean in case the insert did not go through. This could happen if the execution related to the

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/TimerJobEntityManagerImpl.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/impl/persistence/entity/TimerJobEntityManagerImpl.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
 import org.flowable.common.engine.impl.calendar.BusinessCalendar;

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/TaskServiceConfiguration.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/TaskServiceConfiguration.java
@@ -158,6 +158,7 @@ public class TaskServiceConfiguration extends AbstractServiceConfiguration {
 
     public TaskServiceConfiguration setTaskDataManager(TaskDataManager taskDataManager) {
         this.taskDataManager = taskDataManager;
+        this.taskEntityManager.setDataManager(taskDataManager);
         return this;
     }
 
@@ -167,6 +168,7 @@ public class TaskServiceConfiguration extends AbstractServiceConfiguration {
 
     public TaskServiceConfiguration setHistoricTaskInstanceDataManager(HistoricTaskInstanceDataManager historicTaskInstanceDataManager) {
         this.historicTaskInstanceDataManager = historicTaskInstanceDataManager;
+        this.historicTaskInstanceEntityManager.setDataManager(historicTaskInstanceDataManager);
         return this;
     }
 

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/persistence/entity/HistoricTaskInstanceEntityManager.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/persistence/entity/HistoricTaskInstanceEntityManager.java
@@ -15,15 +15,15 @@ package org.flowable.task.service.impl.persistence.entity;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.task.api.history.HistoricTaskInstance;
 import org.flowable.task.service.impl.HistoricTaskInstanceQueryImpl;
+import org.flowable.task.service.impl.persistence.entity.data.HistoricTaskInstanceDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface HistoricTaskInstanceEntityManager extends EntityManager<HistoricTaskInstanceEntity> {
+public interface HistoricTaskInstanceEntityManager extends MutableEntityManager<HistoricTaskInstanceEntity,HistoricTaskInstanceDataManager> {
 
     HistoricTaskInstanceEntity create(TaskEntity task);
     

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/persistence/entity/TaskEntityManager.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/persistence/entity/TaskEntityManager.java
@@ -14,14 +14,13 @@ package org.flowable.task.service.impl.persistence.entity;
 
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskBuilder;
-import org.flowable.task.api.TaskInfo;
 import org.flowable.task.service.impl.TaskQueryImpl;
+import org.flowable.task.service.impl.persistence.entity.data.TaskDataManager;
 
-public interface TaskEntityManager extends EntityManager<TaskEntity> {
+public interface TaskEntityManager extends MutableEntityManager<TaskEntity, TaskDataManager> {
 
     /**
      * Creates {@link TaskEntity} according to {@link TaskInfo} template
@@ -58,6 +57,6 @@ public interface TaskEntityManager extends EntityManager<TaskEntity> {
     void updateTaskTenantIdForDeployment(String deploymentId, String newTenantId);
     
     void updateAllTaskRelatedEntityCountFlags(boolean configProperty);
-    
+
     void deleteTasksByExecutionId(String executionId);
 }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/VariableServiceConfiguration.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/VariableServiceConfiguration.java
@@ -139,6 +139,7 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
 
     public VariableServiceConfiguration setVariableInstanceDataManager(VariableInstanceDataManager variableInstanceDataManager) {
         this.variableInstanceDataManager = variableInstanceDataManager;
+        this.variableInstanceEntityManager.setDataManager(variableInstanceDataManager);
         return this;
     }
     
@@ -148,6 +149,7 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
 
     public VariableServiceConfiguration setHistoricVariableInstanceDataManager(HistoricVariableInstanceDataManager historicVariableInstanceDataManager) {
         this.historicVariableInstanceDataManager = historicVariableInstanceDataManager;
+        this.historicVariableInstanceEntityManager.setDataManager(historicVariableInstanceDataManager);
         return this;
     }
 

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/HistoricVariableInstanceEntityManager.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/HistoricVariableInstanceEntityManager.java
@@ -16,15 +16,15 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.flowable.variable.service.impl.HistoricVariableInstanceQueryImpl;
+import org.flowable.variable.service.impl.persistence.entity.data.HistoricVariableInstanceDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface HistoricVariableInstanceEntityManager extends EntityManager<HistoricVariableInstanceEntity> {
+public interface HistoricVariableInstanceEntityManager extends MutableEntityManager<HistoricVariableInstanceEntity,HistoricVariableInstanceDataManager> {
 
     HistoricVariableInstanceEntity create(VariableInstanceEntity variableInstance, Date createTime);
 

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/VariableInstanceEntityManager.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/persistence/entity/VariableInstanceEntityManager.java
@@ -15,16 +15,16 @@ package org.flowable.variable.service.impl.persistence.entity;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import org.flowable.common.engine.impl.persistence.entity.EntityManager;
+import org.flowable.common.engine.impl.persistence.entity.MutableEntityManager;
 import org.flowable.variable.api.persistence.entity.VariableInstance;
 import org.flowable.variable.service.InternalVariableInstanceQuery;
 import org.flowable.variable.service.impl.VariableInstanceQueryImpl;
+import org.flowable.variable.service.impl.persistence.entity.data.VariableInstanceDataManager;
 
 /**
  * @author Joram Barrez
  */
-public interface VariableInstanceEntityManager extends EntityManager<VariableInstanceEntity> {
+public interface VariableInstanceEntityManager extends MutableEntityManager<VariableInstanceEntity,VariableInstanceDataManager> {
 
     /**
      * Creates a variable instance for the given tenant, name and value.


### PR DESCRIPTION
Allow (re)configuration of the DataManagers of various EntityManager implementations, at runtime, via MutableEntityManager interface.

This change allows the implementation of custom DataManagers without having to reinitialize all EntittManagers or use reflection to set the new DataManager into each EntityManager instance. This matches the expectation that after calling one of the setDataManager methods, the given DataManager is really used, also by the existing entity manager.

#### Check List:
* Unit tests: NA
* Documentation: NA
