### PR TITLE
Feat: Improve variable listener event query

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/EvaluateVariableListenerEventDefinitionsOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/EvaluateVariableListenerEventDefinitionsOperation.java
@@ -65,7 +65,7 @@ public class EvaluateVariableListenerEventDefinitionsOperation extends AbstractO
         }
         
         List<EventSubscriptionEntity> eventSubscriptionEntities = processEngineConfiguration.getEventSubscriptionServiceConfiguration().getEventSubscriptionEntityManager()
-                .findEventSubscriptionsByProcessInstanceAndType(processInstanceId, "variable");
+                .findEventSubscriptionsByProcessInstanceAndTypeAndNames(processInstanceId, "variable", variableSessionData.keySet());
         
         for (EventSubscriptionEntity eventSubscription : eventSubscriptionEntities) {
             

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetExecutionVariablesCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetExecutionVariablesCmd.java
@@ -66,10 +66,12 @@ public class SetExecutionVariablesCmd extends NeedsActiveExecutionCmd<Object> {
         // variable. If not, duplicate variables may occur since optimistic
         // locking doesn't work on inserts
         execution.forceUpdate();
-        
-        if (VariableListenerUtil.hasVariableListenerEventDefinitions(execution.getProcessDefinitionId())) {
-            CommandContextUtil.getAgenda(commandContext).planEvaluateVariableListenerEventsOperation(
-                    execution.getProcessDefinitionId(), execution.getProcessInstanceId());
+
+        for (String variableName : variables.keySet()) {
+            if (VariableListenerUtil.containsVariableListenerForVariableName(execution.getProcessDefinitionId(), variableName)) {
+                CommandContextUtil.getAgenda(commandContext).planEvaluateVariableListenerEventsOperation(
+                        execution.getProcessDefinitionId(), execution.getProcessInstanceId());
+            }
         }
         
         return null;

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetExecutionVariablesCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SetExecutionVariablesCmd.java
@@ -67,6 +67,7 @@ public class SetExecutionVariablesCmd extends NeedsActiveExecutionCmd<Object> {
         // locking doesn't work on inserts
         execution.forceUpdate();
 
+        //only query for event subscriptions, if there is a variable listener associated to the variable that is created/updated
         for (String variableName : variables.keySet()) {
             if (VariableListenerUtil.containsVariableListenerForVariableName(execution.getProcessDefinitionId(), variableName)) {
                 CommandContextUtil.getAgenda(commandContext).planEvaluateVariableListenerEventsOperation(

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/VariableListenerUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/VariableListenerUtil.java
@@ -20,9 +20,9 @@ public class VariableListenerUtil {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(VariableListenerUtil.class);
 
-    public static boolean hasVariableListenerEventDefinitions(String processDefinitionId, String variableName) {
+    public static boolean hasVariableListenerEventDefinitions(String processDefinitionId) {
         BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(processDefinitionId);
-        return bpmnModel.hasVariableListeners() && bpmnModel.containsVariableListenerForVariableName(variableName);
+        return bpmnModel.hasVariableListeners();
     }
 
     public static boolean containsVariableListenerForVariableName(String processDefinitionId, String variableName) {

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/VariableListenerUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/VariableListenerUtil.java
@@ -20,8 +20,13 @@ public class VariableListenerUtil {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(VariableListenerUtil.class);
 
-    public static boolean hasVariableListenerEventDefinitions(String processDefinitionId) {
+    public static boolean hasVariableListenerEventDefinitions(String processDefinitionId, String variableName) {
         BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(processDefinitionId);
-        return bpmnModel.hasVariableListeners();
+        return bpmnModel.hasVariableListeners() && bpmnModel.containsVariableListenerForVariableName(variableName);
+    }
+
+    public static boolean containsVariableListenerForVariableName(String processDefinitionId, String variableName) {
+        BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(processDefinitionId);
+        return bpmnModel.containsVariableListenerForVariableName(variableName);
     }
 }

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManager.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManager.java
@@ -13,6 +13,7 @@
 package org.flowable.eventsubscription.service.impl.persistence.entity;
 
 import java.util.List;
+import java.util.Set;
 
 import org.flowable.common.engine.impl.persistence.entity.EntityManager;
 import org.flowable.eventsubscription.api.EventSubscription;
@@ -77,6 +78,8 @@ public interface EventSubscriptionEntityManager extends EntityManager<EventSubsc
     List<EventSubscriptionEntity> findEventSubscriptionsByExecutionAndType(String executionId, String type);
     
     List<EventSubscriptionEntity> findEventSubscriptionsByProcessInstanceAndType(String processInstanceId, String type);
+
+    List<EventSubscriptionEntity> findEventSubscriptionsByProcessInstanceAndTypeAndNames(String processInstanceId, String type, Set<String> eventNames);
     
     List<EventSubscriptionEntity> findEventSubscriptionsBySubScopeId(String subScopeId);
 

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManagerImpl.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManagerImpl.java
@@ -13,7 +13,12 @@
 
 package org.flowable.eventsubscription.service.impl.persistence.entity;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.model.Signal;

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManagerImpl.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/EventSubscriptionEntityManagerImpl.java
@@ -13,11 +13,7 @@
 
 package org.flowable.eventsubscription.service.impl.persistence.entity;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.List;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.model.Signal;
@@ -150,6 +146,11 @@ public class EventSubscriptionEntityManagerImpl
     @Override
     public List<EventSubscriptionEntity> findEventSubscriptionsByProcessInstanceAndType(final String processInstanceId, final String type) {
         return dataManager.findEventSubscriptionsByProcessInstanceAndType(processInstanceId, type);
+    }
+
+    @Override
+    public List<EventSubscriptionEntity> findEventSubscriptionsByProcessInstanceAndTypeAndNames(final String processInstanceId, final String type, final Set<String> eventNames) {
+        return dataManager.findEventSubscriptionsByProcessInstanceAndTypeAndNames(processInstanceId, type, eventNames);
     }
 
     @Override

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/EventSubscriptionDataManager.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/EventSubscriptionDataManager.java
@@ -14,6 +14,7 @@ package org.flowable.eventsubscription.service.impl.persistence.entity.data;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import org.flowable.common.engine.impl.persistence.entity.data.DataManager;
 import org.flowable.eventsubscription.api.EventSubscription;
@@ -56,6 +57,8 @@ public interface EventSubscriptionDataManager extends DataManager<EventSubscript
     List<EventSubscriptionEntity> findEventSubscriptionsByProcessInstanceAndType(final String processInstanceId, final String type);
 
     List<EventSubscriptionEntity> findEventSubscriptionsByProcessInstanceAndActivityId(final String processInstanceId, final String activityId, final String type);
+
+    List<EventSubscriptionEntity> findEventSubscriptionsByProcessInstanceAndTypeAndNames(String processInstanceId, String type, Set<String> eventNames);
 
     List<EventSubscriptionEntity> findEventSubscriptionsByExecution(final String executionId);
     

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/MybatisEventSubscriptionDataManager.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/MybatisEventSubscriptionDataManager.java
@@ -12,7 +12,12 @@
  */
 package org.flowable.eventsubscription.service.impl.persistence.entity.data.impl;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.impl.cfg.IdGenerator;
@@ -33,7 +38,24 @@ import org.flowable.eventsubscription.service.impl.persistence.entity.SignalEven
 import org.flowable.eventsubscription.service.impl.persistence.entity.SignalEventSubscriptionEntityImpl;
 import org.flowable.eventsubscription.service.impl.persistence.entity.data.AbstractEventSubscriptionDataManager;
 import org.flowable.eventsubscription.service.impl.persistence.entity.data.EventSubscriptionDataManager;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.*;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByExecutionAndTypeMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByExecutionIdMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByNameMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByProcInstTypeAndActivityMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByProcInstTypeAndNameMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByProcessDefinitionIdAndProcessStartEventMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByProcessInstanceAndTypeMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByScopeDefinitionIdAndScopeStartEventMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByScopeDefinitionIdAndTypeAndNullScopeIdMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByScopeDefinitionIdAndTypeMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByScopeIdAndTypeMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsBySubScopeIdMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.MessageEventSubscriptionsByProcInstAndEventNameMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByEventNameMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByNameAndExecutionMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByProcInstAndEventNameMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByScopeAndEventNameMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByScopeIdAndTypeMatcher;
 
 /**
  * @author Joram Barrez

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/MybatisEventSubscriptionDataManager.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/MybatisEventSubscriptionDataManager.java
@@ -33,23 +33,7 @@ import org.flowable.eventsubscription.service.impl.persistence.entity.SignalEven
 import org.flowable.eventsubscription.service.impl.persistence.entity.SignalEventSubscriptionEntityImpl;
 import org.flowable.eventsubscription.service.impl.persistence.entity.data.AbstractEventSubscriptionDataManager;
 import org.flowable.eventsubscription.service.impl.persistence.entity.data.EventSubscriptionDataManager;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByExecutionAndTypeMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByExecutionIdMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByNameMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByProcInstTypeAndActivityMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByProcessDefinitionIdAndProcessStartEventMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByProcessInstanceAndTypeMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByScopeDefinitionIdAndScopeStartEventMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByScopeDefinitionIdAndTypeAndNullScopeIdMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByScopeDefinitionIdAndTypeMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsByScopeIdAndTypeMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.EventSubscriptionsBySubScopeIdMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.MessageEventSubscriptionsByProcInstAndEventNameMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByEventNameMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByNameAndExecutionMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByProcInstAndEventNameMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByScopeAndEventNameMatcher;
-import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.SignalEventSubscriptionByScopeIdAndTypeMatcher;
+import org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher.*;
 
 /**
  * @author Joram Barrez
@@ -76,6 +60,8 @@ public class MybatisEventSubscriptionDataManager extends AbstractEventSubscripti
     protected CachedEntityMatcher<EventSubscriptionEntity> eventSubscriptionsByExecutionAndTypeMatcher = new EventSubscriptionsByExecutionAndTypeMatcher();
     
     protected CachedEntityMatcher<EventSubscriptionEntity> eventSubscriptionsByProcessInstanceAndTypeMatcher = new EventSubscriptionsByProcessInstanceAndTypeMatcher();
+
+    protected CachedEntityMatcher<EventSubscriptionEntity> eventSubscriptionsByProcessInstanceAndTypeAndNamesMatcher = new EventSubscriptionsByProcInstTypeAndNameMatcher();
 
     protected CachedEntityMatcher<EventSubscriptionEntity> eventSubscriptionsByScopeDefinitionIdAndTypeMatcher = new EventSubscriptionsByScopeDefinitionIdAndTypeMatcher();
 
@@ -224,7 +210,7 @@ public class MybatisEventSubscriptionDataManager extends AbstractEventSubscripti
         params.put("processInstanceId", processInstanceId);
         params.put("eventType", type);
         params.put("eventNames", eventNames);
-        return getList("selectEventSubscriptionsByProcessInstanceTypeAndNames", params, eventSubscriptionsByProcInstTypeAndActivityMatcher, true);
+        return getList("selectEventSubscriptionsByProcessInstanceTypeAndNames", params, eventSubscriptionsByProcessInstanceAndTypeAndNamesMatcher, true);
     }
     
     @Override

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/MybatisEventSubscriptionDataManager.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/MybatisEventSubscriptionDataManager.java
@@ -12,11 +12,7 @@
  */
 package org.flowable.eventsubscription.service.impl.persistence.entity.data.impl;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.impl.cfg.IdGenerator;
@@ -220,6 +216,15 @@ public class MybatisEventSubscriptionDataManager extends AbstractEventSubscripti
         params.put("processInstanceId", processInstanceId);
         params.put("eventType", type);
         return getList("selectEventSubscriptionsByProcessInstanceAndType", params, eventSubscriptionsByProcessInstanceAndTypeMatcher, true);
+    }
+
+    @Override
+    public List<EventSubscriptionEntity> findEventSubscriptionsByProcessInstanceAndTypeAndNames(String processInstanceId, String type, Set<String> eventNames) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("processInstanceId", processInstanceId);
+        params.put("eventType", type);
+        params.put("eventNames", eventNames);
+        return getList("selectEventSubscriptionsByProcessInstanceTypeAndNames", params, eventSubscriptionsByProcInstTypeAndActivityMatcher, true);
     }
     
     @Override

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsByProcInstTypeAndNameMatcher.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsByProcInstTypeAndNameMatcher.java
@@ -12,11 +12,11 @@
  */
 package org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher;
 
-import org.flowable.common.engine.impl.persistence.cache.CachedEntityMatcherAdapter;
-import org.flowable.eventsubscription.service.impl.persistence.entity.EventSubscriptionEntity;
-
 import java.util.Map;
 import java.util.Set;
+
+import org.flowable.common.engine.impl.persistence.cache.CachedEntityMatcherAdapter;
+import org.flowable.eventsubscription.service.impl.persistence.entity.EventSubscriptionEntity;
 
 /**
  * @author José Carlos Mendoza

--- a/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsByProcInstTypeAndNameMatcher.java
+++ b/modules/flowable-eventsubscription-service/src/main/java/org/flowable/eventsubscription/service/impl/persistence/entity/data/impl/cachematcher/EventSubscriptionsByProcInstTypeAndNameMatcher.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.eventsubscription.service.impl.persistence.entity.data.impl.cachematcher;
+
+import org.flowable.common.engine.impl.persistence.cache.CachedEntityMatcherAdapter;
+import org.flowable.eventsubscription.service.impl.persistence.entity.EventSubscriptionEntity;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author José Carlos Mendoza
+ */
+public class EventSubscriptionsByProcInstTypeAndNameMatcher extends CachedEntityMatcherAdapter<EventSubscriptionEntity> {
+
+    @Override
+    public boolean isRetained(EventSubscriptionEntity eventSubscriptionEntity, Object parameter) {
+
+        Map<String, Object> params = (Map<String, Object>) parameter;
+        String eventType = params.get("eventType").toString();
+        String processInstanceId = params.get("processInstanceId").toString();
+        Set<String> eventNames = (Set<String>) params.get("eventNames");
+
+        return eventSubscriptionEntity.getEventType() != null && eventSubscriptionEntity.getEventType().equals(eventType)
+                && eventSubscriptionEntity.getProcessInstanceId() != null && eventSubscriptionEntity.getProcessInstanceId().equals(processInstanceId)
+                && eventSubscriptionEntity.getEventName() != null && eventNames.contains(eventSubscriptionEntity.getEventName());
+    }
+}

--- a/modules/flowable-eventsubscription-service/src/main/resources/org/flowable/eventsubscription/service/db/mapping/entity/EventSubscription.xml
+++ b/modules/flowable-eventsubscription-service/src/main/resources/org/flowable/eventsubscription/service/db/mapping/entity/EventSubscription.xml
@@ -299,8 +299,20 @@
     where (EVENT_TYPE_ = #{parameter.eventType, jdbcType=NVARCHAR})
     	and (PROC_INST_ID_ = #{parameter.processInstanceId, jdbcType=NVARCHAR})
   </select>
-  
-  <select id="selectEventSubscriptionsByExecutionTypeAndActivity" resultMap="eventSubscriptionResultMap" parameterType="org.flowable.common.engine.impl.db.ListQueryParameterObject">
+
+  <select id="selectEventSubscriptionsByProcessInstanceTypeAndNames" resultMap="eventSubscriptionResultMap" parameterType="org.flowable.common.engine.impl.db.ListQueryParameterObject">
+    select *
+    from ${prefix}ACT_RU_EVENT_SUBSCR
+    where (EVENT_TYPE_ = #{parameter.eventType, jdbcType=NVARCHAR})
+    	and (EVENT_NAME_ IN
+        <foreach item="item" collection="parameter.eventNames" open="(" separator="," close=")">
+            #{item}
+        </foreach>
+        ) and (PROC_INST_ID_ = #{parameter.processInstanceId, jdbcType=NVARCHAR})
+  </select>
+
+
+    <select id="selectEventSubscriptionsByExecutionTypeAndActivity" resultMap="eventSubscriptionResultMap" parameterType="org.flowable.common.engine.impl.db.ListQueryParameterObject">
     select * 
     from ${prefix}ACT_RU_EVENT_SUBSCR
     where (EVENT_TYPE_ = #{parameter.eventType, jdbcType=NVARCHAR})


### PR DESCRIPTION
Trigger querying the database table ACT_RU_EVENT_SUBSCR only if the variable that is created/updated has a variable listener event associated with it.
The change only applies to processes.

Check List:
- Unit tests: Yes. Those already available
- Documentation: No change here