### PR TITLE
Save element name in extension element if it has any new lines

### DIFF
--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/constants/BpmnXMLConstants.java
@@ -41,6 +41,7 @@ public interface BpmnXMLConstants {
 
     public static final String ATTRIBUTE_ID = "id";
     public static final String ATTRIBUTE_NAME = "name";
+    public static final String ATTRIBUTE_ELEMENT_NAME = "element-name";
     public static final String ATTRIBUTE_TYPE = "type";
     public static final String ATTRIBUTE_EXPORTER = "exporter";
     public static final String ATTRIBUTE_EXPORTER_VERSION = "exporterVersion";

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
@@ -111,6 +111,10 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
 
             FlowElement currentFlowElement = (FlowElement) parsedElement;
             currentFlowElement.setId(elementId);
+
+            if (StringUtils.isNotEmpty(BpmnXMLUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, parsedElement))) {
+                elementName = BpmnXMLUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, parsedElement);
+            }
             currentFlowElement.setName(elementName);
 
             if (currentFlowElement instanceof FlowNode) {
@@ -167,7 +171,14 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
         boolean didWriteExtensionStartElement = false;
         writeDefaultAttribute(ATTRIBUTE_ID, baseElement.getId(), xtw);
         if (baseElement instanceof FlowElement) {
-            writeDefaultAttribute(ATTRIBUTE_NAME, ((FlowElement) baseElement).getName(), xtw);
+            String name = ((FlowElement) baseElement).getName();
+            if (name != null && BpmnXMLUtil.containsNewLine(name)) {
+                // Save name in extension element if name contains any newlines
+                // because new lines are changed into spaces when xml attribute is parsed
+                baseElement.addExtensionElement(BpmnXMLUtil.createExtensionElement(ATTRIBUTE_ELEMENT_NAME, name));
+            } else {
+                writeDefaultAttribute(ATTRIBUTE_NAME, name, xtw);
+            }
         }
 
         if (baseElement instanceof FlowNode) {

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BaseBpmnXMLConverter.java
@@ -111,11 +111,9 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
 
             FlowElement currentFlowElement = (FlowElement) parsedElement;
             currentFlowElement.setId(elementId);
-
-            if (StringUtils.isNotEmpty(BpmnXMLUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, parsedElement))) {
-                elementName = BpmnXMLUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, parsedElement);
+            if (currentFlowElement.getName() == null) {
+                currentFlowElement.setName(elementName);
             }
-            currentFlowElement.setName(elementName);
 
             if (currentFlowElement instanceof FlowNode) {
                 FlowNode flowNode = (FlowNode) currentFlowElement;
@@ -172,11 +170,7 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
         writeDefaultAttribute(ATTRIBUTE_ID, baseElement.getId(), xtw);
         if (baseElement instanceof FlowElement) {
             String name = ((FlowElement) baseElement).getName();
-            if (name != null && BpmnXMLUtil.containsNewLine(name)) {
-                // Save name in extension element if name contains any newlines
-                // because new lines are changed into spaces when xml attribute is parsed
-                baseElement.addExtensionElement(BpmnXMLUtil.createExtensionElement(ATTRIBUTE_ELEMENT_NAME, name));
-            } else {
+            if (!BpmnXMLUtil.containsNewLine(name)) {
                 writeDefaultAttribute(ATTRIBUTE_NAME, name, xtw);
             }
         }
@@ -231,6 +225,8 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
                 xtw.writeCharacters(flowElement.getDocumentation());
                 xtw.writeEndElement();
             }
+
+            didWriteExtensionStartElement = BpmnXMLUtil.writeElementNameExtensionElement(flowElement, didWriteExtensionStartElement, xtw);
         }
 
         didWriteExtensionStartElement = writeExtensionChildElements(baseElement, didWriteExtensionStartElement, xtw);

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BpmnXMLConverter.java
@@ -313,12 +313,6 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
                         ELEMENT_TRANSACTION.equals(xtr.getLocalName()) ||
                         ELEMENT_ADHOC_SUBPROCESS.equals(xtr.getLocalName()))) {
 
-                    // Set name if ATTRIBUTE_ELEMENT_NAME extension element was found in subprocess
-                    SubProcess subProcess = activeSubProcessList.get(activeSubProcessList.size() - 1);
-                    if (StringUtils.isNotEmpty(BpmnXMLUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, subProcess))) {
-                        subProcess.setName(BpmnXMLUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, subProcess));
-                    }
-
                     activeSubProcessList.remove(activeSubProcessList.size() - 1);
                 }
 
@@ -624,6 +618,8 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
             }
 
             boolean didWriteExtensionStartElement = FlowableListenerExport.writeListeners(subProcess, false, xtw);
