### PR TITLE
feat: ServiceConfigurator support for various service configurations

### DIFF
--- a/modules/flowable-batch-service/src/main/java/org/flowable/batch/service/BatchServiceConfiguration.java
+++ b/modules/flowable-batch-service/src/main/java/org/flowable/batch/service/BatchServiceConfiguration.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * @author Tijs Rademakers
  */
-public class BatchServiceConfiguration extends AbstractServiceConfiguration {
+public class BatchServiceConfiguration extends AbstractServiceConfiguration<BatchServiceConfiguration> {
 
     // SERVICES
     // /////////////////////////////////////////////////////////////////
@@ -52,12 +52,21 @@ public class BatchServiceConfiguration extends AbstractServiceConfiguration {
         super(engineName);
     }
 
+    @Override
+    protected BatchServiceConfiguration getService() {
+        return this;
+    }
+
     // init
     // /////////////////////////////////////////////////////////////////////
 
     public void init() {
+        configuratorsBeforeInit();
+        
         initDataManagers();
         initEntityManagers();
+
+        configuratorsAfterInit();
     }
 
     // Data managers
@@ -96,7 +105,7 @@ public class BatchServiceConfiguration extends AbstractServiceConfiguration {
         this.batchService = batchService;
         return this;
     }
-    
+
     public BatchDataManager getBatchDataManager() {
         return batchDataManager;
     }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -471,16 +470,20 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     // Identitylink support
     protected IdentityLinkServiceConfiguration identityLinkServiceConfiguration;
-    
+    protected Collection<ServiceConfigurator<IdentityLinkServiceConfiguration>> identityLinkServiceConfigurators;
+
     // Entitylink support
     protected EntityLinkServiceConfiguration entityLinkServiceConfiguration;
+    protected Collection<ServiceConfigurator<EntityLinkServiceConfiguration>> entityLinkServiceConfigurators;
     protected boolean enableEntityLinks;
     
     // EventSubscription support
     protected EventSubscriptionServiceConfiguration eventSubscriptionServiceConfiguration;
+    protected Collection<ServiceConfigurator<EventSubscriptionServiceConfiguration>> eventSubscriptionServiceConfigurators;
 
     // Task support
     protected TaskServiceConfiguration taskServiceConfiguration;
+    protected Collection<ServiceConfigurator<TaskServiceConfiguration>> taskServiceConfigurators;
     protected InternalHistoryTaskManager internalHistoryTaskManager;
     protected InternalTaskVariableScopeResolver internalTaskVariableScopeResolver;
     protected InternalTaskAssignmentManager internalTaskAssignmentManager;
@@ -489,12 +492,14 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     // Batch support
     protected BatchServiceConfiguration batchServiceConfiguration;
+    protected Collection<ServiceConfigurator<BatchServiceConfiguration>> batchServiceConfigurators;
 
     // Variable support
     protected VariableTypes variableTypes;
     protected List<VariableType> customPreVariableTypes;
     protected List<VariableType> customPostVariableTypes;
     protected VariableServiceConfiguration variableServiceConfiguration;
+    protected Collection<ServiceConfigurator<VariableServiceConfiguration>> variableServiceConfigurators;
     protected InternalHistoryVariableManager internalHistoryVariableManager;
     protected boolean serializableVariableTypeTrackDeserializedObjects = true;
     /**
@@ -1518,6 +1523,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
         this.variableServiceConfiguration.setMaxLengthString(this.getMaxLengthString());
         this.variableServiceConfiguration.setSerializableVariableTypeTrackDeserializedObjects(this.isSerializableVariableTypeTrackDeserializedObjects());
         this.variableServiceConfiguration.setLoggingSessionEnabled(isLoggingSessionEnabled());
+        this.variableServiceConfiguration.setConfigurators(variableServiceConfigurators);
     }
 
     public void initVariableServiceConfiguration() {
@@ -1568,6 +1574,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
         this.taskServiceConfiguration.setEnableTaskRelationshipCounts(this.isEnableTaskRelationshipCounts);
 
+        this.taskServiceConfiguration.setConfigurators(this.taskServiceConfigurators);
         this.taskServiceConfiguration.init();
 
         if (dbSqlSessionFactory != null && taskServiceConfiguration.getTaskDataManager() instanceof AbstractDataManager) {
@@ -1590,6 +1597,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
         this.identityLinkServiceConfiguration.setEventDispatcher(this.eventDispatcher);
         this.identityLinkServiceConfiguration.setIdentityLinkEventHandler(this.identityLinkEventHandler);
 
+        this.identityLinkServiceConfiguration.setConfigurators(this.identityLinkServiceConfigurators);
         this.identityLinkServiceConfiguration.init();
 
         addServiceConfiguration(EngineConfigurationConstants.KEY_IDENTITY_LINK_SERVICE_CONFIG, this.identityLinkServiceConfiguration);
@@ -1608,6 +1616,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
             this.entityLinkServiceConfiguration.setObjectMapper(this.objectMapper);
             this.entityLinkServiceConfiguration.setEventDispatcher(this.eventDispatcher);
     
+            this.entityLinkServiceConfiguration.setConfigurators(this.entityLinkServiceConfigurators);
             this.entityLinkServiceConfiguration.init();
     
             addServiceConfiguration(EngineConfigurationConstants.KEY_ENTITY_LINK_SERVICE_CONFIG, this.entityLinkServiceConfiguration);
@@ -1626,6 +1635,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
         this.eventSubscriptionServiceConfiguration.setEventDispatcher(this.eventDispatcher);
         this.eventSubscriptionServiceConfiguration.setEventSubscriptionLockTime(this.eventRegistryUniqueCaseInstanceStartLockTime);
         
+        this.eventSubscriptionServiceConfiguration.setConfigurators(this.eventSubscriptionServiceConfigurators);
         this.eventSubscriptionServiceConfiguration.init();
 
         addServiceConfiguration(EngineConfigurationConstants.KEY_EVENT_SUBSCRIPTION_SERVICE_CONFIG, this.eventSubscriptionServiceConfiguration);
@@ -1911,6 +1921,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
             this.batchServiceConfiguration.setObjectMapper(this.objectMapper);
             this.batchServiceConfiguration.setEventDispatcher(this.eventDispatcher);
 
+            this.batchServiceConfiguration.setConfigurators(this.batchServiceConfigurators);
             this.batchServiceConfiguration.init();
         }
 
@@ -2895,13 +2906,49 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
         this.identityLinkServiceConfiguration = identityLinkServiceConfiguration;
         return this;
     }
-    
+
+    public Collection<ServiceConfigurator<IdentityLinkServiceConfiguration>> getIdentityLinkServiceConfigurators() {
+        return identityLinkServiceConfigurators;
+    }
+
+    public CmmnEngineConfiguration setIdentityLinkServiceConfigurators(
+                    Collection<ServiceConfigurator<IdentityLinkServiceConfiguration>> identityLinkServiceConfigurators) {
+        this.identityLinkServiceConfigurators = identityLinkServiceConfigurators;
+        return this;
+    }
+
+    public CmmnEngineConfiguration addIdentityLinkServiceConfigurator(ServiceConfigurator<IdentityLinkServiceConfiguration> configurator) {
+        if (this.identityLinkServiceConfigurators == null) {
+            this.identityLinkServiceConfigurators = new ArrayList<>();
+        }
+        this.identityLinkServiceConfigurators.add(configurator);
+        return this;
+    }
+
     public EntityLinkServiceConfiguration getEntityLinkServiceConfiguration() {
         return entityLinkServiceConfiguration;
     }
 
     public CmmnEngineConfiguration setEntityLinkServiceConfiguration(EntityLinkServiceConfiguration entityLinkServiceConfiguration) {
         this.entityLinkServiceConfiguration = entityLinkServiceConfiguration;
+        return this;
+    }
+
+    public Collection<ServiceConfigurator<EntityLinkServiceConfiguration>> getEntityLinkServiceConfigurators() {
+        return entityLinkServiceConfigurators;
+    }
+
+    public CmmnEngineConfiguration setEntityLinkServiceConfigurators(
+                    Collection<ServiceConfigurator<EntityLinkServiceConfiguration>> entityLinkServiceConfigurators) {
+        this.entityLinkServiceConfigurators = entityLinkServiceConfigurators;
+        return this;
+    }
+
+    public CmmnEngineConfiguration addEntityLinkServiceConfigurator(ServiceConfigurator<EntityLinkServiceConfiguration> configurator) {
+        if (this.entityLinkServiceConfigurators == null) {
+            this.entityLinkServiceConfigurators = new ArrayList<>();
+        }
+        this.entityLinkServiceConfigurators.add(configurator);
         return this;
     }
 
@@ -2915,12 +2962,48 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
         return this;
     }
 
+    public Collection<ServiceConfigurator<VariableServiceConfiguration>> getVariableServiceConfigurators() {
+        return variableServiceConfigurators;
+    }
+
+    public CmmnEngineConfiguration setVariableServiceConfigurators(Collection<ServiceConfigurator<VariableServiceConfiguration>> variableServiceConfigurators) {
+        this.variableServiceConfigurators = variableServiceConfigurators;
+        return this;
+    }
+
+    public CmmnEngineConfiguration addVariableServiceConfigurator(ServiceConfigurator<VariableServiceConfiguration> configurator) {
+        if (this.variableServiceConfigurators == null) {
+            this.variableServiceConfigurators = new ArrayList<>();
+        }
+
+        this.variableServiceConfigurators.add(configurator);
+        return this;
+    }
+
     public TaskServiceConfiguration getTaskServiceConfiguration() {
         return taskServiceConfiguration;
     }
 
     public CmmnEngineConfiguration setTaskServiceConfiguration(TaskServiceConfiguration taskServiceConfiguration) {
         this.taskServiceConfiguration = taskServiceConfiguration;
+        return this;
+    }
+
+    public Collection<ServiceConfigurator<TaskServiceConfiguration>> getTaskServiceConfigurators() {
+        return taskServiceConfigurators;
+    }
+
+    public CmmnEngineConfiguration setTaskServiceConfigurators(Collection<ServiceConfigurator<TaskServiceConfiguration>> taskServiceConfigurators) {
+        this.taskServiceConfigurators = taskServiceConfigurators;
+        return this;
+    }
+
+    public CmmnEngineConfiguration addTaskServiceConfigurator(ServiceConfigurator<TaskServiceConfiguration> configurator) {
+        if (this.taskServiceConfigurators == null) {
+            this.taskServiceConfigurators = new ArrayList<>();
+        }
+
+        this.taskServiceConfigurators.add(configurator);
         return this;
     }
 
@@ -2957,6 +3040,25 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     public CmmnEngineConfiguration setBatchServiceConfiguration(BatchServiceConfiguration batchServiceConfiguration) {
         this.batchServiceConfiguration = batchServiceConfiguration;
+        return this;
+    }
+
+    public Collection<ServiceConfigurator<BatchServiceConfiguration>> getBatchServiceConfigurators() {
+        return batchServiceConfigurators;
+    }
+
+    public CmmnEngineConfiguration setBatchServiceConfigurators(Collection<ServiceConfigurator<BatchServiceConfiguration>> batchServiceConfigurators) {
+        this.batchServiceConfigurators = batchServiceConfigurators;
+        return this;
+    }
+
+    public CmmnEngineConfiguration addBatchServiceConfigurator(
+                    ServiceConfigurator<BatchServiceConfiguration> configurator) {
+        if (this.batchServiceConfigurators == null) {
+            this.batchServiceConfigurators = new ArrayList<>();
+        }
+
+        this.batchServiceConfigurators.add(configurator);
         return this;
     }
 
@@ -3968,6 +4070,26 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     public CmmnEngineConfiguration setEventSubscriptionServiceConfiguration(EventSubscriptionServiceConfiguration eventSubscriptionServiceConfiguration) {
         this.eventSubscriptionServiceConfiguration = eventSubscriptionServiceConfiguration;
+        return this;
+    }
+
+    public Collection<ServiceConfigurator<EventSubscriptionServiceConfiguration>> getEventSubscriptionServiceConfigurators() {
+        return eventSubscriptionServiceConfigurators;
+    }
+
+    public CmmnEngineConfiguration setEventSubscriptionServiceConfigurators(
+                    Collection<ServiceConfigurator<EventSubscriptionServiceConfiguration>> eventSubscriptionServiceConfigurators) {
+        this.eventSubscriptionServiceConfigurators = eventSubscriptionServiceConfigurators;
+        return this;
+    }
+
+    public CmmnEngineConfiguration addEventSubscriptionServiceConfigurator(
+                    ServiceConfigurator<EventSubscriptionServiceConfiguration> configurator) {
+        if (this.eventSubscriptionServiceConfigurators == null) {
+            this.eventSubscriptionServiceConfigurators = new ArrayList<>();
+        }
+
+        this.eventSubscriptionServiceConfigurators.add(configurator);
         return this;
     }
 

--- a/modules/flowable-engine-common/src/test/java/org/flowable/common/engine/impl/ServiceConfiguratorTest.java
+++ b/modules/flowable-engine-common/src/test/java/org/flowable/common/engine/impl/ServiceConfiguratorTest.java
@@ -1,0 +1,139 @@
+package org.flowable.common.engine.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+public class ServiceConfiguratorTest {
+
+    @Test
+    public void testNoServiceConfigurators() {
+        AtomicBoolean beforeInit = new AtomicBoolean(false);
+        AtomicBoolean afterInit = new AtomicBoolean(false);
+
+        TestServiceConfiguration serviceConfig = new TestServiceConfiguration("test");
+        serviceConfig.init();
+
+        assertThat(beforeInit.get()).isFalse();
+        assertThat(afterInit.get()).isFalse();
+    }
+
+    @Test
+    public void testSetServiceConfigurators() {
+        AtomicBoolean beforeInit = new AtomicBoolean(false);
+        AtomicBoolean afterInit = new AtomicBoolean(false);
+
+        TestServiceConfiguration serviceConfig = new TestServiceConfiguration("test");
+        serviceConfig.setConfigurators(List.of(new ServiceConfigurator<TestServiceConfiguration>() {
+
+            @Override
+            public void beforeInit(TestServiceConfiguration service) {
+                beforeInit.set(true);
+            }
+
+            @Override
+            public void afterInit(TestServiceConfiguration service) {
+                afterInit.set(true);
+            }
+        }));
+
+        serviceConfig.init();
+
+        assertThat(beforeInit.get()).isTrue();
+        assertThat(afterInit.get()).isTrue();
+    }
+
+    @Test
+    public void testAddServiceConfigurators() {
+        AtomicBoolean beforeInit = new AtomicBoolean(false);
+        AtomicBoolean afterInit = new AtomicBoolean(false);
+
+        TestServiceConfiguration serviceConfig = new TestServiceConfiguration("test");
+        serviceConfig.addConfigurator(new ServiceConfigurator<TestServiceConfiguration>() {
+
+            @Override
+            public void beforeInit(TestServiceConfiguration service) {
+                beforeInit.set(true);
+            }
+
+            @Override
+            public void afterInit(TestServiceConfiguration service) {
+                afterInit.set(true);
+            }
+        });
+
+        serviceConfig.init();
+        assertThat(beforeInit.get()).isTrue();
+        assertThat(afterInit.get()).isTrue();
+    }
+
+    @Test
+    public void testOrderServiceConfigurators() {
+
+        AtomicBoolean beforeInit = new AtomicBoolean(false);
+        AtomicBoolean afterInit = new AtomicBoolean(false);
+
+        TestServiceConfiguration serviceConfig = new TestServiceConfiguration("test");
+
+        serviceConfig.addConfigurator(new ServiceConfigurator<TestServiceConfiguration>() {
+
+            @Override
+            public void beforeInit(TestServiceConfiguration service) {
+                beforeInit.set(true);
+            }
+
+            @Override
+            public void afterInit(TestServiceConfiguration service) {
+                afterInit.set(true);
+            }
+
+            @Override
+            public int getPriority() {
+                return 2;
+            }
+        });
+
+        serviceConfig.addConfigurator(new ServiceConfigurator<TestServiceConfiguration>() {
+
+            @Override
+            public void beforeInit(TestServiceConfiguration service) {
+                beforeInit.set(false);
+            }
+
+            @Override
+            public void afterInit(TestServiceConfiguration service) {
+                afterInit.set(false);
+            }
+
+            @Override
+            public int getPriority() {
+                return 1;
+            }
+        });
+
+        serviceConfig.init();
+        assertThat(beforeInit.get()).isTrue();
+        assertThat(afterInit.get()).isTrue();
+    }
+
+    private static class TestServiceConfiguration extends AbstractServiceConfiguration<TestServiceConfiguration> {
+
+        public TestServiceConfiguration(String engineName) {
+            super(engineName);
+        }
+
+        @Override
+        protected TestServiceConfiguration getService() {
+            return this;
+        }
+
+        public void init() {
+            configuratorsBeforeInit();
+            configuratorsAfterInit();
+        }
+
+    }
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -529,13 +528,19 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected DecisionTableVariableManager decisionTableVariableManager;
 
     protected VariableServiceConfiguration variableServiceConfiguration;
+    protected Collection<ServiceConfigurator<VariableServiceConfiguration>> variableServiceConfigurators;
     protected IdentityLinkServiceConfiguration identityLinkServiceConfiguration;
+    protected Collection<ServiceConfigurator<IdentityLinkServiceConfiguration>> identityLinkServiceConfigurators;
     protected EntityLinkServiceConfiguration entityLinkServiceConfiguration;
+    protected Collection<ServiceConfigurator<EntityLinkServiceConfiguration>> entityLinkServiceConfigurators;
     protected EventSubscriptionServiceConfiguration eventSubscriptionServiceConfiguration;
+    protected Collection<ServiceConfigurator<EventSubscriptionServiceConfiguration>> eventSubscriptionServiceConfigurators;
     protected TaskServiceConfiguration taskServiceConfiguration;
+    protected Collection<ServiceConfigurator<TaskServiceConfiguration>> taskServiceConfigurators;
     protected JobServiceConfiguration jobServiceConfiguration;
     protected Collection<ServiceConfigurator<JobServiceConfiguration>> jobServiceConfigurators;
     protected BatchServiceConfiguration batchServiceConfiguration;
+    protected Collection<ServiceConfigurator<BatchServiceConfiguration>> batchServiceConfigurators;
 
     protected boolean enableEntityLinks;
 
@@ -1416,6 +1421,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.variableServiceConfiguration.setMaxLengthString(this.getMaxLengthString());
         this.variableServiceConfiguration.setSerializableVariableTypeTrackDeserializedObjects(this.isSerializableVariableTypeTrackDeserializedObjects());
         this.variableServiceConfiguration.setLoggingSessionEnabled(isLoggingSessionEnabled());
+        this.variableServiceConfiguration.setConfigurators(variableServiceConfigurators);
     }
 
     public void initVariableServiceConfiguration() {
@@ -1440,6 +1446,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.identityLinkServiceConfiguration.setEventDispatcher(this.eventDispatcher);
         this.identityLinkServiceConfiguration.setIdentityLinkEventHandler(this.identityLinkEventHandler);
 
+        this.identityLinkServiceConfiguration.setConfigurators(this.identityLinkServiceConfigurators);
         this.identityLinkServiceConfiguration.init();
 
         addServiceConfiguration(EngineConfigurationConstants.KEY_IDENTITY_LINK_SERVICE_CONFIG, this.identityLinkServiceConfiguration);
@@ -1458,6 +1465,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             this.entityLinkServiceConfiguration.setObjectMapper(this.objectMapper);
             this.entityLinkServiceConfiguration.setEventDispatcher(this.eventDispatcher);
 
+            this.entityLinkServiceConfiguration.setConfigurators(this.entityLinkServiceConfigurators);
             this.entityLinkServiceConfiguration.init();
 
             addServiceConfiguration(EngineConfigurationConstants.KEY_ENTITY_LINK_SERVICE_CONFIG, this.entityLinkServiceConfiguration);
@@ -1475,9 +1483,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.eventSubscriptionServiceConfiguration.setObjectMapper(this.objectMapper);
         this.eventSubscriptionServiceConfiguration.setEventDispatcher(this.eventDispatcher);
         this.eventSubscriptionServiceConfiguration.setEventSubscriptionLockTime(this.eventRegistryUniqueProcessInstanceStartLockTime);
-        
+
+        this.eventSubscriptionServiceConfiguration.setConfigurators(this.eventSubscriptionServiceConfigurators);
         this.eventSubscriptionServiceConfiguration.init();
-        
+
         addServiceConfiguration(EngineConfigurationConstants.KEY_EVENT_SUBSCRIPTION_SERVICE_CONFIG, this.eventSubscriptionServiceConfiguration);
     }
     
@@ -1528,7 +1537,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.taskServiceConfiguration.setEnableLocalization(this.performanceSettings.isEnableLocalization());
         this.taskServiceConfiguration.setTaskQueryInterceptor(this.taskQueryInterceptor);
         this.taskServiceConfiguration.setHistoricTaskQueryInterceptor(this.historicTaskQueryInterceptor);
-
+        
+        this.taskServiceConfiguration.setConfigurators(this.taskServiceConfigurators);
         this.taskServiceConfiguration.init();
 
         if (dbSqlSessionFactory != null && taskServiceConfiguration.getTaskDataManager() instanceof AbstractDataManager) {
@@ -1657,6 +1667,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             this.batchServiceConfiguration.setObjectMapper(this.objectMapper);
             this.batchServiceConfiguration.setEventDispatcher(this.eventDispatcher);
 
+            this.batchServiceConfiguration.setConfigurators(this.batchServiceConfigurators);
             this.batchServiceConfiguration.init();
         }
 
@@ -3073,12 +3084,48 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return this;
     }
 
+    public Collection<ServiceConfigurator<IdentityLinkServiceConfiguration>> getIdentityLinkServiceConfigurators() {
+        return identityLinkServiceConfigurators;
+    }
+
+    public ProcessEngineConfigurationImpl setIdentityLinkServiceConfigurators(
+                    Collection<ServiceConfigurator<IdentityLinkServiceConfiguration>> identityLinkServiceConfigurators) {
+        this.identityLinkServiceConfigurators = identityLinkServiceConfigurators;
+        return this;
+    }
+
+    public ProcessEngineConfigurationImpl addIdentityLinkServiceConfigurator(ServiceConfigurator<IdentityLinkServiceConfiguration> configurator) {
+        if (this.identityLinkServiceConfigurators == null) {
+            this.identityLinkServiceConfigurators = new ArrayList<>();
+        }
+        this.identityLinkServiceConfigurators.add(configurator);
+        return this;
+    }
+
     public EntityLinkServiceConfiguration getEntityLinkServiceConfiguration() {
         return entityLinkServiceConfiguration;
     }
 
     public ProcessEngineConfigurationImpl setEntityLinkServiceConfiguration(EntityLinkServiceConfiguration entityLinkServiceConfiguration) {
         this.entityLinkServiceConfiguration = entityLinkServiceConfiguration;
+        return this;
+    }
+
+    public Collection<ServiceConfigurator<EntityLinkServiceConfiguration>> getEntityLinkServiceConfigurators() {
+        return entityLinkServiceConfigurators;
+    }
+
+    public ProcessEngineConfigurationImpl setEntityLinkServiceConfigurators(
+                    Collection<ServiceConfigurator<EntityLinkServiceConfiguration>> entityLinkServiceConfigurators) {
+        this.entityLinkServiceConfigurators = entityLinkServiceConfigurators;
+        return this;
+    }
+
+    public ProcessEngineConfigurationImpl addEntityLinkServiceConfigurator(ServiceConfigurator<EntityLinkServiceConfiguration> configurator) {
+        if (this.entityLinkServiceConfigurators == null) {
+            this.entityLinkServiceConfigurators = new ArrayList<>();
+        }
+        this.entityLinkServiceConfigurators.add(configurator);
         return this;
     }
 
@@ -3091,8 +3138,44 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return this;
     }
 
+    public Collection<ServiceConfigurator<TaskServiceConfiguration>> getTaskServiceConfigurators() {
+        return taskServiceConfigurators;
+    }
+
+    public ProcessEngineConfigurationImpl setTaskServiceConfigurators(Collection<ServiceConfigurator<TaskServiceConfiguration>> taskServiceConfigurators) {
+        this.taskServiceConfigurators = taskServiceConfigurators;
+        return this;
+    }
+
+    public ProcessEngineConfigurationImpl addTaskServiceConfigurator(ServiceConfigurator<TaskServiceConfiguration> configurator) {
+        if (this.taskServiceConfigurators == null) {
+            this.taskServiceConfigurators = new ArrayList<>();
+        }
+
+        this.taskServiceConfigurators.add(configurator);
+        return this;
+    }
+
     public ProcessEngineConfigurationImpl setVariableServiceConfiguration(VariableServiceConfiguration variableServiceConfiguration) {
         this.variableServiceConfiguration = variableServiceConfiguration;
+        return this;
+    }
+
+    public Collection<ServiceConfigurator<VariableServiceConfiguration>> getVariableServiceConfigurators() {
+        return variableServiceConfigurators;
+    }
+
+    public ProcessEngineConfigurationImpl setVariableServiceConfigurators(Collection<ServiceConfigurator<VariableServiceConfiguration>> variableServiceConfigurators) {
+        this.variableServiceConfigurators = variableServiceConfigurators;
+        return this;
+    }
+
+    public ProcessEngineConfigurationImpl addVariableServiceConfigurator(ServiceConfigurator<VariableServiceConfiguration> configurator) {
+        if (this.variableServiceConfigurators == null) {
+            this.variableServiceConfigurators = new ArrayList<>();
+        }
+
+        this.variableServiceConfigurators.add(configurator);
         return this;
     }
 
@@ -5397,12 +5480,51 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return this;
     }
 
+    public Collection<ServiceConfigurator<BatchServiceConfiguration>> getBatchServiceConfigurators() {
+        return batchServiceConfigurators;
+    }
+
+    public ProcessEngineConfigurationImpl setBatchServiceConfigurators(Collection<ServiceConfigurator<BatchServiceConfiguration>> batchServiceConfigurators) {
+        this.batchServiceConfigurators = batchServiceConfigurators;
+        return this;
+    }
+
+    public ProcessEngineConfigurationImpl addBatchServiceConfigurator(
+                    ServiceConfigurator<BatchServiceConfiguration> configurator) {
+        if (this.batchServiceConfigurators == null) {
+            this.batchServiceConfigurators = new ArrayList<>();
+        }
+
+        this.batchServiceConfigurators.add(configurator);
+        return this;
+    }
+
     public EventSubscriptionServiceConfiguration getEventSubscriptionServiceConfiguration() {
         return eventSubscriptionServiceConfiguration;
     }
 
     public ProcessEngineConfigurationImpl setEventSubscriptionServiceConfiguration(EventSubscriptionServiceConfiguration eventSubscriptionServiceConfiguration) {
         this.eventSubscriptionServiceConfiguration = eventSubscriptionServiceConfiguration;
+        return this;
+    }
+
+    public Collection<ServiceConfigurator<EventSubscriptionServiceConfiguration>> getEventSubscriptionServiceConfigurators() {
+        return eventSubscriptionServiceConfigurators;
+    }
+
+    public ProcessEngineConfigurationImpl setEventSubscriptionServiceConfigurators(
+                    Collection<ServiceConfigurator<EventSubscriptionServiceConfiguration>> eventSubscriptionServiceConfigurators) {
+        this.eventSubscriptionServiceConfigurators = eventSubscriptionServiceConfigurators;
+        return this;
+    }
+
+    public ProcessEngineConfigurationImpl addEventSubscriptionServiceConfigurator(
+                    ServiceConfigurator<EventSubscriptionServiceConfiguration> configurator) {
+        if (this.eventSubscriptionServiceConfigurators == null) {
+            this.eventSubscriptionServiceConfigurators = new ArrayList<>();
+        }
+
+        this.eventSubscriptionServiceConfigurators.add(configurator);
         return this;
     }
 

--- a/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/EntityLinkServiceConfiguration.java
+++ b/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/EntityLinkServiceConfiguration.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * @author Tijs Rademakers
  */
-public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration {
+public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration<EntityLinkServiceConfiguration> {
 
     // SERVICES
     // /////////////////////////////////////////////////////////////////
@@ -46,26 +46,35 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
     protected HistoricEntityLinkDataManager historicEntityLinkDataManager;
 
     // ENTITY MANAGERS /////////////////////////////////////////////////
-    
+
     protected EntityLinkEntityManager entityLinkEntityManager;
     protected HistoricEntityLinkEntityManager historicEntityLinkEntityManager;
-    
+
     protected HistoryLevel historyLevel;
-    
+
     protected ObjectMapper objectMapper;
-    
+
     public EntityLinkServiceConfiguration(String engineName) {
         super(engineName);
+    }
+
+    @Override
+    protected EntityLinkServiceConfiguration getService() {
+        return this;
     }
 
     // init
     // /////////////////////////////////////////////////////////////////////
 
     public void init() {
+        configuratorsBeforeInit();
+
         initDataManagers();
         initEntityManagers();
+
+        configuratorsAfterInit();
     }
-    
+
     @Override
     public boolean isHistoryLevelAtLeast(HistoryLevel level) {
         if (logger.isDebugEnabled()) {
@@ -110,7 +119,7 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
     public EntityLinkServiceConfiguration getIdentityLinkServiceConfiguration() {
         return this;
     }
-    
+
     public EntityLinkService getEntityLinkService() {
         return entityLinkService;
     }
@@ -119,7 +128,7 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
         this.entityLinkService = entityLinkService;
         return this;
     }
-    
+
     public HistoricEntityLinkService getHistoricEntityLinkService() {
         return historicEntityLinkService;
     }
@@ -137,7 +146,7 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
         this.entityLinkDataManager = entityLinkDataManager;
         return this;
     }
-    
+
     public HistoricEntityLinkDataManager getHistoricEntityLinkDataManager() {
         return historicEntityLinkDataManager;
     }
@@ -155,7 +164,7 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
         this.entityLinkEntityManager = entityLinkEntityManager;
         return this;
     }
-    
+
     public HistoricEntityLinkEntityManager getHistoricEntityLinkEntityManager() {
         return historicEntityLinkEntityManager;
     }
@@ -164,18 +173,18 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
         this.historicEntityLinkEntityManager = historicEntityLinkEntityManager;
         return this;
     }
-    
+
     @Override
     public HistoryLevel getHistoryLevel() {
         return historyLevel;
     }
-    
+
     @Override
     public EntityLinkServiceConfiguration setHistoryLevel(HistoryLevel historyLevel) {
         this.historyLevel = historyLevel;
         return this;
     }
-    
+
     @Override
     public ObjectMapper getObjectMapper() {
         return objectMapper;

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/EventSubscriptionServiceConfiguration.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/EventSubscriptionServiceConfiguration.java
@@ -27,21 +27,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * @author Tijs Rademakers
  */
-public class EventSubscriptionServiceConfiguration extends AbstractServiceConfiguration {
+public class EventSubscriptionServiceConfiguration extends AbstractServiceConfiguration<EventSubscriptionServiceConfiguration> {
 
     // SERVICES
     // /////////////////////////////////////////////////////////////////
 
     protected EventSubscriptionService eventSubscriptionService = new EventSubscriptionServiceImpl(this);
-   
+
     // DATA MANAGERS
     // /////////////////////////////////////////////////
 
     protected EventSubscriptionDataManager eventSubscriptionDataManager;
-    
+
     // ENTITY MANAGERS
     // ///////////////////////////////////////////////
-    
+
     protected EventSubscriptionEntityManager eventSubscriptionEntityManager;
 
     // LOCKING
@@ -57,19 +57,28 @@ public class EventSubscriptionServiceConfiguration extends AbstractServiceConfig
      * The value that should be used when locking eventsubscriptions.
      */
     private String lockOwner = UUID.randomUUID().toString();
-    
+
     protected ObjectMapper objectMapper;
-    
+
     public EventSubscriptionServiceConfiguration(String engineName) {
         super(engineName);
+    }
+
+    @Override
+    protected EventSubscriptionServiceConfiguration getService() {
+        return this;
     }
 
     // init
     // /////////////////////////////////////////////////////////////////////
 
     public void init() {
+        configuratorsBeforeInit();
+
         initDataManagers();
         initEntityManagers();
+
+        configuratorsAfterInit();
     }
 
     // Data managers
@@ -93,7 +102,7 @@ public class EventSubscriptionServiceConfiguration extends AbstractServiceConfig
     public EventSubscriptionServiceConfiguration getIdentityLinkServiceConfiguration() {
         return this;
     }
-    
+
     public EventSubscriptionService getEventSubscriptionService() {
         return eventSubscriptionService;
     }
@@ -102,7 +111,7 @@ public class EventSubscriptionServiceConfiguration extends AbstractServiceConfig
         this.eventSubscriptionService = eventSubscriptionService;
         return this;
     }
-    
+
     public EventSubscriptionDataManager getEventSubscriptionDataManager() {
         return eventSubscriptionDataManager;
     }
@@ -111,7 +120,7 @@ public class EventSubscriptionServiceConfiguration extends AbstractServiceConfig
         this.eventSubscriptionDataManager = eventSubscriptionDataManager;
         return this;
     }
-    
+
     public EventSubscriptionEntityManager getEventSubscriptionEntityManager() {
         return eventSubscriptionEntityManager;
     }
@@ -120,7 +129,7 @@ public class EventSubscriptionServiceConfiguration extends AbstractServiceConfig
         this.eventSubscriptionEntityManager = eventSubscriptionEntityManager;
         return this;
     }
-    
+
     @Override
     public ObjectMapper getObjectMapper() {
         return objectMapper;

--- a/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/IdentityLinkServiceConfiguration.java
+++ b/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/IdentityLinkServiceConfiguration.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * @author Tijs Rademakers
  */
-public class IdentityLinkServiceConfiguration extends AbstractServiceConfiguration {
+public class IdentityLinkServiceConfiguration extends AbstractServiceConfiguration<IdentityLinkServiceConfiguration> {
 
     // SERVICES
     // /////////////////////////////////////////////////////////////////
@@ -58,13 +58,22 @@ public class IdentityLinkServiceConfiguration extends AbstractServiceConfigurati
     public IdentityLinkServiceConfiguration(String engineName) {
         super(engineName);
     }
+    
+    @Override
+    protected IdentityLinkServiceConfiguration getService() {
+        return this;
+    }
 
     // init
     // /////////////////////////////////////////////////////////////////////
 
     public void init() {
+        configuratorsBeforeInit();
+
         initDataManagers();
         initEntityManagers();
+
+        configuratorsAfterInit();
     }
     
     @Override

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/JobServiceConfiguration.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/JobServiceConfiguration.java
@@ -13,15 +13,12 @@
 package org.flowable.job.service;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.flowable.common.engine.impl.AbstractServiceConfiguration;
-import org.flowable.common.engine.impl.ServiceConfigurator;
 import org.flowable.common.engine.impl.calendar.BusinessCalendarManager;
 import org.flowable.common.engine.impl.el.ExpressionManager;
 import org.flowable.common.engine.impl.history.HistoryLevel;
@@ -64,12 +61,12 @@ import org.flowable.job.service.impl.persistence.entity.data.impl.MybatisTimerJo
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * This service configuration contains all settings and instances around job execution and management.
- * Note that a {@link JobServiceConfiguration} is not shared between engines and instantiated for each engine.
+ * This service configuration contains all settings and instances around job execution and management. Note that a {@link JobServiceConfiguration} is
+ * not shared between engines and instantiated for each engine.
  * 
  * @author Tijs Rademakers
  */
-public class JobServiceConfiguration extends AbstractServiceConfiguration {
+public class JobServiceConfiguration extends AbstractServiceConfiguration<JobServiceConfiguration> {
 
     public static final String JOB_EXECUTION_SCOPE_ALL = "all";
     public static final String JOB_EXECUTION_SCOPE_CMMN = "cmmn";
@@ -84,7 +81,6 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
     protected JobManager jobManager;
 
     protected TimerJobScheduler timerJobScheduler;
-    protected Collection<ServiceConfigurator<JobServiceConfiguration>> configurators;
 
     // DATA MANAGERS ///////////////////////////////////////////////////
 
@@ -116,50 +112,43 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
     protected AsyncExecutor asyncExecutor;
     protected int asyncExecutorNumberOfRetries;
     protected int asyncExecutorResetExpiredJobsMaxTimeout;
-    
+
     protected String jobExecutionScope;
     protected Map<String, JobHandler> jobHandlers;
     protected FailedJobCommandFactory failedJobCommandFactory;
     protected List<AsyncRunnableExecutionExceptionHandler> asyncRunnableExecutionExceptionHandlers;
     protected List<JobProcessor> jobProcessors;
-    
+
     protected List<String> enabledJobCategories;
-    
+
     protected AsyncExecutor asyncHistoryExecutor;
     protected int asyncHistoryExecutorNumberOfRetries;
     protected String historyJobExecutionScope;
-    
+
     protected Map<String, HistoryJobHandler> historyJobHandlers;
     protected List<HistoryJobProcessor> historyJobProcessors;
-    
+
     public JobServiceConfiguration(String engineName) {
         super(engineName);
+    }
+
+    @Override
+    protected JobServiceConfiguration getService() {
+        return this;
     }
 
     // init
     // /////////////////////////////////////////////////////////////////////
 
     public void init() {
-        List<ServiceConfigurator<JobServiceConfiguration>> configurators;
-        if (this.configurators != null) {
-            configurators = new ArrayList<>(this.configurators);
-            configurators.sort(Comparator.comparingInt(ServiceConfigurator::getPriority));
-        } else {
-            configurators = Collections.emptyList();
-        }
-
-        for (ServiceConfigurator<JobServiceConfiguration> configurator : configurators) {
-            configurator.beforeInit(this);
-        }
+        configuratorsBeforeInit();
 
         initTimerJobScheduler();
         initJobManager();
         initDataManagers();
         initEntityManagers();
 
-        for (ServiceConfigurator<JobServiceConfiguration> configurator : configurators) {
-            configurator.afterInit(this);
-        }
+        configuratorsAfterInit();
     }
 
     @Override
@@ -290,14 +279,6 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
         this.timerJobScheduler = timerJobScheduler;
     }
 
-    public Collection<ServiceConfigurator<JobServiceConfiguration>> getConfigurators() {
-        return configurators;
-    }
-
-    public void setConfigurators(Collection<ServiceConfigurator<JobServiceConfiguration>> configurators) {
-        this.configurators = configurators;
-    }
-
     public JobDataManager getJobDataManager() {
         return jobDataManager;
     }
@@ -421,7 +402,7 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
     public void setInternalJobManager(InternalJobManager internalJobManager) {
         this.internalJobManager = internalJobManager;
     }
-    
+
     public InternalJobCompatibilityManager getInternalJobCompatibilityManager() {
         return internalJobCompatibilityManager;
     }
@@ -438,7 +419,7 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
         this.asyncExecutor = asyncExecutor;
         return this;
     }
-    
+
     public AsyncExecutor getAsyncHistoryExecutor() {
         return asyncHistoryExecutor;
     }
@@ -447,7 +428,7 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
         this.asyncHistoryExecutor = asyncHistoryExecutor;
         return this;
     }
-    
+
     public int getAsyncHistoryExecutorNumberOfRetries() {
         return asyncHistoryExecutorNumberOfRetries;
     }
@@ -465,7 +446,7 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
         this.jobExecutionScope = jobExecutionScope;
         return this;
     }
-    
+
     public String getHistoryJobExecutionScope() {
         return historyJobExecutionScope;
     }
@@ -501,7 +482,7 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
         this.jobHandlers = jobHandlers;
         return this;
     }
-    
+
     public JobServiceConfiguration addJobHandler(String type, JobHandler jobHandler) {
         if (this.jobHandlers == null) {
             this.jobHandlers = new HashMap<>();
@@ -536,7 +517,7 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
         this.historyJobHandlers = historyJobHandlers;
         return this;
     }
-    
+
     public JobServiceConfiguration addHistoryJobHandler(String type, HistoryJobHandler historyJobHandler) {
         if (this.historyJobHandlers == null) {
             this.historyJobHandlers = new HashMap<>();
@@ -599,7 +580,7 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
     public InternalJobParentStateResolver getJobParentStateResolver() {
         return jobParentStateResolver;
     }
-    
+
     public List<String> getEnabledJobCategories() {
         return enabledJobCategories;
     }
@@ -612,7 +593,7 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration {
         if (enabledJobCategories == null) {
             enabledJobCategories = new ArrayList<>();
         }
-        
+
         enabledJobCategories.add(jobCategory);
     }
 

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/TaskServiceConfiguration.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/TaskServiceConfiguration.java
@@ -37,7 +37,7 @@ import org.flowable.task.service.impl.persistence.entity.data.impl.MyBatisHistor
 import org.flowable.task.service.impl.persistence.entity.data.impl.MybatisHistoricTaskInstanceDataManager;
 import org.flowable.task.service.impl.persistence.entity.data.impl.MybatisTaskDataManager;
 
-public class TaskServiceConfiguration extends AbstractServiceConfiguration {
+public class TaskServiceConfiguration extends AbstractServiceConfiguration<TaskServiceConfiguration> {
 
     public static final String DEFAULT_MYBATIS_MAPPING_FILE = "org/flowable/task/service/db/mapping/mappings.xml";
 
@@ -46,7 +46,7 @@ public class TaskServiceConfiguration extends AbstractServiceConfiguration {
 
     protected TaskService taskService = new TaskServiceImpl(this);
     protected HistoricTaskService historicTaskService = new HistoricTaskServiceImpl(this);
-    
+
     protected IdmIdentityService idmIdentityService;
 
     // DATA MANAGERS ///////////////////////////////////////////////////
@@ -64,10 +64,10 @@ public class TaskServiceConfiguration extends AbstractServiceConfiguration {
     protected InternalHistoryTaskManager internalHistoryTaskManager;
     protected InternalTaskLocalizationManager internalTaskLocalizationManager;
     protected InternalTaskAssignmentManager internalTaskAssignmentManager;
-    
+
     protected boolean enableTaskRelationshipCounts;
     protected boolean enableLocalization;
-    
+
     protected TaskQueryInterceptor taskQueryInterceptor;
     protected HistoricTaskQueryInterceptor historicTaskQueryInterceptor;
 
@@ -75,18 +75,27 @@ public class TaskServiceConfiguration extends AbstractServiceConfiguration {
 
     // Events
     protected boolean enableHistoricTaskLogging;
-    
+
     public TaskServiceConfiguration(String engineName) {
         super(engineName);
+    }
+
+    @Override
+    protected TaskServiceConfiguration getService() {
+        return this;
     }
 
     // init
     // /////////////////////////////////////////////////////////////////////
 
     public void init() {
+        configuratorsBeforeInit();
+
         initDataManagers();
         initEntityManagers();
         initTaskPostProcessor();
+
+        configuratorsAfterInit();
     }
 
     // Data managers
@@ -130,7 +139,7 @@ public class TaskServiceConfiguration extends AbstractServiceConfiguration {
         this.taskService = taskService;
         return this;
     }
-    
+
     public HistoricTaskService getHistoricTaskService() {
         return historicTaskService;
     }

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/VariableServiceConfiguration.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/VariableServiceConfiguration.java
@@ -32,7 +32,7 @@ import org.flowable.variable.service.impl.persistence.entity.data.impl.MybatisVa
 /**
  * @author Tijs Rademakers
  */
-public class VariableServiceConfiguration extends AbstractServiceConfiguration {
+public class VariableServiceConfiguration extends AbstractServiceConfiguration<VariableServiceConfiguration> {
 
     public static final int DEFAULT_GENERIC_MAX_LENGTH_STRING = 4000;
     public static final int DEFAULT_ORACLE_MAX_LENGTH_STRING = 2000;
@@ -49,7 +49,7 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
     protected HistoricVariableInstanceDataManager historicVariableInstanceDataManager;
 
     // ENTITY MANAGERS /////////////////////////////////////////////////
-    
+
     protected VariableInstanceEntityManager variableInstanceEntityManager;
     protected HistoricVariableInstanceEntityManager historicVariableInstanceEntityManager;
     protected VariableTypes variableTypes;
@@ -62,23 +62,32 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
 
     /**
      * This flag determines whether variables of the type 'serializable' will be tracked. This means that, when true, in a JavaDelegate you can write
-     * MySerializableVariable myVariable = (MySerializableVariable) execution.getVariable("myVariable"); myVariable.setNumber(123);
-     * And the changes to the java object will be reflected in the database. Otherwise, a manual call to setVariable will be needed.
-     * By default true for backwards compatibility.
+     * MySerializableVariable myVariable = (MySerializableVariable) execution.getVariable("myVariable"); myVariable.setNumber(123); And the changes to
+     * the java object will be reflected in the database. Otherwise, a manual call to setVariable will be needed. By default true for backwards
+     * compatibility.
      */
     protected boolean serializableVariableTypeTrackDeserializedObjects = true;
-    
+
     public VariableServiceConfiguration(String engineName) {
         super(engineName);
+    }
+
+    @Override
+    protected VariableServiceConfiguration getService() {
+        return this;
     }
 
     // init
     // /////////////////////////////////////////////////////////////////////
 
     public void init() {
+        configuratorsBeforeInit();
+
         initDataManagers();
         initEntityManagers();
         initVariableInstanceValueModifier();
+
+        configuratorsAfterInit();
     }
 
     // Data managers
@@ -114,7 +123,7 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
     public VariableServiceConfiguration getVariableServiceConfiguration() {
         return this;
     }
-    
+
     public VariableService getVariableService() {
         return variableService;
     }
@@ -123,7 +132,7 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
         this.variableService = variableService;
         return this;
     }
-    
+
     public HistoricVariableService getHistoricVariableService() {
         return historicVariableService;
     }
@@ -141,7 +150,7 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
         this.variableInstanceDataManager = variableInstanceDataManager;
         return this;
     }
-    
+
     public HistoricVariableInstanceDataManager getHistoricVariableInstanceDataManager() {
         return historicVariableInstanceDataManager;
     }
@@ -159,7 +168,7 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
         this.variableInstanceEntityManager = variableInstanceEntityManager;
         return this;
     }
-    
+
     public HistoricVariableInstanceEntityManager getHistoricVariableInstanceEntityManager() {
         return historicVariableInstanceEntityManager;
     }
@@ -168,16 +177,16 @@ public class VariableServiceConfiguration extends AbstractServiceConfiguration {
         this.historicVariableInstanceEntityManager = historicVariableInstanceEntityManager;
         return this;
     }
-    
+
     public VariableTypes getVariableTypes() {
         return variableTypes;
     }
-    
+
     public VariableServiceConfiguration setVariableTypes(VariableTypes variableTypes) {
         this.variableTypes = variableTypes;
         return this;
     }
-    
+
     public InternalHistoryVariableManager getInternalHistoryVariableManager() {
         return internalHistoryVariableManager;
     }


### PR DESCRIPTION
Add support for ServiceConfigurator to Variable, Task, IdentityLink, EntityLink, EventSubscription and Batch ServiceConfiguration to allow customisation at init time.

The implementation follows the logic of JobServiceConfiguration that already has support for ServiceConfigurator.

#### Check List:
* Unit tests: YES
* Documentation: NA
