### PR TITLE
#3901: Make sure DefaultAsyncTaskExecutor is started

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableJobConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableJobConfiguration.java
@@ -60,7 +60,9 @@ public class FlowableJobConfiguration {
     public AsyncTaskExecutor flowableAsyncTaskInvokerTaskExecutor(
             @Qualifier("flowableAsyncTaskInvokerTaskExecutorConfiguration") AsyncTaskExecutorConfiguration executorConfiguration
     ) {
-        return new DefaultAsyncTaskExecutor(executorConfiguration);
+        DefaultAsyncTaskExecutor defaultAsyncTaskExecutor = new DefaultAsyncTaskExecutor(executorConfiguration);
+        defaultAsyncTaskExecutor.start();
+        return defaultAsyncTaskExecutor;
     }
 
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/process/ProcessEngineAutoConfigurationTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/process/ProcessEngineAutoConfigurationTest.java
@@ -608,6 +608,7 @@ public class ProcessEngineAutoConfigurationTest {
                                 assertThat(taskExecutor.getMaxPoolSize()).isEqualTo(8);
                                 assertThat(taskExecutor.getQueueSize()).isEqualTo(100);
                                 assertThat(taskExecutor.getThreadPoolNamingPattern()).isEqualTo("flowable-async-task-invoker-%d");
+                                assertThat(taskExecutor.submit(() -> true).join()).isTrue();
                             });
                 });
     }


### PR DESCRIPTION
Fixes #3901 by making sure the `DefaultAsyncTaskExecutor` is started.

Fixes #3875
**Check List:**

- Unit tests: YES
- Documentation: NA