### PR TITLE
Snapshot send-event task expressions at scheduling time for async jobs

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/SendEventTaskActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/SendEventTaskActivityBehavior.java
@@ -49,12 +49,20 @@ import org.flowable.eventregistry.api.runtime.EventInstance;
 import org.flowable.eventregistry.api.runtime.EventPayloadInstance;
 import org.flowable.eventregistry.impl.constant.EventConstants;
 import org.flowable.eventregistry.impl.runtime.EventInstanceImpl;
+import org.flowable.eventregistry.impl.runtime.EventPayloadInstanceImpl;
 import org.flowable.eventregistry.model.ChannelModel;
 import org.flowable.eventregistry.model.EventModel;
+import org.flowable.eventregistry.model.EventPayload;
 import org.flowable.eventsubscription.service.EventSubscriptionService;
 import org.flowable.eventsubscription.service.impl.persistence.entity.EventSubscriptionEntity;
 import org.flowable.job.service.JobService;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Sends an event to the event registry
@@ -92,8 +100,23 @@ public class SendEventTaskActivityBehavior extends AbstractBpmnActivityBehavior 
         boolean sendSynchronously = sendEventServiceTask.isSendSynchronously() || executedAsAsyncJob;
         if (!sendSynchronously) {
             JobService jobService = processEngineConfiguration.getJobServiceConfiguration().getJobService();
-            
+
             JobEntity job = JobUtil.createJob(executionEntity, sendEventServiceTask, AsyncSendEventJobHandler.TYPE, processEngineConfiguration);
+
+            // Resolve every expression (channel keys + eventInParameters) in the current scheduling
+            // context so authenticated user, thread-local backed beans and any other context-dependent
+            // value is captured. The async worker dispatches this snapshot verbatim, making async
+            // sending semantically equivalent to synchronous sending — independent of any thread state
+            // available in the worker.
+            boolean snapshotSendOnSystemChannel = isSendOnSystemChannel(execution);
+            List<String> snapshotChannelKeys = resolveChannelKeys(commandContext, execution);
+            if (snapshotChannelKeys.isEmpty() && !snapshotSendOnSystemChannel) {
+                throw new FlowableException("No channel keys configured for " + execution);
+            }
+            Collection<EventPayloadInstance> snapshotPayloadInstances = EventInstanceBpmnUtil.createEventPayloadInstances(executionEntity,
+                    processEngineConfiguration.getExpressionManager(), execution.getCurrentFlowElement(), eventModel);
+            job.setCustomValues(writeSnapshot(processEngineConfiguration.getObjectMapper(),
+                    snapshotChannelKeys, snapshotSendOnSystemChannel, snapshotPayloadInstances));
 
             jobService.createAsyncJob(job, true);
             jobService.scheduleAsyncJob(job);
@@ -101,11 +124,27 @@ public class SendEventTaskActivityBehavior extends AbstractBpmnActivityBehavior 
         } else {
             commandContext.removeAttribute(AsyncSendEventJobHandler.TYPE);
 
-            Collection<EventPayloadInstance> eventPayloadInstances = EventInstanceBpmnUtil.createEventPayloadInstances(executionEntity,
-                    processEngineConfiguration.getExpressionManager(), execution.getCurrentFlowElement(), eventModel);
+            JsonNode snapshot = (JsonNode) commandContext.getAttribute(AsyncSendEventJobHandler.SNAPSHOT_ATTRIBUTE);
 
-            boolean sendOnSystemChannel = isSendOnSystemChannel(execution);
-            List<ChannelModel> channelModels = getChannelModels(commandContext, execution, sendOnSystemChannel);
+            boolean sendOnSystemChannel;
+            List<ChannelModel> channelModels;
+            Collection<EventPayloadInstance> eventPayloadInstances;
+            if (snapshot != null) {
+                // Async dispatch: every expression was already evaluated when the job was scheduled.
+                // Hydrate the snapshot back into payload instances and resolved channel models without
+                // touching any expression — context-dependent values (authenticated user, beans, ...)
+                // therefore retain their scheduling-time value.
+                sendOnSystemChannel = readSendOnSystemChannel(snapshot);
+                channelModels = resolveChannelModels(commandContext, execution, readChannelKeys(snapshot), sendOnSystemChannel);
+                eventPayloadInstances = readPayloadInstances(snapshot, eventModel);
+            } else {
+                eventPayloadInstances = EventInstanceBpmnUtil.createEventPayloadInstances(executionEntity,
+                        processEngineConfiguration.getExpressionManager(), execution.getCurrentFlowElement(), eventModel);
+
+                sendOnSystemChannel = isSendOnSystemChannel(execution);
+                channelModels = getChannelModels(commandContext, execution, sendOnSystemChannel);
+            }
+
             EventInstanceImpl eventInstance = new EventInstanceImpl(eventModel.getKey(), eventPayloadInstances, execution.getTenantId());
             if (!channelModels.isEmpty()) {
                 eventRegistry.sendEventOutbound(eventInstance, channelModels);
@@ -173,6 +212,10 @@ public class SendEventTaskActivityBehavior extends AbstractBpmnActivityBehavior 
     }
 
     protected List<ChannelModel> getChannelModels(CommandContext commandContext, DelegateExecution execution, boolean sendOnSystemChannel) {
+        return resolveChannelModels(commandContext, execution, resolveChannelKeys(commandContext, execution), sendOnSystemChannel);
+    }
+
+    protected List<String> resolveChannelKeys(CommandContext commandContext, DelegateExecution execution) {
         List<String> channelKeys = new ArrayList<>();
 
         Map<String, List<ExtensionElement>> extensionElements = execution.getCurrentFlowElement().getExtensionElements();
@@ -205,6 +248,12 @@ public class SendEventTaskActivityBehavior extends AbstractBpmnActivityBehavior 
             }
         }
 