+
+            didWriteExtensionStartElement = BpmnXMLUtil.writeElementNameExtensionElement(subProcess, didWriteExtensionStartElement, xtw);
 
             didWriteExtensionStartElement = BpmnXMLUtil.writeExtensionElements(subProcess, didWriteExtensionStartElement, model.getNamespaces(), xtw);
             if (didWriteExtensionStartElement) {

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BpmnXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/BpmnXMLConverter.java
@@ -313,6 +313,12 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
                         ELEMENT_TRANSACTION.equals(xtr.getLocalName()) ||
                         ELEMENT_ADHOC_SUBPROCESS.equals(xtr.getLocalName()))) {
 
+                    // Set name if ATTRIBUTE_ELEMENT_NAME extension element was found in subprocess
+                    SubProcess subProcess = activeSubProcessList.get(activeSubProcessList.size() - 1);
+                    if (StringUtils.isNotEmpty(BpmnXMLUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, subProcess))) {
+                        subProcess.setName(BpmnXMLUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, subProcess));
+                    }
+
                     activeSubProcessList.remove(activeSubProcessList.size() - 1);
                 }
 

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/SequenceFlowXMLConverter.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/SequenceFlowXMLConverter.java
@@ -42,7 +42,6 @@ public class SequenceFlowXMLConverter extends BaseBpmnXMLConverter {
         BpmnXMLUtil.addXMLLocation(sequenceFlow, xtr);
         sequenceFlow.setSourceRef(xtr.getAttributeValue(null, ATTRIBUTE_FLOW_SOURCE_REF));
         sequenceFlow.setTargetRef(xtr.getAttributeValue(null, ATTRIBUTE_FLOW_TARGET_REF));
-        sequenceFlow.setName(xtr.getAttributeValue(null, ATTRIBUTE_NAME));
         sequenceFlow.setSkipExpression(xtr.getAttributeValue(null, ATTRIBUTE_FLOW_SKIP_EXPRESSION));
 
         parseChildElements(getXMLElementName(), sequenceFlow, model, xtr);

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/ElementNameParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/child/ElementNameParser.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.bpmn.converter.child;
+
+import javax.xml.stream.XMLStreamReader;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.bpmn.model.BaseElement;
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.FlowElement;
+
+public class ElementNameParser extends BaseChildElementParser {
+
+    @Override
+    public String getElementName() {
+        return ATTRIBUTE_ELEMENT_NAME;
+    }
+
+    @Override
+    public void parseChildElement(XMLStreamReader xtr, BaseElement parentElement, BpmnModel model) throws Exception {
+        String elementName = xtr.getElementText();
+        if (StringUtils.isNotEmpty(elementName)) {
+            if (parentElement instanceof FlowElement) {
+                ((FlowElement) parentElement).setName(elementName.trim());
+            }
+        }
+    }
+}

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/parser/ExtensionElementsParser.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/parser/ExtensionElementsParser.java
@@ -17,6 +17,7 @@ import java.util.List;
 import javax.xml.stream.XMLStreamReader;
 
 import org.flowable.bpmn.constants.BpmnXMLConstants;
+import org.flowable.bpmn.converter.child.ElementNameParser;
 import org.flowable.bpmn.converter.child.ExecutionListenerParser;
 import org.flowable.bpmn.converter.child.FlowableEventListenerParser;
 import org.flowable.bpmn.converter.util.BpmnXMLUtil;
@@ -50,6 +51,8 @@ public class ExtensionElementsParser implements BpmnXMLConstants {
                     new FlowableEventListenerParser().parseChildElement(xtr, parentElement, model);
                 } else if (ELEMENT_POTENTIAL_STARTER.equals(xtr.getLocalName())) {
                     new PotentialStarterParser().parse(xtr, activeProcess);
+                } else if (ATTRIBUTE_ELEMENT_NAME.equals(xtr.getLocalName())) {
+                    new ElementNameParser().parseChildElement(xtr, parentElement, model);
                 } else {
                     ExtensionElement extensionElement = BpmnXMLUtil.parseExtensionElement(xtr);
                     parentElement.addExtensionElement(extensionElement);

--- a/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/util/BpmnXMLUtil.java
+++ b/modules/flowable-bpmn-converter/src/main/java/org/flowable/bpmn/converter/util/BpmnXMLUtil.java
@@ -208,6 +208,24 @@ public class BpmnXMLUtil implements BpmnXMLConstants {
         return extensionElement;
     }
 
+    public static ExtensionElement createExtensionElement(String name, String value) {
+        ExtensionElement extensionElement = new ExtensionElement();
+        extensionElement.setNamespace(FLOWABLE_EXTENSIONS_NAMESPACE);
+        extensionElement.setNamespacePrefix(FLOWABLE_EXTENSIONS_PREFIX);
+        extensionElement.setName(name);
+        extensionElement.setElementText(value);
+        return extensionElement;
+    }
+
+    public static String getExtensionElementValue(String name, BaseElement element) {
+        String value = "";
+        if (element.getExtensionElements().get(name) != null && !element.getExtensionElements().get(name).isEmpty()) {
+            ExtensionElement extensionElement = element.getExtensionElements().get(name).get(0);
+            value = extensionElement.getElementText();
+        }
+        return value;
+    }
+
     public static String getAttributeValue(String attributeName, XMLStreamReader xtr) {
         String attributeValue = xtr.getAttributeValue(FLOWABLE_EXTENSIONS_NAMESPACE, attributeName);
         if (attributeValue == null) {
@@ -613,5 +631,9 @@ public class BpmnXMLUtil implements BpmnXMLConstants {
                 break;
             }
         }
+    }
+
+    public static boolean containsNewLine(String str) {
+        return str.contains("\n");
     }
 }

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/NameWithNewLineTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/NameWithNewLineTest.java
@@ -27,38 +27,31 @@ class NameWithNewLineTest {
     void validateModel(BpmnModel model) {
         FlowElement flowElement = model.getMainProcess().getFlowElement("startnoneevent1");
         assertThat(flowElement.getName()).isEqualTo("start\nevent");
-        ExtensionElement extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("start\nevent");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         flowElement = model.getMainProcess().getFlowElement("bpmnCatchEvent_12");
         assertThat(flowElement.getName()).isEqualTo("intermediate\nevent");
-        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("intermediate\nevent");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         flowElement = model.getMainProcess().getFlowElement("bpmnGateway_14");
         assertThat(flowElement.getName()).isEqualTo("gate\nway");
-        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("gate\nway");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         flowElement = model.getMainProcess().getFlowElement("bpmnEndEvent_3");
         assertThat(flowElement.getName()).isEqualTo("end\nevent");
-        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("end\nevent");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         SubProcess subProcess = (SubProcess) model.getMainProcess().getFlowElement("bpmnStructure_1");
         assertThat(subProcess.getName()).isEqualTo("sub\nprocess");
-        extensionElement = subProcess.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("sub\nprocess");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         flowElement = subProcess.getFlowElement("bpmnTask_5");
         assertThat(flowElement.getName()).isEqualTo("user\ntask");
-        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("user\ntask");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         flowElement = subProcess.getFlowElement("bpmnBoundaryEvent_10");
         assertThat(flowElement.getName()).isEqualTo("boundary\nevent");
-        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("boundary\nevent");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
     }
 
     @BpmnXmlConverterTest("nameWithoutNewLineTestProcess.bpmn")

--- a/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/NameWithNewLineTest.java
+++ b/modules/flowable-bpmn-converter/src/test/java/org/flowable/editor/language/xml/NameWithNewLineTest.java
@@ -1,0 +1,94 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.editor.language.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.flowable.bpmn.constants.BpmnXMLConstants.ATTRIBUTE_ELEMENT_NAME;
+
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.ExtensionElement;
+import org.flowable.bpmn.model.FlowElement;
+import org.flowable.bpmn.model.SubProcess;
+import org.flowable.editor.language.xml.util.BpmnXmlConverterTest;
+
+class NameWithNewLineTest {
+
+    @BpmnXmlConverterTest("nameWithNewLineTestProcess.bpmn")
+    void validateModel(BpmnModel model) {
+        FlowElement flowElement = model.getMainProcess().getFlowElement("startnoneevent1");
+        assertThat(flowElement.getName()).isEqualTo("start\nevent");
+        ExtensionElement extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("start\nevent");
+
+        flowElement = model.getMainProcess().getFlowElement("bpmnCatchEvent_12");
+        assertThat(flowElement.getName()).isEqualTo("intermediate\nevent");
+        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("intermediate\nevent");
+
+        flowElement = model.getMainProcess().getFlowElement("bpmnGateway_14");
+        assertThat(flowElement.getName()).isEqualTo("gate\nway");
+        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("gate\nway");
+
+        flowElement = model.getMainProcess().getFlowElement("bpmnEndEvent_3");
+        assertThat(flowElement.getName()).isEqualTo("end\nevent");
+        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("end\nevent");
+
+        SubProcess subProcess = (SubProcess) model.getMainProcess().getFlowElement("bpmnStructure_1");
+        assertThat(subProcess.getName()).isEqualTo("sub\nprocess");
+        extensionElement = subProcess.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("sub\nprocess");
+
+        flowElement = subProcess.getFlowElement("bpmnTask_5");
+        assertThat(flowElement.getName()).isEqualTo("user\ntask");
+        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("user\ntask");
+
+        flowElement = subProcess.getFlowElement("bpmnBoundaryEvent_10");
+        assertThat(flowElement.getName()).isEqualTo("boundary\nevent");
+        extensionElement = flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("boundary\nevent");
+    }
+
+    @BpmnXmlConverterTest("nameWithoutNewLineTestProcess.bpmn")
+    void validateModelWithoutNewLines(BpmnModel model) {
+        FlowElement flowElement = model.getMainProcess().getFlowElement("startnoneevent1");
+        assertThat(flowElement.getName()).isEqualTo("startevent");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        flowElement = model.getMainProcess().getFlowElement("bpmnCatchEvent_12");
+        assertThat(flowElement.getName()).isEqualTo("intermediateevent");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        flowElement = model.getMainProcess().getFlowElement("bpmnGateway_14");
+        assertThat(flowElement.getName()).isEqualTo("gateway");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        flowElement = model.getMainProcess().getFlowElement("bpmnEndEvent_3");
+        assertThat(flowElement.getName()).isEqualTo("endevent");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        SubProcess subProcess = (SubProcess) model.getMainProcess().getFlowElement("bpmnStructure_1");
+        assertThat(subProcess.getName()).isEqualTo("subprocess");
+        assertThat(subProcess.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        flowElement = subProcess.getFlowElement("bpmnTask_5");
+        assertThat(flowElement.getName()).isEqualTo("usertask");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        flowElement = subProcess.getFlowElement("bpmnBoundaryEvent_10");
+        assertThat(flowElement.getName()).isEqualTo("boundaryevent");
+        assertThat(flowElement.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+    }
+}

--- a/modules/flowable-bpmn-converter/src/test/resources/nameWithNewLineTestProcess.bpmn
+++ b/modules/flowable-bpmn-converter/src/test/resources/nameWithNewLineTestProcess.bpmn
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:design="http://flowable.org/design" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://flowable.org/test" design:palette="flowable-work-process-palette">
+  <process id="nameWithNewLineTestProcess" name="NameWithNewLineTestProcess" isExecutable="true" flowable:candidateStarterGroups="flowableUser">
+    <extensionElements>
+      <design:stencilid><![CDATA[BPMNDiagram]]></design:stencilid>
+      <design:creationdate><![CDATA[2024-08-07T09:25:57.671Z]]></design:creationdate>
+      <design:modificationdate><![CDATA[2024-08-07T13:18:13.557Z]]></design:modificationdate>
+    </extensionElements>
+    <subProcess id="bpmnStructure_1" name="sub
+process">
+      <extensionElements>
+        <flowable:element-name><![CDATA[sub
+process]]></flowable:element-name>
+        <design:stencilid><![CDATA[ExpandedSubProcess]]></design:stencilid>
+      </extensionElements>
+      <boundaryEvent id="bpmnBoundaryEvent_10" name="boundary
+event" attachedToRef="bpmnTask_5" cancelActivity="true">
+        <extensionElements>
+          <flowable:element-name><![CDATA[boundary
+event]]></flowable:element-name>
+          <design:stencilid><![CDATA[IntermediateTimerEventBoundary]]></design:stencilid>
+          <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+        </extensionElements>
+        <timerEventDefinition>
+          <timeDuration>PT1H</timeDuration>
+        </timerEventDefinition>
+      </boundaryEvent>
+      <sequenceFlow id="bpmnSequenceFlow_11" sourceRef="bpmnBoundaryEvent_10" targetRef="bpmnEndEvent_8">
+        <extensionElements>
+          <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+        </extensionElements>
+      </sequenceFlow>
+      <userTask id="bpmnTask_5" name="user
+task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <flowable:element-name><![CDATA[user
+task]]></flowable:element-name>
+          <design:stencilid><![CDATA[FormTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </userTask>
+      <startEvent id="bpmnStartEvent_6" flowable:initiator="initiator" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+          <design:stencilid><![CDATA[StartNoneEvent]]></design:stencilid>
+        </extensionElements>
+      </startEvent>
+      <endEvent id="bpmnEndEvent_8">
+        <extensionElements>
+          <design:stencilid><![CDATA[EndNoneEvent]]></design:stencilid>
+        </extensionElements>
+      </endEvent>
+      <sequenceFlow id="bpmnSequenceFlow_9" sourceRef="bpmnTask_5" targetRef="bpmnEndEvent_8">
+        <extensionElements>
+          <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+        </extensionElements>
+      </sequenceFlow>
+      <sequenceFlow id="bpmnSequenceFlow_7" sourceRef="bpmnStartEvent_6" targetRef="bpmnTask_5">
+        <extensionElements>
+          <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+        </extensionElements>
+      </sequenceFlow>
+    </subProcess>
+    <userTask id="bpmnTask_16" name="User task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+        <design:stencilid><![CDATA[FormTask]]></design:stencilid>
+        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+      </extensionElements>
+    </userTask>
+    <exclusiveGateway id="bpmnGateway_14" name="gate
+way">
+      <extensionElements>
+        <flowable:element-name><![CDATA[gate
+way]]></flowable:element-name>
+        <design:stencilid><![CDATA[Exclusive_Databased_Gateway]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+    </exclusiveGateway>
+    <startEvent id="startnoneevent1" name="start
+event" flowable:initiator="initiator" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <flowable:element-name><![CDATA[start
+event]]></flowable:element-name>
+        <design:stencilid><![CDATA[StartNoneEvent]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+    </startEvent>
+    <intermediateCatchEvent id="bpmnCatchEvent_12" name="intermediate
+event">
+      <extensionElements>
+        <flowable:element-name><![CDATA[intermediate
+event]]></flowable:element-name>
+        <design:stencilid><![CDATA[IntermediateTimerEvent]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+      <timerEventDefinition></timerEventDefinition>
+    </intermediateCatchEvent>
+    <endEvent id="bpmnEndEvent_3" name="end
+event">
+      <extensionElements>
+        <flowable:element-name><![CDATA[end
+event]]></flowable:element-name>
+        <design:stencilid><![CDATA[EndNoneEvent]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+    </endEvent>
+    <sequenceFlow id="bpmnSequenceFlow_4" sourceRef="bpmnStructure_1" targetRef="bpmnGateway_14">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_18" sourceRef="bpmnTask_16" targetRef="bpmnEndEvent_3">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_15" name="sequence
+flow" sourceRef="bpmnGateway_14" targetRef="bpmnEndEvent_3">
+      <extensionElements>
+        <flowable:element-name><![CDATA[sequence
+flow]]></flowable:element-name>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_17" sourceRef="bpmnGateway_14" targetRef="bpmnTask_16">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_2" sourceRef="startnoneevent1" targetRef="bpmnCatchEvent_12">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_13" sourceRef="bpmnCatchEvent_12" targetRef="bpmnStructure_1">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_nameWithNewLineTestProcess">
+    <bpmndi:BPMNPlane bpmnElement="nameWithNewLineTestProcess" id="BPMNPlane_nameWithNewLineTestProcess">
+      <bpmndi:BPMNShape bpmnElement="bpmnStructure_1" id="BPMNShape_bpmnStructure_1">
+        <omgdc:Bounds height="250.0" width="349.0" x="446.0" y="201.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnBoundaryEvent_10" id="BPMNShape_bpmnBoundaryEvent_10">
+        <omgdc:Bounds height="30.0" width="30.0" x="602.0" y="351.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="50.0" x="554.8" y="390.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnTask_5" id="BPMNShape_bpmnTask_5">
+        <omgdc:Bounds height="80.0" width="100.0" x="567.0" y="286.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnStartEvent_6" id="BPMNShape_bpmnStartEvent_6">
+        <omgdc:Bounds height="30.0" width="30.0" x="476.0" y="311.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnEndEvent_8" id="BPMNShape_bpmnEndEvent_8">
+        <omgdc:Bounds height="28.0" width="28.0" x="738.0" y="312.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnTask_16" id="BPMNShape_bpmnTask_16">
+        <omgdc:Bounds height="80.0" width="100.0" x="967.0" y="437.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnGateway_14" id="BPMNShape_bpmnGateway_14">
+        <omgdc:Bounds height="40.0" width="40.0" x="853.0" y="306.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="23.0" x="860.6" y="252.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="startnoneevent1" id="BPMNShape_startnoneevent1">
+        <omgdc:Bounds height="30.0" width="30.0" x="246.0" y="311.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="29.0" x="246.5" y="345.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnCatchEvent_12" id="BPMNShape_bpmnCatchEvent_12">
+        <omgdc:Bounds height="30.0" width="30.0" x="338.0" y="311.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="66.0" x="321.6" y="356.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnEndEvent_3" id="BPMNShape_bpmnEndEvent_3">
+        <omgdc:Bounds height="28.0" width="28.0" x="1139.0" y="312.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="29.0" x="1140.3" y="260.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_11" id="BPMNEdge_bpmnSequenceFlow_11" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0" flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+        <omgdi:waypoint x="617.0" y="381.0"></omgdi:waypoint>
+        <omgdi:waypoint x="617.0" y="415.0"></omgdi:waypoint>
+        <omgdi:waypoint x="752.0" y="415.0"></omgdi:waypoint>
+        <omgdi:waypoint x="752.0" y="340.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_9" id="BPMNEdge_bpmnSequenceFlow_9" flowable:sourceDockerX="50.0" flowable:sourceDockerY="40.0" flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+        <omgdi:waypoint x="667.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="738.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_13" id="BPMNEdge_bpmnSequenceFlow_13" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0" flowable:targetDockerX="175.0" flowable:targetDockerY="125.0">
+        <omgdi:waypoint x="368.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="446.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_15" id="BPMNEdge_bpmnSequenceFlow_15" flowable:sourceDockerX="20.0" flowable:sourceDockerY="20.0" flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+        <omgdi:waypoint x="893.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="1139.0" y="326.0"></omgdi:waypoint>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="52.0" x="927.0" y="278.8"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_17" id="BPMNEdge_bpmnSequenceFlow_17" flowable:sourceDockerX="20.0" flowable:sourceDockerY="20.0" flowable:targetDockerX="50.0" flowable:targetDockerY="40.0">
+        <omgdi:waypoint x="873.0" y="346.0"></omgdi:waypoint>
+        <omgdi:waypoint x="873.0" y="477.0"></omgdi:waypoint>
+        <omgdi:waypoint x="967.0" y="477.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_4" id="BPMNEdge_bpmnSequenceFlow_4" flowable:sourceDockerX="175.0" flowable:sourceDockerY="125.0" flowable:targetDockerX="20.0" flowable:targetDockerY="20.0">
+        <omgdi:waypoint x="795.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="853.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_18" id="BPMNEdge_bpmnSequenceFlow_18" flowable:sourceDockerX="50.0" flowable:sourceDockerY="40.0" flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+        <omgdi:waypoint x="1067.0" y="477.0"></omgdi:waypoint>
+        <omgdi:waypoint x="1153.0" y="477.0"></omgdi:waypoint>
+        <omgdi:waypoint x="1153.0" y="340.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_2" id="BPMNEdge_bpmnSequenceFlow_2" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0" flowable:targetDockerX="15.0" flowable:targetDockerY="15.0">
+        <omgdi:waypoint x="276.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="338.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_7" id="BPMNEdge_bpmnSequenceFlow_7" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0" flowable:targetDockerX="50.0" flowable:targetDockerY="40.0">
+        <omgdi:waypoint x="506.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="567.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/flowable-bpmn-converter/src/test/resources/nameWithoutNewLineTestProcess.bpmn
+++ b/modules/flowable-bpmn-converter/src/test/resources/nameWithoutNewLineTestProcess.bpmn
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:flowable="http://flowable.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:design="http://flowable.org/design" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://flowable.org/test" design:palette="flowable-work-process-palette">
+  <process id="nameWithNewLineTestProcess" name="NameWithNewLineTestProcess" isExecutable="true" flowable:candidateStarterGroups="flowableUser">
+    <extensionElements>
+      <design:stencilid><![CDATA[BPMNDiagram]]></design:stencilid>
+      <design:creationdate><![CDATA[2024-08-07T09:25:57.671Z]]></design:creationdate>
+      <design:modificationdate><![CDATA[2024-08-07T13:18:13.557Z]]></design:modificationdate>
+    </extensionElements>
+    <subProcess id="bpmnStructure_1" name="subprocess">
+      <extensionElements>
+        <design:stencilid><![CDATA[ExpandedSubProcess]]></design:stencilid>
+      </extensionElements>
+      <boundaryEvent id="bpmnBoundaryEvent_10" name="boundaryevent" attachedToRef="bpmnTask_5" cancelActivity="true">
+        <extensionElements>
+          <design:stencilid><![CDATA[IntermediateTimerEventBoundary]]></design:stencilid>
+          <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+        </extensionElements>
+        <timerEventDefinition>
+          <timeDuration>PT1H</timeDuration>
+        </timerEventDefinition>
+      </boundaryEvent>
+      <sequenceFlow id="bpmnSequenceFlow_11" sourceRef="bpmnBoundaryEvent_10" targetRef="bpmnEndEvent_8">
+        <extensionElements>
+          <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+        </extensionElements>
+      </sequenceFlow>
+      <userTask id="bpmnTask_5" name="usertask" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+          <design:stencilid><![CDATA[FormTask]]></design:stencilid>
+          <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+        </extensionElements>
+      </userTask>
+      <startEvent id="bpmnStartEvent_6" flowable:initiator="initiator" flowable:formFieldValidation="false">
+        <extensionElements>
+          <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+          <design:stencilid><![CDATA[StartNoneEvent]]></design:stencilid>
+        </extensionElements>
+      </startEvent>
+      <endEvent id="bpmnEndEvent_8">
+        <extensionElements>
+          <design:stencilid><![CDATA[EndNoneEvent]]></design:stencilid>
+        </extensionElements>
+      </endEvent>
+      <sequenceFlow id="bpmnSequenceFlow_9" sourceRef="bpmnTask_5" targetRef="bpmnEndEvent_8">
+        <extensionElements>
+          <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+        </extensionElements>
+      </sequenceFlow>
+      <sequenceFlow id="bpmnSequenceFlow_7" sourceRef="bpmnStartEvent_6" targetRef="bpmnTask_5">
+        <extensionElements>
+          <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+        </extensionElements>
+      </sequenceFlow>
+    </subProcess>
+    <userTask id="bpmnTask_16" name="User task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+        <design:stencilid><![CDATA[FormTask]]></design:stencilid>
+        <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+      </extensionElements>
+    </userTask>
+    <exclusiveGateway id="bpmnGateway_14" name="gateway">
+      <extensionElements>
+        <design:stencilid><![CDATA[Exclusive_Databased_Gateway]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+    </exclusiveGateway>
+    <startEvent id="startnoneevent1" name="startevent" flowable:initiator="initiator" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[StartNoneEvent]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+    </startEvent>
+    <intermediateCatchEvent id="bpmnCatchEvent_12" name="intermediateevent">
+      <extensionElements>
+        <design:stencilid><![CDATA[IntermediateTimerEvent]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+      <timerEventDefinition></timerEventDefinition>
+    </intermediateCatchEvent>
+    <endEvent id="bpmnEndEvent_3" name="endevent">
+      <extensionElements>
+        <design:stencilid><![CDATA[EndNoneEvent]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+    </endEvent>
+    <sequenceFlow id="bpmnSequenceFlow_4" sourceRef="bpmnStructure_1" targetRef="bpmnGateway_14">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_18" sourceRef="bpmnTask_16" targetRef="bpmnEndEvent_3">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_15" name="sequenceflow" sourceRef="bpmnGateway_14" targetRef="bpmnEndEvent_3">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+        <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_17" sourceRef="bpmnGateway_14" targetRef="bpmnTask_16">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_2" sourceRef="startnoneevent1" targetRef="bpmnCatchEvent_12">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="bpmnSequenceFlow_13" sourceRef="bpmnCatchEvent_12" targetRef="bpmnStructure_1">
+      <extensionElements>
+        <design:stencilid><![CDATA[SequenceFlow]]></design:stencilid>
+      </extensionElements>
+    </sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_nameWithNewLineTestProcess">
+    <bpmndi:BPMNPlane bpmnElement="nameWithNewLineTestProcess" id="BPMNPlane_nameWithNewLineTestProcess">
+      <bpmndi:BPMNShape bpmnElement="bpmnStructure_1" id="BPMNShape_bpmnStructure_1">
+        <omgdc:Bounds height="250.0" width="349.0" x="446.0" y="201.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnBoundaryEvent_10" id="BPMNShape_bpmnBoundaryEvent_10">
+        <omgdc:Bounds height="30.0" width="30.0" x="602.0" y="351.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="50.0" x="554.8" y="390.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnTask_5" id="BPMNShape_bpmnTask_5">
+        <omgdc:Bounds height="80.0" width="100.0" x="567.0" y="286.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnStartEvent_6" id="BPMNShape_bpmnStartEvent_6">
+        <omgdc:Bounds height="30.0" width="30.0" x="476.0" y="311.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnEndEvent_8" id="BPMNShape_bpmnEndEvent_8">
+        <omgdc:Bounds height="28.0" width="28.0" x="738.0" y="312.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnTask_16" id="BPMNShape_bpmnTask_16">
+        <omgdc:Bounds height="80.0" width="100.0" x="967.0" y="437.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnGateway_14" id="BPMNShape_bpmnGateway_14">
+        <omgdc:Bounds height="40.0" width="40.0" x="853.0" y="306.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="23.0" x="860.6" y="252.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="startnoneevent1" id="BPMNShape_startnoneevent1">
+        <omgdc:Bounds height="30.0" width="30.0" x="246.0" y="311.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="29.0" x="246.5" y="345.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnCatchEvent_12" id="BPMNShape_bpmnCatchEvent_12">
+        <omgdc:Bounds height="30.0" width="30.0" x="338.0" y="311.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="66.0" x="321.6" y="356.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="bpmnEndEvent_3" id="BPMNShape_bpmnEndEvent_3">
+        <omgdc:Bounds height="28.0" width="28.0" x="1139.0" y="312.0"></omgdc:Bounds>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="29.0" x="1140.3" y="260.0"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_11" id="BPMNEdge_bpmnSequenceFlow_11" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0" flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+        <omgdi:waypoint x="617.0" y="381.0"></omgdi:waypoint>
+        <omgdi:waypoint x="617.0" y="415.0"></omgdi:waypoint>
+        <omgdi:waypoint x="752.0" y="415.0"></omgdi:waypoint>
+        <omgdi:waypoint x="752.0" y="340.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_9" id="BPMNEdge_bpmnSequenceFlow_9" flowable:sourceDockerX="50.0" flowable:sourceDockerY="40.0" flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+        <omgdi:waypoint x="667.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="738.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_13" id="BPMNEdge_bpmnSequenceFlow_13" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0" flowable:targetDockerX="175.0" flowable:targetDockerY="125.0">
+        <omgdi:waypoint x="368.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="446.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_15" id="BPMNEdge_bpmnSequenceFlow_15" flowable:sourceDockerX="20.0" flowable:sourceDockerY="20.0" flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+        <omgdi:waypoint x="893.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="1139.0" y="326.0"></omgdi:waypoint>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="36.0" width="52.0" x="927.0" y="278.8"></omgdc:Bounds>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_17" id="BPMNEdge_bpmnSequenceFlow_17" flowable:sourceDockerX="20.0" flowable:sourceDockerY="20.0" flowable:targetDockerX="50.0" flowable:targetDockerY="40.0">
+        <omgdi:waypoint x="873.0" y="346.0"></omgdi:waypoint>
+        <omgdi:waypoint x="873.0" y="477.0"></omgdi:waypoint>
+        <omgdi:waypoint x="967.0" y="477.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_4" id="BPMNEdge_bpmnSequenceFlow_4" flowable:sourceDockerX="175.0" flowable:sourceDockerY="125.0" flowable:targetDockerX="20.0" flowable:targetDockerY="20.0">
+        <omgdi:waypoint x="795.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="853.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_18" id="BPMNEdge_bpmnSequenceFlow_18" flowable:sourceDockerX="50.0" flowable:sourceDockerY="40.0" flowable:targetDockerX="14.0" flowable:targetDockerY="14.0">
+        <omgdi:waypoint x="1067.0" y="477.0"></omgdi:waypoint>
+        <omgdi:waypoint x="1153.0" y="477.0"></omgdi:waypoint>
+        <omgdi:waypoint x="1153.0" y="340.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_2" id="BPMNEdge_bpmnSequenceFlow_2" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0" flowable:targetDockerX="15.0" flowable:targetDockerY="15.0">
+        <omgdi:waypoint x="276.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="338.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="bpmnSequenceFlow_7" id="BPMNEdge_bpmnSequenceFlow_7" flowable:sourceDockerX="15.0" flowable:sourceDockerY="15.0" flowable:targetDockerX="50.0" flowable:targetDockerY="40.0">
+        <omgdi:waypoint x="506.0" y="326.0"></omgdi:waypoint>
+        <omgdi:waypoint x="567.0" y="326.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConstants.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/CmmnXmlConstants.java
@@ -104,6 +104,7 @@ public interface CmmnXmlConstants {
 
     String ATTRIBUTE_ID = "id";
     String ATTRIBUTE_NAME = "name";
+    String ATTRIBUTE_ELEMENT_NAME = "element-name";
     String ATTRIBUTE_INITIATOR_VARIABLE_NAME = "initiatorVariableName";
     String ATTRIBUTE_CASE_CANDIDATE_USERS = "candidateStarterUsers";
     String ATTRIBUTE_CASE_CANDIDATE_GROUPS = "candidateStarterGroups";

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ConversionHelper.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ConversionHelper.java
@@ -59,6 +59,7 @@ public class ConversionHelper {
     protected CmmnDiShape currentDiShape;
     protected CmmnDiEdge currentDiEdge;
     protected GraphicInfo currentLabelGraphicInfo;
+    protected LinkedList<PlanItemDefinition> planItemDefinitionsStack = new LinkedList<>();
 
     protected Map<Case, List<CaseElement>> caseElements = new HashMap<>();
     protected List<Stage> stages = new ArrayList<>();
@@ -247,6 +248,20 @@ public class ConversionHelper {
 
     public void removeCurrentPlanFragment() {
         this.planFragmentsStack.removeLast();
+    }
+
+    public PlanItemDefinition getCurrentPlanItemDefinition() {
+        return planItemDefinitionsStack.peekLast();
+    }
+
+    public void setCurrentPlanItemDefinition(PlanItemDefinition currentPlanItemDefinition) {
+        if (currentPlanItemDefinition != null) {
+            this.planItemDefinitionsStack.add(currentPlanItemDefinition);
+        }
+    }
+
+    public void removeCurrentPlanItemDefinition() {
+        this.planItemDefinitionsStack.removeLast();
     }
 
     public Stage getCurrentStage() {

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ConversionHelper.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ConversionHelper.java
@@ -59,7 +59,6 @@ public class ConversionHelper {
     protected CmmnDiShape currentDiShape;
     protected CmmnDiEdge currentDiEdge;
     protected GraphicInfo currentLabelGraphicInfo;
-    protected LinkedList<PlanItemDefinition> planItemDefinitionsStack = new LinkedList<>();
 
     protected Map<Case, List<CaseElement>> caseElements = new HashMap<>();
     protected List<Stage> stages = new ArrayList<>();
@@ -248,20 +247,6 @@ public class ConversionHelper {
 
     public void removeCurrentPlanFragment() {
         this.planFragmentsStack.removeLast();
-    }
-
-    public PlanItemDefinition getCurrentPlanItemDefinition() {
-        return planItemDefinitionsStack.peekLast();
-    }
-
-    public void setCurrentPlanItemDefinition(PlanItemDefinition currentPlanItemDefinition) {
-        if (currentPlanItemDefinition != null) {
-            this.planItemDefinitionsStack.add(currentPlanItemDefinition);
-        }
-    }
-
-    public void removeCurrentPlanItemDefinition() {
-        this.planItemDefinitionsStack.removeLast();
     }
 
     public Stage getCurrentStage() {

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ExtensionElementsXMLConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/ExtensionElementsXMLConverter.java
@@ -15,6 +15,7 @@ package org.flowable.cmmn.converter;
 
 import static org.flowable.cmmn.converter.CmmnXmlConstants.ATTRIBUTE_CLASS;
 import static org.flowable.cmmn.converter.CmmnXmlConstants.ATTRIBUTE_DELEGATE_EXPRESSION;
+import static org.flowable.cmmn.converter.CmmnXmlConstants.ATTRIBUTE_ELEMENT_NAME;
 import static org.flowable.cmmn.model.ImplementationType.IMPLEMENTATION_TYPE_CLASS;
 import static org.flowable.cmmn.model.ImplementationType.IMPLEMENTATION_TYPE_DELEGATEEXPRESSION;
 
@@ -28,6 +29,7 @@ import org.flowable.cmmn.converter.util.ListenerXmlConverterUtil;
 import org.flowable.cmmn.model.AbstractFlowableHttpHandler;
 import org.flowable.cmmn.model.BaseElement;
 import org.flowable.cmmn.model.Case;
+import org.flowable.cmmn.model.CaseElement;
 import org.flowable.cmmn.model.ChildTask;
 import org.flowable.cmmn.model.CmmnElement;
 import org.flowable.cmmn.model.CompletionNeutralRule;
@@ -124,6 +126,8 @@ public class ExtensionElementsXMLConverter extends CaseElementXmlConverter {
                     } else if (CmmnXmlConstants.ELEMENT_VARIABLE_AGGREGATION.equals(xtr.getLocalName())) {
                         readVariableAggregationDefinition(xtr, conversionHelper);
 
+                    } else if (CmmnXmlConstants.ATTRIBUTE_ELEMENT_NAME.equals(xtr.getLocalName())) {
+                        readElementName(xtr, conversionHelper);
                     } else {
                         ExtensionElement extensionElement = CmmnXmlUtil.parseExtensionElement(xtr);
                         conversionHelper.getCurrentCmmnElement().addExtensionElement(extensionElement);
@@ -459,6 +463,24 @@ public class ExtensionElementsXMLConverter extends CaseElementXmlConverter {
             } catch (Exception e) {
                 LOGGER.warn("Error parsing collection child elements", e);
             }
+        }
+
+    }
+
+    protected void readElementName(XMLStreamReader xtr, ConversionHelper conversionHelper) {
+        CmmnElement currentCmmnElement = conversionHelper.getCurrentCmmnElement();
+
+        if (currentCmmnElement instanceof CaseElement) {
+            try {
+                String elementName = xtr.getElementText();
+
+                if (StringUtils.isNotEmpty(elementName)) {
+                    ((CaseElement) currentCmmnElement).setName(elementName.trim());
+                }
+            } catch (Exception e) {
+                throw new FlowableException("Error while reading " + ATTRIBUTE_ELEMENT_NAME + " extension element", e);
+            }
+
         }
 
     }

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/PlanItemDefinitionXmlConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/PlanItemDefinitionXmlConverter.java
@@ -12,8 +12,12 @@
  */
 package org.flowable.cmmn.converter;
 
+import static org.flowable.cmmn.converter.CmmnXmlConstants.ATTRIBUTE_ELEMENT_NAME;
+
 import javax.xml.stream.XMLStreamReader;
 
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.cmmn.converter.util.CmmnXmlUtil;
 import org.flowable.cmmn.model.BaseElement;
 import org.flowable.cmmn.model.PlanItemDefinition;
 import org.flowable.cmmn.model.Stage;
@@ -35,8 +39,24 @@ public abstract class PlanItemDefinitionXmlConverter extends CaseElementXmlConve
             if (parentStage != null) {
                 parentStage.addPlanItemDefinition(planItemDefinition);
             }
-        }   
+        }
+
+        conversionHelper.setCurrentPlanItemDefinition(planItemDefinition);
+
         return planItemDefinition;
+    }
+
+    @Override
+    protected void elementEnd(XMLStreamReader xtr, ConversionHelper conversionHelper) {
+        super.elementEnd(xtr, conversionHelper);
+
+        PlanItemDefinition planItemDefinition = conversionHelper.getCurrentPlanItemDefinition();
+        // Set name if ATTRIBUTE_ELEMENT_NAME extension element was found in plan item definition
+        if (planItemDefinition != null && StringUtils.isNotEmpty(CmmnXmlUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, planItemDefinition))) {
+            planItemDefinition.setName(CmmnXmlUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, planItemDefinition));
+        }
+
+        conversionHelper.removeCurrentPlanItemDefinition();
     }
     
 }

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/PlanItemDefinitionXmlConverter.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/PlanItemDefinitionXmlConverter.java
@@ -12,12 +12,8 @@
  */
 package org.flowable.cmmn.converter;
 
-import static org.flowable.cmmn.converter.CmmnXmlConstants.ATTRIBUTE_ELEMENT_NAME;
-
 import javax.xml.stream.XMLStreamReader;
 
-import org.apache.commons.lang3.StringUtils;
-import org.flowable.cmmn.converter.util.CmmnXmlUtil;
 import org.flowable.cmmn.model.BaseElement;
 import org.flowable.cmmn.model.PlanItemDefinition;
 import org.flowable.cmmn.model.Stage;
@@ -41,22 +37,7 @@ public abstract class PlanItemDefinitionXmlConverter extends CaseElementXmlConve
             }
         }
 
-        conversionHelper.setCurrentPlanItemDefinition(planItemDefinition);
-
         return planItemDefinition;
-    }
-
-    @Override
-    protected void elementEnd(XMLStreamReader xtr, ConversionHelper conversionHelper) {
-        super.elementEnd(xtr, conversionHelper);
-
-        PlanItemDefinition planItemDefinition = conversionHelper.getCurrentPlanItemDefinition();
-        // Set name if ATTRIBUTE_ELEMENT_NAME extension element was found in plan item definition
-        if (planItemDefinition != null && StringUtils.isNotEmpty(CmmnXmlUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, planItemDefinition))) {
-            planItemDefinition.setName(CmmnXmlUtil.getExtensionElementValue(ATTRIBUTE_ELEMENT_NAME, planItemDefinition));
-        }
-
-        conversionHelper.removeCurrentPlanItemDefinition();
     }
     
 }

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/AbstractPlanItemDefinitionExport.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/AbstractPlanItemDefinitionExport.java
@@ -67,15 +67,8 @@ public abstract class AbstractPlanItemDefinitionExport<T extends PlanItemDefinit
     protected void writePlanItemDefinitionCommonAttributes(T planItemDefinition, XMLStreamWriter xtw) throws Exception {
         xtw.writeAttribute(ATTRIBUTE_ID, planItemDefinition.getId());
 
-        if (StringUtils.isNotEmpty(planItemDefinition.getName())) {
-            String name = planItemDefinition.getName();
-            if (name != null && CmmnXmlUtil.containsNewLine(name)) {
-                // Save name in extension element if name contains any newlines
-                // because new lines are changed into spaces when xml attribute is parsed
-                planItemDefinition.addExtensionElement(CmmnXmlUtil.createExtensionElement(ATTRIBUTE_NAME, name));
-            } else {
-                xtw.writeAttribute(ATTRIBUTE_NAME, planItemDefinition.getName());
-            }
+        if (StringUtils.isNotEmpty(planItemDefinition.getName()) && !CmmnXmlUtil.containsNewLine(planItemDefinition.getName())) {
+            xtw.writeAttribute(ATTRIBUTE_NAME, planItemDefinition.getName());
         }
     }
 
@@ -105,8 +98,10 @@ public abstract class AbstractPlanItemDefinitionExport<T extends PlanItemDefinit
             xtw.writeCharacters(planItemDefinition.getDocumentation());
             xtw.writeEndElement();
         }
+
+        boolean didWriteExtensionStartElement = CmmnXmlUtil.writeElementNameExtensionElement(planItemDefinition, false, xtw);
         
-        return CmmnXmlUtil.writeExtensionElements(planItemDefinition, false, model.getNamespaces(), xtw);
+        return CmmnXmlUtil.writeExtensionElements(planItemDefinition, didWriteExtensionStartElement, model.getNamespaces(), xtw);
     }
     
     protected boolean writePlanItemDefinitionExtensionElements(CmmnModel model, T planItemDefinition, boolean didWriteExtensionElement, XMLStreamWriter xtw) throws Exception {

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/AbstractPlanItemDefinitionExport.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/export/AbstractPlanItemDefinitionExport.java
@@ -68,7 +68,14 @@ public abstract class AbstractPlanItemDefinitionExport<T extends PlanItemDefinit
         xtw.writeAttribute(ATTRIBUTE_ID, planItemDefinition.getId());
 
         if (StringUtils.isNotEmpty(planItemDefinition.getName())) {
-            xtw.writeAttribute(ATTRIBUTE_NAME, planItemDefinition.getName());
+            String name = planItemDefinition.getName();
+            if (name != null && CmmnXmlUtil.containsNewLine(name)) {
+                // Save name in extension element if name contains any newlines
+                // because new lines are changed into spaces when xml attribute is parsed
+                planItemDefinition.addExtensionElement(CmmnXmlUtil.createExtensionElement(ATTRIBUTE_NAME, name));
+            } else {
+                xtw.writeAttribute(ATTRIBUTE_NAME, planItemDefinition.getName());
+            }
         }
     }
 

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/util/CmmnXmlUtil.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/util/CmmnXmlUtil.java
@@ -28,6 +28,7 @@ import javax.xml.stream.XMLStreamWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.cmmn.converter.CmmnXmlConstants;
 import org.flowable.cmmn.model.BaseElement;
+import org.flowable.cmmn.model.CaseElement;
 import org.flowable.cmmn.model.ExtensionAttribute;
 import org.flowable.cmmn.model.ExtensionElement;
 import org.flowable.cmmn.model.GraphicInfo;
@@ -85,24 +86,6 @@ public class CmmnXmlUtil implements CmmnXmlConstants {
             }
         }
         return extensionElement;
-    }
-
-    public static ExtensionElement createExtensionElement(String name, String value) {
-        ExtensionElement extensionElement = new ExtensionElement();
-        extensionElement.setNamespace(FLOWABLE_EXTENSIONS_NAMESPACE);
-        extensionElement.setNamespacePrefix(FLOWABLE_EXTENSIONS_PREFIX);
-        extensionElement.setName(name);
-        extensionElement.setElementText(value);
-        return extensionElement;
-    }
-
-    public static String getExtensionElementValue(String name, BaseElement element) {
-        String value = "";
-        if (element.getExtensionElements().get(name) != null && !element.getExtensionElements().get(name).isEmpty()) {
-            ExtensionElement extensionElement = element.getExtensionElements().get(name).get(0);
-            value = extensionElement.getElementText();
-        }
-        return value;
     }
     
     public static String getAttributeValue(String attributeName, XMLStreamReader xtr) {
@@ -243,6 +226,22 @@ public class CmmnXmlUtil implements CmmnXmlConstants {
         }
     }
 
+    public static boolean writeElementNameExtensionElement(CaseElement element, boolean didWriteExtensionStartElement, XMLStreamWriter xtw) throws Exception {
+        String name = element.getName();
+        if (containsNewLine(name)) {
+            if (!didWriteExtensionStartElement) {
+                xtw.writeStartElement(ELEMENT_EXTENSION_ELEMENTS);
+                didWriteExtensionStartElement = true;
+            }
+
+            xtw.writeStartElement(FLOWABLE_EXTENSIONS_PREFIX, ATTRIBUTE_ELEMENT_NAME, FLOWABLE_EXTENSIONS_NAMESPACE);
+            xtw.writeCharacters(element.getName());
+            xtw.writeEndElement();
+        }
+
+        return didWriteExtensionStartElement;
+    }
+
     public static void writeCustomAttributes(Collection<List<ExtensionAttribute>> attributes, XMLStreamWriter xtw, List<ExtensionAttribute>... blackLists) throws XMLStreamException {
         writeCustomAttributes(attributes, xtw, new LinkedHashMap<>(), blackLists);
     }
@@ -316,6 +315,6 @@ public class CmmnXmlUtil implements CmmnXmlConstants {
     }
 
     public static boolean containsNewLine(String str) {
-        return str.contains("\n");
+        return str != null && str.contains("\n");
     }
 }

--- a/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/util/CmmnXmlUtil.java
+++ b/modules/flowable-cmmn-converter/src/main/java/org/flowable/cmmn/converter/util/CmmnXmlUtil.java
@@ -86,6 +86,24 @@ public class CmmnXmlUtil implements CmmnXmlConstants {
         }
         return extensionElement;
     }
+
+    public static ExtensionElement createExtensionElement(String name, String value) {
+        ExtensionElement extensionElement = new ExtensionElement();
+        extensionElement.setNamespace(FLOWABLE_EXTENSIONS_NAMESPACE);
+        extensionElement.setNamespacePrefix(FLOWABLE_EXTENSIONS_PREFIX);
+        extensionElement.setName(name);
+        extensionElement.setElementText(value);
+        return extensionElement;
+    }
+
+    public static String getExtensionElementValue(String name, BaseElement element) {
+        String value = "";
+        if (element.getExtensionElements().get(name) != null && !element.getExtensionElements().get(name).isEmpty()) {
+            ExtensionElement extensionElement = element.getExtensionElements().get(name).get(0);
+            value = extensionElement.getElementText();
+        }
+        return value;
+    }
     
     public static String getAttributeValue(String attributeName, XMLStreamReader xtr) {
         String attributeValue = xtr.getAttributeValue(FLOWABLE_EXTENSIONS_NAMESPACE, attributeName);
@@ -295,5 +313,9 @@ public class CmmnXmlUtil implements CmmnXmlConstants {
             }
         }
         return false;
+    }
+
+    public static boolean containsNewLine(String str) {
+        return str.contains("\n");
     }
 }

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/NameWithNewLineTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/NameWithNewLineTest.java
@@ -28,28 +28,23 @@ public class NameWithNewLineTest {
 
         PlanItemDefinition itemDefinition = cmmnModel.findPlanItemDefinition("cmmnStage_1");
         assertThat(itemDefinition.getName()).isEqualTo("stage\ntest");
-        ExtensionElement extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("stage\ntest");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         itemDefinition = cmmnModel.findPlanItemDefinition("cmmnTask_2");
         assertThat(itemDefinition.getName()).isEqualTo("human\ntask");
-        extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("human\ntask");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         itemDefinition = cmmnModel.findPlanItemDefinition("cmmnEventListener_3");
         assertThat(itemDefinition.getName()).isEqualTo("timer\nevent");
-        extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("timer\nevent");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         itemDefinition = cmmnModel.findPlanItemDefinition("cmmnPlanFragment_6");
         assertThat(itemDefinition.getName()).isEqualTo("plan\nfragment");
-        extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("plan\nfragment");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
         itemDefinition = cmmnModel.findPlanItemDefinition("cmmnMilestone_7");
         assertThat(itemDefinition.getName()).isEqualTo("mile\nstone");
-        extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
-        assertThat(extensionElement.getElementText()).isEqualTo("mile\nstone");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
 
     }
 

