### PR TITLE
Add tests for IdentityLinkInterceptors and enhance SaveTaskCmds to ha…

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SaveTaskCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SaveTaskCmd.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.flowable.cmmn.engine.CmmnEngineConfiguration;
 import org.flowable.cmmn.engine.impl.task.TaskHelper;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
+import org.flowable.cmmn.engine.interceptor.CmmnIdentityLinkInterceptor;
 import org.flowable.common.engine.api.FlowableIllegalArgumentException;
 import org.flowable.common.engine.api.delegate.event.FlowableEngineEventType;
 import org.flowable.common.engine.impl.history.HistoryLevel;
@@ -76,6 +77,11 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
             
             if (!StringUtils.equals(originalAssignee, task.getAssignee())) {
 
+                CmmnIdentityLinkInterceptor identityLinkInterceptor = cmmnEngineConfiguration.getIdentityLinkInterceptor();
+                if (identityLinkInterceptor != null) {
+                    identityLinkInterceptor.handleAddAssigneeIdentityLinkToTask(task, task.getAssignee());
+                }
+
                 cmmnEngineConfiguration.getListenerNotificationHelper().executeTaskListeners(task, TaskListener.EVENTNAME_ASSIGNMENT);
 
                 if (CommandContextUtil.getEventDispatcher() != null && CommandContextUtil.getEventDispatcher().isEnabled()) {
@@ -83,6 +89,15 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
                             FlowableEngineEventType.TASK_ASSIGNED, task), EngineConfigurationConstants.KEY_CMMN_ENGINE_CONFIG);
                 }
 
+            }
+
+            String originalOwner = originalTaskEntity.getOwner();
+
+            if (!StringUtils.equals(originalOwner, task.getOwner())) {
+                CmmnIdentityLinkInterceptor identityLinkInterceptor = cmmnEngineConfiguration.getIdentityLinkInterceptor();
+                if (identityLinkInterceptor != null) {
+                    identityLinkInterceptor.handleAddOwnerIdentityLinkToTask(task, task.getOwner());
+                }
             }
         }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SaveTaskCmd.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/cmd/SaveTaskCmd.java