+        return channelKeys;
+    }
+
+    protected List<ChannelModel> resolveChannelModels(CommandContext commandContext, DelegateExecution execution,
+            List<String> channelKeys, boolean sendOnSystemChannel) {
+
         if (channelKeys.isEmpty()) {
             if (!sendOnSystemChannel) {
                 // If the event is going to be send on the system channel then it is allowed to not define any other channels
@@ -225,6 +274,95 @@ public class SendEventTaskActivityBehavior extends AbstractBpmnActivityBehavior 
         }
 
         return channelModels;
+    }
+
+    protected static String writeSnapshot(ObjectMapper objectMapper, List<String> channelKeys, boolean sendOnSystemChannel,
+            Collection<EventPayloadInstance> payloadInstances) {
+
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode keysNode = root.putArray("channelKeys");
+        for (String key : channelKeys) {
+            keysNode.add(key);
+        }
+        root.put("sendOnSystemChannel", sendOnSystemChannel);
+        ObjectNode payloadsNode = root.putObject("payloads");
+        for (EventPayloadInstance payloadInstance : payloadInstances) {
+            payloadsNode.set(payloadInstance.getDefinitionName(), objectMapper.valueToTree(payloadInstance.getValue()));
+        }
+        try {
+            return objectMapper.writeValueAsString(root);
+        } catch (JacksonException e) {
+            throw new FlowableException("Could not serialise async send-event snapshot", e);
+        }
+    }
+
+    protected static List<String> readChannelKeys(JsonNode snapshot) {
+        List<String> keys = new ArrayList<>();
+        JsonNode keysNode = snapshot.get("channelKeys");
+        if (keysNode != null && keysNode.isArray()) {
+            for (JsonNode entry : keysNode) {
+                if (entry != null && !entry.isNull()) {
+                    keys.add(entry.asString());
+                }
+            }
+        }
+        return keys;
+    }
+
+    protected static boolean readSendOnSystemChannel(JsonNode snapshot) {
+        JsonNode value = snapshot.get("sendOnSystemChannel");
+        return value != null && value.asBoolean(false);
+    }
+
+    protected static Collection<EventPayloadInstance> readPayloadInstances(JsonNode snapshot, EventModel eventModel) {
+        JsonNode payloadsNode = snapshot.get("payloads");
+        if (payloadsNode == null || !payloadsNode.isObject()) {
+            return Collections.emptyList();
+        }
+        List<EventPayloadInstance> instances = new ArrayList<>();
+        for (Map.Entry<String, JsonNode> entry : payloadsNode.properties()) {
+            EventPayload payloadDefinition = eventModel.getPayload(entry.getKey());
+            if (payloadDefinition != null) {
+                instances.add(new EventPayloadInstanceImpl(payloadDefinition, jsonNodeToValue(entry.getValue())));
+            }
+        }
+        return instances;
+    }
+
+    protected static Object jsonNodeToValue(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isString()) {
+            return node.stringValue();
+        }
+        if (node.isBoolean()) {
+            return node.booleanValue();
+        }
+        if (node.isInt()) {
+            return node.intValue();
+        }
+        if (node.isLong()) {
+            return node.longValue();
+        }
+        if (node.isFloat()) {
+            return node.floatValue();
+        }
+        if (node.isDouble()) {
+            return node.doubleValue();
+        }
+        if (node.isBigDecimal()) {
+            return node.decimalValue();
+        }
+        if (node.isBigInteger()) {
+            return node.bigIntegerValue();
+        }
+        if (node.isShort()) {
+            return node.shortValue();
+        }
+        // Container/binary nodes are passed through; downstream serializers (JSON) handle them as-is
+        // and string targets fall back to JsonNode#toString which yields the canonical JSON form.
+        return node;
     }
 
     @Override

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/AsyncSendEventJobHandler.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/jobexecutor/AsyncSendEventJobHandler.java
@@ -12,15 +12,21 @@
  */
 package org.flowable.engine.impl.jobexecutor;
 