--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/NameWithNewLineTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/NameWithNewLineTest.java
@@ -1,0 +1,82 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.test.cmmn.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.flowable.cmmn.converter.CmmnXmlConstants.ATTRIBUTE_ELEMENT_NAME;
+
+import org.flowable.cmmn.model.CmmnModel;
+import org.flowable.cmmn.model.ExtensionElement;
+import org.flowable.cmmn.model.PlanItemDefinition;
+import org.flowable.test.cmmn.converter.util.CmmnXmlConverterTest;
+
+public class NameWithNewLineTest {
+
+    @CmmnXmlConverterTest("org/flowable/test/cmmn/converter/nameWithNewLineTestCase.cmmn")
+    public void validateModelWithNewLinesInPlanItemDefinitionNames(CmmnModel cmmnModel) {
+        assertThat(cmmnModel).isNotNull();
+
+        PlanItemDefinition itemDefinition = cmmnModel.findPlanItemDefinition("cmmnStage_1");
+        assertThat(itemDefinition.getName()).isEqualTo("stage\ntest");
+        ExtensionElement extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("stage\ntest");
+
+        itemDefinition = cmmnModel.findPlanItemDefinition("cmmnTask_2");
+        assertThat(itemDefinition.getName()).isEqualTo("human\ntask");
+        extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("human\ntask");
+
+        itemDefinition = cmmnModel.findPlanItemDefinition("cmmnEventListener_3");
+        assertThat(itemDefinition.getName()).isEqualTo("timer\nevent");
+        extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("timer\nevent");
+
+        itemDefinition = cmmnModel.findPlanItemDefinition("cmmnPlanFragment_6");
+        assertThat(itemDefinition.getName()).isEqualTo("plan\nfragment");
+        extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("plan\nfragment");
+
+        itemDefinition = cmmnModel.findPlanItemDefinition("cmmnMilestone_7");
+        assertThat(itemDefinition.getName()).isEqualTo("mile\nstone");
+        extensionElement = itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME).get(0);
+        assertThat(extensionElement.getElementText()).isEqualTo("mile\nstone");
+
+    }
+
+    @CmmnXmlConverterTest("org/flowable/test/cmmn/converter/nameWithoutNewLineTestCase.cmmn")
+    public void validateModelWithoutNewLinesInPlanItemDefinitionNames(CmmnModel cmmnModel) {
+        assertThat(cmmnModel).isNotNull();
+
+        PlanItemDefinition itemDefinition = cmmnModel.findPlanItemDefinition("cmmnStage_1");
+        assertThat(itemDefinition.getName()).isEqualTo("stagetest");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        itemDefinition = cmmnModel.findPlanItemDefinition("cmmnTask_2");
+        assertThat(itemDefinition.getName()).isEqualTo("humantask");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        itemDefinition = cmmnModel.findPlanItemDefinition("cmmnEventListener_3");
+        assertThat(itemDefinition.getName()).isEqualTo("timerevent");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        itemDefinition = cmmnModel.findPlanItemDefinition("cmmnPlanFragment_6");
+        assertThat(itemDefinition.getName()).isEqualTo("planfragment");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+        itemDefinition = cmmnModel.findPlanItemDefinition("cmmnMilestone_7");
+        assertThat(itemDefinition.getName()).isEqualTo("milestone");
+        assertThat(itemDefinition.getExtensionElements().get(ATTRIBUTE_ELEMENT_NAME)).isNull();
+
+    }
+
+}

