### PR TITLE
feat(engine,spring-boot): support configurable databaseCatalog via Fl…

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -496,7 +496,7 @@ public abstract class AbstractEngineConfiguration {
      * @see <a href="https://github.com/flowable/flowable-engine/issues/4095">#4095</a>
      */
     protected void initDatabaseCatalogFromDataSource() {
-        if (this.databaseCatalog == null) {
+        if (StringUtils.isBlank(this.databaseCatalog)) {
             try (Connection connection = dataSource.getConnection()) {
                 String catalog = connection.getCatalog();
                 if (StringUtils.isNoneBlank(catalog)) {

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -15,7 +15,6 @@ package org.flowable.common.engine.impl;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.sql.Connection;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,7 +30,6 @@ import java.util.Set;
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.ibatis.builder.xml.XMLConfigBuilder;
 import org.apache.ibatis.builder.xml.XMLMapperBuilder;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
@@ -468,9 +466,6 @@ public abstract class AbstractEngineConfiguration {
             }
         }
 
-        // Flowable issue #4095: Set databaseCatalog from DataSource if not configured
-        initDatabaseCatalogFromDataSource();
-
         if (databaseType == null) {
             initDatabaseType();
         }
@@ -483,28 +478,6 @@ public abstract class AbstractEngineConfiguration {
         // Especially with executions, with 100 as default, this limit is passed.
         if (DATABASE_TYPE_MSSQL.equals(databaseType)) {
             maxNrOfStatementsInBulkInsert = DEFAULT_MAX_NR_OF_STATEMENTS_BULK_INSERT_SQL_SERVER;
-        }
-    }
-
-    /**
-     * Initializes the databaseCatalog from the DataSource if it has not been set.
-     * <p>
-     * This ensures that the catalog is automatically derived from the database connection metadata
-     * when {@link #databaseCatalog} is null.
-     * </p>
-     *
-     * @see <a href="https://github.com/flowable/flowable-engine/issues/4095">#4095</a>
-     */
-    protected void initDatabaseCatalogFromDataSource() {
-        if (StringUtils.isBlank(this.databaseCatalog)) {
-            try (Connection connection = dataSource.getConnection()) {
-                String catalog = connection.getCatalog();
-                if (StringUtils.isNoneBlank(catalog)) {
-                    this.databaseCatalog = catalog;
-                }
-            } catch (Exception e) {
-                throw new FlowableException("Could not set database catalog from DataSource connection", e);
-            }
         }
     }
 

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/AbstractSqlScriptBasedDbSchemaManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/AbstractSqlScriptBasedDbSchemaManager.java
@@ -24,6 +24,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import org.apache.commons.lang3.StringUtils;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.FlowableVersion;
 import org.flowable.common.engine.impl.FlowableVersions;
@@ -129,6 +130,11 @@ public abstract class AbstractSqlScriptBasedDbSchemaManager implements SchemaMan
             ResultSet tables = null;
 
             String catalog = databaseConfiguration.getDatabaseCatalog();
+
+            // Flowable issue #4095: Set catalog from current connection if not configured
+            if (StringUtils.isBlank(catalog)) {
+                catalog = connection.getCatalog();
+            }
 
             String schema = databaseConfiguration.getDatabaseSchema();
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/AbstractEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/AbstractEngineAutoConfiguration.java
@@ -55,6 +55,8 @@ public abstract class AbstractEngineAutoConfiguration {
 
         engineConfiguration.setDataSource(dataSource);
 
+        engineConfiguration.setDatabaseCatalog(defaultText(flowableProperties.getDatabaseCatalog(), engineConfiguration.getDatabaseCatalog()));
+
         engineConfiguration.setDatabaseSchema(defaultText(flowableProperties.getDatabaseSchema(), engineConfiguration.getDatabaseSchema()));
         engineConfiguration.setDatabaseSchemaUpdate(defaultText(flowableProperties.getDatabaseSchemaUpdate(), engineConfiguration
             .getDatabaseSchemaUpdate()));

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableProperties.java
@@ -64,6 +64,11 @@ public class FlowableProperties {
     private String databaseSchemaUpdate = "true";
 
     /**
+     * In some situations you want to set the catalog to use for database checks / generation if the database metadata doesn't return that correctly.
+     */
+    private String databaseCatalog;
+
+    /**
      * In some situations you want to set the schema to use for table checks / generation if the database metadata doesn't return that correctly.
      */
     private String databaseSchema;
@@ -219,6 +224,14 @@ public class FlowableProperties {
 
     public void setDatabaseSchemaUpdate(String databaseSchemaUpdate) {
         this.databaseSchemaUpdate = databaseSchemaUpdate;
+    }
+
+    public String getDatabaseCatalog() {
+        return databaseCatalog;
+    }
+
+    public void setDatabaseCatalog(String databaseCatalog) {
+        this.databaseCatalog = databaseCatalog;
     }
 
     public String getDatabaseSchema() {


### PR DESCRIPTION
feat(engine,spring-boot): support configurable databaseCatalog via FlowableProperties (#4095)

- Added `databaseCatalog` property to `FlowableProperties` to allow explicit configuration in Spring Boot.
- Updated `AbstractEngineAutoConfiguration.configureEngine(...)` to set `databaseCatalog` from properties if not already configured in the engine.
- Added fallback in `AbstractEngineConfiguration` to initialize `databaseCatalog` from the DataSource's connection catalog when no value is set.

#### Check List:
* Unit tests: NA
* Documentation: NA
