### PR TITLE
fix a signal subscription creation bug

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -1533,7 +1533,6 @@ public abstract class AbstractDynamicStateManager {
                         Signal signal = null;
                         if (bpmnModel.containsSignalId(signalEventDefinition.getSignalRef())) {
                             signal = bpmnModel.getSignal(signalEventDefinition.getSignalRef());
-                            signalEventDefinition.setSignalRef(signal.getName());
                         }
 
                         ExecutionEntity signalExecution = processEngineConfiguration.getExecutionEntityManager().createChildExecution(eventSubProcessExecution.getParent());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessInstanceHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/ProcessInstanceHelper.java
@@ -455,7 +455,6 @@ public class ProcessInstanceHelper {
         Signal signal = null;
         if (bpmnModel.containsSignalId(signalEventDefinition.getSignalRef())) {
             signal = bpmnModel.getSignal(signalEventDefinition.getSignalRef());
-            signalEventDefinition.setSignalRef(signal.getName());
         }
 
         ExecutionEntity signalExecution = processEngineConfiguration.getExecutionEntityManager().createChildExecution(parentExecution);


### PR DESCRIPTION
Fixes a bug where for the second process you start, signal event processing would happen differently.
E.g., the scope would always be null for the second process (unless the BPMN model cache runs out in the mean time).

Affects Flowable 6.8.1, 7.0.1

Workaround without this fix: 
Signal ID and name must be the same, e.g. 
` <bpmn:signal id="terminate_product" name="terminate_product" flowable:scope="processInstance" />`

#### Check List:
* Unit tests: YES / NO / NA
  * (as stated elsewhere, I would like to add some, but I need a bit of help getting started - e.g. a pointer to existing test classes that I could extend with 1 or two test cases)
* Documentation: NA
  * (should not be necessary for a simple bugfix)
