### PR TITLE
Filter all exceptions when sendFullErrorException is false

### DIFF
--- a/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/exception/BaseExceptionHandlerAdvice.java
+++ b/modules/flowable-common-rest/src/main/java/org/flowable/common/rest/exception/BaseExceptionHandlerAdvice.java
@@ -51,60 +51,108 @@ public class BaseExceptionHandlerAdvice {
     @ExceptionHandler(FlowableContentNotSupportedException.class)
     @ResponseBody
     public ErrorInfo handleNotSupported(FlowableContentNotSupportedException e, HttpServletRequest request) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Content is not supported. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+        if (sendFullErrorException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Content is not supported. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+            }
+            return new ErrorInfo("Content is not supported", e);
+        } else {
+            String errorIdentifier = UUID.randomUUID().toString();
+            logger.warn("Content is not supported. Error ID: {}. Message: {}, Request: {} {}", errorIdentifier, e.getMessage(), request.getMethod(), request.getRequestURI());
+            ErrorInfo errorInfo = new ErrorInfo("Content is not supported", null);
+            errorInfo.setException("Content is not supported. Error ID: " + errorIdentifier);
+            return errorInfo;
         }
-        return new ErrorInfo("Content is not supported", e);
     }
 
     @ResponseStatus(HttpStatus.CONFLICT) // 409
     @ExceptionHandler(FlowableConflictException.class)
     @ResponseBody
     public ErrorInfo handleConflict(FlowableConflictException e, HttpServletRequest request) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Conflict. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+        if (sendFullErrorException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Conflict. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+            }
+            return new ErrorInfo("Conflict", e);
+        } else {
+            String errorIdentifier = UUID.randomUUID().toString();
+            logger.warn("Conflict. Error ID: {}. Message: {}, Request: {} {}", errorIdentifier, e.getMessage(), request.getMethod(), request.getRequestURI());
+            ErrorInfo errorInfo = new ErrorInfo("Conflict", null);
+            errorInfo.setException("Conflict. Error ID: " + errorIdentifier);
+            return errorInfo;
         }
-        return new ErrorInfo("Conflict", e);
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND) // 404
     @ExceptionHandler(FlowableObjectNotFoundException.class)
     @ResponseBody
     public ErrorInfo handleNotFound(FlowableObjectNotFoundException e, HttpServletRequest request) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Not found. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+        if (sendFullErrorException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Not found. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+            }
+            return new ErrorInfo("Not found", e);
+        } else {
+            String errorIdentifier = UUID.randomUUID().toString();
+            logger.warn("Not found. Error ID: {}. Message: {}, Request: {} {}", errorIdentifier, e.getMessage(), request.getMethod(), request.getRequestURI());
+            ErrorInfo errorInfo = new ErrorInfo("Not found", null);
+            errorInfo.setException("Not found. Error ID: " + errorIdentifier);
+            return errorInfo;
         }
-        return new ErrorInfo("Not found", e);
     }
 
     @ResponseStatus(HttpStatus.FORBIDDEN) // 403
     @ExceptionHandler(FlowableForbiddenException.class)
     @ResponseBody
     public ErrorInfo handleForbidden(FlowableForbiddenException e, HttpServletRequest request) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Forbidden. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+        if (sendFullErrorException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Forbidden. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+            }
+            return new ErrorInfo("Forbidden", e);
+        } else {
+            String errorIdentifier = UUID.randomUUID().toString();
+            logger.warn("Forbidden. Error ID: {}. Message: {}, Request: {} {}", errorIdentifier, e.getMessage(), request.getMethod(), request.getRequestURI());
+            ErrorInfo errorInfo = new ErrorInfo("Forbidden", null);
+            errorInfo.setException("Forbidden. Error ID: " + errorIdentifier);
+            return errorInfo;
         }
-        return new ErrorInfo("Forbidden", e);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST) // 400
     @ExceptionHandler(FlowableIllegalArgumentException.class)
     @ResponseBody
     public ErrorInfo handleIllegalArgument(FlowableIllegalArgumentException e, HttpServletRequest request) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Illegal argument. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+        if (sendFullErrorException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Illegal argument. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+            }
+            return new ErrorInfo("Bad request", e);
+        } else {
+            String errorIdentifier = UUID.randomUUID().toString();
+            logger.warn("Illegal argument. Error ID: {}. Message: {}, Request: {} {}", errorIdentifier, e.getMessage(), request.getMethod(), request.getRequestURI());
+            ErrorInfo errorInfo = new ErrorInfo("Bad request", null);
+            errorInfo.setException("Illegal argument. Error ID: " + errorIdentifier);
+            return errorInfo;
         }
-        return new ErrorInfo("Bad request", e);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST) // 400
     @ExceptionHandler(FlowableIllegalStateException.class)
     @ResponseBody
     public ErrorInfo handleIllegalState(FlowableIllegalStateException e, HttpServletRequest request) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Illegal state. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+        if (sendFullErrorException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Illegal state. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+            }
+            return new ErrorInfo("Bad request", e);
+        } else {
+            String errorIdentifier = UUID.randomUUID().toString();
+            logger.warn("Illegal state. Error ID: {}. Message: {}, Request: {} {}", errorIdentifier, e.getMessage(), request.getMethod(), request.getRequestURI());
+            ErrorInfo errorInfo = new ErrorInfo("Bad request", null);
+            errorInfo.setException("Illegal state. Error ID: " + errorIdentifier);
+            return errorInfo;
         }
