### PR TITLE
Introducing Flowable Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Flowable (V7)
 
 ![Flowable Actions CI](https://github.com/flowable/flowable-engine/actions/workflows/main.yml/badge.svg?branch=main)
 
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Flowable%20Guru-006BFF)](https://gurubase.io/g/flowable)
+
 Homepage: https://www.flowable.org/
 
 ## flowable / flowəb(ə)l /


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Flowable Guru](https://gurubase.io/g/flowable) to Gurubase. Flowable Guru uses the data from this repo and data from the [docs](https://www.flowable.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Flowable Guru", which highlights that Flowable now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Flowable Guru in Gurubase, just let me know that's totally fine.
