### PR TITLE
Fixed missing subscriptions after migration of an active embedded non interrupting event sub process (#3928)

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -822,7 +822,10 @@ public abstract class AbstractDynamicStateManager {
 
         // Build the subProcess hierarchy
         for (SubProcess subProcess : subProcessesToCreate.values()) {
-            if (!processInstanceChangeState.getCreatedEmbeddedSubProcesses().containsKey(subProcess.getId())) {
+            if (subProcess instanceof EventSubProcess) {
+                ExecutionEntity embeddedSubProcess = createEmbeddedSubProcessHierarchy(subProcess, defaultContinueParentExecution, subProcessesToCreate, movingExecutionIds, processInstanceChangeState, commandContext);
+                moveExecutionEntityContainer.addCreatedEventSubProcess(subProcess.getId(), embeddedSubProcess);
+            } else if (!processInstanceChangeState.getCreatedEmbeddedSubProcesses().containsKey(subProcess.getId())) {
                 ExecutionEntity embeddedSubProcess = createEmbeddedSubProcessHierarchy(subProcess, defaultContinueParentExecution, subProcessesToCreate, movingExecutionIds, processInstanceChangeState, commandContext);
                 processInstanceChangeState.addCreatedEmbeddedSubProcess(subProcess.getId(), embeddedSubProcess);
             }
@@ -833,7 +836,9 @@ public abstract class AbstractDynamicStateManager {
         for (FlowElementMoveEntry flowElementMoveEntry : moveToFlowElements) {
             FlowElement newFlowElement = flowElementMoveEntry.getNewFlowElement();
             ExecutionEntity parentExecution;
-            if (newFlowElement.getSubProcess() != null && processInstanceChangeState.getCreatedEmbeddedSubProcesses().containsKey(newFlowElement.getSubProcess().getId())) {
+            if (newFlowElement.getSubProcess() != null && moveExecutionEntityContainer.getCreatedEventSubProcess(newFlowElement.getSubProcess().getId()) != null) {
+                parentExecution = moveExecutionEntityContainer.getCreatedEventSubProcess(newFlowElement.getSubProcess().getId());
+            } else  if (newFlowElement.getSubProcess() != null && processInstanceChangeState.getCreatedEmbeddedSubProcesses().containsKey(newFlowElement.getSubProcess().getId())) {
                 parentExecution = processInstanceChangeState.getCreatedEmbeddedSubProcesses().get(newFlowElement.getSubProcess().getId());
             
             } else if ((newFlowElement instanceof Task || newFlowElement instanceof CallActivity) && isFlowElementMultiInstance(newFlowElement) && !movingExecutions.get(0).isMultiInstanceRoot() &&

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/MoveExecutionEntityContainer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/MoveExecutionEntityContainer.java
@@ -46,6 +46,7 @@ public class MoveExecutionEntityContainer {
     protected Map<String, FlowElementMoveEntry> currentActivityToNewElementMap = new LinkedHashMap<>();
     protected Map<String, Map<String, Object>> flowElementLocalVariableMap = new HashMap<>();
     protected List<String> newExecutionIds = new ArrayList<>();
+    protected Map<String, ExecutionEntity> createdEventSubProcesses = new HashMap<>();
 
     public MoveExecutionEntityContainer(List<ExecutionEntity> executions, List<String> moveToActivityIds) {
         this.executions = executions;
@@ -214,6 +215,14 @@ public class MoveExecutionEntityContainer {
 
     public void addNewExecutionId(String executionId) {
         this.newExecutionIds.add(executionId);
+    }
+
+    public ExecutionEntity getCreatedEventSubProcess(String processDefinitionId) {
+        return createdEventSubProcesses.get(processDefinitionId);
+    }
+
+    public void addCreatedEventSubProcess(String processDefinitionId, ExecutionEntity executionEntity) {
+        createdEventSubProcesses.put(processDefinitionId, executionEntity);
     }
 
     public Map<String, Map<String, Object>> getFlowElementLocalVariableMap() {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationEventRegistryConsumerTest.java
@@ -1,0 +1,124 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.test.api.runtime.migration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
+import org.flowable.engine.test.eventregistry.FlowableEventRegistryBpmnTestCase;
+import org.flowable.eventregistry.api.EventDeployment;
+import org.flowable.eventregistry.api.EventRegistry;
+import org.flowable.eventregistry.api.EventRepositoryService;
+import org.flowable.eventregistry.api.InboundEventChannelAdapter;
+import org.flowable.eventregistry.api.model.EventPayloadTypes;
+import org.flowable.eventregistry.impl.EventRegistryEngineConfiguration;
+import org.flowable.eventregistry.model.InboundChannelModel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Provides a test channel and test events.
+ *
+ * @author Bas Claessen
+ */
+public abstract class AbstractProcessInstanceMigrationEventRegistryConsumerTest extends AbstractProcessInstanceMigrationTest {
+
+    protected TestInboundEventChannelAdapter inboundEventChannelAdapter;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        inboundEventChannelAdapter = setupTestChannel();
+
+        getEventRepositoryService().createEventModelBuilder()
+            .key("myEvent")
+            .resourceName("myEvent.event")
+            .deploy();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        EventRepositoryService eventRepositoryService = getEventRepositoryService();
+        List<EventDeployment> deployments = eventRepositoryService.createDeploymentQuery().list();
+        for (EventDeployment eventDeployment : deployments) {
+            eventRepositoryService.deleteDeployment(eventDeployment.getId());
+        }
+        deleteDeployments();
+    }
+
+    protected TestInboundEventChannelAdapter setupTestChannel() {
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+        Map<Object, Object> beans = getEventRegistryEngineConfiguration().getExpressionManager().getBeans();
+        beans.put("inboundEventChannelAdapter", inboundEventChannelAdapter);
+
+        getEventRepositoryService().createInboundChannelModelBuilder()
+            .key("test-channel")
+            .resourceName("testChannel.channel")
+            .channelAdapter("${inboundEventChannelAdapter}")
+            .jsonDeserializer()
+            .detectEventKeyUsingJsonField("type")
+            .jsonFieldsMapDirectlyToPayload()
+            .deploy();
+
+        return inboundEventChannelAdapter;
+    }
+
+    protected EventRepositoryService getEventRepositoryService() {
+        return getEventRegistryEngineConfiguration().getEventRepositoryService();
+    }
+
+    protected EventRegistryEngineConfiguration getEventRegistryEngineConfiguration() {
+        return (EventRegistryEngineConfiguration) processEngineConfiguration.getEngineConfigurations()
+                .get(EngineConfigurationConstants.KEY_EVENT_REGISTRY_CONFIG);
+    }
+
+    protected static class TestInboundEventChannelAdapter implements InboundEventChannelAdapter {
+
+        public InboundChannelModel inboundChannelModel;
+        public EventRegistry eventRegistry;
+        protected ObjectMapper objectMapper = new ObjectMapper();
+
+        @Override
+        public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {
+            this.inboundChannelModel = inboundChannelModel;
+        }
+
+        @Override
+        public void setEventRegistry(EventRegistry eventRegistry) {
+            this.eventRegistry = eventRegistry;
+        }
+
+        public void triggerTestEvent() {
+            ObjectNode eventNode = createTestEventNode();
+            triggerTestEvent(eventNode);
+        }
+
+        public void triggerTestEvent(ObjectNode eventNode) {
+            try {
+                eventRegistry.eventReceived(inboundChannelModel, objectMapper.writeValueAsString(eventNode));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        
+        protected ObjectNode createTestEventNode() {
+            ObjectNode json = objectMapper.createObjectNode();
+            json.put("type", "myEvent");
+            return json;
+        }
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationEventRegistryConsumerTest.java
@@ -12,24 +12,22 @@
  */
 package org.flowable.engine.test.api.runtime.migration;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.Map;
+
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
-import org.flowable.engine.test.eventregistry.FlowableEventRegistryBpmnTestCase;
 import org.flowable.eventregistry.api.EventDeployment;
 import org.flowable.eventregistry.api.EventRegistry;
 import org.flowable.eventregistry.api.EventRepositoryService;
 import org.flowable.eventregistry.api.InboundEventChannelAdapter;
-import org.flowable.eventregistry.api.model.EventPayloadTypes;
 import org.flowable.eventregistry.impl.EventRegistryEngineConfiguration;
 import org.flowable.eventregistry.model.InboundChannelModel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Provides a test channel and test events.

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventRegistryEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventRegistryEventSubprocessTest.java
@@ -12,6 +12,10 @@
  */
 package org.flowable.engine.test.api.runtime.migration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.assertj.core.groups.Tuple;
 import org.flowable.engine.migration.ProcessInstanceMigrationBuilder;
 import org.flowable.engine.migration.ProcessInstanceMigrationValidationResult;
@@ -22,10 +26,6 @@ import org.flowable.eventsubscription.api.EventSubscription;
 import org.flowable.eventsubscription.service.impl.EventSubscriptionQueryImpl;
 import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Bas Claessen
@@ -155,6 +155,86 @@ public class ProcessInstanceMigrationEventRegistryEventSubprocessTest extends Ab
                 .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
                 .containsExactlyInAnyOrder(
                         Tuple.tuple("processTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId())
+                );
+
+        eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventType, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("myEvent", "eventSubProcessStart", version2ProcessDef.getId()));
+
+        completeProcessInstanceTasks(processInstance.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+    @Test
+    public void testMigrateNonInterruptingEventRegistryEventSubProcessWithTwoStartedSubProcess() {
+        //Deploy first version of the process
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-eventregistry-event-subprocess.bpmn20.xml");
+
+        //Start an instance of the first version of the process for migration
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(version1ProcessDef.getKey());
+
+        //Deploy second version of the same process
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-eventregistry-event-subprocess.bpmn20.xml");
+        assertThat(version1ProcessDef.getId()).isNotEqualTo(version2ProcessDef.getId());
+
+        //Trigger event to create first sub process
+        inboundEventChannelAdapter.triggerTestEvent();
+        //Trigger event to create second sub process
+        inboundEventChannelAdapter.triggerTestEvent();
+
+        //Confirm the state to migrate
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder(
+                        "processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask", "eventSubProcess", "eventSubProcessTask"
+                );
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version1ProcessDef.getId());
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId())
+                );
+        List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventType, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("myEvent", "eventSubProcessStart", version1ProcessDef.getId()));
+
+        //Migrate to the other processDefinition
+        ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
+                .migrateToProcessDefinition(version2ProcessDef.getId());
+
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
+        assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
+
+        processInstanceMigrationBuilder.migrate(processInstance.getId());
+
+        //Confirm
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder(
+                        "processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask", "eventSubProcess", "eventSubProcessTask"
+                );
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version2ProcessDef.getId());
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId()),
                         Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId())
                 );
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventRegistryEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventRegistryEventSubprocessTest.java
@@ -1,0 +1,173 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.test.api.runtime.migration;
+
+import org.assertj.core.groups.Tuple;
+import org.flowable.engine.migration.ProcessInstanceMigrationBuilder;
+import org.flowable.engine.migration.ProcessInstanceMigrationValidationResult;
+import org.flowable.engine.repository.ProcessDefinition;
+import org.flowable.engine.runtime.Execution;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.eventsubscription.api.EventSubscription;
+import org.flowable.eventsubscription.service.impl.EventSubscriptionQueryImpl;
+import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Bas Claessen
+ */
+public class ProcessInstanceMigrationEventRegistryEventSubprocessTest extends AbstractProcessInstanceMigrationEventRegistryConsumerTest {
+
+    @Test
+    public void testMigrateNonInterruptingEventRegistryEventSubProcess() {
+        //Deploy first version of the process
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-eventregistry-event-subprocess.bpmn20.xml");
+
+        //Start an instance of the first version of the process for migration
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(version1ProcessDef.getKey());
+
+        //Deploy second version of the same process
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-eventregistry-event-subprocess.bpmn20.xml");
+        assertThat(version1ProcessDef.getId()).isNotEqualTo(version2ProcessDef.getId());
+
+        //Confirm the state to migrate
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version1ProcessDef.getId());
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("processTask", version1ProcessDef.getId()));
+        List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventType, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("myEvent", "eventSubProcessStart", version1ProcessDef.getId()));
+
+        //Migrate to the other processDefinition
+        ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
+                .migrateToProcessDefinition(version2ProcessDef.getId());
+
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
+        assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
+
+        processInstanceMigrationBuilder.migrate(processInstance.getId());
+
+        //Confirm
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version2ProcessDef.getId());
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("processTask", version2ProcessDef.getId()));
+
+        eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventType, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("myEvent", "eventSubProcessStart", version2ProcessDef.getId()));
+
+        completeProcessInstanceTasks(processInstance.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+    @Test
+    public void testMigrateNonInterruptingEventRegistryEventSubProcessWithStartedSubProcess() {
+        //Deploy first version of the process
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-eventregistry-event-subprocess.bpmn20.xml");
+
+        //Start an instance of the first version of the process for migration
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(version1ProcessDef.getKey());
+
+        //Deploy second version of the same process
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-eventregistry-event-subprocess.bpmn20.xml");
+        assertThat(version1ProcessDef.getId()).isNotEqualTo(version2ProcessDef.getId());
+
+        //Trigger event
+        inboundEventChannelAdapter.triggerTestEvent();
+
+        //Confirm the state to migrate
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version1ProcessDef.getId());
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId())
+                );
+        List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventType, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("myEvent", "eventSubProcessStart", version1ProcessDef.getId()));
+
+        //Migrate to the other processDefinition
+        ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
+                .migrateToProcessDefinition(version2ProcessDef.getId());
+
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
+        assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
+
+        processInstanceMigrationBuilder.migrate(processInstance.getId());
+
+        //Confirm
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask");
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version2ProcessDef.getId());
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId())
+                );
+
+        eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventType, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("myEvent", "eventSubProcessStart", version2ProcessDef.getId()));
+
+        completeProcessInstanceTasks(processInstance.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+    private EventSubscriptionQueryImpl createEventSubscriptionQuery() {
+        return new EventSubscriptionQueryImpl(processEngineConfiguration.getCommandExecutor(), processEngineConfiguration.getEventSubscriptionServiceConfiguration());
+    }
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
@@ -413,6 +413,88 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
     }
 
     @Test
