### PR TITLE
Rewrite Camel Behavior to be more multi instance resilient

### DIFF
--- a/modules/flowable-camel/src/main/java/org/flowable/camel/SpringCamelBehavior.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/SpringCamelBehavior.java
@@ -16,7 +16,6 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.spring.SpringCamelContext;
 import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.api.FlowableException;
-import org.flowable.common.engine.impl.context.Context;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.engine.compatibility.Flowable5CompatibilityHandler;
 import org.flowable.engine.delegate.DelegateExecution;
@@ -32,43 +31,58 @@ public abstract class SpringCamelBehavior extends CamelBehavior {
     
 	private static final long serialVersionUID = 1L;
 
-	@Override
-    protected void setAppropriateCamelContext(DelegateExecution execution) {
+    protected final Object contextLock = new Object();
+
+    @Override
+    protected CamelContext getCamelContext(DelegateExecution execution, boolean isV5Execution) {
         // Get the appropriate String representation of the CamelContext object
         // from ActivityExecution (if available).
         String camelContextValue = getStringFromField(camelContext, execution);
+        if (StringUtils.isEmpty(camelContextValue)) {
+            if (camelContextObj != null) {
+                // No processing required. No custom CamelContext & the default is already set.
+                return camelContextObj;
+            }
 
-        // If the String representation of the CamelContext object from ActivityExecution is empty, use the default.
-        if (StringUtils.isEmpty(camelContextValue) && camelContextObj != null) {
-            // No processing required. No custom CamelContext & the default is already set.
+            // Use a lock to resolve the default camel context.
+            synchronized (contextLock) {
+                // Check again, in case another thread set the member variable in the meantime.
+                if (camelContextObj != null) {
+                    return camelContextObj;
+                }
+                camelContextObj = resolveCamelContext(camelContextValue, isV5Execution);
+            }
+
+            return camelContextObj;
+        } else {
+            return resolveCamelContext(camelContextValue, isV5Execution);
+        }
+    }
+
+    protected CamelContext resolveCamelContext(String camelContextValue, boolean isV5Execution) {
+        ProcessEngineConfiguration engineConfiguration = org.flowable.engine.impl.context.Context.getProcessEngineConfiguration();
+        if (isV5Execution) {
+
+            Flowable5CompatibilityHandler compatibilityHandler = Flowable5Util.getFlowable5CompatibilityHandler();
+            return (CamelContext) compatibilityHandler.getCamelContextObject(camelContextValue);
 
         } else {
-            // Get the ProcessEngineConfiguration object.
-            ProcessEngineConfiguration engineConfiguration = org.flowable.engine.impl.context.Context.getProcessEngineConfiguration();
-            if ((Context.getCommandContext() != null && Flowable5Util.isFlowable5ProcessDefinitionId(Context.getCommandContext(), execution.getProcessDefinitionId())) ||
-                    (Context.getCommandContext() == null && Flowable5Util.getFlowable5CompatibilityHandler() != null)) {
-
-                Flowable5CompatibilityHandler compatibilityHandler = Flowable5Util.getFlowable5CompatibilityHandler();
-                camelContextObj = (CamelContext) compatibilityHandler.getCamelContextObject(camelContextValue);
-
-            } else {
-                // Convert it to a SpringProcessEngineConfiguration. If this doesn't work, throw a RuntimeException.
-                try {
-                    SpringProcessEngineConfiguration springConfiguration = (SpringProcessEngineConfiguration) engineConfiguration;
-                    if (StringUtils.isEmpty(camelContextValue) && camelContextObj == null) {
-                        camelContextValue = springConfiguration.getDefaultCamelContext();
-                    }
-
-                    // Get the CamelContext object and set the super's member variable.
-                    Object ctx = springConfiguration.getApplicationContext().getBean(camelContextValue);
-                    if (!(ctx instanceof SpringCamelContext)) {
-                        throw new FlowableException("Could not find CamelContext named " + camelContextValue + ".");
-                    }
-                    camelContextObj = (SpringCamelContext) ctx;
-
-                } catch (Exception e) {
-                    throw new FlowableException("Expecting a SpringProcessEngineConfiguration for the Camel module.", e);
+            // Convert it to a SpringProcessEngineConfiguration. If this doesn't work, throw a RuntimeException.
+            try {
+                SpringProcessEngineConfiguration springConfiguration = (SpringProcessEngineConfiguration) engineConfiguration;
+                if (StringUtils.isEmpty(camelContextValue)) {
+                    camelContextValue = springConfiguration.getDefaultCamelContext();
                 }
+
+                // Get the CamelContext object and set the super's member variable.
+                Object ctx = springConfiguration.getApplicationContext().getBean(camelContextValue);
+                if (!(ctx instanceof SpringCamelContext)) {
+                    throw new FlowableException("Could not find CamelContext named " + camelContextValue + ".");
+                }
+                return (SpringCamelContext) ctx;
+
+            } catch (Exception e) {
+                throw new FlowableException("Expecting a SpringProcessEngineConfiguration for the Camel module.", e);
             }
         }
     }

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/impl/CamelBehaviorBodyAsMapImpl.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/impl/CamelBehaviorBodyAsMapImpl.java
@@ -13,7 +13,6 @@
 
 package org.flowable.camel.impl;
 
-import org.flowable.camel.FlowableEndpoint;
 import org.flowable.camel.SpringCamelBehavior;
 
 /**
@@ -26,8 +25,7 @@ public class CamelBehaviorBodyAsMapImpl extends SpringCamelBehavior {
     private static final long serialVersionUID = 1L;
 
     @Override
-    protected void setPropertTargetVariable(FlowableEndpoint endpoint) {
-        toTargetType = TargetType.BODY_AS_MAP;
+    protected TargetType getDefaultToTargetType() {
+        return TargetType.BODY_AS_MAP;
     }
-
 }

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/impl/CamelBehaviorCamelBodyImpl.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/impl/CamelBehaviorCamelBodyImpl.java
@@ -13,7 +13,6 @@
 
 package org.flowable.camel.impl;
 
-import org.flowable.camel.FlowableEndpoint;
 import org.flowable.camel.SpringCamelBehavior;
 
 /**
@@ -27,7 +26,7 @@ public class CamelBehaviorCamelBodyImpl extends SpringCamelBehavior {
     private static final long serialVersionUID = 1L;
 
     @Override
-    protected void setPropertTargetVariable(FlowableEndpoint endpoint) {
-        toTargetType = TargetType.BODY;
+    protected TargetType getDefaultToTargetType() {
+        return TargetType.BODY;
     }
 }

--- a/modules/flowable-camel/src/main/java/org/flowable/camel/impl/CamelBehaviorDefaultImpl.java
+++ b/modules/flowable-camel/src/main/java/org/flowable/camel/impl/CamelBehaviorDefaultImpl.java
@@ -13,7 +13,6 @@
 
 package org.flowable.camel.impl;
 
-import org.flowable.camel.FlowableEndpoint;
 import org.flowable.camel.SpringCamelBehavior;
 
 /**
@@ -26,7 +25,7 @@ public class CamelBehaviorDefaultImpl extends SpringCamelBehavior {
     private static final long serialVersionUID = 003L;
 
     @Override
-    protected void setPropertTargetVariable(FlowableEndpoint endpoint) {
-        toTargetType = TargetType.PROPERTIES;
+    protected TargetType getDefaultToTargetType() {
+        return TargetType.PROPERTIES;
     }
 }


### PR DESCRIPTION
Use a synchronized block to determine the default camelContextObj. Do not use class field for the TargetType
