### PR TITLE
Support removing a deployment via the EngineDeployer

### DIFF
--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/deployer/AppDeployer.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/deployer/AppDeployer.java
@@ -122,4 +122,9 @@ public class AppDeployer implements EngineDeployer {
         deployment.addDeployedArtifact(appDefinition);
         deployment.addAppDefinitionCacheEntry(appDefinition.getId(), cacheEntry);
     }
+
+    @Override
+    public void undeploy(EngineDeployment parentDeployment, boolean cascade) {
+        // Nothing to do
+    }
 }

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/deployer/AppDeploymentManager.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/impl/deployer/AppDeploymentManager.java
@@ -13,6 +13,8 @@
 
 package org.flowable.app.engine.impl.deployer;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -125,10 +127,17 @@ public class AppDeploymentManager {
             throw new FlowableObjectNotFoundException("Could not find a deployment with id '" + deploymentId + "'.", AppDeploymentEntity.class);
         }
         
+        List<EngineDeployer> engineUnDeployers = new ArrayList<>(deployers);
+        engineUnDeployers.sort(Comparator.comparingInt(EngineDeployer::getUndeployOrder));
+
+        for (EngineDeployer deployer : engineUnDeployers) {
+            deployer.undeploy(deployment, cascade);
+        }
+
         for (AppDefinition appDefinition : new AppDefinitionQueryImpl().deploymentId(deploymentId).list()) {
             appDefinitionCache.remove(appDefinition.getId());
         }
-        
+
         deploymentEntityManager.deleteDeploymentAndRelatedData(deploymentId, cascade);
     }
 

--- a/modules/flowable-cmmn-engine-configurator/src/main/java/org/flowable/cmmn/engine/configurator/impl/deployer/CmmnDeployer.java
+++ b/modules/flowable-cmmn-engine-configurator/src/main/java/org/flowable/cmmn/engine/configurator/impl/deployer/CmmnDeployer.java
@@ -12,9 +12,11 @@
  */
 package org.flowable.cmmn.engine.configurator.impl.deployer;
 
+import java.util.List;
 import java.util.Map;
 
 import org.flowable.cmmn.api.CmmnRepositoryService;
+import org.flowable.cmmn.api.repository.CmmnDeployment;
 import org.flowable.cmmn.api.repository.CmmnDeploymentBuilder;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
 import org.flowable.common.engine.api.repository.EngineDeployment;
@@ -29,6 +31,8 @@ import org.slf4j.LoggerFactory;
 public class CmmnDeployer implements EngineDeployer {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(CmmnDeployer.class);
+
+    public static final int CMMN_DEFAULT_UNDEPLOY_ORDER = EngineDeployer.DEFAULT_UNDEPLOY_ORDER - 200;
     
     @Override
     public void deploy(EngineDeployment deployment, Map<String, Object> deploymentSettings) {
@@ -61,4 +65,21 @@ public class CmmnDeployer implements EngineDeployer {
         }
     }
 
+    @Override
+    public void undeploy(EngineDeployment parentDeployment, boolean cascade) {
+        CmmnRepositoryService repositoryService = CommandContextUtil.getCmmnRepositoryService();
+        List<CmmnDeployment> deployments = repositoryService
+                .createDeploymentQuery()
+                .parentDeploymentId(parentDeployment.getId())
+                .list();
+
+        for (CmmnDeployment deployment : deployments) {
+            repositoryService.deleteDeployment(deployment.getId(), cascade);
+        }
+    }
+
+    @Override
+    public int getUndeployOrder() {
+        return CMMN_DEFAULT_UNDEPLOY_ORDER;
+    }
 }