+    public void testMigrateNonInterruptingSignalEventSubProcessWithTwoStartedSubProcess() {
+        //Deploy first version of the process
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
+
+        //Start an instance of the first version of the process for migration
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(version1ProcessDef.getKey());
+
+        //Deploy second version of the same process
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-signal-event-subprocess.bpmn20.xml");
+        assertThat(version1ProcessDef.getId()).isNotEqualTo(version2ProcessDef.getId());
+
+        //Fire the signal to start the first sub process
+        runtimeService.signalEventReceived("eventSignal");
+        //Fire the signal to start the second sub process
+        runtimeService.signalEventReceived("eventSignal");
+
+        //Confirm the state to migrate
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder(
+                        "processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask", "eventSubProcess", "eventSubProcessTask"
+                );
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version1ProcessDef.getId());
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId())
+                );
+        List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventName, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventSignal", "eventSubProcessStart", version1ProcessDef.getId()));
+
+        changeStateEventListener.clear();
+
+        //Migrate to the other processDefinition
+        ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
+                .migrateToProcessDefinition(version2ProcessDef.getId());
+
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
+        assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
+
+        processInstanceMigrationBuilder.migrate(processInstance.getId());
+
+        //Confirm
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder(
+                        "processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask", "eventSubProcess", "eventSubProcessTask"
+                );
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version2ProcessDef.getId());
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId())
+                );
+
+        eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventName, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("eventSignal", "eventSubProcessStart", version2ProcessDef.getId()));
+
+        completeProcessInstanceTasks(processInstance.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+    @Test
     public void testMigrateSimpleActivityToActivityInsideNonInterruptingSignalEventSubProcessInNewDefinition() {
         ProcessDefinition procDefOneTask = deployProcessDefinition("my deploy",
                 "org/flowable/engine/test/api/runtime/migration/one-task-simple-process.bpmn20.xml");
@@ -608,6 +690,90 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
                 .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
                 .containsExactlyInAnyOrder(
                         Tuple.tuple("processTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId())
+                );
+
+        eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventName, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("someMessage", "eventSubProcessStart", version2ProcessDef.getId()));
+
+        completeProcessInstanceTasks(processInstance.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+    @Test
+    public void testMigrateNonInterruptingMessageEventSubProcessWithTwoStartedSubProcess() {
+        //Deploy first version of the process
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
+
+        //Start an instance of the first version of the process for migration
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(version1ProcessDef.getKey());
+
+        //Deploy second version of the same process
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-message-event-subprocess.bpmn20.xml");
+        assertThat(version1ProcessDef.getId()).isNotEqualTo(version2ProcessDef.getId());
+
+        Execution messageSubscriptionExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId())
+                .messageEventSubscriptionName("someMessage").singleResult();
+        //Trigger the event to create the first sub process
+        runtimeService.messageEventReceived("someMessage", messageSubscriptionExecution.getId());
+        //Trigger the event to create the second sub process
+        runtimeService.messageEventReceived("someMessage", messageSubscriptionExecution.getId());
+
+        //Confirm the state to migrate
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder(
+                        "processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask", "eventSubProcess", "eventSubProcessTask"
+                );
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version1ProcessDef.getId());
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId())
+                );
+        List<EventSubscription> eventSubscriptions = runtimeService.createEventSubscriptionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(eventSubscriptions)
+                .extracting(EventSubscription::getEventName, EventSubscription::getActivityId, EventSubscription::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(Tuple.tuple("someMessage", "eventSubProcessStart", version1ProcessDef.getId()));
+
+        changeStateEventListener.clear();
+
+        //Migrate to the other processDefinition
+        ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
+                .migrateToProcessDefinition(version2ProcessDef.getId());
+
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
+        assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
+
+        processInstanceMigrationBuilder.migrate(processInstance.getId());
+
+        //Confirm
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder(
+                        "processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask", "eventSubProcess", "eventSubProcessTask"
+                );
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version2ProcessDef.getId());
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId()),
                         Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId())
                 );
 
