### PR TITLE
Add property for configuring the max allowed length of some variable types

### DIFF
--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngineConfiguration.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngineConfiguration.java
@@ -393,7 +393,7 @@ public class AppEngineConfiguration extends AbstractBuildableEngineConfiguration
             }
             variableTypes.addType(new NullType());
             variableTypes.addType(new StringType(getMaxLengthString()));
-            variableTypes.addType(new LongStringType(getMaxLengthString() + 1));
+            variableTypes.addType(new LongStringType(getMaxLengthString() + 1, maxAllowedLengthVariableType));
             variableTypes.addType(new BooleanType());
             variableTypes.addType(new ShortType());
             variableTypes.addType(new IntegerType());
@@ -408,12 +408,12 @@ public class AppEngineConfiguration extends AbstractBuildableEngineConfiguration
             variableTypes.addType(new BigDecimalType());
             variableTypes.addType(new BigIntegerType());
             variableTypes.addType(new UUIDType());
-            variableTypes.addType(new JsonType(getMaxLengthString(), objectMapper, jsonVariableTypeTrackObjects));
+            variableTypes.addType(new JsonType(getMaxLengthString(), maxAllowedLengthVariableType, objectMapper, jsonVariableTypeTrackObjects));
             // longJsonType only needed for reading purposes
-            variableTypes.addType(JsonType.longJsonType(getMaxLengthString(), objectMapper, jsonVariableTypeTrackObjects));
-            variableTypes.addType(new ByteArrayType());
+            variableTypes.addType(JsonType.longJsonType(getMaxLengthString(), maxAllowedLengthVariableType, objectMapper, jsonVariableTypeTrackObjects));
+            variableTypes.addType(new ByteArrayType(maxAllowedLengthVariableType));
             variableTypes.addType(new EmptyCollectionType());
