### PR TITLE
fixed throwing an exception when process contains two boundary events…

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
@@ -395,6 +395,12 @@ public class ContinueProcessOperation extends AbstractOperation {
 
             while (boundaryEventsIterator.hasNext() && boundaryEventExecutionsIterator.hasNext()) {
                 BoundaryEvent boundaryEvent = boundaryEventsIterator.next();
+                if (!(boundaryEvent.getBehavior() instanceof BoundaryEventRegistryEventActivityBehavior)) {
+                    if (CollectionUtil.isEmpty(boundaryEvent.getEventDefinitions())
+                            || (boundaryEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition)) {
+                        continue;
+                    }
+                }
                 ExecutionEntity boundaryEventExecution = boundaryEventExecutionsIterator.next();
                 ActivityBehavior boundaryEventBehavior = ((ActivityBehavior) boundaryEvent.getBehavior());
                 LOGGER.debug("Executing boundary event activityBehavior {} with execution {}", boundaryEventBehavior.getClass(), boundaryEventExecution.getId());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.java
@@ -13,12 +13,6 @@
 
 package org.flowable.engine.test.bpmn.event.compensate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import org.flowable.common.engine.impl.history.HistoryLevel;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
@@ -33,6 +27,12 @@ import org.flowable.engine.test.Deployment;
 import org.flowable.engine.test.EnableVerboseExecutionTreeLogging;
 import org.flowable.eventsubscription.service.impl.persistence.entity.EventSubscriptionEntity;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Tijs Rademakers
@@ -335,6 +335,13 @@ public class CompensateEventTest extends PluggableFlowableTestCase {
 
         assertProcessEnded(processInstance.getId());
 
+    }
+
+    @Test
+    @Deployment
+    public void testTwoBoundaryEventAndFirstIsCompensation() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("compensateProcess");
+        assertThat(processInstance).isNotNull();
     }
 
 }

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testTwoBoundaryEventAndFirstIsCompensation.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/bpmn/event/compensate/CompensateEventTest.testTwoBoundaryEventAndFirstIsCompensation.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:flowable="http://flowable.org/bpmn"
+             typeLanguage="http://www.w3.org/2001/XMLSchema"
+             expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.flowable.org/processdef">
+
+    <process id="compensateProcess">
+
+        <startEvent id="start"/>
+        <sequenceFlow sourceRef="start" targetRef="user"/>
+        <userTask id="user"/>
+        <boundaryEvent id="compensate" attachedToRef="user">
+            <compensateEventDefinition />
+        </boundaryEvent>
+        <boundaryEvent id="error" attachedToRef="user">
+            <errorEventDefinition errorRef="myError"/>
+        </boundaryEvent>
+
+        <sequenceFlow sourceRef="user" targetRef="end"/>
+        <endEvent id="end"/>
+    </process>
+
+</definitions>


### PR DESCRIPTION
… and the first is compensation

#### Check List:
* Unit tests: YES 
* Documentation: YES