--- a/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnAppDeploymentTest.java
+++ b/modules/flowable-cmmn-engine-configurator/src/test/java/org/flowable/cmmn/test/CmmnAppDeploymentTest.java
@@ -1,0 +1,92 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.cmmn.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.flowable.cmmn.api.repository.CaseDefinition;
+import org.flowable.engine.repository.Deployment;
+import org.flowable.engine.repository.ProcessDefinition;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class CmmnAppDeploymentTest extends AbstractProcessEngineIntegrationTest {
+
+    @Test
+    public void deletingProcessDeploymentShouldRemoveChildCaseDeployment() {
+        Deployment deployment = processEngineRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/processTaskSameDeploymentTrue.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml")
+                .deploy();
+
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().list())
+                .extracting(CaseDefinition::getKey)
+                .containsExactlyInAnyOrder("oneProcessTaskCase");
+
+        assertThat(processEngineRepositoryService.createProcessDefinitionQuery().list())
+                .extracting(ProcessDefinition::getKey)
+                .containsExactlyInAnyOrder("oneTask");
+
+        processEngineRepositoryService.deleteDeployment(deployment.getId(), false);
+
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().list())
+                .extracting(CaseDefinition::getKey)
+                .isEmpty();
+
+        assertThat(processEngineRepositoryService.createProcessDefinitionQuery().list())
+                .extracting(ProcessDefinition::getKey)
+                .isEmpty();
+    }
+
+    @Test
+    public void deletingProcessDeploymentShouldRemoveChildCaseDeploymentWithCascade() {
+        Deployment deployment = processEngineRepositoryService.createDeployment()
+                .addClasspathResource("org/flowable/cmmn/test/processTaskSameDeploymentTrue.cmmn")
+                .addClasspathResource("org/flowable/cmmn/test/oneTaskProcess.bpmn20.xml")
+                .deploy();
+
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().list())
+                .extracting(CaseDefinition::getKey)
+                .containsExactlyInAnyOrder("oneProcessTaskCase");
+
+        assertThat(processEngineRepositoryService.createProcessDefinitionQuery().list())
+                .extracting(ProcessDefinition::getKey)
+                .containsExactlyInAnyOrder("oneTask");
+
+        cmmnRuntimeService.createCaseInstanceBuilder()
+                .caseDefinitionKey("oneProcessTaskCase")
+                .start();
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .hasSize(1);
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().list())
+                .hasSize(1);
+
+        processEngineRepositoryService.deleteDeployment(deployment.getId(), true);
+
+        assertThat(cmmnRepositoryService.createCaseDefinitionQuery().list())
+                .extracting(CaseDefinition::getKey)
+                .isEmpty();
+
+        assertThat(processEngineRepositoryService.createProcessDefinitionQuery().list())
+                .extracting(ProcessDefinition::getKey)
+                .isEmpty();
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().list())
+                .isEmpty();
+        assertThat(processEngineRuntimeService.createProcessInstanceQuery().list())
+                .isEmpty();
+    }
+}

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/deployer/CmmnDeployer.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/deployer/CmmnDeployer.java
@@ -446,4 +446,9 @@ public class CmmnDeployer implements EngineDeployer {
             return cmmnEngineConfiguration.getCaseValidator();
         }
     }
+
+    @Override
+    public void undeploy(EngineDeployment parentDeployment, boolean cascade) {
+        // Nothing to do
+    }
 }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/deployer/CmmnDeploymentManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/deployer/CmmnDeploymentManager.java
@@ -13,6 +13,8 @@
 
 package org.flowable.cmmn.engine.impl.deployer;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -125,6 +127,13 @@ public class CmmnDeploymentManager {
             throw new FlowableObjectNotFoundException("Could not find a deployment with id '" + deploymentId + "'.", CmmnDeploymentEntity.class);
         }
         