-            variableTypes.addType(new SerializableType(serializableVariableTypeTrackDeserializedObjects));
+            variableTypes.addType(new SerializableType(serializableVariableTypeTrackDeserializedObjects, maxAllowedLengthVariableType));
             if (customPostVariableTypes != null) {
                 for (VariableType customVariableType : customPostVariableTypes) {
                     variableTypes.addType(customVariableType);

--- a/modules/flowable-app-rest/pom.xml
+++ b/modules/flowable-app-rest/pom.xml
@@ -788,5 +788,10 @@
             <artifactId>unboundid-ldapsdk</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/flowable-app-rest/src/test/java/org/flowable/rest/app/variable/MaxAllowedVariableLengthTest.java
+++ b/modules/flowable-app-rest/src/test/java/org/flowable/rest/app/variable/MaxAllowedVariableLengthTest.java
@@ -1,0 +1,321 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.rest.app.variable;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.BYTE_ARRAY;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.flowable.app.spring.SpringAppEngineConfiguration;
+import org.flowable.cmmn.api.CmmnRuntimeService;
+import org.flowable.cmmn.api.CmmnTaskService;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.spring.impl.test.FlowableCmmnSpringExtension;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.engine.RuntimeService;
+import org.flowable.engine.TaskService;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.Deployment;
+import org.flowable.spring.boot.EngineConfigurationConfigurer;
+import org.flowable.spring.impl.test.FlowableSpringExtension;
+import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * @author Filip Hrisafov
+ */
+@SpringBootTest
+@ExtendWith({
+        FlowableSpringExtension.class,
+        FlowableCmmnSpringExtension.class,
+})
+public class MaxAllowedVariableLengthTest {
+
+    @Autowired
+    protected RuntimeService runtimeService;
+
+    @Autowired
+    protected TaskService taskService;
+
+    @Autowired
+    protected CmmnRuntimeService cmmnRuntimeService;
+
+    @Autowired
+    protected CmmnTaskService cmmnTaskService;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Nested
+    class Bpmn {
+
+        @Test
+        @Deployment(resources = "oneTaskProcess.bpmn20.xml")
+        void stringVariable() {
+            ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                    .processDefinitionKey("oneTaskProcess")
+                    .variable("stringVar", "Test value")
+                    .start();
+
+            assertThatThrownBy(() -> runtimeService.setVariable(processInstance.getId(), "stringVar", RandomStringUtils.insecure().nextAlphanumeric(5001)))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the longString value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: stringVar in scope bpmn with id "
+                                    + processInstance.getId());
+
+            Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+            assertThatThrownBy(() -> taskService.setVariableLocal(task.getId(), "stringVar", RandomStringUtils.insecure().nextAlphanumeric(5001)))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the longString value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: stringVar in scope task with id "
+                                    + task.getId());
+
+            assertThat(runtimeService.getVariable(processInstance.getId(), "stringVar")).isEqualTo("Test value");
+        }
+
+        @Test
+        @Deployment(resources = "oneTaskProcess.bpmn20.xml")
+        void jsonVariable() {
+            ObjectNode customer = objectMapper.createObjectNode();
+            customer.put("name", "John Doe");
+            ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                    .processDefinitionKey("oneTaskProcess")
+                    .variable("jsonVar", customer)
+                    .start();
+
+            customer.put("lastName", RandomStringUtils.insecure().nextAlphanumeric(5001));
+            assertThatThrownBy(() -> runtimeService.setVariable(processInstance.getId(), "jsonVar", customer))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the json value exceeds the maximum allowed length of 5000 characters. Current length: 5034, for variable: jsonVar in scope bpmn with id "
+                                    + processInstance.getId());
+
+            Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+            assertThatThrownBy(() -> taskService.setVariableLocal(task.getId(), "jsonVar", customer))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the json value exceeds the maximum allowed length of 5000 characters. Current length: 5034, for variable: jsonVar in scope task with id "
+                                    + task.getId());
+
+            assertThatJson(runtimeService.getVariable(processInstance.getId(), "jsonVar"))
+                    .isEqualTo("{ name:  'John Doe' }");
+        }
+
+        @Test
+        @Deployment(resources = "oneTaskProcess.bpmn20.xml")
+        void bytesVariable() {
+            ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                    .processDefinitionKey("oneTaskProcess")
+                    .variable("bytesVar", "Test".getBytes(StandardCharsets.UTF_8))
+                    .start();
+
+            byte[] largeBytes = RandomStringUtils.insecure().nextAlphanumeric(5001).getBytes(StandardCharsets.UTF_8);
+            assertThatThrownBy(() -> runtimeService.setVariable(processInstance.getId(), "bytesVar", largeBytes))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the bytes value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: bytesVar in scope bpmn with id "
+                                    + processInstance.getId());
+
+            Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+            assertThatThrownBy(() -> taskService.setVariableLocal(task.getId(), "bytesVar", largeBytes))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the bytes value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: bytesVar in scope task with id "
+                                    + task.getId());
+
+            assertThat(runtimeService.getVariable(processInstance.getId(), "bytesVar", byte[].class))
+                    .asString(StandardCharsets.UTF_8)
+                    .isEqualTo("Test");
+        }
+
+        @Test
+        @Deployment(resources = "oneTaskProcess.bpmn20.xml")
+        void serializableVariable() {
+            ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                    .processDefinitionKey("oneTaskProcess")
+                    .variable("serializableVar", new Customer("Test"))
+                    .start();
+
+            Customer largeCustomer = new Customer(RandomStringUtils.insecure().nextAlphanumeric(5001));
+            assertThatThrownBy(() -> runtimeService.setVariable(processInstance.getId(), "serializableVar", largeCustomer))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessageStartingWith("The length of the serializable value exceeds the maximum allowed length of 5000 characters. Current length: ")
+                    .hasMessageEndingWith(", for variable: serializableVar in scope bpmn with id " + processInstance.getId());
+
+            Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+            assertThatThrownBy(() -> taskService.setVariableLocal(task.getId(), "serializableVar", largeCustomer))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessageStartingWith("The length of the serializable value exceeds the maximum allowed length of 5000 characters. Current length: ")
+                    .hasMessageEndingWith(", for variable: serializableVar in scope task with id " + task.getId());
+
+            assertThat(runtimeService.getVariable(processInstance.getId(), "serializableVar"))
+                    .isInstanceOfSatisfying(Customer.class, customer -> assertThat(customer.name).isEqualTo("Test"));
+        }
+
+    }
+
+    @Nested
+    class Cmmn {
+
+        @Test
+        @CmmnDeployment(resources = "oneHumanTaskCase.cmmn")
+        void stringVariable() {
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneHumanTaskCase")
+                    .variable("stringVar", "Test value")
+                    .start();
+
+            assertThatThrownBy(() -> cmmnRuntimeService.setVariable(caseInstance.getId(), "stringVar", RandomStringUtils.insecure().nextAlphanumeric(5001)))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the longString value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: stringVar in scope cmmn with id "
+                                    + caseInstance.getId());
+
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+            assertThatThrownBy(() -> cmmnTaskService.setVariableLocal(task.getId(), "stringVar", RandomStringUtils.insecure().nextAlphanumeric(5001)))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the longString value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: stringVar in scope task with id "
+                                    + task.getId());
+
+            assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar")).isEqualTo("Test value");
+        }
+
+        @Test
+        @CmmnDeployment(resources = "oneHumanTaskCase.cmmn")
+        void jsonVariable() {
+            ObjectNode customer = objectMapper.createObjectNode();
+            customer.put("name", "John Doe");
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneHumanTaskCase")
+                    .variable("jsonVar", customer)
+                    .start();
+
+            customer.put("lastName", RandomStringUtils.insecure().nextAlphanumeric(5001));
+            assertThatThrownBy(() -> cmmnRuntimeService.setVariable(caseInstance.getId(), "jsonVar", customer))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the json value exceeds the maximum allowed length of 5000 characters. Current length: 5034, for variable: jsonVar in scope cmmn with id "
+                                    + caseInstance.getId());
+
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+            assertThatThrownBy(() -> cmmnTaskService.setVariableLocal(task.getId(), "jsonVar", customer))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the json value exceeds the maximum allowed length of 5000 characters. Current length: 5034, for variable: jsonVar in scope task with id "
+                                    + task.getId());
+
+            assertThatJson(cmmnRuntimeService.getVariable(caseInstance.getId(), "jsonVar"))
+                    .isEqualTo("{ name:  'John Doe' }");
+        }
+
+        @Test
+        @CmmnDeployment(resources = "oneHumanTaskCase.cmmn")
+        void bytesVariable() {
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneHumanTaskCase")
+                    .variable("bytesVar", "Test".getBytes(StandardCharsets.UTF_8))
+                    .start();
+
+            byte[] largeBytes = RandomStringUtils.insecure().nextAlphanumeric(5001).getBytes(StandardCharsets.UTF_8);
+            assertThatThrownBy(() -> cmmnRuntimeService.setVariable(caseInstance.getId(), "bytesVar", largeBytes))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the bytes value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: bytesVar in scope cmmn with id "
+                                    + caseInstance.getId());
+
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+            assertThatThrownBy(() -> cmmnTaskService.setVariableLocal(task.getId(), "bytesVar", largeBytes))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessage(
+                            "The length of the bytes value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: bytesVar in scope task with id "
+                                    + task.getId());
+
+            assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "bytesVar"))
+                    .asInstanceOf(BYTE_ARRAY)
+                    .asString(StandardCharsets.UTF_8)
+                    .isEqualTo("Test");
+        }
+
+        @Test
+        @CmmnDeployment(resources = "oneHumanTaskCase.cmmn")
+        void serializableVariable() {
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneHumanTaskCase")
+                    .variable("serializableVar", new Customer("Test"))
+                    .start();
+
+            Customer largeCustomer = new Customer(RandomStringUtils.insecure().nextAlphanumeric(5001));
+            assertThatThrownBy(() -> cmmnRuntimeService.setVariable(caseInstance.getId(), "serializableVar", largeCustomer))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessageStartingWith("The length of the serializable value exceeds the maximum allowed length of 5000 characters. Current length: ")
+                    .hasMessageEndingWith(", for variable: serializableVar in scope cmmn with id " + caseInstance.getId());
+
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+            assertThatThrownBy(() -> cmmnTaskService.setVariableLocal(task.getId(), "serializableVar", largeCustomer))
+                    .isInstanceOf(FlowableIllegalArgumentException.class)
+                    .hasMessageStartingWith("The length of the serializable value exceeds the maximum allowed length of 5000 characters. Current length: ")
+                    .hasMessageEndingWith(", for variable: serializableVar in scope task with id " + task.getId());
+
+            assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "serializableVar"))
+                    .isInstanceOfSatisfying(Customer.class, customer -> assertThat(customer.name).isEqualTo("Test"));
+        }
+    }
+
+    @TestConfiguration
+    static class CustomConfiguration {
+
+        @Bean
+        public EngineConfigurationConfigurer<SpringAppEngineConfiguration> customAppEngineConfigurationConfigurer() {
+            return appEngineConfiguration -> {
+                appEngineConfiguration.setMaxAllowedLengthVariableType(5000);
+            };
+        }
+    }
+
+    protected static class Customer implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        protected Customer(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/modules/flowable-app-rest/src/test/resources/oneHumanTaskCase.cmmn
+++ b/modules/flowable-app-rest/src/test/resources/oneHumanTaskCase.cmmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL" 
+    xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" 
+    xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI"
+    xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    targetNamespace="http://flowable.org/cmmn">
+
+    <case id="oneHumanTaskCase" name="oneHumanTaskCaseName">
+        <casePlanModel id="myPlanModel" name="My CasePlanModel">
+            <planItem id="planItem1" name="Sub task" definitionRef="theTask" />
+            <humanTask id="theTask" name="Sub task"/>
+        </casePlanModel>
+    </case>
+
+</definitions>

--- a/modules/flowable-app-rest/src/test/resources/oneTaskProcess.bpmn20.xml
+++ b/modules/flowable-app-rest/src/test/resources/oneTaskProcess.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="ExamplesCategory">
+
+  <process id="oneTaskProcess" name="The One Task Process">
+    <documentation>This is a process for testing purposes</documentation>
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />    
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -1396,7 +1396,7 @@ public class CmmnEngineConfiguration extends AbstractBuildableEngineConfiguratio
             }
             variableTypes.addType(new NullType());
             variableTypes.addType(new StringType(getMaxLengthString()));
