### PR TITLE
Add mime type support for text MultiValuePart with configurable multipart mode

### DIFF
--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/api/MultiValuePart.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/api/MultiValuePart.java
@@ -56,6 +56,10 @@ public class MultiValuePart {
         return new MultiValuePart(name, value, null);
     }
 
+    public static MultiValuePart fromText(String name, String value, String mimeType) {
+        return new MultiValuePart(name, value, null, mimeType);
+    }
+
     public static MultiValuePart fromFile(String name, byte[] value, String filename) {
         return new MultiValuePart(name, value, filename);
     }

--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/HttpClientConfig.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/HttpClientConfig.java
@@ -92,6 +92,22 @@ public class HttpClientConfig {
 
     protected boolean useSystemProperties = false;
 
+    /**
+     * The multipart mode to use when building multipart/form-data requests with the Apache HTTP client implementations.
+     * <p>
+     * Supported values:
+     * <ul>
+     *     <li>{@code "STRICT"} - RFC 2046 compliant. Always writes Content-Type headers for all parts,
+     *     including text parts. This is the default and is needed for text parts with a custom mime type to work correctly.</li>
+     *     <li>{@code "BROWSER_COMPATIBLE"} - Mimics browser behavior. Only writes Content-Type headers for parts with a filename.
+     *     This was the default before 8.0. Note that text parts with a custom mime type will not have their Content-Type sent
+     *     in this mode.</li>
+     * </ul>
+     * <p>
+     * This setting has no effect on the Spring WebClient implementation.
+     */
+    protected String multipartMode = "STRICT";
+
     protected FlowableHttpClient httpClient;
     protected Runnable closeRunnable;
 
@@ -148,6 +164,14 @@ public class HttpClientConfig {
         return useSystemProperties;
     }
 
+    public String getMultipartMode() {
+        return multipartMode;
+    }
+
+    public void setMultipartMode(String multipartMode) {
+        this.multipartMode = multipartMode;
+    }
+
     public void merge(HttpClientConfig other) {
         if (this.connectTimeout != other.getConnectTimeout()) {
             setConnectTimeout(other.getConnectTimeout());
@@ -171,6 +195,10 @@ public class HttpClientConfig {
 
         if (this.useSystemProperties != other.isUseSystemProperties()) {
             setUseSystemProperties(other.isUseSystemProperties());
+        }
+
+        if (!Objects.equals(this.multipartMode, other.getMultipartMode())) {
+            setMultipartMode(other.getMultipartMode());
         }
 
         if (!Objects.equals(this.httpClient, other.getHttpClient())) {

--- a/modules/flowable-http/src/test/java/org/flowable/http/BrowserCompatibleApacheHttpClientArgumentProvider.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/BrowserCompatibleApacheHttpClientArgumentProvider.java
@@ -1,0 +1,52 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.http;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import org.flowable.http.common.impl.HttpClientConfig;
+import org.flowable.http.common.impl.apache.ApacheHttpComponentsFlowableHttpClient;
+import org.flowable.http.common.impl.apache.client5.ApacheHttpComponents5FlowableHttpClient;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.ParameterDeclarations;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class BrowserCompatibleApacheHttpClientArgumentProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+        HttpClientConfig config = createClientConfig();
+        return Stream.of(
+                Arguments.of(new ApacheHttpComponentsFlowableHttpClient(config)),
+                Arguments.of(new ApacheHttpComponents5FlowableHttpClient(config))
+        );
+    }
+
+    protected HttpClientConfig createClientConfig() {
+        HttpClientConfig config = new HttpClientConfig();
+        config.setConnectTimeout(Duration.ofSeconds(5));
+        config.setSocketTimeout(Duration.ofSeconds(5));
+        config.setConnectionRequestTimeout(Duration.ofSeconds(5));
+        config.setRequestRetryLimit(5);
+        config.setDisableCertVerify(true);
+        config.setMultipartMode("BROWSER_COMPATIBLE");
+
+        return config;
+    }
+
+}


### PR DESCRIPTION
Add a fromText(name, value, mimeType) factory method to MultiValuePart so that text parts can specify a custom Content-Type (e.g. application/json).

Both Apache HTTP client implementations now respect the mime type on text parts by passing ContentType to addTextBody when set. The multipart entity builder mode is changed from BROWSER_COMPATIBLE/LEGACY to STRICT so that Content-Type headers are written for all parts including text parts.

For backward compatibility, the multipart mode is configurable via HttpClientConfig.setMultipartMode(). Supported values are STRICT (default), BROWSER_COMPATIBLE, LEGACY, and EXTENDED. The Spring WebClient implementation is unaffected as it already handled mime types for all parts.