+        List<EngineDeployer> engineUnDeployers = new ArrayList<>(deployers);
+        engineUnDeployers.sort(Comparator.comparingInt(EngineDeployer::getUndeployOrder));
+
+        for (EngineDeployer deployer : engineUnDeployers) {
+            deployer.undeploy(deployment, cascade);
+        }
+
         deploymentEntityManager.deleteDeploymentAndRelatedData(deploymentId, cascade);
         
         for (CaseDefinition caseDefinition : new CaseDefinitionQueryImpl().deploymentId(deploymentId).list()) {

--- a/modules/flowable-dmn-engine-configurator/src/main/java/org/flowable/dmn/engine/deployer/DmnDeployer.java
+++ b/modules/flowable-dmn-engine-configurator/src/main/java/org/flowable/dmn/engine/deployer/DmnDeployer.java
@@ -12,11 +12,13 @@
  */
 package org.flowable.dmn.engine.deployer;
 
+import java.util.List;
 import java.util.Map;
 
 import org.flowable.common.engine.api.repository.EngineDeployment;
 import org.flowable.common.engine.api.repository.EngineResource;
 import org.flowable.common.engine.impl.EngineDeployer;
+import org.flowable.dmn.api.DmnDeployment;
 import org.flowable.dmn.api.DmnDeploymentBuilder;
 import org.flowable.dmn.api.DmnRepositoryService;
 import org.flowable.dmn.engine.impl.deployer.DmnResourceUtil;
@@ -61,6 +63,19 @@ public class DmnDeployer implements EngineDeployer {
             }
 
             dmnDeploymentBuilder.deploy();
+        }
+    }
+
+    @Override
+    public void undeploy(EngineDeployment parentDeployment, boolean cascade) {
+        DmnRepositoryService repositoryService = CommandContextUtil.getDmnRepositoryService();
+        List<DmnDeployment> deployments = repositoryService
+                .createDeploymentQuery()
+                .parentDeploymentId(parentDeployment.getId())
+                .list();
+
+        for (DmnDeployment deployment : deployments) {
+            repositoryService.deleteDeployment(deployment.getId());
         }
     }
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/EngineDeployer.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/EngineDeployer.java
@@ -21,5 +21,14 @@ import org.flowable.common.engine.api.repository.EngineDeployment;
  */
 public interface EngineDeployer {
 
+    int DEFAULT_UNDEPLOY_ORDER = 0;
+
     void deploy(EngineDeployment deployment, Map<String, Object> deploymentSettings);
+
+    void undeploy(EngineDeployment parentDeployment, boolean cascade);
+
+    default int getUndeployOrder() {
+        return DEFAULT_UNDEPLOY_ORDER;
+    }
+
 }

--- a/modules/flowable-engine-configurator/src/test/java/org/flowable/engine/configurator/test/DeploymentTest.java
+++ b/modules/flowable-engine-configurator/src/test/java/org/flowable/engine/configurator/test/DeploymentTest.java
@@ -13,6 +13,7 @@
 package org.flowable.engine.configurator.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.flowable.app.api.AppRepositoryService;
 import org.flowable.app.api.repository.AppDefinition;
@@ -92,16 +93,26 @@ class DeploymentTest {
             CaseDefinition caseDefinition = cmmnRepositoryService.createCaseDefinitionQuery().deploymentId(cmmnDeployment.getId()).singleResult();
             assertThat(caseDefinition).isNotNull();
             assertThat(caseDefinition.getKey()).isEqualTo("oneTaskCase");
+
+            appRepositoryService.deleteDeployment(appDeployment.getId(), true);
+
+            assertThat(appRepositoryService.createAppDefinitionQuery().list())
+                    .extracting(AppDefinition::getKey)
+                    .isEmpty();
+
+            assertThat(repositoryService.createProcessDefinitionQuery().list())
+                    .extracting(ProcessDefinition::getKey)
+                    .isEmpty();
+
+            assertThat(cmmnRepositoryService.createCaseDefinitionQuery().list())
+                    .extracting(CaseDefinition::getKey)
+                    .isEmpty();
             
             
         } finally {
-            appRepositoryService.deleteDeployment(appDeployment.getId(), true);
-            if (deployment != null) {
-                processEngineConfiguration.getRepositoryService().deleteDeployment(deployment.getId());
-            }
-            
-            if (cmmnDeployment != null) {
-                cmmnEngineConfiguration.getCmmnRepositoryService().deleteDeployment(cmmnDeployment.getId(), true);
+            appDeployment = appRepositoryService.createDeploymentQuery().deploymentId(appDeployment.getId()).singleResult();
+            if (appDeployment != null) {
+                appRepositoryService.deleteDeployment(appDeployment.getId(), true);
             }
         }
     }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/app/AppDeployer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/app/AppDeployer.java