@@ -78,7 +78,7 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
             if (!StringUtils.equals(originalAssignee, task.getAssignee())) {
 
                 CmmnIdentityLinkInterceptor identityLinkInterceptor = cmmnEngineConfiguration.getIdentityLinkInterceptor();
-                if (identityLinkInterceptor != null) {
+                if (identityLinkInterceptor != null && task.getAssignee() != null) {
                     identityLinkInterceptor.handleAddAssigneeIdentityLinkToTask(task, task.getAssignee());
                 }
 
@@ -93,7 +93,7 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
 
             String originalOwner = originalTaskEntity.getOwner();
 
-            if (!StringUtils.equals(originalOwner, task.getOwner())) {
+            if (!StringUtils.equals(originalOwner, task.getOwner()) && task.getOwner() != null) {
                 CmmnIdentityLinkInterceptor identityLinkInterceptor = cmmnEngineConfiguration.getIdentityLinkInterceptor();
                 if (identityLinkInterceptor != null) {
                     identityLinkInterceptor.handleAddOwnerIdentityLinkToTask(task, task.getOwner());

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/task/TaskHelper.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/task/TaskHelper.java
@@ -166,12 +166,18 @@ public class TaskHelper {
     }
     
     protected static void addAssigneeIdentityLinks(TaskEntity taskEntity, CmmnEngineConfiguration cmmnEngineConfiguration) {
+        if (taskEntity.getAssignee() == null) {
+            return;
+        }
         if (cmmnEngineConfiguration.getIdentityLinkInterceptor() != null) {
             cmmnEngineConfiguration.getIdentityLinkInterceptor().handleAddAssigneeIdentityLinkToTask(taskEntity, taskEntity.getAssignee());
         }
     }
 
     protected static void addOwnerIdentityLink(TaskEntity taskEntity, CmmnEngineConfiguration cmmnEngineConfiguration) {
+        if (taskEntity.getOwner() == null) {
+            return;
+        }
         if (cmmnEngineConfiguration.getIdentityLinkInterceptor() != null) {
             cmmnEngineConfiguration.getIdentityLinkInterceptor().handleAddOwnerIdentityLinkToTask(taskEntity, taskEntity.getOwner());
         }

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/interceptor/CmmnIdentityLinkInterceptorTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/interceptor/CmmnIdentityLinkInterceptorTest.java
@@ -130,6 +130,20 @@ public class CmmnIdentityLinkInterceptorTest extends FlowableCmmnTestCase {
 
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testRemoveAssigneeViaSaveTask() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        testInterceptor.assigneeIdentityLinks.clear();
+
+        task.setAssignee(null);
+        cmmnTaskService.saveTask(task);
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(0);
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
     void testClaimTask() {
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
         Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
@@ -154,8 +168,7 @@ public class CmmnIdentityLinkInterceptorTest extends FlowableCmmnTestCase {
 
         cmmnTaskService.unclaim(task.getId());
 
-        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1).extracting(data -> data.taskId, data -> data.assignee)
-                .containsExactly(tuple(task.getId(), null));
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(0);
     }
 
     @Test
@@ -185,6 +198,20 @@ public class CmmnIdentityLinkInterceptorTest extends FlowableCmmnTestCase {
 
         assertThat(testInterceptor.ownerIdentityLinks).hasSize(1).extracting(data -> data.taskId, data -> data.owner)
                 .containsExactly(tuple(task.getId(), "newOwner"));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testRemoveOwnerViaSaveTask() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.ownerIdentityLinks).isEmpty();
+
+        task.setOwner(null);
+        cmmnTaskService.saveTask(task);
+
+        assertThat(testInterceptor.ownerIdentityLinks).hasSize(0);
     }
 
     @Test

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/interceptor/CmmnIdentityLinkInterceptorTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/interceptor/CmmnIdentityLinkInterceptorTest.java
@@ -1,0 +1,321 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.flowable.cmmn.test.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.engine.impl.persistence.entity.CaseInstanceEntity;
+import org.flowable.cmmn.engine.interceptor.CmmnIdentityLinkInterceptor;
+import org.flowable.cmmn.engine.test.CmmnDeployment;
+import org.flowable.cmmn.test.FlowableCmmnTestCase;
+import org.flowable.identitylink.api.IdentityLinkType;
+import org.flowable.identitylink.service.impl.persistence.entity.IdentityLinkEntity;
+import org.flowable.task.api.Task;
+import org.flowable.task.service.impl.persistence.entity.TaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Roman Saratz
+ */
+public class CmmnIdentityLinkInterceptorTest extends FlowableCmmnTestCase {
+
+    private TestCmmnIdentityLinkInterceptor testInterceptor;
+    private CmmnIdentityLinkInterceptor originalInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        testInterceptor = new TestCmmnIdentityLinkInterceptor();
+        originalInterceptor = cmmnEngineConfiguration.getIdentityLinkInterceptor();
+        cmmnEngineConfiguration.setIdentityLinkInterceptor(testInterceptor);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cmmnEngineConfiguration.setIdentityLinkInterceptor(originalInterceptor);
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testCompleteTask() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.completedTasks).isEmpty();
+
+        cmmnTaskService.complete(task.getId());
+
+        assertThat(testInterceptor.completedTasks).hasSize(1);
+        TaskEntity completedTask = testInterceptor.completedTasks.get(0);
+        assertThat(completedTask.getId()).isEqualTo(task.getId());
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testAddCandidateUser() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.addedIdentityLinks).isEmpty();
+
+        cmmnTaskService.addUserIdentityLink(task.getId(), "testUser", IdentityLinkType.CANDIDATE);
+
+        assertThat(testInterceptor.addedIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.identityLink.getType(), data -> data.identityLink.getUserId())
+                .containsExactly(tuple(task.getId(), IdentityLinkType.CANDIDATE, "testUser"));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testAddCandidateGroup() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.addedIdentityLinks).isEmpty();
+
+        cmmnTaskService.addGroupIdentityLink(task.getId(), "testGroup", IdentityLinkType.CANDIDATE);
+
+        assertThat(testInterceptor.addedIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.identityLink.getType(), data -> data.identityLink.getGroupId())
+                .containsExactly(tuple(task.getId(), IdentityLinkType.CANDIDATE, "testGroup"));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testSetAssignee() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1);
+
+        cmmnTaskService.setAssignee(task.getId(), "testAssignee");
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(2).extracting(data -> data.taskId, data -> data.assignee)
+                .containsExactly(tuple(task.getId(), "johnDoe"), tuple(task.getId(), "testAssignee"));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testChangeAssigneeViaSaveTask() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        testInterceptor.assigneeIdentityLinks.clear();
+
+        task.setAssignee("newAssignee");
+        cmmnTaskService.saveTask(task);
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1).extracting(data -> data.taskId, data -> data.assignee)
+                .containsExactly(tuple(task.getId(), "newAssignee"));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testClaimTask() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        // remove initial assignee
+        cmmnTaskService.unclaim(task.getId());
+        testInterceptor.assigneeIdentityLinks.clear();
+
+        cmmnTaskService.claim(task.getId(), "claimUser");
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1).extracting(data -> data.taskId, data -> data.assignee)
+                .containsExactly(tuple(task.getId(), "claimUser"));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testUnclaimTask() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        testInterceptor.assigneeIdentityLinks.clear();
+
+        cmmnTaskService.unclaim(task.getId());
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1).extracting(data -> data.taskId, data -> data.assignee)
+                .containsExactly(tuple(task.getId(), null));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testSetOwner() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.ownerIdentityLinks).isEmpty();
+
+        cmmnTaskService.setOwner(task.getId(), "testOwner");
+
+        assertThat(testInterceptor.ownerIdentityLinks).hasSize(1).extracting(data -> data.taskId, data -> data.owner)
+                .containsExactly(tuple(task.getId(), "testOwner"));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testChangeOwnerViaSaveTask() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.ownerIdentityLinks).isEmpty();
+
+        task.setOwner("newOwner");
+        cmmnTaskService.saveTask(task);
+
+        assertThat(testInterceptor.ownerIdentityLinks).hasSize(1).extracting(data -> data.taskId, data -> data.owner)
+                .containsExactly(tuple(task.getId(), "newOwner"));
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testCreateCaseInstance() {
+        assertThat(testInterceptor.createdCaseInstances).isEmpty();
+
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+
+        assertThat(testInterceptor.createdCaseInstances).hasSize(1).extracting(CaseInstance::getId).containsExactly(caseInstance.getId());
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    void testMultipleIdentityLinkOperations() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("oneTaskCase").start();
+        Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+        cmmnTaskService.addUserIdentityLink(task.getId(), "user1", IdentityLinkType.CANDIDATE);
+        cmmnTaskService.addUserIdentityLink(task.getId(), "user2", IdentityLinkType.CANDIDATE);
+        cmmnTaskService.addGroupIdentityLink(task.getId(), "group1", IdentityLinkType.CANDIDATE);
+
+        cmmnTaskService.setAssignee(task.getId(), "assignee1");
+        cmmnTaskService.setOwner(task.getId(), "owner1");
+
+        cmmnTaskService.complete(task.getId());
+
+        assertThat(testInterceptor.addedIdentityLinks).hasSize(3)
+                .extracting(data -> data.identityLink.getType(), data -> data.identityLink.getUserId(), data -> data.identityLink.getGroupId())
+                .containsExactly(tuple(IdentityLinkType.CANDIDATE, "user1", null), tuple(IdentityLinkType.CANDIDATE, "user2", null),
+                        tuple(IdentityLinkType.CANDIDATE, null, "group1"));
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(2).extracting(data -> data.assignee).containsExactly("johnDoe", "assignee1");
+
+        assertThat(testInterceptor.ownerIdentityLinks).hasSize(1);
+        assertThat(testInterceptor.completedTasks).hasSize(1);
+        assertThat(testInterceptor.createdCaseInstances).hasSize(1);
+    }
+
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/reactivation/Reactivation_Test_Case.cmmn.xml")
+    void testReactivation() {
+        CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder().caseDefinitionKey("reactivationTestCase").start();
+
+        Task taskA = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        cmmnTaskService.complete(taskA.getId());
+
+        Task taskB = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+        cmmnTaskService.complete(taskB.getId());
+
+        assertThat(cmmnRuntimeService.createCaseInstanceQuery().caseInstanceId(caseInstance.getId()).singleResult()).isNull();
+
+        assertThat(testInterceptor.reactivatedCaseInstances).hasSize(0);
+
+        cmmnHistoryService.createCaseReactivationBuilder(caseInstance.getId()).transientVariable("tempVar", "tempVarValue").transientVariable("tempIntVar", 100)
+                .reactivate();
+
+        assertThat(testInterceptor.reactivatedCaseInstances).hasSize(1).extracting(CaseInstance::getId).containsExactly(caseInstance.getId());
+    }
+
+    static class TestCmmnIdentityLinkInterceptor implements CmmnIdentityLinkInterceptor {
+
+        List<TaskEntity> completedTasks = new ArrayList<>();
+        List<IdentityLinkData> addedIdentityLinks = new ArrayList<>();
+        List<AssigneeData> assigneeIdentityLinks = new ArrayList<>();
+        List<OwnerData> ownerIdentityLinks = new ArrayList<>();
+        List<CaseInstance> createdCaseInstances = new ArrayList<>();
+        List<CaseInstance> reactivatedCaseInstances = new ArrayList<>();
+
+        @Override
+        public void handleCompleteTask(TaskEntity task) {
+            completedTasks.add(task);
+        }
+
+        @Override
+        public void handleAddIdentityLinkToTask(TaskEntity taskEntity, IdentityLinkEntity identityLinkEntity) {
+            addedIdentityLinks.add(new IdentityLinkData(taskEntity.getId(), identityLinkEntity));
+        }
+
+        @Override
+        public void handleAddAssigneeIdentityLinkToTask(TaskEntity taskEntity, String assignee) {
+            assigneeIdentityLinks.add(new AssigneeData(taskEntity.getId(), assignee));
+        }
+
+        @Override
+        public void handleAddOwnerIdentityLinkToTask(TaskEntity taskEntity, String owner) {
+            ownerIdentityLinks.add(new OwnerData(taskEntity.getId(), owner));
+        }
+
+        @Override
+        public void handleCreateCaseInstance(CaseInstanceEntity caseInstance) {
+            createdCaseInstances.add(caseInstance);
+        }
+
+        @Override
+        public void handleReactivateCaseInstance(CaseInstanceEntity caseInstance) {
+            reactivatedCaseInstances.add(caseInstance);
+        }
+    }
+
+    static class IdentityLinkData {
+
+        String taskId;
+        IdentityLinkEntity identityLink;
+
+        IdentityLinkData(String taskId, IdentityLinkEntity identityLink) {
+            this.taskId = taskId;
+            this.identityLink = identityLink;
+        }
+    }
+
+    static class AssigneeData {
+
+        String taskId;
+        String assignee;
+
+        AssigneeData(String taskId, String assignee) {
+            this.taskId = taskId;
+            this.assignee = assignee;
+        }
+    }
+
+    static class OwnerData {
+
+        String taskId;
+        String owner;
+
+        OwnerData(String taskId, String owner) {
+            this.taskId = taskId;
+            this.owner = owner;
+        }
+    }
+
+}

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SaveTaskCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SaveTaskCmd.java
@@ -28,6 +28,7 @@ import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.engine.impl.util.CountingEntityUtil;
 import org.flowable.engine.impl.util.Flowable5Util;
 import org.flowable.engine.impl.util.TaskHelper;
