### PR TITLE
Update Spring Framework to 6.1.3 due to CVE-2024-22233

### DIFF
--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -221,6 +221,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
             <scope>test</scope>
         </dependency>

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jpa</artifactId>
-            <version>3.0.0</version>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -252,6 +252,18 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <version>3.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.flowable.spring.boot.app.AppEngineAutoConfiguration;
 import org.flowable.spring.boot.app.AppEngineServicesAutoConfiguration;
 import org.flowable.spring.boot.app.FlowableAppProperties;
 import org.flowable.spring.boot.condition.ConditionalOnCmmnEngine;
+import org.flowable.spring.boot.dmn.DmnEngineAutoConfiguration;
 import org.flowable.spring.boot.eventregistry.FlowableEventRegistryProperties;
 import org.flowable.spring.boot.idm.FlowableIdmProperties;
 import org.flowable.spring.job.service.SpringAsyncExecutor;
@@ -88,7 +89,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfiguration(after = {
     AppEngineAutoConfiguration.class,
     ProcessEngineAutoConfiguration.class,
-    TaskExecutionAutoConfiguration.class
+    TaskExecutionAutoConfiguration.class,
+    DmnEngineAutoConfiguration.class,
 }, before = {
     AppEngineServicesAutoConfiguration.class,
     ProcessEngineServicesAutoConfiguration.class

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>3.1.6</spring.boot.version>
-		<spring.framework.version>6.0.14</spring.framework.version>
+		<spring.boot.version>3.2.2</spring.boot.version>
+		<spring.framework.version>6.1.3</spring.framework.version>
 		<spring.security.version>6.1.5</spring.security.version>
 		<spring.amqp.version>3.0.10</spring.amqp.version>
 		<spring.kafka.version>3.0.13</spring.kafka.version>
@@ -150,7 +150,7 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents.client5</groupId>
 				<artifactId>httpclient5</artifactId>
-				<version>5.1.3</version>
+				<version>5.2.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>


### PR DESCRIPTION
root pom:  Framework to 6.1.3 and boot to 3.2.2 as result of Framework upgrade and errors in flowable-rest.
Apache client bumped due to method not found exceptions in flowable-app-rest unit tests.

flowable-rest pom:  Bumped spring data jpa, test and autoconfigure to align with Framework.
FactoryBeanRegistrySupport.getTypeForFactoryBeanFromAttribute() throws IllegalArgumentException if not done.

flowable-http pom: Added spring-context as umping framework required this as the
org.springframework.context.SmartLifecycle was refactored to it.

flowable-spring-boot - AllEnginesAutoConfibgurationTest.usingAllAutoConfigurationsTogetherShouldWorkCorrectly() was failing                       as the Cmmn autoconfigure was being configured before Dmn. The unit test wanted proces, dmn, cmmn.
  I added the dmmn auto config to the Cmmn Auto configs after list.

#### Check List:
* Unit tests: NA- Just made sure they all succeeded. :)
* Documentation: NA
