### PR TITLE
Spring Boot 3.2 and other dependencies upgrade

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -97,32 +97,32 @@ org.apache.httpcomponents       httpclient                  4.5.13          Apac
 org.apache.httpcomponents       httpcore                    4.4.15          Apache License, Version 2.0
 org.apache.httpcomponents       httpmime                    4.5.13          Apache License, Version 2.0
 org.apache.geronimo.bundles     json                        20090211_1      The Apache Software License, Version 2.0
-org.apache.groovy               groovy                      4.0.15          The Apache Software License, Version 2.0
-org.apache.groovy               groovy-jsr223               4.0.15          The Apache Software License, Version 2.0
+org.apache.groovy               groovy                      4.0.17          The Apache Software License, Version 2.0
+org.apache.groovy               groovy-jsr223               4.0.17          The Apache Software License, Version 2.0
 org.eclipse.angus               angus-mail                  2.0.2           EDL 1.0 / EPL 2.0
 org.liquibase                   liquibase-core              4.5.0           Apache License, Version 2.0
 org.mybatis                     mybatis                     3.5.11          The Apache Software License, Version 2.0
 org.mybatis                     mybatis-spring              3.0.0           The Apache Software License, Version 2.0
 org.mvel                        mvel2                       2.2.6.Final     The Apache Software License, Version 2.0
-org.slf4j                       jcl-over-slf4j              2.0.9           MIT License
-org.slf4j                       slf4j-api                   2.0.9           MIT License
-org.slf4j                       slf4j-log4j12               2.0.9           MIT License
-org.springframework             spring-beans                6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-context              6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-context-support      6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-jdbc                 6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-tx                   6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-web                  6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-webmvc               6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-aop                  6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-core                 6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-expression           6.0.14           The Apache Software License, Version 2.0
-org.springframework             spring-orm                  6.0.14           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-config      6.1.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-core        6.1.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-crypto      6.1.5           The Apache Software License, Version 2.0
-org.springframework.security    spring-security-web         6.1.5           The Apache Software License, Version 2.0
+org.slf4j                       jcl-over-slf4j              2.0.11           MIT License
+org.slf4j                       slf4j-api                   2.0.11           MIT License
+org.slf4j                       slf4j-log4j12               2.0.11           MIT License
+org.springframework             spring-beans                6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-context              6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-context-support      6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-jdbc                 6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-tx                   6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-web                  6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-webmvc               6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-aop                  6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-core                 6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-expression           6.1.3           The Apache Software License, Version 2.0
+org.springframework             spring-orm                  6.1.3           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-config      6.2.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-core        6.2.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-crypto      6.2.1           The Apache Software License, Version 2.0
+org.springframework.security    spring-security-web         6.2.1           The Apache Software License, Version 2.0
 org.tinyjee.jgraphx             jgraphx                     1.10.4.1        JGraph Ltd - 3 clause BSD license
 org.yaml                        snakeyaml                   1.17            The Apache Software License, Version 2.0
 xerces                          xercesImpl                  2.12.1          The Apache Software License, Version 2.0

--- a/modules/flowable-event-registry-spring/src/main/java/org/flowable/eventregistry/spring/kafka/KafkaChannelDefinitionProcessor.java
+++ b/modules/flowable-event-registry-spring/src/main/java/org/flowable/eventregistry/spring/kafka/KafkaChannelDefinitionProcessor.java
@@ -84,11 +84,11 @@ import org.springframework.kafka.retrytopic.DefaultDestinationTopicProcessor;
 import org.springframework.kafka.retrytopic.DefaultDestinationTopicResolver;
 import org.springframework.kafka.retrytopic.DestinationTopic;
 import org.springframework.kafka.retrytopic.DestinationTopicProcessor;
-import org.springframework.kafka.retrytopic.FixedDelayStrategy;
 import org.springframework.kafka.retrytopic.ListenerContainerFactoryConfigurer;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.retrytopic.RetryTopicSchedulerWrapper;
+import org.springframework.kafka.retrytopic.SameIntervalTopicReuseStrategy;
 import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
 import org.springframework.kafka.support.Suffixer;
 import org.springframework.kafka.support.TopicPartitionOffset;
@@ -1024,13 +1024,14 @@ public class KafkaChannelDefinitionProcessor implements BeanFactoryAware, Applic
         RetryTopicConfigurationBuilder retryTopicConfigurationBuilder = RetryTopicConfigurationBuilder.newInstance()
                 .autoStartDltHandler(false)
                 .autoCreateTopics(retryConfiguration.autoCreateTopics, retryConfiguration.numPartitions, retryConfiguration.replicationFactor)