@@ -818,6 +984,98 @@ public class ProcessInstanceMigrationEventSubProcessTest extends AbstractProcess
                 .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
                 .containsExactlyInAnyOrder(
                         Tuple.tuple("processTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId())
+                );
+
+        timerJobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(timerJobs)
+                .extracting(Job::getProcessDefinitionId, Job::getElementId)
+                .containsExactlyInAnyOrder(Tuple.tuple(version2ProcessDef.getId(), "eventSubProcessStart"));
+
+        completeProcessInstanceTasks(processInstance.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+    @Test
+    public void testMigrateNonInterruptingTimerEventSubProcessWithTwoStartedSubProcess() {
+        //Deploy first version of the process
+        ProcessDefinition version1ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess.bpmn20.xml");
+
+        //Start an instance of the first version of the process for migration
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(version1ProcessDef.getKey());
+
+        //Deploy second version of the same process
+        ProcessDefinition version2ProcessDef = deployProcessDefinition("my deploy",
+                "org/flowable/engine/test/api/runtime/migration/non-interrupting-timer-event-subprocess.bpmn20.xml");
+        assertThat(version1ProcessDef.getId()).isNotEqualTo(version2ProcessDef.getId());
+
+        //Trigger the timer job to create the first sub process
+        List<Job> timerJobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(timerJobs).hasSize(1);
+
+        managementService.moveTimerToExecutableJob(timerJobs.get(0).getId());
+        managementService.executeJob(timerJobs.get(0).getId());
+
+        //Trigger the timer job to create the second sub process
+        timerJobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(timerJobs).hasSize(1);
+
+        managementService.moveTimerToExecutableJob(timerJobs.get(0).getId());
+        managementService.executeJob(timerJobs.get(0).getId());
+
+        //Confirm the state to migrate
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder(
+                        "processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask", "eventSubProcess", "eventSubProcessTask"
+                );
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version1ProcessDef.getId());
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version1ProcessDef.getId())
+                );
+
+        timerJobs = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(timerJobs)
+                .extracting(Job::getProcessDefinitionId, Job::getElementId)
+                .containsExactlyInAnyOrder(Tuple.tuple(version1ProcessDef.getId(), "eventSubProcessStart"));
+
+        changeStateEventListener.clear();
+
+        //Migrate to the other processDefinition
+        ProcessInstanceMigrationBuilder processInstanceMigrationBuilder = processMigrationService.createProcessInstanceMigrationBuilder()
+                .migrateToProcessDefinition(version2ProcessDef.getId());
+
+        ProcessInstanceMigrationValidationResult processInstanceMigrationValidationResult = processInstanceMigrationBuilder
+                .validateMigration(processInstance.getId());
+        assertThat(processInstanceMigrationValidationResult.isMigrationValid()).isTrue();
+
+        processInstanceMigrationBuilder.migrate(processInstance.getId());
+
+        //Confirm
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder(
+                        "processTask", "eventSubProcessStart", "eventSubProcess", "eventSubProcessTask", "eventSubProcess", "eventSubProcessTask"
+                );
+        assertThat(executions)
+                .extracting("processDefinitionId")
+                .containsOnly(version2ProcessDef.getId());
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey, Task::getProcessDefinitionId)
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("processTask", version2ProcessDef.getId()),
+                        Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId()),
                         Tuple.tuple("eventSubProcessTask", version2ProcessDef.getId())
                 );
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/ProcessInstanceMigrationEventSubProcessTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.groups.Tuple;
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.impl.test.HistoryTestHelper;

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/migration/non-interrupting-eventregistry-event-subprocess.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/runtime/migration/non-interrupting-eventregistry-event-subprocess.bpmn20.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="nonInterruptingEventRegistryEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="eventSubProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="false">
+                <extensionElements>
+                    <flowable:eventType>myEvent</flowable:eventType>
+                </extensionElements>
+            </startEvent>
+            <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask" />
+            <userTask id="eventSubProcessTask"/>
+            <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd" />
+            <endEvent id="eventSubProcessEnd" />
+        </subProcess>
+    </process>
+
+</definitions>


### PR DESCRIPTION
Fixes #3928

#### Check List:
* Unit tests: YES
* Documentation: NA
