### PR TITLE
Fix potential NullPointerException in addAuthorizationsForNewProcessD…

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/BpmnDeploymentHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/BpmnDeploymentHelper.java
@@ -187,9 +187,10 @@ public class BpmnDeploymentHelper {
      */
     public void addAuthorizationsForNewProcessDefinition(Process process, ProcessDefinitionEntity processDefinition) {
         CommandContext commandContext = Context.getCommandContext();
-
-        addAuthorizationsFromIterator(commandContext, process.getCandidateStarterUsers(), processDefinition, ExpressionType.USER);
-        addAuthorizationsFromIterator(commandContext, process.getCandidateStarterGroups(), processDefinition, ExpressionType.GROUP);
+        if (process != null) {
+            addAuthorizationsFromIterator(commandContext, process.getCandidateStarterUsers(), processDefinition, ExpressionType.USER);
+            addAuthorizationsFromIterator(commandContext, process.getCandidateStarterGroups(), processDefinition, ExpressionType.GROUP);
+        }    
     }
 
     protected void addAuthorizationsFromIterator(CommandContext commandContext, List<String> expressions,


### PR DESCRIPTION
**Description:**
This PR adds a null check for the process parameter in addAuthorizationsForNewProcessDefinition() to prevent potential NullPointerExceptions when this method is called with a null process.

**Issue:**
When the process parameter is null, calling process.getCandidateStarterUsers() or process.getCandidateStarterGroups() throws a NullPointerException, which can cause application crashes.

**Fix:**
Added a conditional check to verify the process parameter is not null before attempting to access its methods.

**References:**
Similar issue was fixed in: https://github.com/Activiti/Activiti/commit/f4ad99958ce6cc0672880732cc69d66fad862da6
This implementation applies the same fix pattern to prevent null dereference