### PR TITLE
Improve exception message for "Start a new instance only when no other instance already exists" event without correlation parameters

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/eventregistry/CmmnEventRegistryEventConsumer.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/eventregistry/CmmnEventRegistryEventConsumer.java
@@ -30,6 +30,7 @@ import org.flowable.cmmn.model.CmmnModel;
 import org.flowable.cmmn.model.EventListener;
 import org.flowable.cmmn.model.ExtensionElement;
 import org.flowable.cmmn.model.PlanItem;
+import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.api.constant.ReferenceTypes;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.lock.LockManager;
@@ -214,6 +215,10 @@ public class CmmnEventRegistryEventConsumer extends BaseEventRegistryEventConsum
 
     protected long countCaseInstances(CmmnRuntimeService cmmnRuntimeService, EventInstance eventInstance,
             CorrelationKey correlationKey, CaseDefinition caseDefinition) {
+
+        if (correlationKey == null) {
+            throw new FlowableIllegalStateException(String.format("Event definition %s does not contain correlation parameters. Cannot verify if case instance already exists.", eventInstance.getEventKey()));
+        }
 
         CaseInstanceQuery caseInstanceQuery = cmmnRuntimeService.createCaseInstanceQuery()
                 .caseDefinitionKey(caseDefinition.getKey())

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/eventregistry/CmmnEventRegistryEventConsumer.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/eventregistry/CmmnEventRegistryEventConsumer.java
@@ -30,7 +30,6 @@ import org.flowable.cmmn.model.CmmnModel;
 import org.flowable.cmmn.model.EventListener;
 import org.flowable.cmmn.model.ExtensionElement;
 import org.flowable.cmmn.model.PlanItem;
-import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.api.constant.ReferenceTypes;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.lock.LockManager;
@@ -134,7 +133,7 @@ public class CmmnEventRegistryEventConsumer extends BaseEventRegistryEventConsum
 
                 if (Objects.equals(startCorrelationConfiguration, CmmnXmlConstants.START_EVENT_CORRELATION_STORE_AS_UNIQUE_REFERENCE_ID)) {
 
-                    CorrelationKey correlationKeyWithAllParameters = getCorrelationKeyWithAllParameters(correlationKeys);
+                    CorrelationKey correlationKeyWithAllParameters = getCorrelationKeyWithAllParameters(correlationKeys, eventInstance);
 
                     CaseDefinition caseDefinition = cmmnEngineConfiguration.getCmmnRepositoryService().getCaseDefinition(eventSubscription.getScopeDefinitionId());
 
@@ -215,10 +214,6 @@ public class CmmnEventRegistryEventConsumer extends BaseEventRegistryEventConsum
 
     protected long countCaseInstances(CmmnRuntimeService cmmnRuntimeService, EventInstance eventInstance,
             CorrelationKey correlationKey, CaseDefinition caseDefinition) {
-
-        if (correlationKey == null) {
-            throw new FlowableIllegalStateException(String.format("Event definition %s does not contain correlation parameters. Cannot verify if case instance already exists.", eventInstance.getEventKey()));
-        }
 
         CaseInstanceQuery caseInstanceQuery = cmmnRuntimeService.createCaseInstanceQuery()
                 .caseDefinitionKey(caseDefinition.getKey())

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/eventregistry/BpmnEventRegistryEventConsumer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/eventregistry/BpmnEventRegistryEventConsumer.java
@@ -24,6 +24,7 @@ import org.flowable.bpmn.constants.BpmnXMLConstants;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.ExtensionElement;
 import org.flowable.bpmn.model.StartEvent;
+import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.api.constant.ReferenceTypes;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.lock.LockManager;
@@ -201,6 +202,10 @@ public class BpmnEventRegistryEventConsumer extends BaseEventRegistryEventConsum
 
     protected long countProcessInstances(RuntimeService runtimeService, EventInstance eventInstance,
             CorrelationKey correlationKey, ProcessDefinition processDefinition) {
+
+        if (correlationKey == null) {
+            throw new FlowableIllegalStateException(String.format("Event definition %s does not contain correlation parameters. Cannot verify if process instance already exists.", eventInstance.getEventKey()));
+        }
 
         ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery()
                 .processDefinitionKey(processDefinition.getKey())

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/eventregistry/BpmnEventRegistryEventConsumer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/eventregistry/BpmnEventRegistryEventConsumer.java
@@ -24,7 +24,6 @@ import org.flowable.bpmn.constants.BpmnXMLConstants;
 import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.ExtensionElement;
 import org.flowable.bpmn.model.StartEvent;
-import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.api.constant.ReferenceTypes;
 import org.flowable.common.engine.api.scope.ScopeTypes;
 import org.flowable.common.engine.impl.lock.LockManager;
@@ -114,7 +113,7 @@ public class BpmnEventRegistryEventConsumer extends BaseEventRegistryEventConsum
 
                 if (Objects.equals(startCorrelationConfiguration, BpmnXMLConstants.START_EVENT_CORRELATION_STORE_AS_UNIQUE_REFERENCE_ID)) {
 
-                    CorrelationKey correlationKeyWithAllParameters = getCorrelationKeyWithAllParameters(correlationKeys);
+                    CorrelationKey correlationKeyWithAllParameters = getCorrelationKeyWithAllParameters(correlationKeys, eventInstance);
 
                     ProcessDefinition processDefinition = processEngineConfiguration.getRepositoryService()
                             .getProcessDefinition(eventSubscription.getProcessDefinitionId());
@@ -202,10 +201,6 @@ public class BpmnEventRegistryEventConsumer extends BaseEventRegistryEventConsum
 
     protected long countProcessInstances(RuntimeService runtimeService, EventInstance eventInstance,
             CorrelationKey correlationKey, ProcessDefinition processDefinition) {
-
-        if (correlationKey == null) {
-            throw new FlowableIllegalStateException(String.format("Event definition %s does not contain correlation parameters. Cannot verify if process instance already exists.", eventInstance.getEventKey()));
-        }
 
         ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery()
                 .processDefinitionKey(processDefinition.getKey())

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/consumer/BaseEventRegistryEventConsumer.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/consumer/BaseEventRegistryEventConsumer.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
 import org.flowable.common.engine.impl.interceptor.CommandExecutor;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
@@ -143,12 +144,15 @@ public abstract class BaseEventRegistryEventConsumer implements EventRegistryEve
         return eventRegistryEngineConfiguration.getEventRegistry();
     }
 
-    protected CorrelationKey getCorrelationKeyWithAllParameters(Collection<CorrelationKey> correlationKeys) {
+    protected CorrelationKey getCorrelationKeyWithAllParameters(Collection<CorrelationKey> correlationKeys, EventInstance eventInstance) {
         CorrelationKey result = null;
         for (CorrelationKey correlationKey : correlationKeys) {
             if (result == null || (correlationKey.getParameterInstances().size() >= result.getParameterInstances().size()) ) {
                 result = correlationKey;
             }
+        }
+        if (result == null) {
+            throw new FlowableIllegalStateException(String.format("Event definition %s does not contain correlation parameters. Cannot verify if instance already exists.", eventInstance.getEventKey()));
         }
         return result;
     }


### PR DESCRIPTION
Throw explicit exception instead of running into NPE