### PR TITLE
Reduce test flakiness

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/PluggableFlowableExtension.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/PluggableFlowableExtension.java
@@ -44,6 +44,14 @@ public class PluggableFlowableExtension extends InternalFlowableExtension {
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(PluggableFlowableExtension.class);
 
     @Override
+    public void beforeEach(ExtensionContext context) {
+        super.beforeEach(context);
+        if (AnnotationSupport.isAnnotated(context.getRequiredTestClass(), EnableVerboseExecutionTreeLogging.class)) {
+            swapCommandInvoker(getProcessEngine(context), true);
+        }
+    }
+
+    @Override
     public void afterEach(ExtensionContext context) throws Exception {
         try {
             super.afterEach(context);
@@ -57,14 +65,7 @@ public class PluggableFlowableExtension extends InternalFlowableExtension {
     @Override
     protected ProcessEngine getProcessEngine(ExtensionContext context) {
         String configurationResource = getConfigurationResource(context);
-        ProcessEngine processEngine = getStore(context).getOrComputeIfAbsent(configurationResource, this::initializeProcessEngine, ProcessEngine.class);
-
-        // Enable verbose execution tree debugging if needed
-        Class<?> testClass = context.getRequiredTestClass();
-        if (AnnotationSupport.isAnnotated(testClass, EnableVerboseExecutionTreeLogging.class)) {
-            swapCommandInvoker(processEngine, true);
-        }
-        return processEngine;
+        return getStore(context).getOrComputeIfAbsent(configurationResource, this::initializeProcessEngine, ProcessEngine.class);
     }
 
     protected ProcessEngine initializeProcessEngine(String configurationResource) {

--- a/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/kafka/KafkaChannelDefinitionProcessorTest.java
+++ b/modules/flowable-event-registry-spring/src/test/java/org/flowable/eventregistry/spring/test/kafka/KafkaChannelDefinitionProcessorTest.java
@@ -1597,6 +1597,7 @@ class KafkaChannelDefinitionProcessorTest {
     }
 
     @Test
+    @Disabled("This can lead to creating invalid retry topics with retry duplicates not being in the end, which is required from Spring Kafka")
     void uniformRandomBackOffRetry() throws Exception {
         createTopic("uniform-random-backoff");
 

--- a/pom.xml
+++ b/pom.xml
@@ -540,7 +540,6 @@
 						<exclude>**/*TestCase.java</exclude>
 					</excludes>
 					<runOrder>alphabetical</runOrder>
-					<rerunFailingTestsCount>5</rerunFailingTestsCount>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
The recent changes I did for the DMN Engine tests led to some flakiness in there due to the fact that we were closing an engine and reusing it later again. With the change here we do not use the `DmnEngines` and leave it up to JUnit Jupiter to close the engines through the `ExtensionContext.Store.CloseableResource`.

Additionally, we had some flakiness in the Process Engine tests due to the way the `EnableVerboseExecutionTreeLogging` was swapping the command executor, it was leading to some inconsistency with the tests that are verifying the DB operations such as the `VariableListenerEventDbQueryTest` and `VerifyDatabaseOperationsTest`. When a test annotate with `EnableVerboseExecutionTreeLogging` run before one of those DB operations tests then they would fail.

Finally, we are removing the `rerunFailingTestsCount` from Maven Surefire in order to avoid re-running the tests if they fail with the goal of achieving stable tests without flakiness.