### PR TITLE
Fix possible null pathInfo

### DIFF
--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentResourceResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentResourceResource.java
@@ -83,8 +83,8 @@ public class DeploymentResourceResource {
             restApiInterceptor.accessDeploymentById(deployment);
         }
 
-        String pathInfo = request.getPathInfo();
-        String resourceName = pathInfo.replace("/repository/deployments/" + deploymentId + "/resources/", "");
+        String ressourceURI = request.getRequestURI();
+        String resourceName = ressourceURI.replace(request.getContextPath()+"/repository/deployments/" + deploymentId + "/resources/", "");
 
         List<String> resourceList = repositoryService.getDeploymentResourceNames(deploymentId);
 


### PR DESCRIPTION
Hello,

This patch is an attemps to fix error like that : 

java.lang.NullPointerException: Cannot invoke "String.replace(java.lang.CharSequence, java.lang.CharSequence)" because "pathInfo" is null
org.flowable.rest.service.api.repository.DeploymentResourceResource.getDeploymentResource(DeploymentResourceResource.java:87) 

caused by pathInfo beeing null.
