### PR TITLE
Fix broken OSGi wiring (#3844)

### DIFF
--- a/modules/flowable-batch-service/pom.xml
+++ b/modules/flowable-batch-service/pom.xml
@@ -89,6 +89,9 @@
 		<flowable.osgi.export.additional>
 			org.flowable.batch.service.db.mapping.entity
 		</flowable.osgi.export.additional>
+		<flowable.osgi.import.additional>
+			org.springframework*;resolution:=optional
+		</flowable.osgi.import.additional>
 	</properties>
 
 	<build>

--- a/modules/flowable-entitylink-service/pom.xml
+++ b/modules/flowable-entitylink-service/pom.xml
@@ -94,6 +94,9 @@
 		<flowable.osgi.export.additional>
 			org.flowable.entitylink.service.db.mapping.entity
 		</flowable.osgi.export.additional>
+		<flowable.osgi.import.additional>
+			org.springframework*;resolution:=optional
+		</flowable.osgi.import.additional>
 	</properties>
 
 	<build>

--- a/modules/flowable-eventsubscription-service/pom.xml
+++ b/modules/flowable-eventsubscription-service/pom.xml
@@ -98,6 +98,9 @@
 		<flowable.osgi.export.additional>
 			org.flowable.eventsubscription.service.db.mapping.entity
 		</flowable.osgi.export.additional>
+		<flowable.osgi.import.additional>
+			org.springframework*;resolution:=optional
+		</flowable.osgi.import.additional>
 	</properties>
 
 	<build>

--- a/modules/flowable-identitylink-service/pom.xml
+++ b/modules/flowable-identitylink-service/pom.xml
@@ -94,6 +94,9 @@
 		<flowable.osgi.export.additional>
 			org.flowable.identitylink.service.db.mapping.entity
 		</flowable.osgi.export.additional>
+		<flowable.osgi.import.additional>
+			org.springframework*;resolution:=optional
+		</flowable.osgi.import.additional>
 	</properties>
 
 	<build>

--- a/modules/flowable-job-service/pom.xml
+++ b/modules/flowable-job-service/pom.xml
@@ -104,9 +104,10 @@
 		<flowable.osgi.export.additional>
 			org.flowable.job.service.db.mapping.entity
 		</flowable.osgi.export.additional>
-        <flowable.osgi.import.additional>
-            jakarta.enterprise.concurrent;resolution:=optional,
-        </flowable.osgi.import.additional>
+		<flowable.osgi.import.additional>
+			jakarta.enterprise.concurrent;resolution:=optional,
+			org.springframework*;resolution:=optional
+		</flowable.osgi.import.additional>
 	</properties>
 
 	<build>

--- a/modules/flowable-task-service/pom.xml
+++ b/modules/flowable-task-service/pom.xml
@@ -98,6 +98,9 @@
         <flowable.osgi.export.additional>
             org.flowable.task.service.db.mapping.entity
         </flowable.osgi.export.additional>
+        <flowable.osgi.import.additional>
+            org.springframework*;resolution:=optional
+        </flowable.osgi.import.additional>
     </properties>
 
     <build>

--- a/modules/flowable-variable-service/pom.xml
+++ b/modules/flowable-variable-service/pom.xml
@@ -96,6 +96,7 @@
         </flowable.osgi.export.additional>
         <flowable.osgi.import.additional>
             jakarta.persistence*;resolution:=optional,
+            org.springframework*;resolution:=optional
         </flowable.osgi.import.additional>
     </properties>
 


### PR DESCRIPTION
This PR fixes kind of trivial bug in generated OSGi wiring `Import-Package` metadata (#3844).

If you don't like the global `flowable.osgi.import.defaults` definition, I have a different branch https://github.com/pavelhoral/flowable-engine/tree/fix-osgi-wiring that updates all respective pom.xml files to fix the tests.

#### Check List:

* Unit tests: NA
* Documentation: NA

Fixes #3844
