### PR TITLE
Move from getText() to getElementText() for XMLStreamReader

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
@@ -298,8 +298,8 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
         while (!readyWithExtensionElement && xtr.hasNext()) {
             xtr.next();
             if (xtr.isCharacters() || XMLStreamReader.CDATA == xtr.getEventType()) {
-                if (StringUtils.isNotEmpty(xtr.getText().trim())) {
-                    extensionElement.setElementText(xtr.getText().trim());
+                if (StringUtils.isNotEmpty(xtr.getElementText().trim())) {
+                    extensionElement.setElementText(xtr.getElementText().trim());
                 }
             } else if (xtr.isStartElement()) {
                 ExtensionElement childExtensionElement = parseExtensionElement(xtr);

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/util/BpmnXMLUtil.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/util/BpmnXMLUtil.java
@@ -195,8 +195,8 @@ public class BpmnXMLUtil implements BpmnXMLConstants {
         while (!readyWithExtensionElement && xtr.hasNext()) {
             xtr.next();
             if (xtr.isCharacters() || XMLStreamReader.CDATA == xtr.getEventType()) {
-                if (StringUtils.isNotEmpty(xtr.getText().trim())) {
-                    extensionElement.setElementText(xtr.getText().trim());
+                if (StringUtils.isNotEmpty(xtr.getElementText().trim())) {
+                    extensionElement.setElementText(xtr.getElementText().trim());
                 }
             } else if (xtr.isStartElement()) {
                 ExtensionElement childExtensionElement = parseExtensionElement(xtr);

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/util/CmmnXmlUtil.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/util/CmmnXmlUtil.java
@@ -74,8 +74,8 @@ public class CmmnXmlUtil implements CmmnXmlConstants {
         while (!readyWithExtensionElement && xtr.hasNext()) {
             xtr.next();
             if (xtr.isCharacters() || XMLStreamReader.CDATA == xtr.getEventType()) {
-                if (StringUtils.isNotEmpty(xtr.getText().trim())) {
-                    extensionElement.setElementText(xtr.getText().trim());
+                if (StringUtils.isNotEmpty(xtr.getElementText().trim())) {
+                    extensionElement.setElementText(xtr.getElementText().trim());
                 }
             } else if (xtr.isStartElement()) {
                 ExtensionElement childExtensionElement = parseExtensionElement(xtr);

--- a/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/converter/util/DmnXMLUtil.java
+++ b/modules/flowable-dmn-xml-converter/src/main/java/org/flowable/dmn/converter/util/DmnXMLUtil.java
@@ -143,8 +143,8 @@ public class DmnXMLUtil implements DmnXMLConstants {
         while (!readyWithExtensionElement && xtr.hasNext()) {
             xtr.next();
             if (xtr.isCharacters() || XMLStreamReader.CDATA == xtr.getEventType()) {
-                if (StringUtils.isNotEmpty(xtr.getText().trim())) {
-                    extensionElement.setElementText(xtr.getText().trim());
+                if (StringUtils.isNotEmpty(xtr.getElementText().trim())) {
+                    extensionElement.setElementText(xtr.getElementText().trim());
                 }
             } else if (xtr.isStartElement()) {
                 DmnExtensionElement childExtensionElement = parseExtensionElement(xtr);


### PR DESCRIPTION
XMLStreamReader#next() may split characters into several chunks, and if so, getText() will only return the text of the current chunk instead of the entire element if javax.xml.stream.IS_COALESCING is not set to true. Using getElementText() always returns the full text.