### PR TITLE
Remove Joda Time support

### DIFF
--- a/distro/src/readme.html
+++ b/distro/src/readme.html
@@ -40,6 +40,26 @@
         Date properties e.g., Process Instance start time will be returned as an ISO 8601 in the UTC timezone.
         E.g., if the start time was returned as <code>2025-09-24T09:58:12.609+02:00</code> now it is returned as <code>2025-09-24T07:58:12.609Z</code>.
     </li>
+    <li>
+        Remove Joda Time support.
+        If Joda Time variables were being used, then the Joda LocalDate variable is now an instance of java.time.LocalDate
+        and the Joda DateTime variable is now an instance of java.time.Instant.
+        If variables should keep being read as Joda Time (e.g., for custom scripts etc.), then with Spring Boot the property <code>flowable.joda-time-variable-support</code>
+        can be set to <code>WRITE</code>.
+        The available values for <code>flowable.joda-time-variable-support</code> are:
+        <ul>
+            <li><code>DISABLE</code> - Completely disables Joda Time. If you have Joda Time variables in the database then reading those variables will fail.
+            </li>
+            <li><code>READ_AS_JAVA_TIME</code> - Reads Joda Time variables from the database as Java LocalDate and DateTime. This is the default configuration.
+            </li>
+            <li><code>WRITE</code> - Reads and Writes Joda Time variables. This is the same as prior to Flowable 8. The joda-time dependency has to be available
+                on the classpath.
+            </li>
+        </ul>
+        Keep in mind that this only works for variables, Flowable itself no longer supports Joda Time, i.e., due dates, timers, etc. no longer support Joda Time
+        values.
+    </li>
+
 </ul>
 <h3>Release Notes - Flowable - 7.2.0</h3>
 

--- a/docs/docusaurus/docs/cmmn/ch06-cmmn.md
+++ b/docs/docusaurus/docs/cmmn/ch06-cmmn.md
@@ -929,7 +929,7 @@ Properties:
 
 -   **Timer expression**: an expression that defines when the timer should occur. The following options are possible:
 
-    -   An expression resolving to a java.util.Date or org.joda.time.DateTime instance (for example, \_${someBean.calculateNextDate(someCaseInstanceVariable)})
+    -   An expression resolving to a java.util.Date, java.time.Instant, java.time.LocalDate or java.time.LocalDateTime instance (for example, \_${someBean.calculateNextDate(someCaseInstanceVariable)})
 
     -   An ISO8601 date
 