+import org.apache.commons.lang3.StringUtils;
 import org.flowable.bpmn.model.FlowElement;
 import org.flowable.bpmn.model.SendEventServiceTask;
 import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
 import org.flowable.engine.impl.delegate.ActivityBehavior;
 import org.flowable.engine.impl.persistence.entity.ExecutionEntity;
+import org.flowable.engine.impl.util.CommandContextUtil;
 import org.flowable.job.service.JobHandler;
 import org.flowable.job.service.impl.persistence.entity.JobEntity;
 import org.flowable.variable.api.delegate.VariableScope;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  *
@@ -29,6 +35,13 @@ import org.flowable.variable.api.delegate.VariableScope;
 public class AsyncSendEventJobHandler implements JobHandler {
 
     public static final String TYPE = "async-send-event";
+
+    /**
+     * CommandContext attribute key under which the parsed snapshot ({@link JsonNode}) is exposed
+     * to {@code SendEventTaskActivityBehavior}. The behavior dispatches from the snapshot instead of
+     * re-evaluating expressions in the worker thread.
+     */
+    public static final String SNAPSHOT_ATTRIBUTE = "async-send-event.snapshot";
 
     @Override
     public String getType() {
@@ -50,11 +63,39 @@ public class AsyncSendEventJobHandler implements JobHandler {
                     "Unexpected activity behavior (" + behavior.getClass() + ") found for " + job + " at " + executionEntity);
         }
 
+        // The snapshot was captured at scheduling time when the original variables, authenticated
+        // user, beans and any other thread-local context were available. Hand it to the behavior so
+        // it dispatches the resolved values verbatim — no expression is re-evaluated in this worker
+        // thread. Jobs scheduled by an older engine version do not carry a snapshot; for those we
+        // fall back to the legacy behavior of re-resolving in the worker (matches pre-fix semantics).
+        JsonNode snapshot = readSnapshot(job, commandContext);
+        boolean snapshotAttached = false;
+        if (snapshot != null) {
+            commandContext.addAttribute(SNAPSHOT_ATTRIBUTE, snapshot);
+            snapshotAttached = true;
+        }
+
         try {
             commandContext.addAttribute(TYPE, true); // Will be read in the SendEventTaskActivityBehavior
             activityBehavior.execute(executionEntity);
         } finally {
             commandContext.removeAttribute(TYPE);
+            if (snapshotAttached) {
+                commandContext.removeAttribute(SNAPSHOT_ATTRIBUTE);
+            }
+        }
+    }
+
+    protected JsonNode readSnapshot(JobEntity job, CommandContext commandContext) {
+        String snapshotJson = job.getCustomValues();
+        if (StringUtils.isEmpty(snapshotJson)) {
+            return null;
+        }
+        ObjectMapper objectMapper = CommandContextUtil.getProcessEngineConfiguration(commandContext).getObjectMapper();
+        try {
+            return objectMapper.readTree(snapshotJson);
+        } catch (JacksonException e) {
+            throw new FlowableException("Could not read async send-event snapshot for " + job, e);
         }
     }
 

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendEventTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/eventregistry/SendEventTaskTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.flowable.common.engine.impl.history.HistoryLevel;
+import org.flowable.common.engine.impl.identity.Authentication;
 import org.flowable.common.engine.impl.interceptor.EngineConfigurationConstants;
 import org.flowable.engine.history.HistoricActivityInstance;
 import org.flowable.engine.impl.jobexecutor.AsyncSendEventJobHandler;
@@ -322,6 +323,117 @@ public class SendEventTaskTest extends FlowableEventRegistryBpmnTestCase {
                         + " }");
     }
     
