### PR TITLE
Fix order by clause missing "order by"

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
@@ -56,7 +56,7 @@ public abstract class BaseNativeQuery<T extends NativeQuery<?, ?>, U> implements
         parameterMap.put("needsPaging", firstResult >= 0);
         String orderBy = (String) parameterMap.get("orderBy");
         if (orderBy != null && !"".equals(orderBy)) {
-            String columns = "RES." + orderBy;
+            String columns = "order by RES." + orderBy;
             parameterMap.put("orderBy", columns);
             parameterMap.put("orderByColumns", columns);
             parameterMap.put("orderByForWindow", columns);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
@@ -56,9 +56,9 @@ public abstract class BaseNativeQuery<T extends NativeQuery<?, ?>, U> implements
         parameterMap.put("needsPaging", firstResult >= 0);
         String orderBy = (String) parameterMap.get("orderBy");
         if (orderBy != null && !"".equals(orderBy)) {
-            String columns = "order by RES." + orderBy;
-            parameterMap.put("orderBy", columns);
-            parameterMap.put("orderByColumns", columns);
+            String columns = "RES." + orderBy;
+            parameterMap.put("orderBy", "order by " + columns);
+            parameterMap.put("orderByColumns", "order by " + columns);
             parameterMap.put("orderByForWindow", columns);
         } else {
             parameterMap.put("orderBy", "order by RES.ID_ asc");

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
@@ -60,9 +60,9 @@ public abstract class BaseNativeQuery<T extends NativeQuery<?, ?>, U> implements
         } else {
             orderBy = "RES.ID_ asc";
         }
-        parameterMap.put("orderBy", "order by " + columns);
-        parameterMap.put("orderByForWindow", "order by " + columns);
-        parameterMap.put("orderByColumns", columns);
+        parameterMap.put("orderBy", "order by " + orderBy);
+        parameterMap.put("orderByForWindow", "order by " + orderBy);
+        parameterMap.put("orderByColumns", orderBy);
 
         int firstRow = firstResult + 1;
         parameterMap.put("firstRow", firstRow);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
@@ -56,15 +56,13 @@ public abstract class BaseNativeQuery<T extends NativeQuery<?, ?>, U> implements
         parameterMap.put("needsPaging", firstResult >= 0);
         String orderBy = (String) parameterMap.get("orderBy");
         if (orderBy != null && !"".equals(orderBy)) {
-            String columns = "RES." + orderBy;
-            parameterMap.put("orderBy", "order by " + columns);
-            parameterMap.put("orderByForWindow", "order by " + columns);
-            parameterMap.put("orderByColumns", columns);
+            orderBy = "RES.ID_ asc";
         } else {
-            parameterMap.put("orderBy", "order by RES.ID_ asc");
-            parameterMap.put("orderByForWindow", "order by RES.ID_ asc");
-            parameterMap.put("orderByColumns", "RES.ID_ asc");
+            orderBy = "RES." + orderBy;
         }
+        parameterMap.put("orderBy", "order by " + columns);
+        parameterMap.put("orderByForWindow", "order by " + columns);
+        parameterMap.put("orderByColumns", columns);
 
         int firstRow = firstResult + 1;
         parameterMap.put("firstRow", firstRow);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
@@ -58,8 +58,8 @@ public abstract class BaseNativeQuery<T extends NativeQuery<?, ?>, U> implements
         if (orderBy != null && !"".equals(orderBy)) {
             String columns = "RES." + orderBy;
             parameterMap.put("orderBy", "order by " + columns);
-            parameterMap.put("orderByColumns", "order by " + columns);
-            parameterMap.put("orderByForWindow", columns);
+            parameterMap.put("orderByForWindow", "order by " + columns);
+            parameterMap.put("orderByColumns", columns);
         } else {
             parameterMap.put("orderBy", "order by RES.ID_ asc");
             parameterMap.put("orderByForWindow", "order by RES.ID_ asc");

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/query/BaseNativeQuery.java
@@ -56,9 +56,9 @@ public abstract class BaseNativeQuery<T extends NativeQuery<?, ?>, U> implements
         parameterMap.put("needsPaging", firstResult >= 0);
         String orderBy = (String) parameterMap.get("orderBy");
         if (orderBy != null && !"".equals(orderBy)) {
-            orderBy = "RES.ID_ asc";
-        } else {
             orderBy = "RES." + orderBy;
+        } else {
+            orderBy = "RES.ID_ asc";
         }
         parameterMap.put("orderBy", "order by " + columns);
         parameterMap.put("orderByForWindow", "order by " + columns);


### PR DESCRIPTION
The generated ORDER BY clause is incorrect, leading to syntax errors in the resulting query. The ELSE branch in lines 64-55 did it correctly (but I refactored the code to combine the code).

I'm not set up to add/run tests for this, but I think this change should be looked at ASAP since the bug breaks a lot of queries.

#### Check List:
* Unit tests: NO
* Documentation: NO