+import org.flowable.engine.interceptor.IdentityLinkInterceptor;
 import org.flowable.task.api.Task;
 import org.flowable.task.api.TaskInfo;
 import org.flowable.task.service.TaskService;
@@ -89,6 +90,11 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
             if (!StringUtils.equals(originalTaskEntity.getAssignee(), task.getAssignee())) {
                 handleAssigneeChange(commandContext, processEngineConfiguration);
             }
+
+            // Special care needed to detect the owner of the task has changed
+            if (!StringUtils.equals(originalTaskEntity.getOwner(), task.getOwner())) {
+                handleOwnerChange(processEngineConfiguration);
+            }
             
             // Special care needed to detect the parent task has changed
             if (!StringUtils.equals(originalTaskEntity.getParentTaskId(), task.getParentTaskId())) {
@@ -100,9 +106,20 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
         return null;
     }
 
+    protected void handleOwnerChange(ProcessEngineConfigurationImpl processEngineConfiguration) {
+        IdentityLinkInterceptor identityLinkInterceptor = processEngineConfiguration.getIdentityLinkInterceptor();
+        if (identityLinkInterceptor != null) {
+            identityLinkInterceptor.handleAddOwnerIdentityLinkToTask(task, task.getOwner());
+        }
+    }
+
     protected void handleAssigneeChange(CommandContext commandContext, ProcessEngineConfigurationImpl processEngineConfiguration) {
         processEngineConfiguration.getListenerNotificationHelper().executeTaskListeners(task, TaskListener.EVENTNAME_ASSIGNMENT);
 
+        IdentityLinkInterceptor identityLinkInterceptor = processEngineConfiguration.getIdentityLinkInterceptor();
+        if (identityLinkInterceptor != null) {
+            identityLinkInterceptor.handleAddAssigneeIdentityLinkToTask(task, task.getAssignee());
+        }
         FlowableEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();
         if (eventDispatcher != null && eventDispatcher.isEnabled()) {
             CommandContextUtil.getEventDispatcher().dispatchEvent(FlowableTaskEventBuilder.createEntityEvent(FlowableEngineEventType.TASK_ASSIGNED, task),

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SaveTaskCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/SaveTaskCmd.java
@@ -108,7 +108,7 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
 
     protected void handleOwnerChange(ProcessEngineConfigurationImpl processEngineConfiguration) {
         IdentityLinkInterceptor identityLinkInterceptor = processEngineConfiguration.getIdentityLinkInterceptor();
-        if (identityLinkInterceptor != null) {
+        if (identityLinkInterceptor != null && task.getOwner() != null) {
             identityLinkInterceptor.handleAddOwnerIdentityLinkToTask(task, task.getOwner());
         }
     }
@@ -117,7 +117,7 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
         processEngineConfiguration.getListenerNotificationHelper().executeTaskListeners(task, TaskListener.EVENTNAME_ASSIGNMENT);
 
         IdentityLinkInterceptor identityLinkInterceptor = processEngineConfiguration.getIdentityLinkInterceptor();
-        if (identityLinkInterceptor != null) {
+        if (identityLinkInterceptor != null && task.getAssignee() != null) {
             identityLinkInterceptor.handleAddAssigneeIdentityLinkToTask(task, task.getAssignee());
         }
         FlowableEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java
@@ -293,6 +293,9 @@ public class TaskHelper {
     }
 
     public static void addAssigneeIdentityLinks(TaskEntity taskEntity) {
+        if (taskEntity.getAssignee() == null) {
+            return;
+        }
         ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration();
         if (processEngineConfiguration.getIdentityLinkInterceptor() != null) {
             processEngineConfiguration.getIdentityLinkInterceptor().handleAddAssigneeIdentityLinkToTask(taskEntity, taskEntity.getAssignee());

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/interceptor/IdentityLinkInterceptorTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/interceptor/IdentityLinkInterceptorTest.java
@@ -1,0 +1,391 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.flowable.engine.test.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.CallActivity;
+import org.flowable.bpmn.model.EndEvent;
+import org.flowable.bpmn.model.SequenceFlow;
+import org.flowable.bpmn.model.StartEvent;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
+import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.interceptor.IdentityLinkInterceptor;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.Deployment;
+import org.flowable.identitylink.api.IdentityLinkType;
+import org.flowable.identitylink.service.impl.persistence.entity.IdentityLinkEntity;
+import org.flowable.task.api.Task;
+import org.flowable.task.service.impl.persistence.entity.TaskEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Roman Saratz
+ */
+public class IdentityLinkInterceptorTest extends PluggableFlowableTestCase {
+
+    private TestIdentityLinkInterceptor testInterceptor;
+    private IdentityLinkInterceptor originalInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        testInterceptor = new TestIdentityLinkInterceptor();
+        originalInterceptor = processEngineConfiguration.getIdentityLinkInterceptor();
+        processEngineConfiguration.setIdentityLinkInterceptor(testInterceptor);
+    }
+
+    @AfterEach
+    void tearDown() {
+        processEngineConfiguration.setIdentityLinkInterceptor(originalInterceptor);
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testCompleteTask() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.completedTasks).isEmpty();
+
+        taskService.complete(task.getId());
+
+        assertThat(testInterceptor.completedTasks).hasSize(1);
+        TaskEntity completedTask = testInterceptor.completedTasks.get(0);
+        assertThat(completedTask.getId()).isEqualTo(task.getId());
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testAddCandidateUser() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.addedIdentityLinks).isEmpty();
+
+        taskService.addCandidateUser(task.getId(), "testUser");
+
+        assertThat(testInterceptor.addedIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.identityLink.getType(), data -> data.identityLink.getUserId())
+                .containsExactly(tuple(task.getId(), IdentityLinkType.CANDIDATE, "testUser"));
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testAddCandidateGroup() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.addedIdentityLinks).isEmpty();
+
+        taskService.addCandidateGroup(task.getId(), "testGroup");
+
+        assertThat(testInterceptor.addedIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.identityLink.getType(), data -> data.identityLink.getGroupId())
+                .containsExactly(tuple(task.getId(), IdentityLinkType.CANDIDATE, "testGroup"));
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testSetAssignee() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1);
+
+        taskService.setAssignee(task.getId(), "testAssignee");
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(2)
+                .extracting(data -> data.taskId, data -> data.assignee)
+                .containsExactly(
+                        tuple(task.getId(), "testUser"),
+                        tuple(task.getId(), "testAssignee")
+                );
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testChangeAssigneeViaSaveTask() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        // Clear initial assignee data
+        testInterceptor.assigneeIdentityLinks.clear();
+
+        // Retrieve task, change assignee and save
+        task.setAssignee("newAssignee");
+        taskService.saveTask(task);
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.assignee)
+                .containsExactly(tuple(task.getId(), "newAssignee"));
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testClaimTask() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        // remove initial assignee
+        taskService.unclaim(task.getId());
+        testInterceptor.assigneeIdentityLinks.clear();
+
+        taskService.claim(task.getId(), "claimUser");
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.assignee)
+                .containsExactly(tuple(task.getId(), "claimUser"));
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testUnclaimTask() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        testInterceptor.assigneeIdentityLinks.clear();
+
+        taskService.unclaim(task.getId());
+
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.assignee)
+                .containsExactly(tuple(task.getId(), null));
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testSetOwner() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.ownerIdentityLinks).isEmpty();
+
+        taskService.setOwner(task.getId(), "testOwner");
+
+        assertThat(testInterceptor.ownerIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.owner)
+                .containsExactly(tuple(task.getId(), "testOwner"));
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testChangeOwnerViaSaveTask() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        assertThat(testInterceptor.ownerIdentityLinks).isEmpty();
+
+        task.setOwner("newOwner");
+        taskService.saveTask(task);
+
+        assertThat(testInterceptor.ownerIdentityLinks).hasSize(1)
+                .extracting(data -> data.taskId, data -> data.owner)
+                .containsExactly(tuple(task.getId(), "newOwner"));
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testCreateProcessInstance() {
+        assertThat(testInterceptor.createdProcessInstances).isEmpty();
+
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+
+        assertThat(testInterceptor.createdProcessInstances).hasSize(1)
+                .extracting(DelegateExecution::getId, DelegateExecution::isProcessInstanceType)
+                .containsExactly(tuple(processInstance.getId(), true));
+    }
+
+    @Test
+    void testCreateSubProcessInstance() {
+        // Deploy main process with call activity
+        BpmnModel mainModel = createMainProcessWithCallActivity();
+        org.flowable.engine.repository.Deployment mainDeployment = repositoryService.createDeployment()
+                .addBpmnModel("mainProcess.bpmn20.xml", mainModel).deploy();
+        deploymentIdsForAutoCleanup.add(mainDeployment.getId());
+
+        // Deploy subprocess
+        String subprocessDefinitionId = deployOneTaskTestProcess();
+
+        assertThat(testInterceptor.createdSubProcessInstances).isEmpty();
+
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("mainProcess");
+
+        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().processDefinitionId(subprocessDefinitionId).singleResult();
+
+        assertThat(testInterceptor.createdSubProcessInstances).hasSize(1)
+                .extracting(
+                        data -> data.subProcessExecution.getId(),
+                        data -> data.superExecution.getProcessInstanceId()
+                )
+                .containsExactly(tuple(subProcessInstance.getId(), processInstance.getId()));
+    }
+
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/bpmn/oneTask.bpmn20.xml")
+    void testMultipleIdentityLinkOperations() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startToEnd");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        // Add multiple candidates
+        taskService.addCandidateUser(task.getId(), "user1");
+        taskService.addCandidateUser(task.getId(), "user2");
+        taskService.addCandidateGroup(task.getId(), "group1");
+
+        // Set assignee and owner
+        taskService.setAssignee(task.getId(), "assignee1");
+        taskService.setOwner(task.getId(), "owner1");
+
+        // Complete task
+        taskService.complete(task.getId());
+
+        // Verify identity link additions
+        assertThat(testInterceptor.addedIdentityLinks).hasSize(3)
+                .extracting(data -> data.identityLink.getType(), data -> data.identityLink.getUserId(), data -> data.identityLink.getGroupId())
+                .containsExactly(
+                        tuple(IdentityLinkType.CANDIDATE, "user1", null),
+                        tuple(IdentityLinkType.CANDIDATE, "user2", null),
+                        tuple(IdentityLinkType.CANDIDATE, null, "group1")
+                );
+
+        // Verify assignee operations
+        assertThat(testInterceptor.assigneeIdentityLinks).hasSize(2)
+                .extracting(data -> data.assignee)
+                .containsExactly("testUser", "assignee1");
+
+        // Verify other operations
+        assertThat(testInterceptor.ownerIdentityLinks).hasSize(1);
+        assertThat(testInterceptor.completedTasks).hasSize(1);
+        assertThat(testInterceptor.createdProcessInstances).hasSize(1);
+    }
+
+    private BpmnModel createMainProcessWithCallActivity() {
+        BpmnModel model = new BpmnModel();
+        org.flowable.bpmn.model.Process process = new org.flowable.bpmn.model.Process();
+        model.addProcess(process);
+        process.setId("mainProcess");
+        process.setName("Main Process");
+
+        StartEvent startEvent = new StartEvent();
+        startEvent.setId("start");
+        process.addFlowElement(startEvent);
+
+        CallActivity callActivity = new CallActivity();
+        callActivity.setId("callActivity");
+        callActivity.setCalledElement("oneTaskProcess");
+        process.addFlowElement(callActivity);
+
+        EndEvent endEvent = new EndEvent();
+        endEvent.setId("end");
+        process.addFlowElement(endEvent);
+
+        process.addFlowElement(new SequenceFlow("start", "callActivity"));
+        process.addFlowElement(new SequenceFlow("callActivity", "end"));
+
+        return model;
+    }
+
+    static class TestIdentityLinkInterceptor implements IdentityLinkInterceptor {
+
+        List<TaskEntity> completedTasks = new ArrayList<>();
+        List<IdentityLinkData> addedIdentityLinks = new ArrayList<>();
+        List<AssigneeData> assigneeIdentityLinks = new ArrayList<>();
+        List<OwnerData> ownerIdentityLinks = new ArrayList<>();
+        List<ExecutionEntity> createdProcessInstances = new ArrayList<>();
+        List<SubProcessData> createdSubProcessInstances = new ArrayList<>();
+
+        @Override
+        public void handleCompleteTask(TaskEntity task) {
+            completedTasks.add(task);
+        }
+
+        @Override
+        public void handleAddIdentityLinkToTask(TaskEntity taskEntity, IdentityLinkEntity identityLinkEntity) {
+            addedIdentityLinks.add(new IdentityLinkData(taskEntity.getId(), identityLinkEntity));
+        }
+
+        @Override
+        public void handleAddAssigneeIdentityLinkToTask(TaskEntity taskEntity, String assignee) {
+            assigneeIdentityLinks.add(new AssigneeData(taskEntity.getId(), assignee));
+        }
+
+        @Override
+        public void handleAddOwnerIdentityLinkToTask(TaskEntity taskEntity, String owner) {
+            ownerIdentityLinks.add(new OwnerData(taskEntity.getId(), owner));
+        }
+
+        @Override
+        public void handleCreateProcessInstance(ExecutionEntity processInstanceExecution) {
+            createdProcessInstances.add(processInstanceExecution);
+        }
+
+        @Override
+        public void handleCreateSubProcessInstance(ExecutionEntity subProcessInstanceExecution, ExecutionEntity superExecution) {
+            createdSubProcessInstances.add(new SubProcessData(subProcessInstanceExecution, superExecution));
+        }
+    }
+
+    static class IdentityLinkData {
+
+        String taskId;
+        IdentityLinkEntity identityLink;
+
+        IdentityLinkData(String taskId, IdentityLinkEntity identityLink) {
+            this.taskId = taskId;
+            this.identityLink = identityLink;
+        }
+    }
+
+    static class AssigneeData {
+
+        String taskId;
+        String assignee;
+
+        AssigneeData(String taskId, String assignee) {
+            this.taskId = taskId;
+            this.assignee = assignee;
+        }
+    }
+
+    static class OwnerData {
+
+        String taskId;
+        String owner;
+
+        OwnerData(String taskId, String owner) {
+            this.taskId = taskId;
+            this.owner = owner;
+        }
+    }
+
+    static class SubProcessData {
+
+        ExecutionEntity subProcessExecution;
+        ExecutionEntity superExecution;
+
+        SubProcessData(ExecutionEntity subProcessExecution, ExecutionEntity superExecution) {
+            this.subProcessExecution = subProcessExecution;
+            this.superExecution = superExecution;
+        }
+    }
+}


### PR DESCRIPTION
Add logic to the SaveTaskCmds to trigger the IdentityLinkInterceptors in BPMN and CMMN when changing task assignee or task owner.

Added tests for all methods of the IdentityLinkInterceptors.

One additional note: I've noticed that in the process engine, when setting the task owner to null, the identity link interceptor is not executed. It is executed when setting the task assignee to null in the process engine, or when setting owner or assignee to null in the CMMN engine. 

Process engine: https://github.com/flowable/flowable-engine/blob/main/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java#L302

CMMN engine: https://github.com/flowable/flowable-engine/blob/main/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/task/TaskHelper.java#L168

I've kept it for now, but might make sense to make behavior consistent.

#### Check List:
* Unit tests: YES
* Documentation: NO