-            variableTypes.addType(new LongStringType(getMaxLengthString() + 1));
+            variableTypes.addType(new LongStringType(getMaxLengthString() + 1, maxAllowedLengthVariableType));
             variableTypes.addType(new BooleanType());
             variableTypes.addType(new ShortType());
             variableTypes.addType(new IntegerType());
@@ -1411,13 +1411,13 @@ public class CmmnEngineConfiguration extends AbstractBuildableEngineConfiguratio
             variableTypes.addType(new BigDecimalType());
             variableTypes.addType(new BigIntegerType());
             variableTypes.addType(new UUIDType());
-            variableTypes.addType(new JsonType(getMaxLengthString(), objectMapper, jsonVariableTypeTrackObjects));
+            variableTypes.addType(new JsonType(getMaxLengthString(), maxAllowedLengthVariableType, objectMapper, jsonVariableTypeTrackObjects));
             // longJsonType only needed for reading purposes
-            variableTypes.addType(JsonType.longJsonType(getMaxLengthString(), objectMapper, jsonVariableTypeTrackObjects));
+            variableTypes.addType(JsonType.longJsonType(getMaxLengthString(), maxAllowedLengthVariableType, objectMapper, jsonVariableTypeTrackObjects));
             variableTypes.addType(new CmmnAggregatedVariableType(this));