@@ -56,4 +56,9 @@ public class AppDeployer implements EngineDeployer {
             deploymentManager.getAppResourceCache().add(deployment.getId(), appResourceObject);
         }
     }
+
+    @Override
+    public void undeploy(EngineDeployment parentDeployment, boolean cascade) {
+        // Nothing to do
+    }
 }

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -116,6 +116,11 @@ public class BpmnDeployer implements EngineDeployer {
         }
     }
 
+    @Override
+    public void undeploy(EngineDeployment parentDeployment, boolean cascade) {
+        // Nothing to do
+    }
+
     /**
      * Creates new diagrams for process definitions if the deployment is new, the process definition in question supports it, and the engine is configured to make new diagrams.
      *

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/deploy/DeploymentManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/persistence/deploy/DeploymentManager.java
@@ -189,6 +189,10 @@ public class DeploymentManager {
             return;
         }
 
+        for (EngineDeployer deployer : deployers) {
+            deployer.undeploy(deployment, cascade);
+        }
+
         // Remove any process definition from the cache
         List<ProcessDefinition> processDefinitions = new ProcessDefinitionQueryImpl().deploymentId(deploymentId).list();
         ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/rules/RulesDeployer.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/rules/RulesDeployer.java
@@ -63,4 +63,9 @@ public class RulesDeployer implements EngineDeployer {
             deploymentManager.getKnowledgeBaseCache().add(deployment.getId(), kieBase);
         }
     }
+
+    @Override
+    public void undeploy(EngineDeployment parentDeployment, boolean cascade) {
+        // Nothing to do
+    }
 }

--- a/modules/flowable-event-registry-configurator/src/main/java/org/flowable/eventregistry/impl/configurator/deployer/EventDeployer.java
+++ b/modules/flowable-event-registry-configurator/src/main/java/org/flowable/eventregistry/impl/configurator/deployer/EventDeployer.java
@@ -12,11 +12,13 @@
  */
 package org.flowable.eventregistry.impl.configurator.deployer;
 
+import java.util.List;
 import java.util.Map;
 
 import org.flowable.common.engine.api.repository.EngineDeployment;
 import org.flowable.common.engine.api.repository.EngineResource;
 import org.flowable.common.engine.impl.EngineDeployer;
+import org.flowable.eventregistry.api.EventDeployment;
 import org.flowable.eventregistry.api.EventDeploymentBuilder;
 import org.flowable.eventregistry.api.EventRepositoryService;
 import org.flowable.eventregistry.impl.util.CommandContextUtil;
@@ -69,6 +71,18 @@ public class EventDeployer implements EngineDeployer {
             }
 
             eventDeploymentBuilder.deploy();
+        }
+    }
+
+    @Override
+    public void undeploy(EngineDeployment parentDeployment, boolean cascade) {
+        EventRepositoryService repositoryService = CommandContextUtil.getEventRepositoryService();
+        List<EventDeployment> eventDeployments = repositoryService.createDeploymentQuery()
+                .parentDeploymentId(parentDeployment.getId())
+                .list();
+
+        for (EventDeployment eventDeployment : eventDeployments) {
+            repositoryService.deleteDeployment(eventDeployment.getId());
         }
     }
 }


### PR DESCRIPTION
With this changes we are making it possible to cascade the removal of a deployment to the child deployments as well