### PR TITLE
Improve exception message for "Start a new instance only when no other instance already exists" event without correlation parameters

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/eventregistry/CmmnEventRegistryEventConsumer.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/eventregistry/CmmnEventRegistryEventConsumer.java
@@ -133,7 +133,7 @@ public class CmmnEventRegistryEventConsumer extends BaseEventRegistryEventConsum
 
                 if (Objects.equals(startCorrelationConfiguration, CmmnXmlConstants.START_EVENT_CORRELATION_STORE_AS_UNIQUE_REFERENCE_ID)) {
 
-                    CorrelationKey correlationKeyWithAllParameters = getCorrelationKeyWithAllParameters(correlationKeys);
+                    CorrelationKey correlationKeyWithAllParameters = getCorrelationKeyWithAllParameters(correlationKeys, eventInstance);
 
                     CaseDefinition caseDefinition = cmmnEngineConfiguration.getCmmnRepositoryService().getCaseDefinition(eventSubscription.getScopeDefinitionId());
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/eventregistry/BpmnEventRegistryEventConsumer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/eventregistry/BpmnEventRegistryEventConsumer.java
@@ -113,7 +113,7 @@ public class BpmnEventRegistryEventConsumer extends BaseEventRegistryEventConsum
 
                 if (Objects.equals(startCorrelationConfiguration, BpmnXMLConstants.START_EVENT_CORRELATION_STORE_AS_UNIQUE_REFERENCE_ID)) {
 
-                    CorrelationKey correlationKeyWithAllParameters = getCorrelationKeyWithAllParameters(correlationKeys);
+                    CorrelationKey correlationKeyWithAllParameters = getCorrelationKeyWithAllParameters(correlationKeys, eventInstance);
 
                     ProcessDefinition processDefinition = processEngineConfiguration.getRepositoryService()
                             .getProcessDefinition(eventSubscription.getProcessDefinitionId());

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/consumer/BaseEventRegistryEventConsumer.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/consumer/BaseEventRegistryEventConsumer.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.FlowableIllegalStateException;
 import org.flowable.common.engine.impl.AbstractEngineConfiguration;
 import org.flowable.common.engine.impl.interceptor.CommandExecutor;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
@@ -143,12 +144,15 @@ public abstract class BaseEventRegistryEventConsumer implements EventRegistryEve
         return eventRegistryEngineConfiguration.getEventRegistry();
     }
 
-    protected CorrelationKey getCorrelationKeyWithAllParameters(Collection<CorrelationKey> correlationKeys) {
+    protected CorrelationKey getCorrelationKeyWithAllParameters(Collection<CorrelationKey> correlationKeys, EventInstance eventInstance) {
         CorrelationKey result = null;
         for (CorrelationKey correlationKey : correlationKeys) {
             if (result == null || (correlationKey.getParameterInstances().size() >= result.getParameterInstances().size()) ) {
                 result = correlationKey;
             }
+        }
+        if (result == null) {
+            throw new FlowableIllegalStateException(String.format("Event definition %s does not contain correlation parameters. Cannot verify if instance already exists.", eventInstance.getEventKey()));
         }
         return result;
     }


### PR DESCRIPTION
Behavior stays the same, throw nicer exception instead of NPE