-            variableTypes.addType(new ByteArrayType());
+            variableTypes.addType(new ByteArrayType(maxAllowedLengthVariableType));
             variableTypes.addType(new EmptyCollectionType());
-            variableTypes.addType(new SerializableType(serializableVariableTypeTrackDeserializedObjects));
+            variableTypes.addType(new SerializableType(serializableVariableTypeTrackDeserializedObjects, maxAllowedLengthVariableType));
 
         } else {
             if (customPreVariableTypes != null) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MaxAllowedVariableLengthTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/runtime/MaxAllowedVariableLengthTest.java
@@ -1,0 +1,170 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test.runtime;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.BYTE_ARRAY;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.engine.CmmnEngineConfiguration;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.test.impl.CustomCmmnConfigurationFlowableTestCase;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.task.api.Task;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class MaxAllowedVariableLengthTest extends CustomCmmnConfigurationFlowableTestCase {
+
+    @Override
+    protected String getEngineName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    protected void configureConfiguration(CmmnEngineConfiguration cmmnEngineConfiguration) {
+        cmmnEngineConfiguration.setMaxAllowedLengthVariableType(5000);
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn")
+    public void stringVariable() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneHumanTaskCase")
+                .variable("stringVar", "Test value")
+                .start();
+
+        assertThatThrownBy(() -> cmmnRuntimeService.setVariable(caseInstance.getId(), "stringVar", RandomStringUtils.insecure().nextAlphanumeric(5001)))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the longString value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: stringVar in scope cmmn with id "
+                                + caseInstance.getId());
+
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        assertThatThrownBy(() -> cmmnTaskService.setVariableLocal(task.getId(), "stringVar", RandomStringUtils.insecure().nextAlphanumeric(5001)))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the longString value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: stringVar in scope task with id "
+                                + task.getId());
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "stringVar")).isEqualTo("Test value");
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn")
+    public void jsonVariable() {
+        ObjectNode customer = cmmnEngineConfiguration.getObjectMapper()
+                .createObjectNode();
+        customer.put("name", "John Doe");
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneHumanTaskCase")
+                .variable("jsonVar", customer)
+                .start();
+
+        customer.put("lastName", RandomStringUtils.insecure().nextAlphanumeric(5001));
+        assertThatThrownBy(() -> cmmnRuntimeService.setVariable(caseInstance.getId(), "jsonVar", customer))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the json value exceeds the maximum allowed length of 5000 characters. Current length: 5034, for variable: jsonVar in scope cmmn with id "
+                                + caseInstance.getId());
+
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        assertThatThrownBy(() -> cmmnTaskService.setVariableLocal(task.getId(), "jsonVar", customer))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the json value exceeds the maximum allowed length of 5000 characters. Current length: 5034, for variable: jsonVar in scope task with id "
+                                + task.getId());
+
+        assertThatJson(cmmnRuntimeService.getVariable(caseInstance.getId(), "jsonVar"))
+                .isEqualTo("{ name:  'John Doe' }");
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn")
+    public void bytesVariable() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneHumanTaskCase")
+                .variable("bytesVar", "Test".getBytes(StandardCharsets.UTF_8))
+                .start();
+
+        byte[] largeBytes = RandomStringUtils.insecure().nextAlphanumeric(5001).getBytes(StandardCharsets.UTF_8);
+        assertThatThrownBy(() -> cmmnRuntimeService.setVariable(caseInstance.getId(), "bytesVar", largeBytes))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the bytes value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: bytesVar in scope cmmn with id "
+                                + caseInstance.getId());
+
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        assertThatThrownBy(() -> cmmnTaskService.setVariableLocal(task.getId(), "bytesVar", largeBytes))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the bytes value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: bytesVar in scope task with id "
+                                + task.getId());
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "bytesVar"))
+                .asInstanceOf(BYTE_ARRAY)
+                .asString(StandardCharsets.UTF_8)
+                .isEqualTo("Test");
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/runtime/oneHumanTaskCase.cmmn")
+    public void serializableVariable() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneHumanTaskCase")
+                .variable("serializableVar", new Customer("Test"))
+                .start();
+
+        Customer largeCustomer = new Customer(RandomStringUtils.insecure().nextAlphanumeric(5001));
+        assertThatThrownBy(() -> cmmnRuntimeService.setVariable(caseInstance.getId(), "serializableVar", largeCustomer))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageStartingWith("The length of the serializable value exceeds the maximum allowed length of 5000 characters. Current length: ")
+                .hasMessageEndingWith(", for variable: serializableVar in scope cmmn with id " + caseInstance.getId());
+
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        assertThatThrownBy(() -> cmmnTaskService.setVariableLocal(task.getId(), "serializableVar", largeCustomer))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageStartingWith("The length of the serializable value exceeds the maximum allowed length of 5000 characters. Current length: ")
+                .hasMessageEndingWith(", for variable: serializableVar in scope task with id " + task.getId());
+
+        assertThat(cmmnRuntimeService.getVariable(caseInstance.getId(), "serializableVar"))
+                .isInstanceOfSatisfying(Customer.class, customer -> assertThat(customer.name).isEqualTo("Test"));
+    }
+
+    protected static class Customer implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        protected Customer(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -400,6 +400,12 @@ public abstract class AbstractEngineConfiguration {
      */
     protected int maxLengthStringVariableType = -1;
 
+    /**
+     * Define a max allowed length for storing large variables, e.g. String, JSON, etc. in the database.
+     * If the length of the variable exceeds this value, there will be an exception thrown when trying to store the variable.
+     */
+    protected int maxAllowedLengthVariableType = -1;
+
     protected void initEngineConfigurations() {
         addEngineConfiguration(getEngineCfgKey(), getEngineScopeType(), this);
     }
@@ -1932,6 +1938,15 @@ public abstract class AbstractEngineConfiguration {
 
     public AbstractEngineConfiguration setMaxLengthStringVariableType(int maxLengthStringVariableType) {
         this.maxLengthStringVariableType = maxLengthStringVariableType;
+        return this;
+    }
+
+    public int getMaxAllowedLengthVariableType() {
+        return maxAllowedLengthVariableType;
+    }
+
+    public AbstractEngineConfiguration setMaxAllowedLengthVariableType(int maxAllowedLengthVariableType) {
+        this.maxAllowedLengthVariableType = maxAllowedLengthVariableType;
         return this;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2176,7 +2176,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             }
             variableTypes.addType(new NullType());
             variableTypes.addType(new StringType(getMaxLengthString()));
-            variableTypes.addType(new LongStringType(getMaxLengthString() + 1));
+            variableTypes.addType(new LongStringType(getMaxLengthString() + 1, maxAllowedLengthVariableType));
             variableTypes.addType(new BooleanType());
             variableTypes.addType(new ShortType());
             variableTypes.addType(new IntegerType());
@@ -2191,14 +2191,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             variableTypes.addType(new BigDecimalType());
             variableTypes.addType(new BigIntegerType());
             variableTypes.addType(new UUIDType());
-            variableTypes.addType(new JsonType(getMaxLengthString(), objectMapper, jsonVariableTypeTrackObjects));
+            variableTypes.addType(new JsonType(getMaxLengthString(), maxAllowedLengthVariableType, objectMapper, jsonVariableTypeTrackObjects));
             // longJsonType only needed for reading purposes
-            variableTypes.addType(JsonType.longJsonType(getMaxLengthString(), objectMapper, jsonVariableTypeTrackObjects));
+            variableTypes.addType(JsonType.longJsonType(getMaxLengthString(), maxAllowedLengthVariableType, objectMapper, jsonVariableTypeTrackObjects));
             variableTypes.addType(new ParallelMultiInstanceLoopVariableType(this));
             variableTypes.addType(new BpmnAggregatedVariableType(this));
-            variableTypes.addType(new ByteArrayType());
+            variableTypes.addType(new ByteArrayType(maxAllowedLengthVariableType));
             variableTypes.addType(new EmptyCollectionType());
-            variableTypes.addType(new SerializableType(serializableVariableTypeTrackDeserializedObjects));
+            variableTypes.addType(new SerializableType(serializableVariableTypeTrackDeserializedObjects, maxAllowedLengthVariableType));
 
         } else {
             if (customPreVariableTypes != null) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/variable/MaxAllowedVariableLengthTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/variable/MaxAllowedVariableLengthTest.java
@@ -1,0 +1,167 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.engine.test.variable;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.Deployment;
+import org.flowable.engine.test.impl.CustomConfigurationFlowableTestCase;
+import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class MaxAllowedVariableLengthTest extends CustomConfigurationFlowableTestCase {
+
+    public MaxAllowedVariableLengthTest() {
+        super(MaxAllowedVariableLengthTest.class.getSimpleName());
+    }
+
+    @Override
+    protected void configureConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {
+        processEngineConfiguration.setMaxAllowedLengthVariableType(5000);
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    void stringVariable() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .variable("stringVar", "Test value")
+                .start();
+
+        assertThatThrownBy(() -> runtimeService.setVariable(processInstance.getId(), "stringVar", RandomStringUtils.insecure().nextAlphanumeric(5001)))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the longString value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: stringVar in scope bpmn with id "
+                                + processInstance.getId());
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        assertThatThrownBy(() -> taskService.setVariableLocal(task.getId(), "stringVar", RandomStringUtils.insecure().nextAlphanumeric(5001)))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the longString value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: stringVar in scope task with id "
+                                + task.getId());
+
+        assertThat(runtimeService.getVariable(processInstance.getId(), "stringVar")).isEqualTo("Test value");
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    void jsonVariable() {
+        ObjectNode customer = processEngineConfiguration.getObjectMapper()
+                .createObjectNode();
+        customer.put("name", "John Doe");
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .variable("jsonVar", customer)
+                .start();
+
+        customer.put("lastName", RandomStringUtils.insecure().nextAlphanumeric(5001));
+        assertThatThrownBy(() -> runtimeService.setVariable(processInstance.getId(), "jsonVar", customer))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the json value exceeds the maximum allowed length of 5000 characters. Current length: 5034, for variable: jsonVar in scope bpmn with id "
+                                + processInstance.getId());
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        assertThatThrownBy(() -> taskService.setVariableLocal(task.getId(), "jsonVar", customer))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the json value exceeds the maximum allowed length of 5000 characters. Current length: 5034, for variable: jsonVar in scope task with id "
+                                + task.getId());
+
+        assertThatJson(runtimeService.getVariable(processInstance.getId(), "jsonVar"))
+                .isEqualTo("{ name:  'John Doe' }");
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    void bytesVariable() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .variable("bytesVar", "Test".getBytes(StandardCharsets.UTF_8))
+                .start();
+
+        byte[] largeBytes = RandomStringUtils.insecure().nextAlphanumeric(5001).getBytes(StandardCharsets.UTF_8);
+        assertThatThrownBy(() -> runtimeService.setVariable(processInstance.getId(), "bytesVar", largeBytes))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the bytes value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: bytesVar in scope bpmn with id "
+                                + processInstance.getId());
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        assertThatThrownBy(() -> taskService.setVariableLocal(task.getId(), "bytesVar", largeBytes))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessage(
+                        "The length of the bytes value exceeds the maximum allowed length of 5000 characters. Current length: 5001, for variable: bytesVar in scope task with id "
+                                + task.getId());
+
+        assertThat(runtimeService.getVariable(processInstance.getId(), "bytesVar", byte[].class))
+                .asString(StandardCharsets.UTF_8)
+                .isEqualTo("Test");
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/oneTaskProcess.bpmn20.xml")
+    void serializableVariable() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                .processDefinitionKey("oneTaskProcess")
+                .variable("serializableVar", new Customer("Test"))
+                .start();
+
+        Customer largeCustomer = new Customer(RandomStringUtils.insecure().nextAlphanumeric(5001));
+        assertThatThrownBy(() -> runtimeService.setVariable(processInstance.getId(), "serializableVar", largeCustomer))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageStartingWith("The length of the serializable value exceeds the maximum allowed length of 5000 characters. Current length: ")
+                .hasMessageEndingWith(", for variable: serializableVar in scope bpmn with id " + processInstance.getId());
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        assertThatThrownBy(() -> taskService.setVariableLocal(task.getId(), "serializableVar", largeCustomer))
+                .isInstanceOf(FlowableIllegalArgumentException.class)
+                .hasMessageStartingWith("The length of the serializable value exceeds the maximum allowed length of 5000 characters. Current length: ")
+                .hasMessageEndingWith(", for variable: serializableVar in scope task with id " + task.getId());
+
+        assertThat(runtimeService.getVariable(processInstance.getId(), "serializableVar"))
+                .isInstanceOfSatisfying(Customer.class, customer -> assertThat(customer.name).isEqualTo("Test"));
+    }
+
+    protected static class Customer implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        protected Customer(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/ByteArrayType.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/ByteArrayType.java
@@ -14,6 +14,7 @@ package org.flowable.variable.service.impl.types;
 
 import org.flowable.variable.api.types.ValueFields;
 import org.flowable.variable.api.types.VariableType;
+import org.flowable.variable.service.impl.util.VariableTypeUtils;
 
 /**
  * @author Tom Baeyens
@@ -23,6 +24,16 @@ public class ByteArrayType implements VariableType {
     public static final String TYPE_NAME = "bytes";
 
     private static final long serialVersionUID = 1L;
+
+    protected final int maxAllowedLength;
+
+    public ByteArrayType() {
+        this(-1);
+    }
+
+    public ByteArrayType(int maxAllowedLength) {
+        this.maxAllowedLength = maxAllowedLength;
+    }
 
     @Override
     public String getTypeName() {
@@ -41,6 +52,14 @@ public class ByteArrayType implements VariableType {
 
     @Override
     public void setValue(Object value, ValueFields valueFields) {
+        if (value == null) {
+            valueFields.setBytes(null);
+            return;
+        }
+
+        byte[] bytes = (byte[]) value;
+        VariableTypeUtils.validateMaxAllowedLength(maxAllowedLength, bytes.length, valueFields, this);
+
         valueFields.setBytes((byte[]) value);
     }
 

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/LongStringType.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/LongStringType.java
@@ -12,6 +12,9 @@
  */
 package org.flowable.variable.service.impl.types;
 
+import org.flowable.variable.api.types.ValueFields;
+import org.flowable.variable.service.impl.util.VariableTypeUtils;
+
 /**
  * @author Martin Grofcik
  */
@@ -21,12 +24,29 @@ public class LongStringType extends SerializableType {
     private final int minLength;
 
     public LongStringType(int minLength) {
+        this(minLength, -1);
+    }
+
+    public LongStringType(int minLength, int maxAllowedLength) {
+        super(false, maxAllowedLength);
         this.minLength = minLength;
     }
 
     @Override
     public String getTypeName() {
         return TYPE_NAME;
+    }
+
+    @Override
+    public void setValue(Object value, ValueFields valueFields) {
+        if (value == null) {
+            valueFields.setCachedValue(null);
+            valueFields.setBytes(null);
+        }
+        String textValue = (String) value;
+        VariableTypeUtils.validateMaxAllowedLength(maxAllowedLength, textValue.length(), valueFields, this);
+        byte[] serializedValue = serialize(textValue, valueFields);
+        valueFields.setBytes(serializedValue);
     }
 
     @Override

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/SerializableType.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/SerializableType.java
@@ -54,9 +54,15 @@ public class SerializableType extends ByteArrayType implements MutableVariableTy
     }
 
     public SerializableType() {
+        this(false, -1);
     }
 
     public SerializableType(boolean trackDeserializedObjects) {
+        this(trackDeserializedObjects, -1);
+    }
+
+    public SerializableType(boolean trackDeserializedObjects, int maxAllowedLength) {
+        super(maxAllowedLength);
         this.trackDeserializedObjects = trackDeserializedObjects;
     }
 

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/util/VariableTypeUtils.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/util/VariableTypeUtils.java
@@ -1,0 +1,52 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.variable.service.impl.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.common.engine.api.FlowableIllegalArgumentException;
+import org.flowable.common.engine.api.FlowableIllegalStateException;
+import org.flowable.common.engine.api.scope.ScopeTypes;
+import org.flowable.variable.api.types.ValueFields;
+import org.flowable.variable.api.types.VariableType;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class VariableTypeUtils {
+
+    public static void validateMaxAllowedLength(int maxAllowedLength, int length, ValueFields valueFields, VariableType variableType) {
+        if (maxAllowedLength < 0) {
+            return;
+        }
+
+        if (maxAllowedLength > 0 && length > maxAllowedLength) {
+            String scopeId;
+            String scopeType;
+            if (StringUtils.isNotEmpty(valueFields.getTaskId())) {
+                scopeId = valueFields.getTaskId();
+                scopeType = ScopeTypes.TASK;
+            } else if (StringUtils.isNotEmpty(valueFields.getProcessInstanceId())) {
+                scopeId = valueFields.getProcessInstanceId();
+                scopeType = ScopeTypes.BPMN;
+            } else {
+                scopeId = valueFields.getScopeId();
+                scopeType = valueFields.getScopeType();
+            }
+            throw new FlowableIllegalArgumentException(
+                    "The length of the " + variableType.getTypeName() + " value exceeds the maximum allowed length of " + maxAllowedLength
+                            + " characters. Current length: " + length
+                            + ", for variable: " + valueFields.getName() + " in scope " + scopeType + " with id " + scopeId);
+        }
+    }
+
+}

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/SerializableType.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/variable/SerializableType.java
@@ -38,6 +38,10 @@ public class SerializableType extends ByteArrayType {
 
     public static final String TYPE_NAME = "serializable";
 
+    public SerializableType() {
+        super(-1);
+    }
+
     @Override
     public String getTypeName() {
         return TYPE_NAME;


### PR DESCRIPTION
This PR adds support for configuring the maximum allowed size for some variable (e.g. String, Json, Bytes, etc.)

#### Check List:
* Unit tests: YES
* Documentation: NA
