### PR TITLE
fix: When a node in the main process moves to the node that calls the activity && processEngineConfiguration.isEnableEntityLinks() ==false  EntityLinkUtil 41 line throw NullPointerException  The reason is that only when it is true ，ProcessEngineConfigurationImpl#entityLinkServiceConfiguration Will be initialized

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -1101,8 +1101,10 @@ public abstract class AbstractDynamicStateManager {
         }
 
         ExecutionEntity subProcessInstance = executionEntityManager.createSubprocessInstance(subProcessDefinition, parentExecution, businessKey, initialActivityId);
-        EntityLinkUtil.createEntityLinks(parentExecution.getProcessInstanceId(), parentExecution.getId(), callActivity.getId(),
-                subProcessInstance.getId(), ScopeTypes.BPMN);
+        if (processEngineConfiguration.isEnableEntityLinks()) {
+            EntityLinkUtil.createEntityLinks(parentExecution.getProcessInstanceId(), parentExecution.getId(), callActivity.getId(),
+                    subProcessInstance.getId(), ScopeTypes.BPMN);
+        }
         CommandContextUtil.getActivityInstanceEntityManager(commandContext).recordSubProcessInstanceStart(parentExecution, subProcessInstance);
 
         FlowableEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();


### PR DESCRIPTION
fix: When a node in the main process moves to the node that calls the activity && processEngineConfiguration.isEnableEntityLinks() ==false

EntityLinkUtil 41 line throw NullPointerException

The reason is that only when it is true ，ProcessEngineConfigurationImpl#entityLinkServiceConfiguration Will be initialized


The reason why it is normal in the test cases on GitHub is because ChangeStateForCallActiveTest # testSetCurrentActivityInSubProcessInstance  is running during the process   

ProcessEngineConfigurationImpl#entityLinkServiceConfiguration   is true， Resulting in the inability to reproduce official test cases