-                .dltSuffix(dltTopicSuffix)
                 .retryTopicSuffix(retryTopicSuffix)
-                .useSingleTopicForFixedDelays(retryConfiguration.fixedDelayTopicStrategy)
+                .sameIntervalTopicReuseStrategy(retryConfiguration.sameIntervalTopicReuseStrategy)
                 .setTopicSuffixingStrategy(retryConfiguration.topicSuffixingStrategy);
 
         if (dltTopicSuffix == null) {
             retryTopicConfigurationBuilder.doNotConfigureDlt();
+        } else {
+            retryTopicConfigurationBuilder.dltSuffix(dltTopicSuffix);
         }
 
         if (retryConfiguration.hasRetryTopic()) {
@@ -1061,10 +1062,10 @@ public class KafkaChannelDefinitionProcessor implements BeanFactoryAware, Applic
         resolvedRetryConfiguration.dltTopicSuffix = resolveExpressionAsString(retry.getDltTopicSuffix(), "retry.dltTopicSuffix");
         resolvedRetryConfiguration.retryTopicSuffix = resolveExpressionAsString(retry.getRetryTopicSuffix(), "retry.retryTopicSuffix");
 
-        String fixedDelayTopicStrategy = resolveExpressionAsString(retry.getFixedDelayTopicStrategy(), "retry.fixedDelayTopicStrategy");
+        String sameIntervalTopicReuseStrategy = resolveExpressionAsString(retry.getFixedDelayTopicStrategy(), "retry.fixedDelayTopicStrategy");
         // Different default from Spring Kafka
-        resolvedRetryConfiguration.fixedDelayTopicStrategy =
-                fixedDelayTopicStrategy == null ? FixedDelayStrategy.SINGLE_TOPIC : FixedDelayStrategy.valueOf(fixedDelayTopicStrategy);
+        resolvedRetryConfiguration.sameIntervalTopicReuseStrategy =
+                sameIntervalTopicReuseStrategy == null ? SameIntervalTopicReuseStrategy.SINGLE_TOPIC : SameIntervalTopicReuseStrategy.valueOf(sameIntervalTopicReuseStrategy);
 
         String topicSuffixingStrategy = resolveExpressionAsString(retry.getTopicSuffixingStrategy(), "retry.topicSuffixingStrategy");
         // Different default from Spring Kafka
@@ -1133,7 +1134,7 @@ public class KafkaChannelDefinitionProcessor implements BeanFactoryAware, Applic
         protected Integer attempts;
         protected String dltTopicSuffix;
         protected String retryTopicSuffix;
-        protected FixedDelayStrategy fixedDelayTopicStrategy;
+        protected SameIntervalTopicReuseStrategy sameIntervalTopicReuseStrategy;
         protected TopicSuffixingStrategy topicSuffixingStrategy;
         protected SleepingBackOffPolicy<?> nonBlockingBackOff;
         protected boolean autoCreateTopics;

--- a/modules/flowable-http/pom.xml
+++ b/modules/flowable-http/pom.xml
@@ -224,6 +224,16 @@
             <artifactId>spring-webflux</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+            The SpringWebClientFlowableHttpClient is using ReactorClientHttpConnector,
+            which since Spring Framework 6.1 is implementing SmartLifecycle and thus needs spring-context.
+            See https://github.com/spring-projects/spring-framework/issues/31180#issuecomment-1934453468 for more information.
+         -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>

--- a/modules/flowable-rest/pom.xml
+++ b/modules/flowable-rest/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jpa</artifactId>
-            <version>3.0.0</version>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/AllEnginesAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/AllEnginesAutoConfigurationTest.java
@@ -163,7 +163,7 @@ public class AllEnginesAutoConfigurationTest {
             SpringProcessEngineConfigurator processConfigurator = context.getBean(SpringProcessEngineConfigurator.class);
             assertThat(appEngineConfiguration.getConfigurators())
                     .as("AppEngineConfiguration configurators")
-                    .containsExactly(
+                    .containsExactlyInAnyOrder(
                             processConfigurator,
                             dmnConfigurator,
                             cmmnConfigurator

--- a/pom.xml
+++ b/pom.xml
@@ -14,35 +14,35 @@
 		<distributionManagementSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</distributionManagementSnapshotsUrl>
 		<jdk.version>17</jdk.version>
 		<!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-		<spring.boot.version>3.1.6</spring.boot.version>
-		<spring.framework.version>6.0.14</spring.framework.version>
-		<spring.security.version>6.1.5</spring.security.version>
-		<spring.amqp.version>3.0.10</spring.amqp.version>
-		<spring.kafka.version>3.0.13</spring.kafka.version>
-		<spring.ldap.version>3.1.1</spring.ldap.version>
-		<reactor-netty.version>1.1.8</reactor-netty.version>
+		<spring.boot.version>3.2.2</spring.boot.version>
+		<spring.framework.version>6.1.3</spring.framework.version>
+		<spring.security.version>6.2.1</spring.security.version>
+		<spring.amqp.version>3.1.1</spring.amqp.version>
+		<spring.kafka.version>3.1.1</spring.kafka.version>
+		<spring.ldap.version>3.2.1</spring.ldap.version>
+		<reactor-netty.version>1.1.15</reactor-netty.version>
 		<jackson.version>2.15.3</jackson.version>
 		<jakarta-jms.version>3.1.0</jakarta-jms.version>
         <camel.version>4.0.0</camel.version>
 		<cxf.version>4.0.2</cxf.version>
-		<slf4j.version>2.0.9</slf4j.version>
-		<groovy.version>4.0.15</groovy.version>
+		<slf4j.version>2.0.11</slf4j.version>
+		<groovy.version>4.0.17</groovy.version>
 		<jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
 		<native-build-tools-plugin.version>0.9.27</native-build-tools-plugin.version>
 
 		<junit.version>4.13.2</junit.version>
-		<junit.jupiter.version>5.9.3</junit.jupiter.version>
+		<junit.jupiter.version>5.10.1</junit.jupiter.version>
 		<hikari.version>5.0.1</hikari.version>
 		<maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
 		<maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
-		<mockito.version>5.5.0</mockito.version>
+		<mockito.version>5.7.0</mockito.version>
 		<!--
 		 	AssertJ 3.24.2 is pulling older byte buddy not compatible with Java 21.
 			Therefore, we are fixing it like this.
 		-->
-		<byte-buddy.version>1.14.8</byte-buddy.version>
-		<testcontainers.version>1.18.3</testcontainers.version>
-		<artemis.version>2.28.0</artemis.version>
+		<byte-buddy.version>1.14.11</byte-buddy.version>
+		<testcontainers.version>1.19.3</testcontainers.version>
+		<artemis.version>2.31.2</artemis.version>
 
 		<oracle.jdbc.version>21.9.0.0</oracle.jdbc.version>
 		<oracle.jdbc.artifact>ojdbc8</oracle.jdbc.artifact>
@@ -151,7 +151,7 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents.client5</groupId>
 				<artifactId>httpclient5</artifactId>
-				<version>5.1.3</version>
+				<version>5.2.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>
@@ -271,7 +271,7 @@
 			<dependency>
 				<groupId>org.hibernate.orm</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>6.2.13.Final</version>
+				<version>6.4.1.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.groovy</groupId>


### PR DESCRIPTION
The following dependencies have been upgraded:

* Spring Boot 3.2.2
* Spring Framework 6.1.3
* Spring Security 6.2.1
* Spring AMQP 3.1.1
* Spring Kafka 3.1.1
* Spring LDAP 3.2.1
* Reactor Netty 1.1.15
* SLF4J 2.0.11
* Groovy 4.0.17
* JUnit Jupiter 5.10.1
* Mockito 5.7.0
* Byte Buddy 1.14.11
* Testcontainer 1.19.3
* Artemis 2.31.2
* Http Client5 5.2.3
* Hibernate Core 6.4.1.Final
* Spring Data JPA 3.2.2

The assertion in `AllEnginesAutoConfigurationTest` has been changed to use `containsExactlyInAnyOrder` since the order there isn't important, and it seems like the beans are created in a different order now.
The `AppEngineConfiguration` is going to anyways order all the available contributors before applying them. The configurators are only the ones that have been registered during bean registration.

Our Spring Kafka integration has been adapted to use the new `SameIntervalTopicReuseStrategy` instead of the deprecated (in 3.0) and removed (in 3.1) spring-kafka `FixedDelayStrategy`. It is the same thing, just named differently for clarification reasons by the Spring Kafka team.

We have also added `spring-context` as a test dependency in `flowable-http` , because the `SpringWebClientFlowableHttpClient` is using `ReactorClientHttpConnector` from `spring-web`, which since Spring Framework 6.1 is implementing `SmartLifecycle` and thus needs spring-context