--- a/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/nameWithNewLineTestCase.cmmn
+++ b/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/nameWithNewLineTestCase.cmmn
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn" design:palette="flowable-work-case-palette">
+  <case id="nameWithNewLineTestCase" name="NameWithNewLineTestCase" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="case plan" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItemcmmnStage_1" name="stage
+test" definitionRef="cmmnStage_1"></planItem>
+      <planItem id="planItemcmmnPlanFragment_6" name="plan
+fragment" definitionRef="cmmnPlanFragment_6"></planItem>
+      <stage id="cmmnStage_1" name="stage
+test">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+          <flowable:element-name><![CDATA[stage
+test]]></flowable:element-name>
+        </extensionElements>
+        <planItem id="planItemcmmnTask_2" name="human
+task" definitionRef="cmmnTask_2">
+          <entryCriterion id="cmmnEntrySentry_4" sentryRef="sentrycmmnEntrySentry_4"></entryCriterion>
+        </planItem>
+        <planItem id="planItemcmmnEventListener_3" name="timer
+event" definitionRef="cmmnEventListener_3"></planItem>
+        <sentry id="sentrycmmnEntrySentry_4">
+          <extensionElements>
+            <design:stencilid><![CDATA[EntryCriterion]]></design:stencilid>
+          </extensionElements>
+          <planItemOnPart id="sentryOnPartcmmnEntrySentry_4" sourceRef="planItemcmmnEventListener_3">
+            <standardEvent>occur</standardEvent>
+          </planItemOnPart>
+        </sentry>
+        <humanTask id="cmmnTask_2" name="human
+task" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+            <flowable:element-name><![CDATA[human
+task]]></flowable:element-name>
+          </extensionElements>
+        </humanTask>
+        <timerEventListener id="cmmnEventListener_3" name="timer
+event">
+          <extensionElements>
+            <design:stencilid><![CDATA[TimerEventListener]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+            <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+            <flowable:element-name><![CDATA[timer
+event]]></flowable:element-name>
+          </extensionElements>
+        </timerEventListener>
+      </stage>
+      <planFragment id="cmmnPlanFragment_6" name="plan
+fragment">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedPlanFragment]]></design:stencilid>
+          <flowable:element-name><![CDATA[plan
+fragment]]></flowable:element-name>
+        </extensionElements>
+        <planItem id="planItemcmmnMilestone_7" name="mile
+stone" definitionRef="cmmnMilestone_7"></planItem>
+      </planFragment>
+      <milestone id="cmmnMilestone_7" name="mile
+stone" flowable:milestoneVariable="milestone">
+        <extensionElements>
+          <design:stencilid><![CDATA[Milestone]]></design:stencilid>
+          <flowable:element-name><![CDATA[mile
+stone]]></flowable:element-name>
+        </extensionElements>
+      </milestone>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_nameWithNewLineTestCase">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="679.0" width="830.0" x="270.0" y="120.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnStage_1" cmmnElementRef="planItemcmmnStage_1">
+        <dc:Bounds height="233.0" width="474.0" x="453.0" y="240.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnTask_2" cmmnElementRef="planItemcmmnTask_2">
+        <dc:Bounds height="80.0" width="100.0" x="755.0" y="314.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_cmmnEntrySentry_4" cmmnElementRef="cmmnEntrySentry_4">
+        <dc:Bounds height="28.0" width="18.0" x="746.0" y="340.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnEventListener_3" cmmnElementRef="planItemcmmnEventListener_3">
+        <dc:Bounds height="30.0" width="30.0" x="533.0" y="339.0"></dc:Bounds>
+        <cmmndi:CMMNLabel>
+          <dc:Bounds height="36.0" width="29.0" x="533.7" y="383.0"></dc:Bounds>
+        </cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnPlanFragment_6" cmmnElementRef="planItemcmmnPlanFragment_6">
+        <dc:Bounds height="208.0" width="474.0" x="453.0" y="523.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnMilestone_7" cmmnElementRef="planItemcmmnMilestone_7">
+        <dc:Bounds height="55.0" width="150.0" x="586.0" y="591.5"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="CMMNEdge_cmmnConnector_5" cmmnElementRef="planItemcmmnEventListener_3" targetCMMNElementRef="cmmnEntrySentry_4">
+        <di:extension>
+          <flowable:docker type="source" x="15.0" y="15.0"></flowable:docker>
+          <flowable:docker type="target" x="9.0" y="14.0"></flowable:docker>
+        </di:extension>
+        <di:waypoint x="563.0" y="354.0"></di:waypoint>
+        <di:waypoint x="746.0" y="354.0"></di:waypoint>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>

--- a/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/nameWithoutNewLineTestCase.cmmn
+++ b/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/nameWithoutNewLineTestCase.cmmn
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/cmmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:design="http://flowable.org/design" targetNamespace="http://flowable.org/cmmn" design:palette="flowable-work-case-palette">
+  <case id="nameWithNewLineTestCase" name="NameWithNewLineTestCase" flowable:initiatorVariableName="initiator" flowable:candidateStarterGroups="flowableUser">
+    <casePlanModel id="onecaseplanmodel1" name="case plan" flowable:formFieldValidation="false">
+      <extensionElements>
+        <flowable:default-menu-navigation-size><![CDATA[expanded]]></flowable:default-menu-navigation-size>
+        <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
+        <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
+      </extensionElements>
+      <planItem id="planItemcmmnStage_1" name="stagetest" definitionRef="cmmnStage_1"></planItem>
+      <planItem id="planItemcmmnPlanFragment_6" name="planfragment" definitionRef="cmmnPlanFragment_6"></planItem>
+      <stage id="cmmnStage_1" name="stagetest">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedStage]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItemcmmnTask_2" name="humantask" definitionRef="cmmnTask_2">
+          <entryCriterion id="cmmnEntrySentry_4" sentryRef="sentrycmmnEntrySentry_4"></entryCriterion>
+        </planItem>
+        <planItem id="planItemcmmnEventListener_3" name="timerevent" definitionRef="cmmnEventListener_3"></planItem>
+        <sentry id="sentrycmmnEntrySentry_4">
+          <extensionElements>
+            <design:stencilid><![CDATA[EntryCriterion]]></design:stencilid>
+          </extensionElements>
+          <planItemOnPart id="sentryOnPartcmmnEntrySentry_4" sourceRef="planItemcmmnEventListener_3">
+            <standardEvent>occur</standardEvent>
+          </planItemOnPart>
+        </sentry>
+        <humanTask id="cmmnTask_2" name="humantask" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+          <extensionElements>
+            <flowable:task-candidates-type><![CDATA[all]]></flowable:task-candidates-type>
+            <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+          </extensionElements>
+        </humanTask>
+        <timerEventListener id="cmmnEventListener_3" name="timerevent">
+          <extensionElements>
+            <design:stencilid><![CDATA[TimerEventListener]]></design:stencilid>
+            <design:stencilsuperid><![CDATA[EventListener]]></design:stencilsuperid>
+            <design:display_ref_in_diagram><![CDATA[true]]></design:display_ref_in_diagram>
+          </extensionElements>
+        </timerEventListener>
+      </stage>
+      <planFragment id="cmmnPlanFragment_6" name="planfragment">
+        <extensionElements>
+          <design:stencilid><![CDATA[ExpandedPlanFragment]]></design:stencilid>
+        </extensionElements>
+        <planItem id="planItemcmmnMilestone_7" name="milestone" definitionRef="cmmnMilestone_7"></planItem>
+      </planFragment>
+      <milestone id="cmmnMilestone_7" name="milestone" flowable:milestoneVariable="milestone">
+        <extensionElements>
+          <design:stencilid><![CDATA[Milestone]]></design:stencilid>
+        </extensionElements>
+      </milestone>
+    </casePlanModel>
+  </case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="CMMNDiagram_nameWithNewLineTestCase">
+      <cmmndi:CMMNShape id="CMMNShape_onecaseplanmodel1" cmmnElementRef="onecaseplanmodel1">
+        <dc:Bounds height="679.0" width="830.0" x="270.0" y="120.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnStage_1" cmmnElementRef="planItemcmmnStage_1">
+        <dc:Bounds height="233.0" width="474.0" x="453.0" y="240.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnTask_2" cmmnElementRef="planItemcmmnTask_2">
+        <dc:Bounds height="80.0" width="100.0" x="755.0" y="314.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_cmmnEntrySentry_4" cmmnElementRef="cmmnEntrySentry_4">
+        <dc:Bounds height="28.0" width="18.0" x="746.0" y="340.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnEventListener_3" cmmnElementRef="planItemcmmnEventListener_3">
+        <dc:Bounds height="30.0" width="30.0" x="533.0" y="339.0"></dc:Bounds>
+        <cmmndi:CMMNLabel>
+          <dc:Bounds height="36.0" width="29.0" x="533.7" y="383.0"></dc:Bounds>
+        </cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnPlanFragment_6" cmmnElementRef="planItemcmmnPlanFragment_6">
+        <dc:Bounds height="208.0" width="474.0" x="453.0" y="523.0"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="CMMNShape_planItemcmmnMilestone_7" cmmnElementRef="planItemcmmnMilestone_7">
+        <dc:Bounds height="55.0" width="150.0" x="586.0" y="591.5"></dc:Bounds>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="CMMNEdge_cmmnConnector_5" cmmnElementRef="planItemcmmnEventListener_3" targetCMMNElementRef="cmmnEntrySentry_4">
+        <di:extension>
+          <flowable:docker type="source" x="15.0" y="15.0"></flowable:docker>
+          <flowable:docker type="target" x="9.0" y="14.0"></flowable:docker>
+        </di:extension>
+        <di:waypoint x="563.0" y="354.0"></di:waypoint>
+        <di:waypoint x="746.0" y="354.0"></di:waypoint>
+        <cmmndi:CMMNLabel></cmmndi:CMMNLabel>
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</definitions>


### PR DESCRIPTION
If an element name has any newlines, save it in an extension element instead of in an attribute because new lines are changed into spaces when xml attribute is **parsed**

* Unit tests: YES
* Documentation: NA
