### PR TITLE
Use cmmn script task expression value if no string value is missing and do not throw exception if field is missing

### DIFF
--- a/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ScriptServiceTaskCmmnXmlConverterTest.java
+++ b/modules/flowable-cmmn-converter/src/test/java/org/flowable/test/cmmn/converter/ScriptServiceTaskCmmnXmlConverterTest.java
@@ -84,4 +84,34 @@ public class ScriptServiceTaskCmmnXmlConverterTest {
                 });
     }
 
+
+    @CmmnXmlConverterTest("org/flowable/test/cmmn/converter/script-task-expression-field.cmmn")
+    public void scriptTaskWithExpressionField(CmmnModel cmmnModel) {
+        assertThat(cmmnModel).isNotNull();
+
+        PlanItem planItemTaskA = cmmnModel.findPlanItem("planItemTaskA");
+        assertThat(planItemTaskA.getEntryCriteria()).isEmpty();
+
+        PlanItemDefinition planItemDefinition = planItemTaskA.getPlanItemDefinition();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ScriptServiceTask.class, scriptTask -> {
+                    assertThat(scriptTask.getType()).isEqualTo(ScriptServiceTask.SCRIPT_TASK);
+                    assertThat(scriptTask.getScriptFormat()).isEqualTo("javascript");
+                    assertThat(scriptTask.getScript()).isEqualTo("var a = '${testA}';");
+                    assertThat(scriptTask.getResultVariableName()).isEqualTo("scriptResult");
+                    assertThat(scriptTask.isAutoStoreVariables()).isFalse();
+                    assertThat(scriptTask.isBlocking()).isTrue();
+                    assertThat(scriptTask.isAsync()).isFalse();
+                });
+
+        PlanItem planItemTaskB = cmmnModel.findPlanItem("planItemTaskB");
+        planItemDefinition = planItemTaskB.getPlanItemDefinition();
+        assertThat(planItemDefinition)
+                .isInstanceOfSatisfying(ScriptServiceTask.class, scriptServiceTask -> {
+                    assertThat(scriptServiceTask.getScriptFormat()).isEqualTo("groovy");
+                    assertThat(scriptServiceTask.getScript()).isEqualTo("var b = '${testB}';");
+                    assertThat(scriptServiceTask.isAutoStoreVariables()).isTrue();
+                });
+    }
+
 }

--- a/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/script-task-expression-field.cmmn
+++ b/modules/flowable-cmmn-converter/src/test/resources/org/flowable/test/cmmn/converter/script-task-expression-field.cmmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL"
+             xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC"
+             xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI"
+             xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+             xsi:schemaLocation="http://www.omg.org/spec/CMMN/20151109/MODEL https://www.omg.org/spec/CMMN/20151109/CMMN11.xsd
+                    http://www.omg.org/spec/CMMN/20151109/DC https://www.omg.org/spec/CMMN/20151109/DC.xsd
+                    http://www.omg.org/spec/CMMN/20151109/DI https://www.omg.org/spec/CMMN/20151109/DI.xsd
+                    http://www.omg.org/spec/CMMN/20151109/CMMNDI https://www.omg.org/spec/CMMN/20151109/CMMNDI11.xsd"
+             xmlns:flowable="http://flowable.org/cmmn"
+             targetNamespace="http://flowable.org/cmmn">
+    
+    <case id="scriptCase" flowable:initiatorVariableName="test">
+        <casePlanModel id="myScriptPlanModel" name="My Script CasePlanModel">
+        
+            <planItem id="planItemTaskA" definitionRef="taskA" />
+            <planItem id="planItemTaskB" definitionRef="taskB" />
+            <task id="taskA" name="A" flowable:type="script" flowable:scriptFormat="javascript" flowable:resultVariableName="scriptResult" flowable:autoStoreVariables="false">
+                <extensionElements>
+                    <flowable:field name="script">
+                        <expression><![CDATA[var a = '${testA}';]]></expression>
+                    </flowable:field>
+                </extensionElements>
+            </task>
+
+            <task id="taskB" name="B" flowable:type="script" flowable:scriptFormat="groovy" flowable:autoStoreVariables="true">
+                <extensionElements>
+                    <flowable:field name="script">
+                        <expression><![CDATA[var b = '${testB}';]]></expression>
+                    </flowable:field>
+                </extensionElements>
+            </task>
+
+        </casePlanModel>
+    </case>
+    
+</definitions>

--- a/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/ScriptServiceTask.java
+++ b/modules/flowable-cmmn-model/src/main/java/org/flowable/cmmn/model/ScriptServiceTask.java
@@ -12,9 +12,7 @@
  */
 package org.flowable.cmmn.model;
 
-import java.util.Optional;
-
-import org.flowable.common.engine.api.FlowableException;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Dennis
@@ -38,11 +36,16 @@ public class ScriptServiceTask extends ServiceTask {
     }
 
     public String getScript() {
-        Optional<String> script = fieldExtensions.stream()
-                .filter(e -> "script".equalsIgnoreCase(e.getFieldName()))
-                .findFirst()
-                .map(FieldExtension::getStringValue);
-        return script.orElseThrow(() -> new FlowableException("Missing script"));
+        for (FieldExtension fieldExtension : fieldExtensions) {
+            if ("script".equalsIgnoreCase(fieldExtension.getFieldName())) {
+                String script = fieldExtension.getStringValue();
+                if (StringUtils.isNotEmpty(script)) {
+                    return script;
+                }
+                return fieldExtension.getExpression();
+            }
+        }
+        return null;
     }
 
     public boolean isAutoStoreVariables() {


### PR DESCRIPTION
Not throwing the exception aligns this with the way it works for BPMN, where no exception is thrown by the model. There will eventually be an exception thrown when the script is executed