+    @Test
+    @Deployment
+    public void testSendEventWithAuthenticatedUserExpression() throws Exception {
+        Authentication.setAuthenticatedUserId("alice");
+        try {
+            ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                    .processDefinitionKey("process")
+                    .variable("accountNumber", 123)
+                    .start();
+
+            assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
+
+            Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task).isNotNull();
+
+            taskService.complete(task.getId());
+
+            Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(job).isNotNull();
+            assertThat(job.getJobHandlerType()).isEqualTo(AsyncSendEventJobHandler.TYPE);
+            assertThat(job.getElementId()).isEqualTo("sendEventTask");
+
+            assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
+
+            // Clear the authenticated user before the job runs to prove the captured value is restored
+            // by the AsyncSendEventJobHandler instead of relying on a thread-local that the job worker
+            // does not inherit.
+            Authentication.setAuthenticatedUserId(null);
+
+            JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
+
+            assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
+
+            JsonNode jsonNode = processEngineConfiguration.getObjectMapper().readTree(outboundEventChannelAdapter.receivedEvents.get(0));
+            assertThatJson(jsonNode)
+                    .isEqualTo("{"
+                            + "   nameProperty: 'alice',"
+                            + "   numberProperty: 123"
+                            + " }");
+        } finally {
+            Authentication.setAuthenticatedUserId(null);
+        }
+    }
+
+    @Test
+    @Deployment
+    public void testSendEventWithThreadLocalBeanExpression() throws Exception {
+        // Generalises the authenticated-user case: any expression backed by thread-local state
+        // (custom security beans, tenant resolvers, request-scoped helpers, ...) must resolve
+        // against the scheduling thread, not the async worker. We register a custom bean whose
+        // method reads from a ThreadLocal, schedule the send-event, then clear the ThreadLocal
+        // before the worker picks up the job. The captured snapshot must still carry the
+        // scheduling-time value.
+        ThreadLocalContextBean contextBean = new ThreadLocalContextBean();
+        contextBean.set("alice");
+
+        Map<Object, Object> originalBeans = processEngineConfiguration.getExpressionManager().getBeans();
+        Map<Object, Object> beans = new HashMap<>();
+        beans.put("ctxBean", contextBean);
+        processEngineConfiguration.getExpressionManager().setBeans(beans);
+
+        try {
+            ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                    .processDefinitionKey("process")
+                    .variable("accountNumber", 123)
+                    .start();
+
+            Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            taskService.complete(task.getId());
+
+            Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(job).isNotNull();
+            assertThat(job.getJobHandlerType()).isEqualTo(AsyncSendEventJobHandler.TYPE);
+            assertThat(outboundEventChannelAdapter.receivedEvents).isEmpty();
+
+            // Clear the thread-local before the job worker picks up the job. If the snapshot
+            // was captured at scheduling time the channel receives "alice"; if expressions were
+            // re-evaluated in the worker the value would be null.
+            contextBean.clear();
+
+            JobTestHelper.waitForJobExecutorToProcessAllJobs(processEngineConfiguration, managementService, 5000, 200);
+
+            assertThat(outboundEventChannelAdapter.receivedEvents).hasSize(1);
+            JsonNode jsonNode = processEngineConfiguration.getObjectMapper().readTree(outboundEventChannelAdapter.receivedEvents.get(0));
+            assertThatJson(jsonNode)
+                    .isEqualTo("{"
+                            + "   nameProperty: 'alice',"
+                            + "   numberProperty: 123"
+                            + " }");
+        } finally {
+            contextBean.clear();
+            processEngineConfiguration.getExpressionManager().setBeans(originalBeans);
+        }
+    }
+
+    public static class ThreadLocalContextBean {
+        private final ThreadLocal<String> holder = new ThreadLocal<>();
+
+        public void set(String value) {
+            holder.set(value);
+        }
+
+        public void clear() {
+            holder.remove();
+        }
+
+        public String getValue() {
+            return holder.get();
+        }
+    }
+
     @Test
     @Deployment
     public void testSendEventSkipExpression() throws Exception {

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/eventregistry/SendEventTaskTest.testSendEventWithAuthenticatedUserExpression.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/eventregistry/SendEventTaskTest.testSendEventWithAuthenticatedUserExpression.bpmn20.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:flowable="http://flowable.org/bpmn"
+  targetNamespace="Examples"
+  xmlns:tns="Examples">
+
+  <process id="process">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow sourceRef="theStart" targetRef="task" />
+
+    <userTask id="task" />
+
+    <sequenceFlow sourceRef="task" targetRef="sendEventTask" />
+
+    <serviceTask id="sendEventTask" flowable:type="send-event">
+        <extensionElements>
+            <flowable:eventType>anotherEvent</flowable:eventType>
+            <flowable:channelKey>out-channel</flowable:channelKey>
+            <flowable:eventInParameter source="${authenticatedUserId}" target="nameProperty" />
+            <flowable:eventInParameter source="${accountNumber}" target="numberProperty" />
+        </extensionElements>
+    </serviceTask>
+
+    <sequenceFlow sourceRef="sendEventTask" targetRef="taskAfter" />
+
+    <userTask id="taskAfter" />
+
+    <sequenceFlow sourceRef="taskAfter" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/eventregistry/SendEventTaskTest.testSendEventWithThreadLocalBeanExpression.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/eventregistry/SendEventTaskTest.testSendEventWithThreadLocalBeanExpression.bpmn20.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:flowable="http://flowable.org/bpmn"
+  targetNamespace="Examples"
+  xmlns:tns="Examples">
+
+  <process id="process">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow sourceRef="theStart" targetRef="task" />
+
+    <userTask id="task" />
+
+    <sequenceFlow sourceRef="task" targetRef="sendEventTask" />
+
+    <serviceTask id="sendEventTask" flowable:type="send-event">
+        <extensionElements>
+            <flowable:eventType>anotherEvent</flowable:eventType>
+            <flowable:channelKey>out-channel</flowable:channelKey>
+            <flowable:eventInParameter sourceExpression="${ctxBean.value}" target="nameProperty" />
+            <flowable:eventInParameter source="${accountNumber}" target="numberProperty" />
+        </extensionElements>
+    </serviceTask>
+
+    <sequenceFlow sourceRef="sendEventTask" targetRef="taskAfter" />
+
+    <userTask id="taskAfter" />
+
+    <sequenceFlow sourceRef="taskAfter" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
## Summary

Replaces #4205 with a fix at the root of the problem.

The async send-event job today re-evaluates `eventInParameter` and `channelKey` expressions in a worker thread, losing every thread-local backed context: `${authenticatedUserId}` resolves to `null`, custom security beans return empty values, tenant-scoped helpers fall back to defaults. Behaviour diverges from `sendSynchronously=true` even though both paths end at the same dispatch. #4205 fixes the specific `${authenticatedUserId}` symptom by capturing/restoring the authenticated user across the job boundary, but anything else context-dependent stays broken.

This PR resolves every expression in the **scheduling** thread — where variables, authenticated user, beans and other context are still available — and persists the result as a JSON snapshot on `JobEntity.customValues`. The async handler reads the snapshot, exposes it on the command context and lets `SendEventTaskActivityBehavior` dispatch the captured values verbatim. No expression is evaluated in the worker thread.

Async sending is now semantically identical to synchronous sending regardless of which thread-local context the `eventInParameters` depend on. Jobs scheduled by an older engine fall back to the legacy re-evaluation path so in-flight upgrades stay safe.

## Changes

* `SendEventTaskActivityBehavior` — async branch captures channel keys + payload values via `writeSnapshot` into `customValues`; sync branch consumes the snapshot exposed by the handler if present, otherwise resolves expressions as before. `getChannelModels` is split into `resolveChannelKeys` + `resolveChannelModels` for reuse.
* `AsyncSendEventJobHandler` — reads `customValues`, parses the JSON snapshot and exposes it on the `CommandContext` under `SNAPSHOT_ATTRIBUTE`. The PR #4205 mechanism (`jobHandlerConfiguration` carrying the authenticated user) is no longer needed.
* `SendEventTaskTest` — keeps `testSendEventWithAuthenticatedUserExpression` from #4205 as a regression case; adds `testSendEventWithThreadLocalBeanExpression` which registers a custom bean backed by a `ThreadLocal`, proving the fix is not specific to `Authentication`.

## Notes on payload value round-trip

Payload values are persisted via the engine's `ObjectMapper`. Strings, numbers, booleans, JSON nodes and `null` round-trip losslessly. Custom POJOs / dates pass through Jackson's default serialization — the same path the existing JSON outbound serializer would use, so the observable channel output is unchanged for the common cases.

## Test plan

- [x] `mvn test -pl modules/flowable-engine -Dtest=SendEventTaskTest` — 14/14 pass
- [x] Broader regression: `mvn test -pl modules/flowable-engine -Dtest='*EventRegistry*,*SendEvent*,*ReceiveEvent*'` — 81/81 pass