-        return new ErrorInfo("Bad request", e);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST) // 400
@@ -129,10 +177,18 @@ public class BaseExceptionHandlerAdvice {
     @ExceptionHandler(FlowableTaskAlreadyClaimedException.class)
     @ResponseBody
     public ErrorInfo handleTaskAlreadyClaimed(FlowableTaskAlreadyClaimedException e, HttpServletRequest request) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Task was already claimed. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+        if (sendFullErrorException) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Task was already claimed. Message: {}, Request: {} {}", e.getMessage(), request.getMethod(), request.getRequestURI());
+            }
+            return new ErrorInfo("Task was already claimed", e);
+        } else {
+            String errorIdentifier = UUID.randomUUID().toString();
+            logger.warn("Task was already claimed. Error ID: {}. Message: {}, Request: {} {}", errorIdentifier, e.getMessage(), request.getMethod(), request.getRequestURI());
+            ErrorInfo errorInfo = new ErrorInfo("Task was already claimed", null);
+            errorInfo.setException("Task was already claimed. Error ID: " + errorIdentifier);
+            return errorInfo;
         }
-        return new ErrorInfo("Task was already claimed", e);
     }
 
     // Fall back

--- a/modules/flowable-common-rest/src/test/java/org/flowable/common/rest/exception/BaseExceptionHandlerAdviceTest.java
+++ b/modules/flowable-common-rest/src/test/java/org/flowable/common/rest/exception/BaseExceptionHandlerAdviceTest.java
@@ -85,7 +85,7 @@ class BaseExceptionHandlerAdviceTest {
         assertThatJson(body)
                 .isEqualTo("{"
                         + "  message: 'Content is not supported',"
-                        + "  exception: 'other test content not supported'"
+                        + "  exception: '${json-unit.regex}Content is not supported[.] Error ID: .+'"
                         + "}");
 
     }
@@ -122,7 +122,7 @@ class BaseExceptionHandlerAdviceTest {
         assertThatJson(body)
                 .isEqualTo("{"
                         + "  message: 'Conflict',"
-                        + "  exception: 'task already exists'"
+                        + "  exception: '${json-unit.regex}Conflict[.] Error ID: .+'"
                         + "}");
 
     }
@@ -159,7 +159,7 @@ class BaseExceptionHandlerAdviceTest {
         assertThatJson(body)
                 .isEqualTo("{"
                         + "  message: 'Not found',"
-                        + "  exception: 'task not found'"
+                        + "  exception: '${json-unit.regex}Not found[.] Error ID: .+'"
                         + "}");
 
     }
@@ -196,7 +196,7 @@ class BaseExceptionHandlerAdviceTest {
         assertThatJson(body)
                 .isEqualTo("{"
                         + "  message: 'Forbidden',"
-                        + "  exception: 'no access to task'"
+                        + "  exception: '${json-unit.regex}Forbidden[.] Error ID: .+'"
                         + "}");
 
     }
@@ -233,7 +233,7 @@ class BaseExceptionHandlerAdviceTest {
         assertThatJson(body)
                 .isEqualTo("{"
                         + "  message: 'Bad request',"
-                        + "  exception: 'task name is mandatory'"
+                        + "  exception: '${json-unit.regex}Illegal argument[.] Error ID: .+'"
                         + "}");
 
     }
@@ -270,7 +270,7 @@ class BaseExceptionHandlerAdviceTest {
         assertThatJson(body)
                 .isEqualTo("{"
                         + "  message: 'Bad request',"
-                        + "  exception: 'task not active'"
+                        + "  exception: '${json-unit.regex}Illegal state[.] Error ID: .+'"
                         + "}");
 
     }
@@ -307,7 +307,7 @@ class BaseExceptionHandlerAdviceTest {
         assertThatJson(body)
                 .isEqualTo("{"
                         + "  message: 'Task was already claimed',"
-                        + "  exception: \"Task 'task-2' is already claimed by someone else.\""
+                        + "  exception: '${json-unit.regex}Task was already claimed[.] Error ID: .+'"
                         + "}");
 
     }
@@ -344,10 +344,8 @@ class BaseExceptionHandlerAdviceTest {
         assertThatJson(body)
                 .isEqualTo("{"
                         + "  message: 'Internal server error',"
-                        + "  exception: '${json-unit.any-string}'"
+                        + "  exception: '${json-unit.regex}Error with ID: .+'"
                         + "}");
-        assertThatJson(body)
-                .inPath("exception").asString().startsWith("Error with ID: ");
     }
 
     @RestController


### PR DESCRIPTION
Previously, only handleBadMessageConversion and handleOtherException in BaseExceptionHandlerAdvice respected the sendFullErrorException flag. All other exception handlers (handleNotSupported, handleConflict, handleNotFound, handleForbidden, handleIllegalArgument, handleIllegalState, handleTaskAlreadyClaimed) always returned the full exception message in the response, regardless of the flag.

This change applies the same pattern consistently to all handlers: when sendFullErrorException is false, a UUID error identifier is generated and logged at WARN level, and only the error identifier is returned to the client — preventing internal error details from leaking in the REST API response.

The test class has been updated accordingly, using ${json-unit.regex} matchers to verify the error ID pattern in each handler's response.