### PR TITLE
Handle deleting task candidates

### DIFF
--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/DeleteCandidateTaskListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/DeleteCandidateTaskListener.java
@@ -12,12 +12,34 @@
  */
 package org.flowable.engine.test.api.task;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.flowable.engine.delegate.TaskListener;
+import org.flowable.identitylink.api.IdentityLink;
 import org.flowable.task.service.delegate.DelegateTask;
 
 public class DeleteCandidateTaskListener implements TaskListener {
+    public static final String VARNAME_CANDIDATE_USERS = "candidateUsers";
+    public static final String VARNAME_CANDIDATE_GROUPS = "candidateGroups";
+
     @Override
     public void notify(DelegateTask delegateTask) {
         delegateTask.deleteCandidateUser("admin");
+        delegateTask.deleteCandidateGroup("admins");
+
+        Set<IdentityLink> candidates = delegateTask.getCandidates();
+        Set<String> candidateUsers = new HashSet<>();
+        Set<String> candidateGroups = new HashSet<>();
+        for (IdentityLink candidate : candidates) {
+            if (candidate.getUserId() != null) {
+                candidateUsers.add(candidate.getUserId());
+            } else if (candidate.getGroupId() != null) {
+                candidateGroups.add(candidate.getGroupId());
+            }
+        }
+        delegateTask.setVariable(VARNAME_CANDIDATE_USERS, candidateUsers);
+        delegateTask.setVariable(VARNAME_CANDIDATE_GROUPS, candidateGroups);
+
     }
 }

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
@@ -339,6 +339,20 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
                 .extracting(IdentityLink::getGroupId)
                 .containsExactly("users");
 
+        if (HistoryTestHelper.isHistoryLevelAtLeast(HistoryLevel.AUDIT, processEngineConfiguration)) {
+            List<HistoricIdentityLink> historicIdentityLinks = historyService.getHistoricIdentityLinksForTask(taskId);
+
+            assertThat(historicIdentityLinks)
+                    .filteredOn(identityLink -> identityLink.getUserId() != null)
+                    .extracting(HistoricIdentityLink::getUserId)
+                    .containsExactly("user");
+
+            assertThat(historicIdentityLinks)
+                    .filteredOn(identityLink -> identityLink.getGroupId() != null)
+                    .extracting(HistoricIdentityLink::getGroupId)
+                    .containsExactly("users");
+        }
+
         @SuppressWarnings("unchecked")
         Set<String> candidateUsers = (Set<String>) taskService.getVariable(taskId, DeleteCandidateTaskListener.VARNAME_CANDIDATE_USERS);
         assertThat(candidateUsers)

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/task/TaskIdentityLinksTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.history.HistoryLevel;
@@ -321,16 +322,32 @@ public class TaskIdentityLinksTest extends PluggableFlowableTestCase {
     }
 
     @Test
-    @Deployment(resources = "org/flowable/engine/test/api/task/TaskIdentityLinksTest.testDeleteCandidateUser.bpmn20.xml")
-    public void testDeleteCandidateUser() {
+    @Deployment(resources = "org/flowable/engine/test/api/task/TaskIdentityLinksTest.testDeleteCandidates.bpmn20.xml")
+    public void testDeleteCandidates() {
         runtimeService.startProcessInstanceByKey("TaskIdentityLinks");
 
         String taskId = taskService.createTaskQuery().singleResult().getId();
 
         List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(taskId);
         assertThat(identityLinks)
+                .filteredOn(identityLink -> identityLink.getUserId() != null)
                 .extracting(IdentityLink::getUserId)
                 .containsExactly("user");
+
+        assertThat(identityLinks)
+                .filteredOn(identityLink -> identityLink.getGroupId() != null)
+                .extracting(IdentityLink::getGroupId)
+                .containsExactly("users");
+
+        @SuppressWarnings("unchecked")
+        Set<String> candidateUsers = (Set<String>) taskService.getVariable(taskId, DeleteCandidateTaskListener.VARNAME_CANDIDATE_USERS);
+        assertThat(candidateUsers)
+                .containsExactly("user");
+
+        @SuppressWarnings("unchecked")
+        Set<String> candidateGroups = (Set<String>) taskService.getVariable(taskId, DeleteCandidateTaskListener.VARNAME_CANDIDATE_GROUPS);
+        assertThat(candidateGroups)
+                .containsExactly("users");
     }
 
     @Test

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/task/TaskIdentityLinksTest.testDeleteCandidates.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/task/TaskIdentityLinksTest.testDeleteCandidates.bpmn20.xml
@@ -14,7 +14,7 @@
       </extensionElements>
       <potentialOwner>
         <resourceAssignmentExpression>
-          <formalExpression>user(user),user(admin)</formalExpression>
+          <formalExpression>user(user),user(admin),group(users),group(admins)</formalExpression>
         </resourceAssignmentExpression>
       </potentialOwner>
     </userTask>

--- a/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/persistence/entity/TaskEntityImpl.java
+++ b/modules/flowable-task-service/src/main/java/org/flowable/task/service/impl/persistence/entity/TaskEntityImpl.java
@@ -395,13 +395,27 @@ public class TaskEntityImpl extends AbstractTaskServiceVariableScopeEntity imple
     @Override
     public void deleteUserIdentityLink(String userId, String identityLinkType) {
         IdentityLinkEntityManager identityLinkEntityManager = getIdentityLinkServiceConfiguration().getIdentityLinkEntityManager();
-        identityLinkEntityManager.deleteTaskIdentityLink(this.id, getIdentityLinks(), userId, null, identityLinkType);
+        List<IdentityLinkEntity> identityLinkEntities = identityLinkEntityManager.deleteTaskIdentityLink(this.id,
+                getIdentityLinks(), userId, null, identityLinkType);
+        InternalTaskAssignmentManager taskAssignmentManager = getTaskAssignmentManager();
+        if (taskAssignmentManager != null) {
+            for (IdentityLinkEntity identityLink : identityLinkEntities) {
+                taskAssignmentManager.deleteUserIdentityLink(this, identityLink);
+            }
+        }
     }
     
     @Override
     public void deleteGroupIdentityLink(String groupId, String identityLinkType) {
         IdentityLinkEntityManager identityLinkEntityManager = getIdentityLinkServiceConfiguration().getIdentityLinkEntityManager();
-        identityLinkEntityManager.deleteTaskIdentityLink(this.id, getIdentityLinks(), null, groupId,identityLinkType);
+        List<IdentityLinkEntity> identityLinkEntities = identityLinkEntityManager.deleteTaskIdentityLink(this.id,
+                getIdentityLinks(), null, groupId, identityLinkType);
+        InternalTaskAssignmentManager taskAssignmentManager = getTaskAssignmentManager();
+        if (taskAssignmentManager != null) {
+            for (IdentityLinkEntity identityLink : identityLinkEntities) {
+                taskAssignmentManager.deleteGroupIdentityLink(this, identityLink);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Handle removal of task identity links by calling the appropriate methods from the task assignment manager, same as when adding identity links.

I haven't found any existing unit tests related to this functionality to modify and creating the entire test from scratch would be out of scope for this simple change. Please correct me if I'm wrong.

#### Check List:
* Unit tests: NO
* Documentation: NA