--- a/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-app-engine-rest/src/test/java/org/flowable/app/rest/service/BaseSpringRestTestCase.java
@@ -13,7 +13,6 @@
 package org.flowable.app.rest.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -21,13 +20,13 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.TimeZone;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -50,8 +49,6 @@ import org.flowable.app.rest.util.TestServer;
 import org.flowable.common.engine.impl.test.EnsureCleanDb;
 import org.flowable.common.engine.impl.test.LoggingExtension;
 import org.flowable.common.rest.util.RestUrlBuilder;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -271,19 +268,11 @@ public class BaseSpringRestTestCase {
      * Extract a date from the given string. Assertion fails when invalid date has been provided.
      */
     protected Date getDateFromISOString(String isoString) {
-        DateTimeFormatter dateFormat = ISODateTimeFormat.dateTime();
-        try {
-            return dateFormat.parseDateTime(isoString).toDate();
-        } catch (IllegalArgumentException iae) {
-            fail("Illegal date provided: " + isoString);
-            return null;
-        }
+        return Date.from(Instant.parse(isoString));
     }
 
     protected String getISODateString(Date time) {
-        TimeZone tz = TimeZone.getTimeZone("UTC");
-        longDateFormat.setTimeZone(tz);
-        return longDateFormat.format(time);
+        return time.toInstant().toString();
     }
 
     protected String buildUrl(String[] fragments, Object... arguments) {

--- a/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngineConfiguration.java
+++ b/modules/flowable-app-engine/src/main/java/org/flowable/app/engine/AppEngineConfiguration.java
@@ -69,6 +69,7 @@ import org.flowable.common.engine.impl.el.DefaultExpressionManager;
 import org.flowable.common.engine.impl.el.ExpressionManager;
 import org.flowable.common.engine.impl.interceptor.CommandInterceptor;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
+import org.flowable.common.engine.impl.joda.JodaDeprecationLogger;
 import org.flowable.common.engine.impl.persistence.deploy.DefaultDeploymentCache;
 import org.flowable.common.engine.impl.persistence.deploy.DeploymentCache;
 import org.flowable.common.engine.impl.persistence.entity.TableDataManager;
@@ -80,6 +81,7 @@ import org.flowable.idm.engine.configurator.IdmEngineConfigurator;
 import org.flowable.variable.api.types.VariableType;
 import org.flowable.variable.api.types.VariableTypes;
 import org.flowable.variable.service.VariableServiceConfiguration;
+import org.flowable.variable.service.impl.JodaTimeVariableSupport;
 import org.flowable.variable.service.impl.db.IbatisVariableTypeHandler;
 import org.flowable.variable.service.impl.types.BigDecimalType;
 import org.flowable.variable.service.impl.types.BigIntegerType;
@@ -91,8 +93,6 @@ import org.flowable.variable.service.impl.types.DoubleType;
 import org.flowable.variable.service.impl.types.EmptyCollectionType;
 import org.flowable.variable.service.impl.types.InstantType;
 import org.flowable.variable.service.impl.types.IntegerType;
-import org.flowable.variable.service.impl.types.JodaDateTimeType;
-import org.flowable.variable.service.impl.types.JodaDateType;
 import org.flowable.variable.service.impl.types.JsonType;
 import org.flowable.variable.service.impl.types.LocalDateTimeType;
 import org.flowable.variable.service.impl.types.LocalDateType;
@@ -155,6 +155,8 @@ public class AppEngineConfiguration extends AbstractBuildableEngineConfiguration
      * And the changes to the JsonNode will be reflected in the database. Otherwise, a manual call to setVariable will be needed.
      */
     protected boolean jsonVariableTypeTrackObjects = true;
+
+    protected JodaTimeVariableSupport jodaTimeVariableSupport = JodaTimeVariableSupport.READ_AS_JAVA_TIME;
 
 
     protected BusinessCalendarManager businessCalendarManager;
@@ -402,8 +404,7 @@ public class AppEngineConfiguration extends AbstractBuildableEngineConfiguration
             variableTypes.addType(new InstantType());
             variableTypes.addType(new LocalDateType());
             variableTypes.addType(new LocalDateTimeType());
-            variableTypes.addType(new JodaDateType());
-            variableTypes.addType(new JodaDateTimeType());
+            jodaTimeVariableSupport.registerJodaTypes(variableTypes);
             variableTypes.addType(new DoubleType());
             variableTypes.addType(new BigDecimalType());
             variableTypes.addType(new BigIntegerType());
@@ -737,6 +738,19 @@ public class AppEngineConfiguration extends AbstractBuildableEngineConfiguration
 
     public AppEngineConfiguration setJsonVariableTypeTrackObjects(boolean jsonVariableTypeTrackObjects) {
         this.jsonVariableTypeTrackObjects = jsonVariableTypeTrackObjects;
+        return this;
+    }
+
+    public JodaTimeVariableSupport getJodaTimeVariableSupport() {
+        return jodaTimeVariableSupport;
+    }
+
+    public AppEngineConfiguration setJodaTimeVariableSupport(JodaTimeVariableSupport jodaTimeVariableSupport) {
+        //noinspection deprecation
+        if (JodaTimeVariableSupport.WRITE == jodaTimeVariableSupport) {
+            JodaDeprecationLogger.LOGGER.warn("Using deprecated joda time write support for the app engine configuration");
+        }
+        this.jodaTimeVariableSupport = jodaTimeVariableSupport;
         return this;
     }
 

--- a/modules/flowable-batch-service/pom.xml
+++ b/modules/flowable-batch-service/pom.xml
@@ -38,10 +38,6 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/modules/flowable-bpmn-converter/pom.xml
+++ b/modules/flowable-bpmn-converter/pom.xml
@@ -54,10 +54,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -255,6 +255,7 @@ import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandInterceptor;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 import org.flowable.common.engine.impl.javax.el.ELResolver;
+import org.flowable.common.engine.impl.joda.JodaDeprecationLogger;
 import org.flowable.common.engine.impl.persistence.deploy.DefaultDeploymentCache;
 import org.flowable.common.engine.impl.persistence.deploy.DeploymentCache;
 import org.flowable.common.engine.impl.persistence.entity.TableDataManager;
@@ -304,6 +305,7 @@ import org.flowable.variable.api.types.VariableType;
 import org.flowable.variable.api.types.VariableTypes;
 import org.flowable.variable.service.VariableServiceConfiguration;
 import org.flowable.variable.service.history.InternalHistoryVariableManager;
+import org.flowable.variable.service.impl.JodaTimeVariableSupport;
 import org.flowable.variable.service.impl.db.IbatisVariableTypeHandler;
 import org.flowable.variable.service.impl.types.BigDecimalType;
 import org.flowable.variable.service.impl.types.BigIntegerType;
@@ -315,8 +317,6 @@ import org.flowable.variable.service.impl.types.DoubleType;
 import org.flowable.variable.service.impl.types.EmptyCollectionType;
 import org.flowable.variable.service.impl.types.InstantType;
 import org.flowable.variable.service.impl.types.IntegerType;
-import org.flowable.variable.service.impl.types.JodaDateTimeType;
-import org.flowable.variable.service.impl.types.JodaDateType;
 import org.flowable.variable.service.impl.types.JsonType;
 import org.flowable.variable.service.impl.types.LocalDateTimeType;
 import org.flowable.variable.service.impl.types.LocalDateType;
@@ -513,6 +513,8 @@ public class CmmnEngineConfiguration extends AbstractBuildableEngineConfiguratio
      * And the changes to the JsonNode will be reflected in the database. Otherwise, a manual call to setVariable will be needed.
      */
     protected boolean jsonVariableTypeTrackObjects = true;
+
+    protected JodaTimeVariableSupport jodaTimeVariableSupport = JodaTimeVariableSupport.READ_AS_JAVA_TIME;
 
     protected List<CaseInstanceMigrationCallback> caseInstanceMigrationCallbacks;
 
@@ -1408,8 +1410,7 @@ public class CmmnEngineConfiguration extends AbstractBuildableEngineConfiguratio
             variableTypes.addType(new InstantType());
             variableTypes.addType(new LocalDateType());
             variableTypes.addType(new LocalDateTimeType());
-            variableTypes.addType(new JodaDateType());
-            variableTypes.addType(new JodaDateTimeType());
+            jodaTimeVariableSupport.registerJodaTypes(variableTypes);
             variableTypes.addType(new DoubleType());
             variableTypes.addType(new BigDecimalType());
             variableTypes.addType(new BigIntegerType());
@@ -2964,6 +2965,19 @@ public class CmmnEngineConfiguration extends AbstractBuildableEngineConfiguratio
 
     public CmmnEngineConfiguration setJsonVariableTypeTrackObjects(boolean jsonVariableTypeTrackObjects) {
         this.jsonVariableTypeTrackObjects = jsonVariableTypeTrackObjects;
+        return this;
+    }
+
+    public JodaTimeVariableSupport getJodaTimeVariableSupport() {
+        return jodaTimeVariableSupport;
+    }
+
+    public CmmnEngineConfiguration setJodaTimeVariableSupport(JodaTimeVariableSupport jodaTimeVariableSupport) {
+        //noinspection deprecation
+        if (JodaTimeVariableSupport.WRITE == jodaTimeVariableSupport) {
+            JodaDeprecationLogger.LOGGER.warn("Using deprecated joda time write support for the CMMN engine configuration");
+        }
+        this.jodaTimeVariableSupport = jodaTimeVariableSupport;
         return this;
     }
 

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/TimerEventListenerActivityBehaviour.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/behavior/impl/TimerEventListenerActivityBehaviour.java
@@ -40,14 +40,12 @@ import org.flowable.common.engine.impl.calendar.CycleBusinessCalendar;
 import org.flowable.common.engine.impl.calendar.DueDateBusinessCalendar;
 import org.flowable.common.engine.impl.el.ExpressionManager;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
-import org.flowable.common.engine.impl.joda.JodaDeprecationLogger;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.common.engine.impl.util.DateUtil;
 import org.flowable.job.service.JobServiceConfiguration;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntityManager;
-import org.joda.time.DateTime;
 
 /**
  * {@link CmmnActivityBehavior} implementation for the CMMN Timer Event Listener.
@@ -101,12 +99,6 @@ public class TimerEventListenerActivityBehaviour extends CoreCmmnActivityBehavio
             if (timerValue instanceof Date) {
                 timerDueDate = (Date) timerValue;
 
-            } else if (timerValue instanceof DateTime timerDateTime) {
-                JodaDeprecationLogger.LOGGER.warn(
-                        "Using Joda-Time DateTime has been deprecated and will be removed in a future version. Timer event listener expression {} in {} resolved to a Joda-Time DateTime. ",
-                        timerEventListener.getTimerExpression(), planItemInstance);
-                timerDueDate = timerDateTime.toDate();
-
             } else if (timerValue instanceof String timerString) {
 
                 BusinessCalendarManager businessCalendarManager = CommandContextUtil.getCmmnEngineConfiguration(commandContext).getBusinessCalendarManager();
@@ -146,7 +138,7 @@ public class TimerEventListenerActivityBehaviour extends CoreCmmnActivityBehavio
         }
 
         if (timerDueDate == null) {
-            throw new FlowableException("Timer expression '" + timerEventListener.getTimerExpression() + "' did not resolve to java.util.Date, org.joda.time.DateTime, "
+            throw new FlowableException("Timer expression '" + timerEventListener.getTimerExpression() + "' did not resolve to java.util.Date, "
                     + "java.time.Instant, java.time.LocalDate, java.time.LocalDateTime or "
                     + "an ISO8601 date/duration/repetition string or a cron expression for " + planItemInstance);
         }

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/delegate/JsonPlanItemVariableAggregator.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/delegate/JsonPlanItemVariableAggregator.java
@@ -35,8 +35,8 @@ import org.flowable.variable.service.impl.types.DateType;
 import org.flowable.variable.service.impl.types.DoubleType;
 import org.flowable.variable.service.impl.types.InstantType;
 import org.flowable.variable.service.impl.types.IntegerType;
-import org.flowable.variable.service.impl.types.JodaDateTimeType;
-import org.flowable.variable.service.impl.types.JodaDateType;
+import org.flowable.variable.service.impl.types.JodaDateTimeFallbackType;
+import org.flowable.variable.service.impl.types.JodaDateFallbackType;
 import org.flowable.variable.service.impl.types.JsonType;
 import org.flowable.variable.service.impl.types.LocalDateTimeType;
 import org.flowable.variable.service.impl.types.LocalDateType;
@@ -140,8 +140,8 @@ public class JsonPlanItemVariableAggregator implements PlanItemVariableAggregato
                         case InstantType.TYPE_NAME:
                         case LocalDateType.TYPE_NAME:
                         case LocalDateTimeType.TYPE_NAME:
-                        case JodaDateType.TYPE_NAME:
-                        case JodaDateTimeType.TYPE_NAME:
+                        case JodaDateFallbackType.TYPE_NAME:
+                        case JodaDateTimeFallbackType.TYPE_NAME:
                         case UUIDType.TYPE_NAME:
                             // For all these types it is OK to use toString as their string representation is what we want to have
                             objectNode.put(targetVarName, varInstance.getValue().toString());

--- a/modules/flowable-common-rest/pom.xml
+++ b/modules/flowable-common-rest/pom.xml
@@ -51,12 +51,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
-        <!-- Joda time -->
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
         <!--- Commons -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/modules/flowable-content-api/pom.xml
+++ b/modules/flowable-content-api/pom.xml
@@ -25,10 +25,6 @@
 			<groupId>org.flowable</groupId>
 			<artifactId>flowable-engine-common-api</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
 	</dependencies>
 
 </project>

--- a/modules/flowable-dmn-api/pom.xml
+++ b/modules/flowable-dmn-api/pom.xml
@@ -29,10 +29,6 @@
 			<groupId>org.flowable</groupId>
 			<artifactId>flowable-engine-common-api</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
 	</dependencies>
 
 </project>

--- a/modules/flowable-dmn-api/src/main/java/org/flowable/dmn/api/DecisionExecutionAuditContainer.java
+++ b/modules/flowable-dmn-api/src/main/java/org/flowable/dmn/api/DecisionExecutionAuditContainer.java
@@ -13,6 +13,7 @@
 package org.flowable.dmn.api;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
@@ -22,8 +23,6 @@ import java.util.Map;
 
 import org.flowable.dmn.model.DecisionRule;
 import org.flowable.dmn.model.HitPolicy;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -258,8 +257,7 @@ public class DecisionExecutionAuditContainer {
     }
 
     protected static boolean isDate(Object obj) {
-        return (obj instanceof Date || obj instanceof DateTime || obj instanceof LocalDate || obj instanceof java.time.LocalDate || obj instanceof LocalDateTime
-                || obj instanceof Instant);
+        return (obj instanceof Date || obj instanceof LocalDate || obj instanceof LocalDateTime || obj instanceof Instant);
     }
 
     protected static boolean isNumber(Object obj) {

--- a/modules/flowable-dmn-engine/pom.xml
+++ b/modules/flowable-dmn-engine/pom.xml
@@ -80,10 +80,6 @@
             <artifactId>spring-beans</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
         	<groupId>com.fasterxml.uuid</groupId>
         	<artifactId>java-uuid-generator</artifactId>
       	</dependency>

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/ELExecutionContextBuilder.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/ELExecutionContextBuilder.java
@@ -14,13 +14,13 @@ package org.flowable.dmn.engine.impl.el;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.flowable.common.engine.api.FlowableException;
-import org.flowable.common.engine.impl.joda.JodaDeprecationLogger;
 import org.flowable.dmn.api.ExecuteDecisionContext;
 import org.flowable.dmn.engine.impl.audit.DecisionExecutionAuditUtil;
 import org.flowable.dmn.model.Decision;
@@ -28,7 +28,6 @@ import org.flowable.dmn.model.DecisionService;
 import org.flowable.dmn.model.DecisionTable;
 import org.flowable.dmn.model.InputClause;
 import org.flowable.dmn.model.OutputClause;
-import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,14 +119,7 @@ public class ELExecutionContextBuilder {
             try {
                 Object inputVariableValue = inputVariable.getValue();
                 if (inputVariableValue instanceof LocalDate) {
-                    JodaDeprecationLogger.LOGGER.warn(
-                            "Using Joda-Time LocalDate has been deprecated and will be removed in a future version."
-                                    + " Input variable {} from {} {} for decision table {} is a Joda-Time LocalDate. ",
-                            inputVariableName, executeDecisionInfo.getScopeType(), executeDecisionInfo.getInstanceId(), decisionTable.getId());
-                    Date transformedDate = ((LocalDate) inputVariableValue).toDate();
-                    inputVariables.put(inputVariableName, transformedDate);
-                } else if (inputVariableValue instanceof java.time.LocalDate) {
-                    Date transformedDate = Date.from(((java.time.LocalDate) inputVariableValue).atStartOfDay()
+                    Date transformedDate = Date.from(((LocalDate) inputVariableValue).atStartOfDay()
                             .atZone(ZoneId.systemDefault())
                             .toInstant());
                     inputVariables.put(inputVariableName, transformedDate);

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/util/DMNParseUtil.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/util/DMNParseUtil.java
@@ -13,6 +13,8 @@
 package org.flowable.dmn.engine.impl.el.util;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -20,9 +22,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.flowable.common.engine.impl.joda.JodaDeprecationLogger;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,8 +127,10 @@ public class DMNParseUtil {
         if (Date.class.equals(collectionType)) {
             return DateUtil.toDate(value);
         } else if (LocalDate.class.equals(collectionType)) {
-            JodaDeprecationLogger.LOGGER.warn("Using Joda-Time LocalDate has been deprecated and will be removed in a future version.");
-            return new DateTime(DateUtil.toDate(value)).toLocalDate();
+            return DateUtil.toDate(value)
+                    .toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDate();
         } else if (Integer.class.equals(collectionType) || Long.class.equals(collectionType) || Float.class.equals(collectionType)
             || Double.class.equals(collectionType) || BigInteger.class.equals(collectionType)) {
             return getNumberValue(value.toString(), collectionType);

--- a/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/util/DateUtil.java
+++ b/modules/flowable-dmn-engine/src/main/java/org/flowable/dmn/engine/impl/el/util/DateUtil.java
@@ -12,13 +12,10 @@
  */
 package org.flowable.dmn.engine.impl.el.util;
 
+import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
-
-import org.flowable.common.engine.impl.joda.JodaDeprecationLogger;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 /**
  * @author Yvo Swillens
@@ -33,41 +30,36 @@ public class DateUtil {
         if (dateObject instanceof Date) {
             return (Date) dateObject;
         } else if (dateObject instanceof LocalDate) {
-            JodaDeprecationLogger.LOGGER.warn("Using Joda-Time LocalDate has been deprecated and will be removed in a future version.");
-            return ((LocalDate) dateObject).toDate();
-        } else if (dateObject instanceof java.time.LocalDate) {
-            return Date.from(((java.time.LocalDate) dateObject).atStartOfDay()
+            return Date.from(((LocalDate) dateObject).atStartOfDay()
                     .atZone(ZoneId.systemDefault())
                     .toInstant());
         } else {
-            DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyy-MM-dd");
-            LocalDate dateTime = dtf.parseLocalDate((String) dateObject);
-            return dateTime.toDate();
+            return Date.from(LocalDate.parse((String) dateObject)
+                    .atStartOfDay(ZoneId.systemDefault())
+                    .toInstant());
         }
     }
 
     public static Date addDate(Object startDate, Object years, Object months, Object days) {
-        LocalDate currentDate = new LocalDate(startDate);
-        
-        currentDate = currentDate.plusYears(intValue(years));
-        currentDate = currentDate.plusMonths(intValue(months));
-        currentDate = currentDate.plusDays(intValue(days));
-
-        return currentDate.toDate();
+        Date currentDate = toDate(startDate);
+        return Date.from(ZonedDateTime.ofInstant(currentDate.toInstant(), ZoneId.systemDefault())
+                .plusYears(intValue(years))
+                .plusMonths(intValue(months))
+                .plusDays(intValue(days))
+                .toInstant());
     }
 
     public static Date subtractDate(Object startDate, Object years, Object months, Object days) {
-        LocalDate currentDate = new LocalDate(startDate);
-
-        currentDate = currentDate.minusYears(intValue(years));
-        currentDate = currentDate.minusMonths(intValue(months));
-        currentDate = currentDate.minusDays(intValue(days));
-
-        return currentDate.toDate();
+        Date currentDate = toDate(startDate);
+        return Date.from(ZonedDateTime.ofInstant(currentDate.toInstant(), ZoneId.systemDefault())
+                .minusYears(intValue(years))
+                .minusMonths(intValue(months))
+                .minusDays(intValue(days))
+                .toInstant());
     }
 
     public static Date now() {
-        return new LocalDate().toDate();
+        return Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
     
     protected static Integer intValue(Object value) {

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsContainsTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CollectionsContainsTest.java
@@ -15,6 +15,8 @@ package org.flowable.dmn.engine.test.runtime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -25,9 +27,6 @@ import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.api.DmnDecisionService;
 import org.flowable.dmn.engine.test.BaseFlowableDmnTest;
 import org.flowable.dmn.engine.test.DmnDeployment;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,7 +42,6 @@ class CollectionsContainsTest extends BaseFlowableDmnTest {
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/runtime/contains_IN.dmn")
     public void testContainsTrue() {
         Map<String, Object> processVariablesInput = new HashMap<>();
-        DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyy-MM-dd");
 
         List inputVariable1 = Arrays.asList("test1", "test2", "test3");
         List inputVariable2 = Arrays.asList("test1", "test2", "test3");
@@ -53,7 +51,7 @@ class CollectionsContainsTest extends BaseFlowableDmnTest {
         List inputVariable6 = Arrays.asList("tes,t6", "te,st5");
         List inputVariable7 = Arrays.asList(BigInteger.valueOf(100), BigInteger.valueOf(101));
         List inputVariable8 = Arrays.asList("100", "101");
-        LocalDate date1 = dtf.parseLocalDate("2021-02-02");
+        Date date1 = Date.from(LocalDate.parse("2021-02-02").atStartOfDay(ZoneId.systemDefault()).toInstant());
 
         ObjectMapper objectMapper = dmnEngineConfiguration.getObjectMapper();
         ArrayNode arrayNode1 = objectMapper.createArrayNode().add("test1").add("test2").add("test3");
@@ -78,7 +76,7 @@ class CollectionsContainsTest extends BaseFlowableDmnTest {
         processVariablesInput.put("arrayNode5", arrayNode5);
         processVariablesInput.put("nestedArrayNode1", nestedArrayNode1);
         processVariablesInput.put("bigInteger1", BigInteger.valueOf(101));
-        processVariablesInput.put("date1", date1.toDate());
+        processVariablesInput.put("date1", date1);
 
         DmnDecisionService dmnRuleService = dmnEngine.getDmnDecisionService();
 
@@ -119,7 +117,6 @@ class CollectionsContainsTest extends BaseFlowableDmnTest {
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/runtime/contains_IN.dmn")
     public void testContainsFalse() {
         Map<String, Object> processVariablesInput = new HashMap<>();
-        DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyy-MM-dd");
 
         List inputVariable1 = Arrays.asList("test1", "test2", "test3");
         List inputVariable2 = Arrays.asList("test1", "test2", "test3");
@@ -137,7 +134,7 @@ class CollectionsContainsTest extends BaseFlowableDmnTest {
         ArrayNode arrayNode4 = objectMapper.createArrayNode().add(5.5555F).add(10.5555F).add(20.5555F).add(50.5555F);
         ArrayNode arrayNode5 = objectMapper.createArrayNode().add(5.5555F).add(10.5555F);
         ObjectNode nestedArrayNode1 = objectMapper.createObjectNode().putPOJO("property1", arrayNode1);
-        LocalDate date1 = dtf.parseLocalDate("2021-02-02");
+        LocalDate date1 = LocalDate.parse("2021-02-02");
 
         processVariablesInput.put("collection1", inputVariable1);
         processVariablesInput.put("collection2", inputVariable2);
@@ -176,17 +173,14 @@ class CollectionsContainsTest extends BaseFlowableDmnTest {
     public void testContainsTypeCheck() {
         Map<String, Object> processVariablesInput = new HashMap<>();
 
-        DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyy-MM-dd");
-        LocalDate date1 = dtf.parseLocalDate("2017-12-25");
-        LocalDate date2 = dtf.parseLocalDate("2018-12-25");
-
-        java.time.format.DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        java.time.LocalDate date3 = java.time.LocalDate.parse("2017-12-25", formatter);
+        LocalDate date1 = LocalDate.parse("2017-12-25");
+        LocalDate date2 = LocalDate.parse("2018-12-25");
 
         List<String> collectionString = Arrays.asList("test1", "test2", "test3");
         List<Boolean> collectionBoolean = Arrays.asList(Boolean.TRUE, Boolean.FALSE);
-        List<Date> collectionDate = Arrays.asList(date1.toDate(), date2.toDate());
         List<LocalDate> collectionLocalDate = Arrays.asList(date1, date2);
+        List<Date> collectionDate = collectionLocalDate.stream().map(localDate -> Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant()))
+                .toList();
         List<Integer> collectionInteger = Arrays.asList(5, 10, 20, 50);
         List<Long> collectionLong = Arrays.asList(5L, 10L, 20L, 50L);
         List<Float> collectionFloat = Arrays.asList(5F, 10F, 20F, 50F);
@@ -201,8 +195,7 @@ class CollectionsContainsTest extends BaseFlowableDmnTest {
         processVariablesInput.put("collectionFloat", collectionFloat);
         processVariablesInput.put("collectionDouble", collectionDouble);
         processVariablesInput.put("stringLocalDate", "2017-12-25");
-        processVariablesInput.put("jodaLocalDate", date1);
-        processVariablesInput.put("javaLocalDate", date3);
+        processVariablesInput.put("javaLocalDate", date1);
 
         DmnDecisionService dmnRuleService = dmnEngine.getDmnDecisionService();
 

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomConfigRuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/CustomConfigRuntimeTest.java
@@ -14,6 +14,9 @@ package org.flowable.dmn.engine.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.Map;
 
 import org.flowable.dmn.api.DecisionExecutionAuditContainer;
@@ -21,9 +24,6 @@ import org.flowable.dmn.api.DmnDecisionService;
 import org.flowable.dmn.engine.test.BaseFlowableDmnTest;
 import org.flowable.dmn.engine.test.DmnConfigurationResource;
 import org.flowable.dmn.engine.test.DmnDeployment;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -45,12 +45,12 @@ public class CustomConfigRuntimeTest {
         public void postCustomExpressionFunction() {
             DmnDecisionService ruleService = dmnEngine.getDmnDecisionService();
 
-            DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-            LocalDate localDate = dateTimeFormatter.parseLocalDate("2015-09-18");
+            LocalDate localDate = LocalDate.parse("2015-09-18");
+            Date input1 = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
 
             Map<String, Object> result = ruleService.createExecuteDecisionBuilder()
                     .decisionKey("decision")
-                    .variable("input1", localDate.toDate())
+                    .variable("input1", input1)
                     .executeWithSingleResult();
 
             assertThat(result).containsEntry("output1", "test2");
@@ -67,12 +67,12 @@ public class CustomConfigRuntimeTest {
         public void customExpressionFunctionMissingDefaultFunction() {
             DmnDecisionService ruleService = dmnEngine.getDmnDecisionService();
 
-            DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-            LocalDate localDate = dateTimeFormatter.parseLocalDate("2015-09-18");
+            LocalDate localDate = LocalDate.parse("2015-09-18");
+            Date input1 = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
 
             DecisionExecutionAuditContainer result = ruleService.createExecuteDecisionBuilder()
                     .decisionKey("decision")
-                    .variable("input1", localDate.toDate())
+                    .variable("input1", input1)
                     .executeWithAuditTrail();
 
             assertThat(result.getDecisionResult()).isEmpty();

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyOutputOrderTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/HitPolicyOutputOrderTest.java
@@ -14,6 +14,9 @@ package org.flowable.dmn.engine.test.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +24,6 @@ import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.api.DmnDecisionService;
 import org.flowable.dmn.engine.test.BaseFlowableDmnTest;
 import org.flowable.dmn.engine.test.DmnDeployment;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -99,7 +101,11 @@ class HitPolicyOutputOrderTest extends BaseFlowableDmnTest {
 
         assertThat(result)
                 .extracting("outputVariable1")
-                .containsExactly(new DateTime("2000-01-01").toDate(), new DateTime("2020-01-01").toDate(), new DateTime("2010-01-01").toDate());
+                .containsExactly(
+                        Date.from(LocalDate.parse("2000-01-01").atStartOfDay(ZoneId.systemDefault()).toInstant()),
+                        Date.from(LocalDate.parse("2020-01-01").atStartOfDay(ZoneId.systemDefault()).toInstant()),
+                        Date.from(LocalDate.parse("2010-01-01").atStartOfDay(ZoneId.systemDefault()).toInstant())
+                );
     }
 
     @Test

--- a/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
+++ b/modules/flowable-dmn-engine/src/test/java/org/flowable/dmn/engine/test/runtime/RuntimeTest.java
@@ -16,6 +16,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,9 +26,6 @@ import java.util.Map;
 import org.flowable.dmn.api.DecisionExecutionAuditContainer;
 import org.flowable.dmn.engine.test.BaseFlowableDmnTest;
 import org.flowable.dmn.engine.test.DmnDeployment;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -51,12 +51,11 @@ public class RuntimeTest extends BaseFlowableDmnTest {
     @Test
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/deployment/dates_1.dmn")
     public void staticDates() {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-        LocalDate localDate = dateTimeFormatter.parseLocalDate("2015-09-18");
+        Date date = Date.from(LocalDate.parse("2015-09-18").atStartOfDay(ZoneId.systemDefault()).toInstant());
 
         Map<String, Object> result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
-                .variable("input1", localDate.toDate())
+                .variable("input1", date)
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
         assertThat(result).containsEntry("output1", "test2");
@@ -65,12 +64,11 @@ public class RuntimeTest extends BaseFlowableDmnTest {
     @Test
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/deployment/dates_2.dmn")
     public void dynamicDatesAdd() {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-        LocalDate localDate = dateTimeFormatter.parseLocalDate("2015-09-18");
+        Date date = Date.from(LocalDate.parse("2015-09-18").atStartOfDay(ZoneId.systemDefault()).toInstant());
 
         Map<String, Object> result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
-                .variable("input1", localDate.toDate())
+                .variable("input1", date)
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
         assertThat(result).containsEntry("output1", "test2");
@@ -79,12 +77,11 @@ public class RuntimeTest extends BaseFlowableDmnTest {
     @Test
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/deployment/dates_3.dmn")
     public void dynamicDatesSubtract() {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-        LocalDate localDate = dateTimeFormatter.parseLocalDate("2025-09-18");
+        Date date = Date.from(LocalDate.parse("2025-09-18").atStartOfDay(ZoneId.systemDefault()).toInstant());
 
         Map<String, Object> result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
-                .variable("input1", localDate.toDate())
+                .variable("input1", date)
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
         assertThat(result).containsEntry("output1", "test2");
@@ -93,12 +90,11 @@ public class RuntimeTest extends BaseFlowableDmnTest {
     @Test
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/deployment/dates_5.dmn")
     public void datesEquals() {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-        LocalDate localDate = dateTimeFormatter.parseLocalDate("2015-09-18");
+        Date date = Date.from(LocalDate.parse("2015-09-18").atStartOfDay(ZoneId.systemDefault()).toInstant());
 
         Map<String, Object> result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
-                .variable("input1", localDate.toDate())
+                .variable("input1", date)
                 .executeWithSingleResult();
         assertThat(result.get("output1").getClass()).isSameAs(String.class);
         assertThat(result).containsEntry("output1", "test2");
@@ -107,8 +103,7 @@ public class RuntimeTest extends BaseFlowableDmnTest {
     @Test
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/deployment/dates_5.dmn")
     public void localDatesEquals() {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-        LocalDate localDate = dateTimeFormatter.parseLocalDate("2015-09-18");
+        LocalDate localDate = LocalDate.parse("2015-09-18");
 
         Map<String, Object> result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
@@ -285,12 +280,11 @@ public class RuntimeTest extends BaseFlowableDmnTest {
     @Test
     @DmnDeployment(resources = "org/flowable/dmn/engine/test/deployment/reservered_word.dmn")
     public void reservedWord() {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd");
-        LocalDate localDate = dateTimeFormatter.parseLocalDate("2025-09-18");
+        Date date = Date.from(LocalDate.parse("2025-09-18").atStartOfDay(ZoneId.systemDefault()).toInstant());
 
         Map<String, Object> result = ruleService.createExecuteDecisionBuilder()
                 .decisionKey("decision")
-                .variable("date", localDate.toDate())
+                .variable("date", date)
                 .executeWithSingleResult();
         assertThat(result).containsEntry("output1", "test2");
     }

--- a/modules/flowable-dmn-engine/src/test/resources/org/flowable/dmn/engine/test/runtime/contains_IN_types.dmn
+++ b/modules/flowable-dmn-engine/src/test/resources/org/flowable/dmn/engine/test/runtime/contains_IN_types.dmn
@@ -48,11 +48,6 @@
       </input>
       <input>
         <inputExpression id="inputExpression_10" typeRef="date">
-          <text>jodaLocalDate</text>
-        </inputExpression>
-      </input>
-      <input>
-        <inputExpression id="inputExpression_11" typeRef="date">
           <text>javaLocalDate</text>
         </inputExpression>
       </input>
@@ -86,9 +81,6 @@
           <text><![CDATA[${collection:contains('"2017-12-25", "2017-12-25"', "2017-12-25")}]]></text>
         </inputEntry>
          <inputEntry id="inputEntry_1_10">
-          <text><![CDATA[${collection:contains('"2017-12-25", "2017-12-25"', jodaLocalDate)}]]></text>
-        </inputEntry>
-        <inputEntry id="inputEntry_1_11">
           <text><![CDATA[${collection:contains('"2017-12-25", "2017-12-25"', javaLocalDate)}]]></text>
         </inputEntry>
         <outputEntry id="outputEntry_2_1">
@@ -125,9 +117,6 @@
           <text><![CDATA[-]]></text>
         </inputEntry>
          <inputEntry id="inputEntry_2_10">
-          <text><![CDATA[-]]></text>
-            </inputEntry>
-         <inputEntry id="inputEntry_2_11">
           <text><![CDATA[-]]></text>
             </inputEntry>
         <outputEntry id="outputEntry_2_2">

--- a/modules/flowable-engine-common/pom.xml
+++ b/modules/flowable-engine-common/pom.xml
@@ -99,10 +99,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/logging/LoggingSessionUtil.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/logging/LoggingSessionUtil.java
@@ -12,18 +12,17 @@
  */
 package org.flowable.common.engine.impl.logging;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.flowable.common.engine.impl.context.Context;
 import org.flowable.common.engine.impl.persistence.StrongUuidGenerator;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -134,23 +133,28 @@ public class LoggingSessionUtil {
 
     public static String formatDate(Date date) {
         if (date != null) {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
-            dateFormat.setTimeZone(utcTimeZone);
-            return dateFormat.format(date);
+            return date.toInstant().toString();
         }
         return null;
     }
     
-    public static String formatDate(DateTime date) {
+    public static String formatDate(Instant date) {
         if (date != null) {
-            return date.toString("yyyy-MM-dd'T'hh:mm:ss.sss'Z'");
+            return date.toString();
         }
         return null;
     }
     
     public static String formatDate(LocalDate date) {
         if (date != null) {
-            return date.toString("yyyy-MM-dd");
+            return date.toString();
+        }
+        return null;
+    }
+
+    public static String formatDate(LocalDateTime date) {
+        if (date != null) {
+            return date.toString();
         }
         return null;
     }

--- a/modules/flowable-engine/pom.xml
+++ b/modules/flowable-engine/pom.xml
@@ -225,10 +225,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -93,6 +93,7 @@ import org.flowable.common.engine.impl.interceptor.CommandInterceptor;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 import org.flowable.common.engine.impl.interceptor.SessionFactory;
 import org.flowable.common.engine.impl.javax.el.ELResolver;
+import org.flowable.common.engine.impl.joda.JodaDeprecationLogger;
 import org.flowable.common.engine.impl.logging.LoggingSession;
 import org.flowable.common.engine.impl.logging.LoggingSessionFactory;
 import org.flowable.common.engine.impl.persistence.GenericManagerFactory;
@@ -401,6 +402,7 @@ import org.flowable.variable.api.types.VariableType;
 import org.flowable.variable.api.types.VariableTypes;
 import org.flowable.variable.service.VariableServiceConfiguration;
 import org.flowable.variable.service.history.InternalHistoryVariableManager;
+import org.flowable.variable.service.impl.JodaTimeVariableSupport;
 import org.flowable.variable.service.impl.db.IbatisVariableTypeHandler;
 import org.flowable.variable.service.impl.types.BigDecimalType;
 import org.flowable.variable.service.impl.types.BigIntegerType;
@@ -416,8 +418,6 @@ import org.flowable.variable.service.impl.types.InstantType;
 import org.flowable.variable.service.impl.types.IntegerType;
 import org.flowable.variable.service.impl.types.JPAEntityListVariableType;
 import org.flowable.variable.service.impl.types.JPAEntityVariableType;
-import org.flowable.variable.service.impl.types.JodaDateTimeType;
-import org.flowable.variable.service.impl.types.JodaDateType;
 import org.flowable.variable.service.impl.types.JsonType;
 import org.flowable.variable.service.impl.types.LocalDateTimeType;
 import org.flowable.variable.service.impl.types.LocalDateType;
@@ -721,6 +721,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
      * And the changes to the JsonNode will be reflected in the database. Otherwise, a manual call to setVariable will be needed.
      */
     protected boolean jsonVariableTypeTrackObjects = true;
+
+    protected JodaTimeVariableSupport jodaTimeVariableSupport = JodaTimeVariableSupport.READ_AS_JAVA_TIME;
 
     /**
      * Whether the Parallel Multi instance should perform the leave operation through an async exclusive job.
@@ -2187,8 +2189,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             variableTypes.addType(new InstantType());
             variableTypes.addType(new LocalDateType());
             variableTypes.addType(new LocalDateTimeType());
-            variableTypes.addType(new JodaDateType());
-            variableTypes.addType(new JodaDateTimeType());
+            jodaTimeVariableSupport.registerJodaTypes(variableTypes);
             variableTypes.addType(new DoubleType());
             variableTypes.addType(new BigDecimalType());
             variableTypes.addType(new BigIntegerType());
@@ -3221,6 +3222,19 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setJsonVariableTypeTrackObjects(boolean jsonVariableTypeTrackObjects) {
         this.jsonVariableTypeTrackObjects = jsonVariableTypeTrackObjects;
+        return this;
+    }
+
+    public JodaTimeVariableSupport getJodaTimeVariableSupport() {
+        return jodaTimeVariableSupport;
+    }
+
+    public ProcessEngineConfigurationImpl setJodaTimeVariableSupport(JodaTimeVariableSupport jodaTimeVariableSupport) {
+        //noinspection deprecation
+        if (JodaTimeVariableSupport.WRITE == jodaTimeVariableSupport) {
+            JodaDeprecationLogger.LOGGER.warn("Using deprecated joda time write support for the Process engine configuration");
+        }
+        this.jodaTimeVariableSupport = jodaTimeVariableSupport;
         return this;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/delegate/JsonVariableAggregator.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/delegate/JsonVariableAggregator.java
@@ -35,8 +35,8 @@ import org.flowable.variable.service.impl.types.DateType;
 import org.flowable.variable.service.impl.types.DoubleType;
 import org.flowable.variable.service.impl.types.InstantType;
 import org.flowable.variable.service.impl.types.IntegerType;
-import org.flowable.variable.service.impl.types.JodaDateTimeType;
-import org.flowable.variable.service.impl.types.JodaDateType;
+import org.flowable.variable.service.impl.types.JodaDateTimeFallbackType;
+import org.flowable.variable.service.impl.types.JodaDateFallbackType;
 import org.flowable.variable.service.impl.types.JsonType;
 import org.flowable.variable.service.impl.types.LocalDateTimeType;
 import org.flowable.variable.service.impl.types.LocalDateType;
@@ -141,8 +141,8 @@ public class JsonVariableAggregator implements VariableAggregator {
                         case InstantType.TYPE_NAME:
                         case LocalDateType.TYPE_NAME:
                         case LocalDateTimeType.TYPE_NAME:
-                        case JodaDateType.TYPE_NAME:
-                        case JodaDateTimeType.TYPE_NAME:
+                        case JodaDateFallbackType.TYPE_NAME:
+                        case JodaDateTimeFallbackType.TYPE_NAME:
                         case UUIDType.TYPE_NAME:
                             // For all these types it is OK to use toString as their string representation is what we want to have
                             objectNode.put(targetVarName, varInstance.getValue().toString());

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TimerUtil.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TimerUtil.java
@@ -37,7 +37,6 @@ import org.flowable.common.engine.impl.calendar.CycleBusinessCalendar;
 import org.flowable.common.engine.impl.calendar.DueDateBusinessCalendar;
 import org.flowable.common.engine.impl.calendar.DurationBusinessCalendar;
 import org.flowable.common.engine.impl.el.ExpressionManager;
-import org.flowable.common.engine.impl.joda.JodaDeprecationLogger;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.engine.delegate.event.impl.FlowableEventBuilder;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -49,7 +48,6 @@ import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.job.service.impl.persistence.entity.TimerJobEntity;
 import org.flowable.variable.api.delegate.VariableScope;
 import org.flowable.variable.service.impl.el.NoExecutionVariableScope;
-import org.joda.time.DateTime;
 
 /**
  * @author Joram Barrez
@@ -116,13 +114,6 @@ public class TimerUtil {
         } else if (dueDateValue instanceof Date) {
             duedate = (Date) dueDateValue;
 
-        } else if (dueDateValue instanceof DateTime) {
-            JodaDeprecationLogger.LOGGER.warn(
-                    "Using Joda-Time DateTime has been deprecated and will be removed in a future version. Timer event listener expression {} in {} resolved to a Joda-Time DateTime. ",
-                    expression.getExpressionText(), scopeForExpression);
-            // JodaTime support
-            duedate = ((DateTime) dueDateValue).toDate();
-
         } else if (dueDateValue instanceof Duration) {
         	dueDateString = ((Duration) dueDateValue).toString();
 
@@ -137,7 +128,7 @@ public class TimerUtil {
 
         } else if (dueDateValue != null) {
             throw new FlowableException("Timer '" + executionEntity.getActivityId()
-                    + "' in " + executionEntity + " was not configured with a valid duration/time, either hand in a java.util.Date, java.time.LocalDate, java.time.LocalDateTime or a java.time.Instant or a org.joda.time.DateTime or a String in format 'yyyy-MM-dd'T'hh:mm:ss'");
+                    + "' in " + executionEntity + " was not configured with a valid duration/time, either hand in a java.util.Date, java.time.LocalDate, java.time.LocalDateTime or a java.time.Instant or a String in format 'yyyy-MM-dd'T'hh:mm:ss'");
         }
 
         if (duedate == null && dueDateString != null) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -32,7 +33,6 @@ import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.engine.impl.test.ResourceFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
-import org.joda.time.Period;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -121,10 +121,9 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         assertThat(task.getDueDate()).isNotNull();
-        Period period = new Period(task.getCreateTime().getTime(), task.getDueDate().getTime());
-        assertThat(period.getDays()).isEqualTo(2);
-        assertThat(period.getHours()).isEqualTo(5);
-        assertThat(period.getMinutes()).isEqualTo(40);
+        Duration duration = Duration.between(task.getCreateTime().toInstant(), task.getDueDate().toInstant());
+        assertThat(duration)
+                .isEqualTo(Duration.ofDays(2).plusHours(5).plusMinutes(40));
         clock.reset();
     }
 

--- a/modules/flowable-entitylink-service/pom.xml
+++ b/modules/flowable-entitylink-service/pom.xml
@@ -39,10 +39,6 @@
 			<artifactId>spring-beans</artifactId>
 		</dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
 			<groupId>jakarta.persistence</groupId>
 			<artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/BaseSpringRestTestCase.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/service/BaseSpringRestTestCase.java
@@ -13,7 +13,6 @@
 package org.flowable.eventregistry.rest.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -23,10 +22,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.TimeZone;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -59,9 +56,6 @@ import org.flowable.idm.api.Group;
 import org.flowable.idm.api.IdmIdentityService;
 import org.flowable.idm.api.User;
 import org.flowable.spring.impl.test.FlowableSpringExtension;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -328,32 +322,6 @@ public abstract class BaseSpringRestTestCase {
         HttpPost post = new HttpPost(SERVER_URL_PREFIX + url);
         post.setEntity(new StringEntity(body.toString()));
         closeResponse(executeRequest(post, statusCode));
-    }
-
-    /**
-     * Extract a date from the given string. Assertion fails when invalid date has been provided.
-     */
-    protected Date getDateFromISOString(String isoString) {
-        DateTimeFormatter dateFormat = ISODateTimeFormat.dateTime();
-        try {
-            return dateFormat.parseDateTime(isoString).toDate();
-        } catch (IllegalArgumentException iae) {
-            fail("Illegal date provided: " + isoString);
-            return null;
-        }
-    }
-
-    protected String getISODateString(Date time) {
-        TimeZone tz = TimeZone.getTimeZone("UTC");
-        longDateFormat.setTimeZone(tz);
-        return longDateFormat.format(time);
-    }
-
-    protected String getISODateStringWithTZ(Date date) {
-        if (date == null) {
-            return null;
-        }
-        return ISODateTimeFormat.dateTime().print(new DateTime(date));
     }
 
     protected String buildUrl(String[] fragments, Object... arguments) {

--- a/modules/flowable-event-registry/pom.xml
+++ b/modules/flowable-event-registry/pom.xml
@@ -51,10 +51,6 @@
             <artifactId>spring-beans</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
         </dependency>

--- a/modules/flowable-eventsubscription-service/pom.xml
+++ b/modules/flowable-eventsubscription-service/pom.xml
@@ -43,10 +43,6 @@
 			<artifactId>spring-beans</artifactId>
 		</dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
 			<groupId>jakarta.persistence</groupId>
 			<artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>

--- a/modules/flowable-groovy-script-static-engine/pom.xml
+++ b/modules/flowable-groovy-script-static-engine/pom.xml
@@ -43,10 +43,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>

--- a/modules/flowable-identitylink-service/pom.xml
+++ b/modules/flowable-identitylink-service/pom.xml
@@ -39,10 +39,6 @@
 			<artifactId>spring-beans</artifactId>
 		</dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
 			<groupId>jakarta.persistence</groupId>
 			<artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>

--- a/modules/flowable-idm-engine/pom.xml
+++ b/modules/flowable-idm-engine/pom.xml
@@ -62,10 +62,6 @@
 			<artifactId>spring-beans</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.fasterxml.uuid</groupId>
 			<artifactId>java-uuid-generator</artifactId>
 		</dependency>

--- a/modules/flowable-job-service/pom.xml
+++ b/modules/flowable-job-service/pom.xml
@@ -39,10 +39,6 @@
 			<artifactId>mybatis</artifactId>
 		</dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
 			<groupId>jakarta.persistence</groupId>
 			<artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>

--- a/modules/flowable-osgi/src/test/java/org/flowable/osgi/blueprint/BlueprintBasicTest.java
+++ b/modules/flowable-osgi/src/test/java/org/flowable/osgi/blueprint/BlueprintBasicTest.java
@@ -125,7 +125,6 @@ public class BlueprintBasicTest {
                 mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-annotations").versionAsInProject(),
                 mavenBundle().groupId("jakarta.activation").artifactId("jakarta.activation-api").versionAsInProject(),
                 mavenBundle().groupId("jakarta.mail").artifactId("jakarta.mail-api").versionAsInProject(),
-                mavenBundle().groupId("joda-time").artifactId("joda-time").versionAsInProject(),
                 mavenBundle().groupId("com.h2database").artifactId("h2").versionAsInProject(),
                 mavenBundle().groupId("org.eclipse.angus").artifactId("angus-mail").versionAsInProject(),
                 mavenBundle().groupId("org.mybatis").artifactId("mybatis").versionAsInProject(),

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/repository/ProcessDefinitionResourceTest.java
@@ -16,7 +16,9 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Calendar;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
@@ -28,8 +30,6 @@ import org.flowable.engine.repository.ProcessDefinition;
 import org.flowable.engine.test.Deployment;
 import org.flowable.rest.service.BaseSpringRestTestCase;
 import org.flowable.rest.service.api.RestUrls;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -165,12 +165,10 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
 
         ObjectNode requestNode = objectMapper.createObjectNode();
 
-        Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.HOUR, 2);
+        Instant suspensionTime = Instant.now().plus(2, ChronoUnit.HOURS);
 
         // Format the date using ISO date format
-        DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
-        String dateString = formatter.print(cal.getTimeInMillis());
+        String dateString = suspensionTime.toString();
 
         requestNode.put("action", "suspend");
         requestNode.put("date", dateString);
@@ -193,8 +191,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         assertThat(processDefinition.isSuspended()).isFalse();
 
         // Force suspension by altering time
-        cal.add(Calendar.HOUR, 1);
-        processEngineConfiguration.getClock().setCurrentTime(cal.getTime());
+        processEngineConfiguration.getClock().setCurrentTime(Date.from(suspensionTime.plus(1, ChronoUnit.HOURS)));
         waitForJobExecutorToProcessAllJobs(7000, 100);
 
         // Check if process-definition is suspended
@@ -270,12 +267,10 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
 
         ObjectNode requestNode = objectMapper.createObjectNode();
 
-        Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.HOUR, 2);
+        Instant activationTime = Instant.now().plus(2, ChronoUnit.HOURS);
 
         // Format the date using ISO date format
-        DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
-        String dateString = formatter.print(cal.getTimeInMillis());
+        String dateString = activationTime.toString();
 
         requestNode.put("action", "activate");
         requestNode.put("date", dateString);
@@ -298,8 +293,7 @@ public class ProcessDefinitionResourceTest extends BaseSpringRestTestCase {
         assertThat(processDefinition.isSuspended()).isTrue();
 
         // Force activation by altering time
-        cal.add(Calendar.HOUR, 1);
-        processEngineConfiguration.getClock().setCurrentTime(cal.getTime());
+        processEngineConfiguration.getClock().setCurrentTime(Date.from(activationTime.plus(1, ChronoUnit.HOURS)));
         waitForJobExecutorToProcessAllJobs(7000, 100);
 
         // Check if process-definition is activated

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/pom.xml
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/pom.xml
@@ -261,6 +261,11 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableProperties.java
@@ -136,6 +136,12 @@ public class FlowableProperties {
     private Duration historyCleaningAfter = Duration.ofDays(365);
     private int historyCleaningBatchSize = 100;
 
+    /**
+     * Indicates how joda time variables should be supported.
+     * By default old joda time variables are read as Java Time.
+     */
+    private JodaTimeVariableSupport jodaTimeVariableSupport;
+
     public boolean isAsyncExecutorActivate() {
         return asyncExecutorActivate;
     }
@@ -398,5 +404,31 @@ public class FlowableProperties {
 
     public void setHistoryCleaningBatchSize(int historyCleaningBatchSize) {
         this.historyCleaningBatchSize = historyCleaningBatchSize;
+    }
+
+    public JodaTimeVariableSupport getJodaTimeVariableSupport() {
+        return jodaTimeVariableSupport;
+    }
+
+    public void setJodaTimeVariableSupport(JodaTimeVariableSupport jodaTimeVariableSupport) {
+        this.jodaTimeVariableSupport = jodaTimeVariableSupport;
+    }
+
+    public enum JodaTimeVariableSupport {
+        /**
+         * Disable all Joda Time support.
+         * Also disables reading joda variables.
+         */
+        DISABLE,
+        /**
+         * Support for reading Joda time variables as Java time variables.
+         * Joda variables cannot be saved
+         */
+        READ_AS_JAVA_TIME,
+        /**
+         * Support for writing and reading Joda time variables.
+         * This requires having joda-time as a dependency.
+         */
+        WRITE
     }
 }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.flowable.spring.configurator.SingleResourceAutoDeploymentStrategy;
 import org.flowable.spring.job.service.SpringAsyncExecutor;
 import org.flowable.spring.job.service.SpringAsyncHistoryExecutor;
 import org.flowable.spring.job.service.SpringRejectedJobsHandler;
+import org.flowable.variable.service.impl.JodaTimeVariableSupport;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -285,6 +286,11 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
         deploymentStrategies.add(new SingleResourceAutoDeploymentStrategy(deploymentProperties));
         deploymentStrategies.add(new ResourceParentFolderAutoDeploymentStrategy(deploymentProperties));
         conf.setDeploymentStrategies(deploymentStrategies);
+
+        FlowableProperties.JodaTimeVariableSupport jodaTimeVariableSupport = flowableProperties.getJodaTimeVariableSupport();
+        if (jodaTimeVariableSupport != null) {
+            conf.setJodaTimeVariableSupport(JodaTimeVariableSupport.valueOf(jodaTimeVariableSupport.name()));
+        }
 
         return conf;
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/app/AppEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/app/AppEngineAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.flowable.spring.boot.FlowableProperties;
 import org.flowable.spring.boot.condition.ConditionalOnAppEngine;
 import org.flowable.spring.boot.eventregistry.FlowableEventRegistryProperties;
 import org.flowable.spring.boot.idm.FlowableIdmProperties;
+import org.flowable.variable.service.impl.JodaTimeVariableSupport;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -103,6 +104,11 @@ public class AppEngineAutoConfiguration extends AbstractSpringEngineAutoConfigur
         // Always add the out of the box auto deployment strategies as last
         deploymentStrategies.add(new DefaultAutoDeploymentStrategy(deploymentProperties));
         conf.setDeploymentStrategies(deploymentStrategies);
+
+        FlowableProperties.JodaTimeVariableSupport jodaTimeVariableSupport = flowableProperties.getJodaTimeVariableSupport();
+        if (jodaTimeVariableSupport != null) {
+            conf.setJodaTimeVariableSupport(JodaTimeVariableSupport.valueOf(jodaTimeVariableSupport.name()));
+        }
 
         return conf;
     }

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
@@ -53,6 +53,7 @@ import org.flowable.spring.boot.eventregistry.FlowableEventRegistryProperties;
 import org.flowable.spring.boot.idm.FlowableIdmProperties;
 import org.flowable.spring.job.service.SpringAsyncExecutor;
 import org.flowable.spring.job.service.SpringRejectedJobsHandler;
+import org.flowable.variable.service.impl.JodaTimeVariableSupport;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -238,6 +239,11 @@ public class CmmnEngineAutoConfiguration extends AbstractSpringEngineAutoConfigu
         configuration.setHistoryCleaningTimeCycleConfig(flowableProperties.getHistoryCleaningCycle());
         configuration.setCleanInstancesEndedAfter(flowableProperties.getHistoryCleaningAfter());
         configuration.setCleanInstancesBatchSize(flowableProperties.getHistoryCleaningBatchSize());
+
+        FlowableProperties.JodaTimeVariableSupport jodaTimeVariableSupport = flowableProperties.getJodaTimeVariableSupport();
+        if (jodaTimeVariableSupport != null) {
+            configuration.setJodaTimeVariableSupport(JodaTimeVariableSupport.valueOf(jodaTimeVariableSupport.name()));
+        }
 
         return configuration;
     }

--- a/modules/flowable-variable-service/pom.xml
+++ b/modules/flowable-variable-service/pom.xml
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/JodaTimeVariableSupport.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/JodaTimeVariableSupport.java
@@ -1,0 +1,56 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.variable.service.impl;
+
+import org.flowable.common.engine.api.FlowableIllegalStateException;
+import org.flowable.variable.api.types.VariableTypes;
+import org.flowable.variable.service.impl.types.JodaDateFallbackType;
+import org.flowable.variable.service.impl.types.JodaDateTimeFallbackType;
+import org.flowable.variable.service.impl.types.JodaDateTimeType;
+import org.flowable.variable.service.impl.types.JodaDateType;
+import org.springframework.util.ClassUtils;
+
+/**
+ * @author Filip Hrisafov
+ */
+public enum JodaTimeVariableSupport {
+
+    DISABLE {
+        @Override
+        public void registerJodaTypes(VariableTypes variableTypes) {
+            // Nothing to do
+        }
+    },
+    READ_AS_JAVA_TIME {
+        @Override
+        public void registerJodaTypes(VariableTypes variableTypes) {
+            variableTypes.addType(new JodaDateFallbackType());
+            variableTypes.addType(new JodaDateTimeFallbackType());
+        }
+    },
+    @Deprecated
+    WRITE {
+        @Override
+        public void registerJodaTypes(VariableTypes variableTypes) {
+            if (ClassUtils.isPresent("org.joda.time.DateTime", null)) {
+                variableTypes.addType(new JodaDateType());
+                variableTypes.addType(new JodaDateTimeType());
+            } else {
+                throw new FlowableIllegalStateException("Cannot use write JodaTimeVariable support when joda-time is not present");
+            }
+        }
+    },
+    ;
+
+    public abstract void registerJodaTypes(VariableTypes variableTypes);
+}

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JodaDateFallbackType.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JodaDateFallbackType.java
@@ -1,0 +1,64 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.variable.service.impl.types;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.flowable.common.engine.api.FlowableIllegalStateException;
+import org.flowable.variable.api.types.ValueFields;
+import org.flowable.variable.api.types.VariableType;
+
+/**
+ * @author Tijs Rademakers
+ */
+public class JodaDateFallbackType implements VariableType {
+
+    public static final String TYPE_NAME = "jodadate";
+
+    @Override
+    public String getTypeName() {
+        return TYPE_NAME;
+    }
+
+    @Override
+    public boolean isCachable() {
+        return true;
+    }
+
+    @Override
+    public boolean isAbleToStore(Object value) {
+        return false;
+    }
+
+    @Override
+    public Object getValue(ValueFields valueFields) {
+        Long longValue = valueFields.getLongValue();
+        if (longValue != null) {
+            // This is similar logic to what Joda LocalDate time did.
+            // The stored information is the number of milliseconds since the epoch at the start of the day in the server timezone.
+            return LocalDate.ofInstant(Instant.ofEpochMilli(longValue), ZoneId.systemDefault());
+        }
+        return null;
+    }
+
+    @Override
+    public void setValue(Object value, ValueFields valueFields) {
+        if (value != null) {
+            throw new FlowableIllegalStateException("JodaDateType is not able to store values");
+        } else {
+            valueFields.setLongValue(null);
+        }
+    }
+}

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JodaDateTimeFallbackType.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JodaDateTimeFallbackType.java
@@ -1,0 +1,60 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.variable.service.impl.types;
+
+import java.time.Instant;
+
+import org.flowable.common.engine.api.FlowableIllegalStateException;
+import org.flowable.variable.api.types.ValueFields;
+import org.flowable.variable.api.types.VariableType;
+
+/**
+ * @author Tijs Rademakers
+ */
+public class JodaDateTimeFallbackType implements VariableType {
+
+    public static final String TYPE_NAME = "jodadatetime";
+
+    @Override
+    public String getTypeName() {
+        return TYPE_NAME;
+    }
+
+    @Override
+    public boolean isCachable() {
+        return true;
+    }
+
+    @Override
+    public boolean isAbleToStore(Object value) {
+        return false;
+    }
+
+    @Override
+    public Object getValue(ValueFields valueFields) {
+        Long longValue = valueFields.getLongValue();
+        if (longValue != null) {
+            return Instant.ofEpochMilli(longValue);
+        }
+        return null;
+    }
+
+    @Override
+    public void setValue(Object value, ValueFields valueFields) {
+        if (value != null) {
+            throw new FlowableIllegalStateException("JodaDateTimeFallbackType is not able to store values");
+        } else {
+            valueFields.setLongValue(null);
+        }
+    }
+}

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JodaDateTimeType.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JodaDateTimeType.java
@@ -20,9 +20,10 @@ import org.joda.time.DateTime;
 /**
  * @author Tijs Rademakers
  */
+@Deprecated
 public class JodaDateTimeType implements VariableType {
 
-    public static final String TYPE_NAME = "jodadatetime";
+    public static final String TYPE_NAME = JodaDateTimeFallbackType.TYPE_NAME;
 
     @Override
     public String getTypeName() {

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JodaDateType.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/types/JodaDateType.java
@@ -20,9 +20,10 @@ import org.joda.time.LocalDate;
 /**
  * @author Tijs Rademakers
  */
+@Deprecated
 public class JodaDateType implements VariableType {
 
-    public static final String TYPE_NAME = "jodadate";
+    public static final String TYPE_NAME = JodaDateFallbackType.TYPE_NAME;
 
     @Override
     public String getTypeName() {

--- a/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/util/VariableLoggingSessionUtil.java
+++ b/modules/flowable-variable-service/src/main/java/org/flowable/variable/service/impl/util/VariableLoggingSessionUtil.java
@@ -14,6 +14,9 @@ package org.flowable.variable.service.impl.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
 
@@ -25,17 +28,18 @@ import org.flowable.variable.service.impl.types.BigIntegerType;
 import org.flowable.variable.service.impl.types.BooleanType;
 import org.flowable.variable.service.impl.types.DateType;
 import org.flowable.variable.service.impl.types.DoubleType;
+import org.flowable.variable.service.impl.types.InstantType;
 import org.flowable.variable.service.impl.types.IntegerType;
-import org.flowable.variable.service.impl.types.JodaDateTimeType;
-import org.flowable.variable.service.impl.types.JodaDateType;
+import org.flowable.variable.service.impl.types.JodaDateTimeFallbackType;
+import org.flowable.variable.service.impl.types.JodaDateFallbackType;
 import org.flowable.variable.service.impl.types.JsonType;
+import org.flowable.variable.service.impl.types.LocalDateTimeType;
+import org.flowable.variable.service.impl.types.LocalDateType;
 import org.flowable.variable.service.impl.types.LongType;
 import org.flowable.variable.service.impl.types.NullType;
 import org.flowable.variable.service.impl.types.ShortType;
 import org.flowable.variable.service.impl.types.StringType;
 import org.flowable.variable.service.impl.types.UUIDType;
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -94,10 +98,12 @@ public class VariableLoggingSessionUtil {
             loggingNode.put(variableRawValueName, (Short) variableValue);
         } else if (DateType.TYPE_NAME.equals(variableTypeName)) {
             loggingNode.put(variableRawValueName, LoggingSessionUtil.formatDate((Date) variableValue));
-        } else if (JodaDateTimeType.TYPE_NAME.equals(variableTypeName)) {
-            loggingNode.put(variableRawValueName, LoggingSessionUtil.formatDate((DateTime) variableValue));
-        } else if (JodaDateType.TYPE_NAME.equals(variableTypeName)) {
+        } else if (InstantType.TYPE_NAME.equals(variableTypeName) || JodaDateTimeFallbackType.TYPE_NAME.equals(variableTypeName)) {
+            loggingNode.put(variableRawValueName, LoggingSessionUtil.formatDate((Instant) variableValue));
+        } else if (LocalDateType.TYPE_NAME.equals(variableTypeName) || JodaDateFallbackType.TYPE_NAME.equals(variableTypeName)) {
             loggingNode.put(variableRawValueName, LoggingSessionUtil.formatDate((LocalDate) variableValue));
+        } else if (LocalDateTimeType.TYPE_NAME.equals(variableTypeName)) {
+            loggingNode.put(variableRawValueName, LoggingSessionUtil.formatDate((LocalDateTime) variableValue));
         } else if (BooleanType.TYPE_NAME.equals(variableTypeName)) {
             loggingNode.put(variableRawValueName, (Boolean) variableValue);
         } else if (JsonType.TYPE_NAME.equals(variableTypeName)) {
@@ -114,10 +120,6 @@ public class VariableLoggingSessionUtil {
         
         if (DateType.TYPE_NAME.equals(variableTypeName)) {
             loggingNode.put(variableValueName, LoggingSessionUtil.formatDate((Date) variableValue));
-        } else if (JodaDateTimeType.TYPE_NAME.equals(variableTypeName)) {
-            loggingNode.put(variableValueName, LoggingSessionUtil.formatDate((DateTime) variableValue));
-        } else if (JodaDateType.TYPE_NAME.equals(variableTypeName)) {
-            loggingNode.put(variableValueName, LoggingSessionUtil.formatDate((LocalDate) variableValue));
         } else {
             loggingNode.put(variableValueName, String.valueOf(variableValue));
         }

--- a/modules/flowable5-engine/pom.xml
+++ b/modules/flowable5-engine/pom.xml
@@ -114,10 +114,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerDeclarationImpl.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerDeclarationImpl.java
@@ -14,6 +14,7 @@ package org.activiti.engine.impl.jobexecutor;
 
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
 
 import org.activiti.engine.ActivitiException;
@@ -26,7 +27,6 @@ import org.flowable.common.engine.api.delegate.Expression;
 import org.flowable.common.engine.impl.calendar.BusinessCalendar;
 import org.flowable.engine.impl.jobexecutor.TimerDeclarationType;
 import org.flowable.variable.api.delegate.VariableScope;
-import org.joda.time.DateTime;
 
 /**
  * @author Tom Baeyens
@@ -145,9 +145,8 @@ public class TimerDeclarationImpl implements Serializable {
                 endDateString = (String) endDateValue;
             } else if (endDateValue instanceof Date) {
                 endDate = (Date) endDateValue;
-            } else if (endDateValue instanceof DateTime) {
-                // Joda DateTime support
-                duedate = ((DateTime) endDateValue).toDate();
+            } else if (endDateValue instanceof Instant endDateInstant) {
+                duedate = Date.from(endDateInstant);
             } else {
                 throw new ActivitiException("Timer '" + executionEntity.getActivityId() + "' was not configured with a valid duration/time, either hand in a java.util.Date or a String in format 'yyyy-MM-dd'T'hh:mm:ss'");
             }
@@ -162,9 +161,8 @@ public class TimerDeclarationImpl implements Serializable {
             dueDateString = (String) dueDateValue;
         } else if (dueDateValue instanceof Date) {
             duedate = (Date) dueDateValue;
-        } else if (dueDateValue instanceof DateTime) {
-            // Joda DateTime support
-            duedate = ((DateTime) dueDateValue).toDate();
+        } else if (dueDateValue instanceof Instant dueDateInstant) {
+            duedate = Date.from(dueDateInstant);
         } else if (dueDateValue != null) {
             // dueDateValue==null is OK - but unexpected class type must throw an error.
             throw new ActivitiException("Timer '" + executionEntity.getActivityId() + "' was not configured with a valid duration/time, either hand in a java.util.Date or a String in format 'yyyy-MM-dd'T'hh:mm:ss'");

--- a/modules/flowable5-test/pom.xml
+++ b/modules/flowable5-test/pom.xml
@@ -131,10 +131,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEnd.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventRepeatWithEnd.java
@@ -13,6 +13,7 @@ package org.activiti.engine.test.bpmn.event.timer;
  * limitations under the License.
  */
 
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -21,9 +22,6 @@ import org.activiti.engine.impl.test.PluggableFlowableTestCase;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 /**
  * @author Vasile Dirla
@@ -33,14 +31,11 @@ public class BoundaryTimerEventRepeatWithEnd extends PluggableFlowableTestCase {
     @Deployment
     public void testRepeatWithEnd() throws Throwable {
 
-        Calendar calendar = Calendar.getInstance();
-        Date baseTime = calendar.getTime();
+        OffsetDateTime now = OffsetDateTime.now();
+        Date baseTime = Date.from(now.toInstant());
 
-        calendar.add(Calendar.MINUTE, 20);
         // expect to stop boundary jobs after 20 minutes
-        DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
-        DateTime dt = new DateTime(calendar.getTime());
-        String dateStr = fmt.print(dt);
+        String dateStr = now.plusMinutes(20).toString();
 
         // reset the timer
         Calendar nextTimeCal = Calendar.getInstance();

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/IntermediateTimerEventRepeatWithEndTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/event/timer/IntermediateTimerEventRepeatWithEndTest.java
@@ -13,6 +13,7 @@ package org.activiti.engine.test.bpmn.event.timer;
  * limitations under the License.
  */
 
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -24,9 +25,6 @@ import org.flowable.engine.history.HistoricProcessInstance;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
 import org.flowable.job.api.Job;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 /**
  * @author Vasile Dirla
@@ -36,24 +34,14 @@ public class IntermediateTimerEventRepeatWithEndTest extends PluggableFlowableTe
     @Deployment
     public void testRepeatWithEnd() throws Throwable {
         Clock clock = processEngineConfiguration.getClock();
-        Calendar calendar = Calendar.getInstance();
-        Date baseTime = calendar.getTime();
+        OffsetDateTime now = OffsetDateTime.now();
+        Date baseTime = Date.from(now.toInstant());
 
-        // expect to stop boundary jobs after 20 minutes
-        DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
+        // after 10 minutes the end Date will be reached but the intermediate timers will ignore it
+        // since the end date is validated only when a new timer is going to be created
 
-        calendar.setTime(baseTime);
-        calendar.add(Calendar.HOUR, 2);
-        // expect to wait after competing task B for 1 hour even I set the end date for 2 hours (the expression will trigger the execution)
-        DateTime dt = new DateTime(calendar.getTime());
-        String dateStr1 = fmt.print(dt);
-
-        calendar.setTime(baseTime);
-        calendar.add(Calendar.HOUR, 1);
-        calendar.add(Calendar.MINUTE, 30);
-        // expect to wait after competing task B for 1 hour and 30 minutes (the end date will be reached, the expression will not be considered)
-        dt = new DateTime(calendar.getTime());
-        String dateStr2 = fmt.print(dt);
+        String dateStr1 = now.plusMinutes(10).toString();
+        String dateStr2 = now.plusHours(1).plusMinutes(30).toString();
 
         // reset the timer
         Calendar nextTimeCal = Calendar.getInstance();

--- a/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/flowable5-test/src/test/java/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -13,7 +13,10 @@
 
 package org.activiti.engine.test.bpmn.usertask;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -24,7 +27,6 @@ import org.flowable.common.engine.impl.calendar.BusinessCalendar;
 import org.flowable.common.engine.impl.runtime.Clock;
 import org.flowable.engine.runtime.ProcessInstance;
 import org.flowable.engine.test.Deployment;
-import org.joda.time.Period;
 
 /**
  * @author Frederik Heremans
@@ -80,10 +82,11 @@ public class TaskDueDateExtensionsTest extends ResourceFlowableTestCase {
         org.flowable.task.api.Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
 
         assertNotNull(task.getDueDate());
-        Period period = new Period(task.getCreateTime().getTime(), task.getDueDate().getTime());
-        assertEquals(2, period.getDays());
-        assertEquals(5, period.getHours());
-        assertEquals(40, period.getMinutes());
+        Duration duration = Duration.between(task.getCreateTime().toInstant(), task.getDueDate().toInstant());
+        assertThat(duration)
+                .hasDays(2)
+                .hasHours(5)
+                .hasMinutes(40);
         clock.reset();
     }
 


### PR DESCRIPTION
This PR removes the support for Joda Time.

Joda variables will be read from the database as Java Time

* Joda DateTime -> java.time.instant
* Joda LocalDate -> java.time.LocalDate