### PR TITLE
Reduce creations of a new instance of ObjectMapper and use the one from the engine configuration

### DIFF
--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/el/VariableFunctionDelegatesTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/el/VariableFunctionDelegatesTest.java
@@ -211,7 +211,7 @@ public class VariableFunctionDelegatesTest extends FlowableCmmnTestCase {
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
 
         // ArrayNode
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = cmmnEngine.getCmmnEngineConfiguration().getObjectMapper();
         ArrayNode arrayNode = objectMapper.createArrayNode();
         arrayNode.add(1);
         arrayNode.add(2);
@@ -262,7 +262,7 @@ public class VariableFunctionDelegatesTest extends FlowableCmmnTestCase {
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
 
         // ArrayNode
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = cmmnEngineConfiguration.getObjectMapper();
         caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testIsNotEmptyFunction")
                 .variable("myVar", objectMapper.createArrayNode())
@@ -306,7 +306,7 @@ public class VariableFunctionDelegatesTest extends FlowableCmmnTestCase {
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
 
         // ArrayNode
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = cmmnEngineConfiguration.getObjectMapper();
         caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testContainsFunction")
                 .variable("myVar", objectMapper.createArrayNode())
@@ -373,7 +373,7 @@ public class VariableFunctionDelegatesTest extends FlowableCmmnTestCase {
     @Test
     @CmmnDeployment
     public void testVariableContainsAllArrayNode() {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = cmmnEngineConfiguration.getObjectMapper();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testContainsFunction")
                 .variable("myVar", objectMapper.createArrayNode())
@@ -423,7 +423,7 @@ public class VariableFunctionDelegatesTest extends FlowableCmmnTestCase {
         assertThat(cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).count()).isEqualTo(2);
 
         // ArrayNode
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = cmmnEngineConfiguration.getObjectMapper();
         caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testContainsAnyFunction")
                 .variable("myVar", objectMapper.createArrayNode())
@@ -476,7 +476,7 @@ public class VariableFunctionDelegatesTest extends FlowableCmmnTestCase {
     @Test
     @CmmnDeployment
     public void testVariableContainsAnyArrayNode() {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = cmmnEngineConfiguration.getObjectMapper();
         CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
                 .caseDefinitionKey("testContainsAnyFunction")
                 .variable("myVar", objectMapper.createArrayNode())

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/AbstractCmmnEventRegistryConsumerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/AbstractCmmnEventRegistryConsumerTest.java
@@ -41,7 +41,7 @@ public abstract class AbstractCmmnEventRegistryConsumerTest extends FlowableEven
 
     @BeforeEach
     public void registerEventDefinition() {
-        inboundEventChannelAdapter = setupTestChannel();
+        inboundEventChannelAdapter = setupTestChannel(cmmnEngineConfiguration.getObjectMapper());
 
         getEventRepositoryService().createEventModelBuilder()
                 .key("myEvent")
@@ -53,8 +53,8 @@ public abstract class AbstractCmmnEventRegistryConsumerTest extends FlowableEven
                 .deploy();
     }
 
-    protected TestInboundEventChannelAdapter setupTestChannel() {
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+    protected TestInboundEventChannelAdapter setupTestChannel(ObjectMapper objectMapper) {
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(objectMapper);
         Map<Object, Object> beans = getEventRegistryEngineConfiguration().getExpressionManager().getBeans();
         beans.put("inboundEventChannelAdapter", inboundEventChannelAdapter);
 
@@ -83,7 +83,11 @@ public abstract class AbstractCmmnEventRegistryConsumerTest extends FlowableEven
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
-        protected ObjectMapper objectMapper = new ObjectMapper();
+        protected final ObjectMapper objectMapper;
+
+        protected TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/CmmnEventRegistryConsumerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/CmmnEventRegistryConsumerTest.java
@@ -38,8 +38,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class CmmnEventRegistryConsumerTest extends AbstractCmmnEventRegistryConsumerTest {
 
-    protected ObjectMapper objectMapper = new ObjectMapper();
-
     @Test
     @CmmnDeployment
     public void testGenericEventListenerNoCorrelation() {
@@ -583,6 +581,7 @@ public class CmmnEventRegistryConsumerTest extends AbstractCmmnEventRegistryCons
                 .caseDefinitionKey("testEventListenerInRepeatableStage")
                 .start();
 
+        ObjectMapper objectMapper = cmmnEngineConfiguration.getObjectMapper();
         ObjectNode eventJson = objectMapper.createObjectNode();
         eventJson.put("type", "startEvent");
         eventJson.put("eventField1", "abc");
@@ -634,6 +633,8 @@ public class CmmnEventRegistryConsumerTest extends AbstractCmmnEventRegistryCons
                 .caseDefinitionKey("testEventListenerInRepeatableStage")
                 .start()
                 .getId();
+
+        ObjectMapper objectMapper = cmmnEngineConfiguration.getObjectMapper();
 
         inboundEventChannelAdapter.triggerTestEventWithJson(objectMapper.createObjectNode().put("type", "startEvent").put("eventField1", "a"));
         inboundEventChannelAdapter.triggerTestEventWithJson(objectMapper.createObjectNode().put("type", "startEvent").put("eventField1", "b"));

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/CmmnHeaderEventRegistryConsumerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/CmmnHeaderEventRegistryConsumerTest.java
@@ -48,7 +48,7 @@ public class CmmnHeaderEventRegistryConsumerTest extends FlowableEventRegistryCm
 
     @BeforeEach
     public void registerEventDefinition() {
-        inboundEventChannelAdapter = setupTestChannel();
+        inboundEventChannelAdapter = setupTestChannel(cmmnEngineConfiguration.getObjectMapper());
 
         getEventRepositoryService().createEventModelBuilder()
                 .key("myEvent")
@@ -62,8 +62,8 @@ public class CmmnHeaderEventRegistryConsumerTest extends FlowableEventRegistryCm
                 .deploy();
     }
 
-    protected TestInboundEventChannelAdapter setupTestChannel() {
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+    protected TestInboundEventChannelAdapter setupTestChannel(ObjectMapper objectMapper) {
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(objectMapper);
         Map<Object, Object> beans = getEventRegistryEngineConfiguration().getExpressionManager().getBeans();
         beans.put("inboundEventChannelAdapter", inboundEventChannelAdapter);
 
@@ -112,7 +112,11 @@ public class CmmnHeaderEventRegistryConsumerTest extends FlowableEventRegistryCm
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
-        protected ObjectMapper objectMapper = new ObjectMapper();
+        protected final ObjectMapper objectMapper;
+
+        private TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/MultiTenantCmmnEventRegistryConsumerTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/eventregistry/MultiTenantCmmnEventRegistryConsumerTest.java
@@ -71,10 +71,11 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
     public void setup() {
         getEventRegistryEngineConfiguration().setFallbackToDefaultTenant(true);
         Map<Object, Object> beans = getEventRegistryEngineConfiguration().getExpressionManager().getBeans();
-        beans.put("inboundChannelAdapter", new TestInboundChannelAdapter());
-        beans.put("sharedInboundChannelAdapter", new TestInboundChannelAdapter());
-        beans.put("tenantAChannelAdapter", new TestInboundChannelAdapter());
-        beans.put("tenantBChannelAdapter", new TestInboundChannelAdapter());
+        ObjectMapper objectMapper = cmmnEngineConfiguration.getObjectMapper();
+        beans.put("inboundChannelAdapter", new TestInboundChannelAdapter(objectMapper));
+        beans.put("sharedInboundChannelAdapter", new TestInboundChannelAdapter(objectMapper));
+        beans.put("tenantAChannelAdapter", new TestInboundChannelAdapter(objectMapper));
+        beans.put("tenantBChannelAdapter", new TestInboundChannelAdapter(objectMapper));
 
         // Shared channel and event in default tenant
         getEventRepositoryService().createInboundChannelModelBuilder()
@@ -394,6 +395,11 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
+        protected final ObjectMapper objectMapper;
+
+        private TestInboundChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {
@@ -406,8 +412,6 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         }
 
         public void triggerEventWithoutTenantId(String customerId) {
-            ObjectMapper objectMapper = new ObjectMapper();
-
             ObjectNode json = objectMapper.createObjectNode();
             json.put("type", "tenantAKey");
             if (customerId != null) {
@@ -424,8 +428,6 @@ public class MultiTenantCmmnEventRegistryConsumerTest extends FlowableEventRegis
         }
 
         public void triggerEventForTenantId(String customerId, String tenantId) {
-            ObjectMapper objectMapper = new ObjectMapper();
-
             ObjectNode json = objectMapper.createObjectNode();
             json.put("type", "tenantAKey");
             if (customerId != null) {

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.java
@@ -37,8 +37,7 @@ public class DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest extends Flowa
     @Test
     @CmmnDeployment
     public void testDynamicNameWithRepetitionCollection() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        ArrayNode arrayNode = objectMapper.createArrayNode();
+        ArrayNode arrayNode = cmmnEngineConfiguration.getObjectMapper().createArrayNode();
 
         arrayNode.addObject().put("name", "A").put("foo", "a");
         arrayNode.addObject().put("name", "B").put("foo", "b");
@@ -60,8 +59,7 @@ public class DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest extends Flowa
     @Test
     @CmmnDeployment
     public void testDynamicNameWithRepetitionCollectionNoFallbackExpression() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        ArrayNode arrayNode = objectMapper.createArrayNode();
+        ArrayNode arrayNode = cmmnEngineConfiguration.getObjectMapper().createArrayNode();
 
         arrayNode.addObject().put("name", "A").put("bar", "a");
         arrayNode.addObject().put("name", "B").put("bar", "b");
@@ -83,8 +81,7 @@ public class DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest extends Flowa
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/itemcontrol/DynamicPlanItemNameWithRepetitionBasedOnJsonArrayTest.testDynamicNameWithRepetitionCollectionNoFallbackExpression.cmmn")
     public void testDynamicNameWithRepetitionCollectionNoFallbackExpressionWithAvailablePlanItem() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        ArrayNode arrayNode = objectMapper.createArrayNode();
+        ArrayNode arrayNode = cmmnEngineConfiguration.getObjectMapper().createArrayNode();
 
         arrayNode.addObject().put("name", "A").put("bar", "a");
         arrayNode.addObject().put("name", "B").put("bar", "b");

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnMailTaskTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/task/CmmnMailTaskTest.java
@@ -187,7 +187,7 @@ public class CmmnMailTaskTest extends FlowableCmmnTestCase {
     @Test
     @CmmnDeployment(resources = "org/flowable/cmmn/test/task/CmmnMailTaskTest.testTextMailExpressions.cmmn")
     public void testDynamicRecipientsArrayNode() throws MessagingException {
-        ArrayNode recipients = new ObjectMapper().createArrayNode().add("flowable@localhost").add("misspiggy@flowable.org");
+        ArrayNode recipients = cmmnEngineConfiguration.getObjectMapper().createArrayNode().add("flowable@localhost").add("misspiggy@flowable.org");
         testDynamicRecipientsInternal(recipients);
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/AbstractFlowableTestCase.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/test/AbstractFlowableTestCase.java
@@ -63,7 +63,6 @@ import org.flowable.task.api.history.HistoricTaskInstance;
 import org.junit.jupiter.api.BeforeEach;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Tom Baeyens
@@ -488,9 +487,9 @@ public abstract class AbstractFlowableTestCase extends AbstractTestCase {
     }
 
     protected String getJobActivityId(Job job) {
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
-            Map<String, Object> jobConfigurationMap = objectMapper.readValue(job.getJobHandlerConfiguration(), new TypeReference<>() {
+            Map<String, Object> jobConfigurationMap = processEngineConfiguration.getObjectMapper()
+                    .readValue(job.getJobHandlerConfiguration(), new TypeReference<>() {
 
             });
             return (String) jobConfigurationMap.get("activityId");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/runtime/migration/AbstractProcessInstanceMigrationEventRegistryConsumerTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractProcessInstanceMigrationEventRegistryConsumerTest 
     }
 
     protected TestInboundEventChannelAdapter setupTestChannel() {
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(processEngineConfiguration.getObjectMapper());
         Map<Object, Object> beans = getEventRegistryEngineConfiguration().getExpressionManager().getBeans();
         beans.put("inboundEventChannelAdapter", inboundEventChannelAdapter);
 
@@ -88,7 +88,11 @@ public abstract class AbstractProcessInstanceMigrationEventRegistryConsumerTest 
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
-        protected ObjectMapper objectMapper = new ObjectMapper();
+        protected final ObjectMapper objectMapper;
+
+        protected TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/ParallelMultiInstanceAsyncTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/bpmn/multiinstance/ParallelMultiInstanceAsyncTest.java
@@ -33,8 +33,7 @@ public class ParallelMultiInstanceAsyncTest extends PluggableFlowableTestCase {
                 .deploy();
 
         Map<String, Object> variables = new HashMap<>();
-        ObjectMapper objectMapper = new ObjectMapper();
-        ArrayNode arrayNode = objectMapper.createArrayNode();
+        ArrayNode arrayNode = processEngineConfiguration.getObjectMapper().createArrayNode();
         for (int i = 0; i < 10; i++) {
             ObjectNode varNode = arrayNode.addObject();
             varNode.put("value", i + "");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/JsonVariableContainerExpressionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/el/JsonVariableContainerExpressionTest.java
@@ -31,8 +31,7 @@ public class JsonVariableContainerExpressionTest extends PluggableFlowableTestCa
     @Test
     public void setNestedJsonVariableValueWithVariableContainerWrapper() {
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        ObjectNode objectNode = objectMapper.createObjectNode();
+        ObjectNode objectNode = processEngineConfiguration.getObjectMapper().createObjectNode();
 
         Map<String, Object> variables = new HashMap<>();
         variables.put("muppetshow", objectNode);
@@ -50,8 +49,7 @@ public class JsonVariableContainerExpressionTest extends PluggableFlowableTestCa
     @Test
     public void setNestedJsonVariableValueWithMapDelegateVariableContainer() {
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        ObjectNode objectNode = objectMapper.createObjectNode();
+        ObjectNode objectNode = processEngineConfiguration.getObjectMapper().createObjectNode();
         MapDelegateVariableContainer simpleVariableContainer = new MapDelegateVariableContainer().addTransientVariable("muppetshow", objectNode);
         assertThatJson(executeSetValueExpression("${muppetshow.characters.frog.name}", "Kermit", simpleVariableContainer)
                 .getVariable("muppetshow"))

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/AbstractBpmnEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/AbstractBpmnEventRegistryConsumerTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractBpmnEventRegistryConsumerTest extends FlowableEven
     }
     
     protected TestInboundEventChannelAdapter setupTestChannel() {
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(processEngineConfiguration.getObjectMapper());
         Map<Object, Object> beans = getEventRegistryEngineConfiguration().getExpressionManager().getBeans();
         beans.put("inboundEventChannelAdapter", inboundEventChannelAdapter);
 
@@ -82,7 +82,11 @@ public abstract class AbstractBpmnEventRegistryConsumerTest extends FlowableEven
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
-        protected ObjectMapper objectMapper = new ObjectMapper();
+        protected final ObjectMapper objectMapper;
+
+        protected TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/BpmnHeaderEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/BpmnHeaderEventRegistryConsumerTest.java
@@ -61,7 +61,7 @@ public class BpmnHeaderEventRegistryConsumerTest extends FlowableEventRegistryBp
     }
     
     protected TestInboundEventChannelAdapter setupTestChannel() {
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(processEngineConfiguration.getObjectMapper());
         Map<Object, Object> beans = getEventRegistryEngineConfiguration().getExpressionManager().getBeans();
         beans.put("inboundEventChannelAdapter", inboundEventChannelAdapter);
 
@@ -116,7 +116,11 @@ public class BpmnHeaderEventRegistryConsumerTest extends FlowableEventRegistryBp
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
-        protected ObjectMapper objectMapper = new ObjectMapper();
+        protected final ObjectMapper objectMapper;
+
+        private TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventPayloadTypesConversionTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventPayloadTypesConversionTest.java
@@ -71,7 +71,7 @@ public class EventPayloadTypesConversionTest extends FlowableEventRegistryBpmnTe
     }
 
     protected TestInboundEventChannelAdapter setupTestInboundChannel() {
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(processEngineConfiguration.getObjectMapper());
         getEventRegistryEngineConfiguration().getExpressionManager().getBeans()
             .put("inboundEventChannelAdapter", inboundEventChannelAdapter);
 
@@ -287,6 +287,11 @@ public class EventPayloadTypesConversionTest extends FlowableEventRegistryBpmnTe
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
+        protected final ObjectMapper objectMapper;
+
+        private TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {
@@ -299,7 +304,6 @@ public class EventPayloadTypesConversionTest extends FlowableEventRegistryBpmnTe
         }
 
         public void testTriggerEvent() {
-            ObjectMapper objectMapper = new ObjectMapper();
 
             ObjectNode json = objectMapper.createObjectNode();
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryEventSubprocessTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/EventRegistryEventSubprocessTest.java
@@ -68,7 +68,7 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
     }
     
     protected TestInboundEventChannelAdapter setupTestChannel() {
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(processEngineConfiguration.getObjectMapper());
         getEventRegistryEngineConfiguration().getExpressionManager().getBeans()
             .put("inboundEventChannelAdapter", inboundEventChannelAdapter);
         
@@ -395,6 +395,11 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
+        protected final ObjectMapper objectMapper;
+
+        private TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {
@@ -411,8 +416,6 @@ public class EventRegistryEventSubprocessTest extends FlowableEventRegistryBpmnT
         }
 
         public void triggerTestEvent(String customerId, String orderId) {
-            ObjectMapper objectMapper = new ObjectMapper();
-
             ObjectNode json = objectMapper.createObjectNode();
             json.put("type", "myEvent");
             if (customerId != null) {

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/MultiTenantBpmnEventRegistryConsumerTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/MultiTenantBpmnEventRegistryConsumerTest.java
@@ -80,10 +80,11 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         getEventRegistryEngineConfiguration().setFallbackToDefaultTenant(true);
 
         Map<Object, Object> beans = getEventRegistryEngineConfiguration().getExpressionManager().getBeans();
-        beans.put("testInboundChannelAdapter", new TestInboundChannelAdapter());
-        beans.put("testInboundChannelAdapter2", new TestInboundChannelAdapter());
-        beans.put("testInboundChannelAdapter3", new TestInboundChannelAdapter());
-        beans.put("testInboundChannelAdapter4", new TestInboundChannelAdapter());
+        ObjectMapper objectMapper = processEngineConfiguration.getObjectMapper();
+        beans.put("testInboundChannelAdapter", new TestInboundChannelAdapter(objectMapper));
+        beans.put("testInboundChannelAdapter2", new TestInboundChannelAdapter(objectMapper));
+        beans.put("testInboundChannelAdapter3", new TestInboundChannelAdapter(objectMapper));
+        beans.put("testInboundChannelAdapter4", new TestInboundChannelAdapter(objectMapper));
         
         // Shared channel and event in default tenant
         getEventRepositoryService().createInboundChannelModelBuilder()
@@ -414,6 +415,11 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
 
         protected InboundChannelModel inboundChannelModel;
         protected EventRegistry eventRegistry;
+        protected final ObjectMapper objectMapper;
+
+        private TestInboundChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {
@@ -426,7 +432,6 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         }
 
         public void triggerEventWithoutTenantId(String customerId) {
-            ObjectMapper objectMapper = new ObjectMapper();
 
             ObjectNode json = objectMapper.createObjectNode();
             json.put("type", "tenantAKey");
@@ -444,7 +449,6 @@ public class MultiTenantBpmnEventRegistryConsumerTest extends FlowableEventRegis
         }
 
         public void triggerEventForTenantId(String customerId, String tenantId) {
-            ObjectMapper objectMapper = new ObjectMapper();
 
             ObjectNode json = objectMapper.createObjectNode();
             json.put("type", "tenantAKey");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/MultiTenantSendEventTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/MultiTenantSendEventTaskTest.java
@@ -240,7 +240,7 @@ public class MultiTenantSendEventTaskTest extends FlowableEventRegistryBpmnTestC
 
         // Triggering
         InboundChannelModel inboundChannel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("test-channel");
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = processEngineConfiguration.getObjectMapper();
 
         ObjectNode json = objectMapper.createObjectNode();
         json.put("type", "myTriggerEvent");

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendEventTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendEventTaskTest.java
@@ -384,7 +384,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
                         + "   eventProperty: 'test'"
                         + " }");
 
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = processEngineConfiguration.getObjectMapper();
 
         InboundChannelModel inboundChannel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("test-channel");
         ObjectNode json = objectMapper.createObjectNode();
@@ -414,7 +414,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
         assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
 
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = processEngineConfiguration.getObjectMapper();
 
         InboundChannelModel inboundChannel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("test-channel");
         ObjectNode json = objectMapper.createObjectNode();
@@ -454,7 +454,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
         assertThat(jsonNode).hasSize(1);
         assertThat(jsonNode.get("eventProperty").asText()).isEqualTo("test");
 
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = processEngineConfiguration.getObjectMapper();
 
         InboundChannelModel inboundChannel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("test-channel");
         ObjectNode json = objectMapper.createObjectNode();
@@ -509,7 +509,7 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
                         + "   eventProperty: 'test'"
                         + " }");
 
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = processEngineConfiguration.getObjectMapper();
 
         InboundChannelModel inboundChannel = (InboundChannelModel) getEventRepositoryService().getChannelModelByKey("test-channel");
         ObjectNode json = objectMapper.createObjectNode();

--- a/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithEventRegistryTest.java
+++ b/modules/flowable-event-registry-integration-test/src/test/java/org/flowable/eventregistry/integrationtest/ProcessWithEventRegistryTest.java
@@ -639,8 +639,7 @@ public class ProcessWithEventRegistryTest {
             "org/flowable/eventregistry/integrationtest/issueEvent.event"})
     public void testMultiInstanceSendSystemEvent() {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            ArrayNode issueArray = objectMapper.createArrayNode();
+            ArrayNode issueArray = eventEngineConfiguration.getObjectMapper().createArrayNode();
             addIssue(issueArray, "1", "bug");
             addIssue(issueArray, "2", "task");
             addIssue(issueArray, "3", "question");

--- a/modules/flowable-event-registry-json-converter/src/main/java/org/flowable/eventregistry/json/converter/ChannelJsonConverter.java
+++ b/modules/flowable-event-registry-json-converter/src/main/java/org/flowable/eventregistry/json/converter/ChannelJsonConverter.java
@@ -40,18 +40,28 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class ChannelJsonConverter {
 
-    protected ObjectMapper objectMapper = new ObjectMapper();
+    protected ObjectMapper objectMapper;
 
     protected List<ChannelValidator> validators = new ArrayList<>();
     protected Map<String, Class<? extends ChannelModel>> channelModelClasses = new HashMap<>();
 
     public ChannelJsonConverter() {
+        this(new ObjectMapper());
+    }
+
+    public ChannelJsonConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
         addValidator(new OutboundChannelModelValidator());
         addValidator(new InboundChannelModelValidator());
         addDefaultChannelModelClasses();
     }
 
     public ChannelJsonConverter(Collection<ChannelValidator> validators) {
+        this(validators, new ObjectMapper());
+    }
+
+    public ChannelJsonConverter(Collection<ChannelValidator> validators, ObjectMapper objectMapper) {
+        this(objectMapper);
         this.validators = new ArrayList<>(validators);
         addDefaultChannelModelClasses();
     }

--- a/modules/flowable-event-registry-json-converter/src/main/java/org/flowable/eventregistry/json/converter/EventJsonConverter.java
+++ b/modules/flowable-event-registry-json-converter/src/main/java/org/flowable/eventregistry/json/converter/EventJsonConverter.java
@@ -28,7 +28,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class EventJsonConverter {
 
-    protected ObjectMapper objectMapper = new ObjectMapper();
+    protected ObjectMapper objectMapper;
+
+    public EventJsonConverter() {
+        this(new ObjectMapper());
+    }
+
+    public EventJsonConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     public EventModel convertToEventModel(String modelJson) {
         try {

--- a/modules/flowable-event-registry-json-converter/src/test/java/org/flowable/eventregistry/converter/EventJsonConverterTest.java
+++ b/modules/flowable-event-registry-json-converter/src/test/java/org/flowable/eventregistry/converter/EventJsonConverterTest.java
@@ -36,7 +36,7 @@ public class EventJsonConverterTest {
     private static final String JSON_RESOURCE_1 = "org/flowable/eventregistry/converter/simpleEvent.json";
     private static final String JSON_RESOURCE_2 = "org/flowable/eventregistry/converter/simpleEventCorrelationPayload.json";
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    protected EventJsonConverter converter = new EventJsonConverter();
 
     @Test
     public void testConvertJsonToModel() {
@@ -94,12 +94,12 @@ public class EventJsonConverterTest {
 
     protected EventModel readJson(String resource) {
         String modelJson = readJsonToString(resource);
-        return new EventJsonConverter().convertToEventModel(modelJson);
+        return converter.convertToEventModel(modelJson);
     }
 
     protected EventModel exportAndReadModel(EventModel eventModel) {
-        String modelJson = new EventJsonConverter().convertToJson(eventModel);
-        return new EventJsonConverter().convertToEventModel(modelJson);
+        String modelJson = converter.convertToJson(eventModel);
+        return converter.convertToEventModel(modelJson);
     }
 
 }

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/TestInboundEventChannelAdapter.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/TestInboundEventChannelAdapter.java
@@ -26,6 +26,11 @@ public class TestInboundEventChannelAdapter implements InboundEventChannelAdapte
 
     public InboundChannelModel inboundChannelModel;
     public EventRegistry eventRegistry;
+    protected final ObjectMapper objectMapper;
+
+    public TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {
@@ -50,7 +55,6 @@ public class TestInboundEventChannelAdapter implements InboundEventChannelAdapte
     }
 
     public void triggerTestEvent(String customerId, String orderId) {
-        ObjectMapper objectMapper = new ObjectMapper();
 
         ObjectNode json = objectMapper.createObjectNode();
         json.put("type", "myEvent");

--- a/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/conf/engine/EngineConfiguration.java
+++ b/modules/flowable-event-registry-rest/src/test/java/org/flowable/eventregistry/rest/conf/engine/EngineConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration(proxyBeanMethods = false)
@@ -175,8 +176,8 @@ public class EngineConfiguration {
     }
     
     @Bean(name = "testInboundEventChannelAdapter")
-    public TestInboundEventChannelAdapter testInboundEventChannelAdapter() {
-        return new TestInboundEventChannelAdapter();
+    public TestInboundEventChannelAdapter testInboundEventChannelAdapter(ObjectMapper objectMapper) {
+        return new TestInboundEventChannelAdapter(objectMapper);
     }
     
     protected EventRegistryEngineConfiguration getEventRegistryEngineConfiguration(ProcessEngine processEngine) {

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/EventRegistryEngineConfiguration.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/EventRegistryEngineConfiguration.java
@@ -124,8 +124,8 @@ public class EventRegistryEngineConfiguration extends AbstractBuildableEngineCon
     protected Collection<ELResolver> preBeanELResolvers;
     protected Collection<ELResolver> postDefaultELResolvers;
 
-    protected EventJsonConverter eventJsonConverter = new EventJsonConverter();
-    protected ChannelJsonConverter channelJsonConverter = new ChannelJsonConverter();
+    protected EventJsonConverter eventJsonConverter;
+    protected ChannelJsonConverter channelJsonConverter;
 
     // DEPLOYERS
     // ////////////////////////////////////////////////////////////////
@@ -251,6 +251,7 @@ public class EventRegistryEngineConfiguration extends AbstractBuildableEngineCon
         configuratorsAfterInit();
         initDataManagers();
         initEntityManagers();
+        initJsonConverters();
         initEventRegistry();
         initInboundEventProcessor();
         initOutboundEventProcessor();
@@ -499,6 +500,15 @@ public class EventRegistryEngineConfiguration extends AbstractBuildableEngineCon
     public void initInboundChannelModelCacheManager() {
         if (inboundChannelModelCacheManager == null) {
             inboundChannelModelCacheManager = new DefaultInboundChannelModelCacheManager(this);
+        }
+    }
+
+    protected void initJsonConverters() {
+        if (eventJsonConverter == null) {
+            eventJsonConverter = new EventJsonConverter(objectMapper);
+        }
+        if (channelJsonConverter == null) {
+            channelJsonConverter = new ChannelJsonConverter(objectMapper);
         }
     }
     

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/pipeline/InboundChannelModelProcessor.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/pipeline/InboundChannelModelProcessor.java
@@ -83,13 +83,12 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
             boolean fallbackToDefaultTenant) {
         
         if (channelModel instanceof InboundChannelModel) {
-            registerChannelModel((InboundChannelModel) channelModel, eventRepositoryService,
-                    objectMapper, fallbackToDefaultTenant);
+            registerChannelModel((InboundChannelModel) channelModel, eventRepositoryService, fallbackToDefaultTenant);
         }
     }
 
-    protected void registerChannelModel(InboundChannelModel inboundChannelModel, EventRepositoryService eventRepositoryService, 
-            ObjectMapper objectMapper, boolean fallbackToDefaultTenant) {
+    protected void registerChannelModel(InboundChannelModel inboundChannelModel, EventRepositoryService eventRepositoryService,
+            boolean fallbackToDefaultTenant) {
         
         if (inboundChannelModel.getInboundEventProcessingPipeline() == null) {
 
@@ -98,13 +97,13 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
             if (StringUtils.isNotEmpty(inboundChannelModel.getPipelineDelegateExpression())) {
                 eventProcessingPipeline = resolveExpression(inboundChannelModel.getPipelineDelegateExpression(), InboundEventProcessingPipeline.class);
             } else if ("json".equals(inboundChannelModel.getDeserializerType())) {
-                eventProcessingPipeline = createJsonEventProcessingPipeline(inboundChannelModel, eventRepositoryService, objectMapper);
+                eventProcessingPipeline = createJsonEventProcessingPipeline(inboundChannelModel, eventRepositoryService);
 
             } else if ("xml".equals(inboundChannelModel.getDeserializerType())) {
                 eventProcessingPipeline = createXmlEventProcessingPipeline(inboundChannelModel, eventRepositoryService);
 
             } else if ("expression".equals(inboundChannelModel.getDeserializerType())) {
-                eventProcessingPipeline = createExpressionEventProcessingPipeline(inboundChannelModel, eventRepositoryService, objectMapper);
+                eventProcessingPipeline = createExpressionEventProcessingPipeline(inboundChannelModel, eventRepositoryService);
 
             } else {
                 eventProcessingPipeline = null;
@@ -117,13 +116,12 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
         }
     }
 
-    protected InboundEventProcessingPipeline createJsonEventProcessingPipeline(InboundChannelModel channelModel, 
-            EventRepositoryService eventRepositoryService,
-            ObjectMapper objectMapper) {
+    protected InboundEventProcessingPipeline createJsonEventProcessingPipeline(InboundChannelModel channelModel,
+            EventRepositoryService eventRepositoryService) {
         
         InboundEventDeserializer<JsonNode> eventDeserializer;
         if (StringUtils.isEmpty(channelModel.getDeserializerDelegateExpression())) {
-            eventDeserializer = new StringToJsonDeserializer();
+            eventDeserializer = new StringToJsonDeserializer(objectMapper);
         } else {
             //noinspection unchecked
             eventDeserializer = resolveExpression(channelModel.getDeserializerDelegateExpression(), InboundEventDeserializer.class);
@@ -286,7 +284,7 @@ public class InboundChannelModelProcessor implements ChannelModelProcessor {
     }
 
     protected InboundEventProcessingPipeline createExpressionEventProcessingPipeline(InboundChannelModel channelModel,
-            EventRepositoryService eventRepositoryService, ObjectMapper objectMapper) {
+            EventRepositoryService eventRepositoryService) {
         
         InboundEventDeserializer<?> eventDeserializer;
         if (StringUtils.isNotEmpty(channelModel.getDeserializerDelegateExpression())) {

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/pipeline/OutboundChannelModelProcessor.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/pipeline/OutboundChannelModelProcessor.java
@@ -70,7 +70,7 @@ public class OutboundChannelModelProcessor implements ChannelModelProcessor {
                 eventProcessingPipeline = resolveExpression(outboundChannelModel.getPipelineDelegateExpression(), OutboundEventProcessingPipeline.class);
                 
             } else if ("json".equals(outboundChannelModel.getSerializerType())) {
-                OutboundEventSerializer eventSerializer = new EventPayloadToJsonStringSerializer();
+                OutboundEventSerializer eventSerializer = new EventPayloadToJsonStringSerializer(objectMapper);
                 eventProcessingPipeline = new DefaultOutboundEventProcessingPipeline(eventSerializer);
                 
             } else if ("xml".equals(outboundChannelModel.getSerializerType())) {

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/serialization/EventPayloadToJsonStringSerializer.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/serialization/EventPayloadToJsonStringSerializer.java
@@ -35,7 +35,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class EventPayloadToJsonStringSerializer implements OutboundEventSerializer {
 
-    protected ObjectMapper objectMapper = new ObjectMapper();
+    protected final ObjectMapper objectMapper;
+
+    public EventPayloadToJsonStringSerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public String serialize(EventInstance eventInstance) {

--- a/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/serialization/StringToJsonDeserializer.java
+++ b/modules/flowable-event-registry/src/main/java/org/flowable/eventregistry/impl/serialization/StringToJsonDeserializer.java
@@ -26,7 +26,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class StringToJsonDeserializer implements InboundEventDeserializer<JsonNode> {
 
-    protected ObjectMapper objectMapper = new ObjectMapper();
+    protected final ObjectMapper objectMapper;
+
+    public StringToJsonDeserializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public JsonNode deserialize(Object rawEvent) {

--- a/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/DefaultEventRegistryTest.java
+++ b/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/DefaultEventRegistryTest.java
@@ -316,7 +316,7 @@ public class DefaultEventRegistryTest extends AbstractFlowableEventTest {
     }
 
     protected TestInboundEventChannelAdapter setupTestChannel() {
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(eventEngineConfiguration.getObjectMapper());
         eventEngineConfiguration.getExpressionManager().getBeans()
                 .put("inboundEventChannelAdapter", inboundEventChannelAdapter);
 
@@ -344,7 +344,7 @@ public class DefaultEventRegistryTest extends AbstractFlowableEventTest {
                 .jsonFieldsMapDirectlyToPayload()
                 .deploy();
 
-        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter();
+        TestInboundEventChannelAdapter inboundEventChannelAdapter = new TestInboundEventChannelAdapter(eventEngineConfiguration.getObjectMapper());
         InboundChannelModel inboundChannelModel = (InboundChannelModel) eventEngineConfiguration.getEventRepositoryService()
                 .getChannelModelByKey("test-channel");
         DefaultInboundEventProcessingPipeline<Customer> inboundEventProcessingPipeline = (DefaultInboundEventProcessingPipeline<Customer>) inboundChannelModel
@@ -354,7 +354,7 @@ public class DefaultEventRegistryTest extends AbstractFlowableEventTest {
             @Override
             public Customer deserialize(Object rawEvent) {
                 try {
-                    return new ObjectMapper().readValue(rawEvent.toString(), Customer.class);
+                    return eventEngineConfiguration.getObjectMapper().readValue(rawEvent.toString(), Customer.class);
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
@@ -422,6 +422,11 @@ public class DefaultEventRegistryTest extends AbstractFlowableEventTest {
 
         public InboundChannelModel inboundChannelModel;
         public EventRegistry eventRegistry;
+        protected final ObjectMapper objectMapper;
+
+        private TestInboundEventChannelAdapter(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {
@@ -434,8 +439,6 @@ public class DefaultEventRegistryTest extends AbstractFlowableEventTest {
         }
 
         public void triggerTestEvent() {
-            ObjectMapper objectMapper = new ObjectMapper();
-
             ObjectNode json = objectMapper.createObjectNode();
             json.put("type", "myEvent");
             json.put("customerId", "test");

--- a/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/deployment/DeploymentTest.java
+++ b/modules/flowable-event-registry/src/test/java/org/flowable/eventregistry/test/deployment/DeploymentTest.java
@@ -780,11 +780,10 @@ public class DeploymentTest extends AbstractFlowableEventTest {
 
         @Override
         protected void registerChannelModel(InboundChannelModel inboundChannelModel,
-                EventRepositoryService eventRepositoryService,
-                ObjectMapper objectMapper, boolean fallbackToDefaultTenant) {
+                EventRepositoryService eventRepositoryService, boolean fallbackToDefaultTenant) {
 
             registeredChannelModels.add(inboundChannelModel);
-            super.registerChannelModel(inboundChannelModel, eventRepositoryService, objectMapper, fallbackToDefaultTenant);
+            super.registerChannelModel(inboundChannelModel, eventRepositoryService, fallbackToDefaultTenant);
         }
 
         @Override

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTest.java
@@ -59,8 +59,6 @@ import net.javacrumbs.jsonunit.core.Option;
  */
 public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
 
-    private ObjectMapper mapper = new ObjectMapper();
-
     @Test
     @Deployment
     public void testSimpleGetOnly() {
@@ -390,6 +388,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         // Response body assertions
         String body = (String) runtimeService.getVariable(process.getId(), "resultResponseBody");
         assertThat(body).isNotNull();
+        ObjectMapper mapper = processEngineConfiguration.getObjectMapper();
         JsonNode jsonNode = mapper.readValue(body, JsonNode.class);
         mapper.convertValue(jsonNode, HttpTestData.class);
         continueProcess(process);
@@ -504,6 +503,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         // Response body assertions
         String responseBody = (String) runtimeService.getVariable(process.getId(), "httpPostResponseBody");
         assertThat(responseBody).isNotNull();
+        ObjectMapper mapper = processEngineConfiguration.getObjectMapper();
         JsonNode jsonNode = mapper.readValue(responseBody, JsonNode.class);
         HttpTestData testData = mapper.convertValue(jsonNode, HttpTestData.class);
         assertThat(testData.getBody()).isEqualTo(body);
@@ -624,6 +624,7 @@ public class HttpServiceTaskTest extends HttpServiceTaskTestCase {
         // Response body assertions
         String responseBody = (String) runtimeService.getVariable(process.getId(), "httpPatchResponseBody");
         assertThat(responseBody).isNotNull();
+        ObjectMapper mapper = processEngineConfiguration.getObjectMapper();
         JsonNode jsonNode = mapper.readValue(responseBody, JsonNode.class);
         HttpTestData testData = mapper.convertValue(jsonNode, HttpTestData.class);
         assertThat(testData.getBody()).isEqualTo(body);

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTestServer.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTestServer.java
@@ -98,11 +98,12 @@ public class HttpServiceTaskTestServer {
             ServletContextHandler contextHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
             contextHandler.setContextPath("/");
             MultipartConfigElement multipartConfig = new MultipartConfigElement((String) null);
-            ServletHolder httpServiceTaskServletHolder = new ServletHolder(new HttpServiceTaskTestServlet());
+            ObjectMapper mapper = new ObjectMapper();
+            ServletHolder httpServiceTaskServletHolder = new ServletHolder(new HttpServiceTaskTestServlet(mapper));
             httpServiceTaskServletHolder.getRegistration().setMultipartConfig(multipartConfig);
             contextHandler.addServlet(httpServiceTaskServletHolder, "/api/*");
-            contextHandler.addServlet(new ServletHolder(new SimpleHttpServiceTaskTestServlet()), "/test");
-            contextHandler.addServlet(new ServletHolder(new HelloServlet()), "/hello");
+            contextHandler.addServlet(new ServletHolder(new SimpleHttpServiceTaskTestServlet(mapper)), "/test");
+            contextHandler.addServlet(new ServletHolder(new HelloServlet(mapper)), "/hello");
             contextHandler.addServlet(new ServletHolder(new ArrayResponseServlet()), "/array-response");
             contextHandler.addServlet(new ServletHolder(new DeleteResponseServlet()), "/delete");
             contextHandler.addServlet(new ServletHolder(new ClasspathResourceServlet()), "/resource");
@@ -135,9 +136,10 @@ public class HttpServiceTaskTestServer {
         public static Map<String, String> headerMap = new HashMap<>();
 
         private String name = "test servlet";
-        private ObjectMapper mapper = new ObjectMapper();
+        private ObjectMapper mapper;
 
-        public HttpServiceTaskTestServlet() {
+        public HttpServiceTaskTestServlet(ObjectMapper mapper) {
+            this.mapper = mapper;
         }
 
         public HttpServiceTaskTestServlet(String name) {
@@ -280,7 +282,11 @@ public class HttpServiceTaskTestServer {
 
         private static final long serialVersionUID = 1L;
 
-        private ObjectMapper objectMapper = new ObjectMapper();
+        private final ObjectMapper objectMapper;
+
+        private SimpleHttpServiceTaskTestServlet(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
 
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -300,8 +306,12 @@ public class HttpServiceTaskTestServer {
 
         private static final long serialVersionUID = 1L;
 
-        private ObjectMapper objectMapper = new ObjectMapper();
-        
+        private final ObjectMapper objectMapper;
+
+        private HelloServlet(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
+
         @Override
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
             resp.setStatus(200);

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/api/engine/variable/QueryVariableTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/api/engine/variable/QueryVariableTest.java
@@ -20,11 +20,8 @@ import org.flowable.rest.service.api.engine.variable.QueryVariable;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class QueryVariableTest extends BaseSpringRestTestCase {
-
-    protected ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     public void testSerializeQueryVariable() throws Exception {

--- a/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/form/FormDataResourceTest.java
+++ b/modules/flowable-rest/src/test/java/org/flowable/rest/service/api/form/FormDataResourceTest.java
@@ -34,7 +34,6 @@ import org.flowable.variable.api.history.HistoricVariableInstance;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -46,8 +45,6 @@ import net.javacrumbs.jsonunit.core.Option;
  * @author Tijs Rademakers
  */
 public class FormDataResourceTest extends BaseSpringRestTestCase {
-
-    protected ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     @Deployment

--- a/modules/flowable-spring/src/test/java/org/flowable/spring/test/eventregistry/TestInboundEventChannelAdapter.java
+++ b/modules/flowable-spring/src/test/java/org/flowable/spring/test/eventregistry/TestInboundEventChannelAdapter.java
@@ -26,6 +26,7 @@ public class TestInboundEventChannelAdapter implements InboundEventChannelAdapte
 
     public InboundChannelModel inboundChannelModel;
     public EventRegistry eventRegistry;
+    protected final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void setInboundChannelModel(InboundChannelModel inboundChannelModel) {
@@ -50,8 +51,6 @@ public class TestInboundEventChannelAdapter implements InboundEventChannelAdapte
     }
 
     public void triggerTestEvent(String customerId, String orderId) {
-        ObjectMapper objectMapper = new ObjectMapper();
-
         ObjectNode json = objectMapper.createObjectNode();
         json.put("type", "myEvent");
         if (customerId != null) {


### PR DESCRIPTION
#### Check List:
* Unit tests: NA
* Documentation: NA
