### PR TITLE
Remove not needed historyLevel from service configurations and remove history check in historic task instance entity manager

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -1508,7 +1508,6 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
     public void configureVariableServiceConfiguration() {
         this.variableServiceConfiguration = instantiateVariableServiceConfiguration();
 
-        this.variableServiceConfiguration.setHistoryLevel(this.historyLevel);
         this.variableServiceConfiguration.setClock(this.clock);
         this.variableServiceConfiguration.setIdGenerator(this.idGenerator);
         this.variableServiceConfiguration.setObjectMapper(this.objectMapper);
@@ -1541,7 +1540,6 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     public void initTaskServiceConfiguration() {
         this.taskServiceConfiguration = instantiateTaskServiceConfiguration();
-        this.taskServiceConfiguration.setHistoryLevel(this.historyLevel);
         this.taskServiceConfiguration.setClock(this.clock);
         this.taskServiceConfiguration.setIdGenerator(this.idGenerator);
         this.taskServiceConfiguration.setObjectMapper(this.objectMapper);
@@ -1590,7 +1588,6 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     public void initIdentityLinkServiceConfiguration() {
         this.identityLinkServiceConfiguration = instantiateIdentityLinkServiceConfiguration();
-        this.identityLinkServiceConfiguration.setHistoryLevel(this.historyLevel);
         this.identityLinkServiceConfiguration.setClock(this.clock);
         this.identityLinkServiceConfiguration.setIdGenerator(this.idGenerator);
         this.identityLinkServiceConfiguration.setObjectMapper(this.objectMapper);
@@ -1610,7 +1607,6 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
     public void initEntityLinkServiceConfiguration() {
         if (this.enableEntityLinks) {
             this.entityLinkServiceConfiguration = instantiateEntityLinkServiceConfiguration();
-            this.entityLinkServiceConfiguration.setHistoryLevel(this.historyLevel);
             this.entityLinkServiceConfiguration.setClock(this.clock);
             this.entityLinkServiceConfiguration.setIdGenerator(this.idGenerator);
             this.entityLinkServiceConfiguration.setObjectMapper(this.objectMapper);
@@ -1707,7 +1703,6 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
     public void configureJobServiceConfiguration() {
         if (jobServiceConfiguration == null) {
             this.jobServiceConfiguration = instantiateJobServiceConfiguration();
-            this.jobServiceConfiguration.setHistoryLevel(this.historyLevel);
             this.jobServiceConfiguration.setClock(this.clock);
             this.jobServiceConfiguration.setIdGenerator(this.idGenerator);
             this.jobServiceConfiguration.setObjectMapper(this.objectMapper);

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractServiceConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractServiceConfiguration.java
@@ -22,7 +22,6 @@ import org.flowable.common.engine.api.delegate.event.FlowableEventDispatcher;
 import org.flowable.common.engine.api.delegate.event.FlowableEventListener;
 import org.flowable.common.engine.impl.cfg.IdGenerator;
 import org.flowable.common.engine.impl.event.EventDispatchAction;
-import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +48,6 @@ public abstract class AbstractServiceConfiguration<S> {
     protected Map<String, List<FlowableEventListener>> typedEventListeners;
     protected List<EventDispatchAction> additionalEventDispatchActions;
 
-    protected HistoryLevel historyLevel;
-
     protected ObjectMapper objectMapper;
 
     protected Clock clock;
@@ -61,21 +58,6 @@ public abstract class AbstractServiceConfiguration<S> {
     }
 
     protected abstract S getService();
-
-    public boolean isHistoryLevelAtLeast(HistoryLevel level) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Current history level: {}, level required: {}", historyLevel, level);
-        }
-        // Comparing enums actually compares the location of values declared in the enum
-        return historyLevel.isAtLeast(level);
-    }
-
-    public boolean isHistoryEnabled() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Current history level: {}", historyLevel);
-        }
-        return historyLevel != HistoryLevel.NONE;
-    }
 
     public String getEngineName() {
         return engineName;
@@ -177,15 +159,6 @@ public abstract class AbstractServiceConfiguration<S> {
 
     public AbstractServiceConfiguration<S> setAdditionalEventDispatchActions(List<EventDispatchAction> additionalEventDispatchActions) {
         this.additionalEventDispatchActions = additionalEventDispatchActions;
-        return this;
-    }
-
-    public HistoryLevel getHistoryLevel() {
-        return historyLevel;
-    }
-
-    public AbstractServiceConfiguration<S> setHistoryLevel(HistoryLevel historyLevel) {
-        this.historyLevel = historyLevel;
         return this;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1406,7 +1406,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public void configureVariableServiceConfiguration() {
         this.variableServiceConfiguration = instantiateVariableServiceConfiguration();
-        this.variableServiceConfiguration.setHistoryLevel(this.historyLevel);
         this.variableServiceConfiguration.setClock(this.clock);
         this.variableServiceConfiguration.setIdGenerator(this.idGenerator);
         this.variableServiceConfiguration.setObjectMapper(this.objectMapper);
@@ -1439,7 +1438,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public void initIdentityLinkServiceConfiguration() {
         this.identityLinkServiceConfiguration = instantiateIdentityLinkServiceConfiguration();
-        this.identityLinkServiceConfiguration.setHistoryLevel(this.historyLevel);
         this.identityLinkServiceConfiguration.setClock(this.clock);
         this.identityLinkServiceConfiguration.setIdGenerator(this.idGenerator);
         this.identityLinkServiceConfiguration.setObjectMapper(this.objectMapper);
@@ -1459,7 +1457,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     public void initEntityLinkServiceConfiguration() {
         if (this.enableEntityLinks) {
             this.entityLinkServiceConfiguration = instantiateEntityLinkServiceConfiguration();
-            this.entityLinkServiceConfiguration.setHistoryLevel(this.historyLevel);
             this.entityLinkServiceConfiguration.setClock(this.clock);
             this.entityLinkServiceConfiguration.setIdGenerator(this.idGenerator);
             this.entityLinkServiceConfiguration.setObjectMapper(this.objectMapper);
@@ -1496,7 +1493,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public void initTaskServiceConfiguration() {
         this.taskServiceConfiguration = instantiateTaskServiceConfiguration();
-        this.taskServiceConfiguration.setHistoryLevel(this.historyLevel);
         this.taskServiceConfiguration.setClock(this.clock);
         this.taskServiceConfiguration.setIdGenerator(this.idGenerator);
         this.taskServiceConfiguration.setObjectMapper(this.objectMapper);
@@ -1555,7 +1551,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     public void configureJobServiceConfiguration() {
         if (jobServiceConfiguration == null) {
             this.jobServiceConfiguration = instantiateJobServiceConfiguration();
-            this.jobServiceConfiguration.setHistoryLevel(this.historyLevel);
             this.jobServiceConfiguration.setClock(this.clock);
             this.jobServiceConfiguration.setIdGenerator(this.idGenerator);
             this.jobServiceConfiguration.setObjectMapper(this.objectMapper);

--- a/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/EntityLinkServiceConfiguration.java
+++ b/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/EntityLinkServiceConfiguration.java
@@ -13,7 +13,6 @@
 package org.flowable.entitylink.service;
 
 import org.flowable.common.engine.impl.AbstractServiceConfiguration;
-import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.entitylink.api.EntityLinkService;
 import org.flowable.entitylink.api.history.HistoricEntityLinkService;
 import org.flowable.entitylink.service.impl.EntityLinkServiceImpl;
@@ -50,8 +49,6 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
     protected EntityLinkEntityManager entityLinkEntityManager;
     protected HistoricEntityLinkEntityManager historicEntityLinkEntityManager;
 
-    protected HistoryLevel historyLevel;
-
     protected ObjectMapper objectMapper;
 
     public EntityLinkServiceConfiguration(String engineName) {
@@ -73,23 +70,6 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
         initEntityManagers();
 
         configuratorsAfterInit();
-    }
-
-    @Override
-    public boolean isHistoryLevelAtLeast(HistoryLevel level) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Current history level: {}, level required: {}", historyLevel, level);
-        }
-        // Comparing enums actually compares the location of values declared in the enum
-        return historyLevel.isAtLeast(level);
-    }
-
-    @Override
-    public boolean isHistoryEnabled() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Current history level: {}", historyLevel);
-        }
-        return historyLevel != HistoryLevel.NONE;
     }
 
     // Data managers
@@ -171,17 +151,6 @@ public class EntityLinkServiceConfiguration extends AbstractServiceConfiguration
 
     public EntityLinkServiceConfiguration setHistoricEntityLinkEntityManager(HistoricEntityLinkEntityManager historicEntityLinkEntityManager) {
         this.historicEntityLinkEntityManager = historicEntityLinkEntityManager;
-        return this;
-    }
-
-    @Override
-    public HistoryLevel getHistoryLevel() {
-        return historyLevel;
-    }
-
-    @Override
-    public EntityLinkServiceConfiguration setHistoryLevel(HistoryLevel historyLevel) {
-        this.historyLevel = historyLevel;
         return this;
     }
 

--- a/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/IdentityLinkServiceConfiguration.java
+++ b/modules/flowable-identitylink-service/src/main/java/org/flowable/identitylink/service/IdentityLinkServiceConfiguration.java
@@ -13,7 +13,6 @@
 package org.flowable.identitylink.service;
 
 import org.flowable.common.engine.impl.AbstractServiceConfiguration;
-import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.identitylink.service.impl.HistoricIdentityLinkServiceImpl;
 import org.flowable.identitylink.service.impl.IdentityLinkServiceImpl;
 import org.flowable.identitylink.service.impl.persistence.entity.HistoricIdentityLinkEntityManager;
@@ -51,8 +50,6 @@ public class IdentityLinkServiceConfiguration extends AbstractServiceConfigurati
     /** IdentityLink event handler */
     protected IdentityLinkEventHandler identityLinkEventHandler;
     
-    protected HistoryLevel historyLevel;
-    
     protected ObjectMapper objectMapper;
     
     public IdentityLinkServiceConfiguration(String engineName) {
@@ -74,23 +71,6 @@ public class IdentityLinkServiceConfiguration extends AbstractServiceConfigurati
         initEntityManagers();
 
         configuratorsAfterInit();
-    }
-    
-    @Override
-    public boolean isHistoryLevelAtLeast(HistoryLevel level) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Current history level: {}, level required: {}", historyLevel, level);
-        }
-        // Comparing enums actually compares the location of values declared in the enum
-        return historyLevel.isAtLeast(level);
-    }
-
-    @Override
-    public boolean isHistoryEnabled() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Current history level: {}", historyLevel);
-        }
-        return historyLevel != HistoryLevel.NONE;
     }
 
     // Data managers
@@ -172,17 +152,6 @@ public class IdentityLinkServiceConfiguration extends AbstractServiceConfigurati
 
     public IdentityLinkServiceConfiguration setHistoricIdentityLinkEntityManager(HistoricIdentityLinkEntityManager historicIdentityLinkEntityManager) {
         this.historicIdentityLinkEntityManager = historicIdentityLinkEntityManager;
-        return this;
-    }
-    
-    @Override
-    public HistoryLevel getHistoryLevel() {
-        return historyLevel;
-    }
-    
-    @Override
-    public IdentityLinkServiceConfiguration setHistoryLevel(HistoryLevel historyLevel) {
-        this.historyLevel = historyLevel;
         return this;
     }
     

--- a/modules/flowable-job-service/src/main/java/org/flowable/job/service/JobServiceConfiguration.java
+++ b/modules/flowable-job-service/src/main/java/org/flowable/job/service/JobServiceConfiguration.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import org.flowable.common.engine.impl.AbstractServiceConfiguration;
 import org.flowable.common.engine.impl.calendar.BusinessCalendarManager;
 import org.flowable.common.engine.impl.el.ExpressionManager;
-import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.common.engine.impl.interceptor.CommandExecutor;
 import org.flowable.job.service.impl.HistoryJobServiceImpl;
 import org.flowable.job.service.impl.JobServiceImpl;
@@ -149,23 +148,6 @@ public class JobServiceConfiguration extends AbstractServiceConfiguration<JobSer
         initEntityManagers();
 
         configuratorsAfterInit();
-    }
-
-    @Override
-    public boolean isHistoryLevelAtLeast(HistoryLevel level) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Current history level: {}, level required: {}", historyLevel, level);
-        }
-        // Comparing enums actually compares the location of values declared in the enum
-        return historyLevel.isAtLeast(level);
-    }
-
-    @Override
-    public boolean isHistoryEnabled() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Current history level: {}", historyLevel);
-        }
-        return historyLevel != HistoryLevel.NONE;
     }
 
     protected void initTimerJobScheduler() {

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/persistence/entity/HistoricTaskInstanceEntityManagerImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/persistence/entity/HistoricTaskInstanceEntityManagerImpl.java
@@ -14,7 +14,6 @@
 package org.flowable.task.service.impl.persistence.entity;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -67,28 +66,19 @@ public class HistoricTaskInstanceEntityManagerImpl
 
     @Override
     public long findHistoricTaskInstanceCountByQueryCriteria(HistoricTaskInstanceQueryImpl historicTaskInstanceQuery) {
-        if (serviceConfiguration.isHistoryEnabled()) {
-            return dataManager.findHistoricTaskInstanceCountByQueryCriteria(historicTaskInstanceQuery);
-        }
-        return 0;
+        return dataManager.findHistoricTaskInstanceCountByQueryCriteria(historicTaskInstanceQuery);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public List<HistoricTaskInstance> findHistoricTaskInstancesByQueryCriteria(HistoricTaskInstanceQueryImpl historicTaskInstanceQuery) {
-        if (serviceConfiguration.isHistoryEnabled()) {
-            return dataManager.findHistoricTaskInstancesByQueryCriteria(historicTaskInstanceQuery);
-        }
-        return Collections.EMPTY_LIST;
+        return dataManager.findHistoricTaskInstancesByQueryCriteria(historicTaskInstanceQuery);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public List<HistoricTaskInstance> findHistoricTaskInstancesAndRelatedEntitiesByQueryCriteria(HistoricTaskInstanceQueryImpl historicTaskInstanceQuery) {
-        if (serviceConfiguration.isHistoryEnabled()) {
-            return dataManager.findHistoricTaskInstancesAndRelatedEntitiesByQueryCriteria(historicTaskInstanceQuery);
-        }
-        return Collections.EMPTY_LIST;
+        return dataManager.findHistoricTaskInstancesAndRelatedEntitiesByQueryCriteria(historicTaskInstanceQuery);
     }
 
     @Override


### PR DESCRIPTION
History check in the historic task instance entity manager is not needed since history level on the engine could be none, but on the definition level it could be task or higher
