### PR TITLE
Remove historic entity link orphans on task, process and case deletion

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CmmnHistoryHelper.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/CmmnHistoryHelper.java
@@ -49,7 +49,7 @@ public class CmmnHistoryHelper {
         
         if (cmmnEngineConfiguration.isEnableEntityLinks()) {
             cmmnEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService()
-                    .bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(ScopeTypes.CMMN, caseInstanceIds);
+                    .bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(ScopeTypes.CMMN, caseInstanceIds);
         }
 
         HistoricVariableInstanceEntityManager historicVariableInstanceEntityManager = cmmnEngineConfiguration.getVariableServiceConfiguration().getHistoricVariableInstanceEntityManager();

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/DefaultCmmnHistoryManager.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/history/DefaultCmmnHistoryManager.java
@@ -213,7 +213,7 @@ public class DefaultCmmnHistoryManager implements CmmnHistoryManager {
 
             if (cmmnEngineConfiguration.isEnableEntityLinks()) {
                 cmmnEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService()
-                        .deleteHistoricEntityLinksByScopeIdAndScopeType(historicCaseInstance.getId(), ScopeTypes.CMMN);
+                        .deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(historicCaseInstance.getId(), ScopeTypes.CMMN);
             }
 
             HistoricVariableInstanceEntityManager historicVariableInstanceEntityManager = cmmnEngineConfiguration.getVariableServiceConfiguration().getHistoricVariableInstanceEntityManager();

--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/task/TaskHelper.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/impl/task/TaskHelper.java
@@ -224,6 +224,11 @@ public class TaskHelper {
 
                 cmmnEngineConfiguration.getIdentityLinkServiceConfiguration().getHistoricIdentityLinkService().deleteHistoricIdentityLinksByTaskId(taskId);
     
+                if (cmmnEngineConfiguration.isEnableEntityLinks()) {
+                    cmmnEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService()
+                            .deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(taskId, ScopeTypes.TASK);
+                }
+
                 historicTaskService.deleteHistoricTask(historicTaskInstance);
             }
         }
@@ -283,6 +288,11 @@ public class TaskHelper {
         cmmnEngineConfiguration.getVariableServiceConfiguration().getHistoricVariableService().bulkDeleteHistoricVariableInstancesByTaskIds(taskIds);
         cmmnEngineConfiguration.getIdentityLinkServiceConfiguration().getHistoricIdentityLinkService().bulkDeleteHistoricIdentityLinksForTaskIds(taskIds);
         
+        if (cmmnEngineConfiguration.isEnableEntityLinks()) {
+            cmmnEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService()
+                    .bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(ScopeTypes.TASK, taskIds);
+        }
+
         historicTaskService.bulkDeleteHistoricTaskInstances(taskIds);
         
         historicTaskService.bulkDeleteHistoricTaskLogEntriesForTaskIds(taskIds);

--- a/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/BulkCaseInstanceDeleteTest.java
+++ b/modules/flowable-cmmn-engine/src/test/java/org/flowable/cmmn/test/history/BulkCaseInstanceDeleteTest.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.flowable.cmmn.api.runtime.CaseInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstance;
+import org.flowable.cmmn.api.runtime.PlanItemInstanceState;
 import org.flowable.cmmn.engine.impl.util.CommandContextUtil;
 import org.flowable.cmmn.engine.test.CmmnDeployment;
 import org.flowable.cmmn.test.FlowableCmmnTestCase;
@@ -328,6 +330,93 @@ public class BulkCaseInstanceDeleteTest extends FlowableCmmnTestCase {
         }
     }
     
+    @Test
+    @CmmnDeployment(resources = "org/flowable/cmmn/test/one-human-task-model.cmmn")
+    public void deleteHistoricTaskInstanceRemovesReferenceScopeOrphans() {
+        HistoryLevel historyLevel = cmmnEngineConfiguration.getHistoryLevel();
+        try {
+            cmmnEngineConfiguration.setHistoryLevel(HistoryLevel.FULL);
+            CaseInstance caseInstance = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("oneTaskCase")
+                    .start();
+
+            Task task = cmmnTaskService.createTaskQuery().caseInstanceId(caseInstance.getId()).singleResult();
+
+            waitForAsyncHistoryExecutorToProcessAllJobs();
+
+            // The case-task entity link points at the task as the REFERENCE_SCOPE_ID_.
+            assertThat(cmmnHistoryService.getHistoricEntityLinkParentsForTask(task.getId())).isNotEmpty();
+
+            cmmnTaskService.complete(task.getId());
+            waitForAsyncHistoryExecutorToProcessAllJobs();
+
+            cmmnHistoryService.deleteHistoricTaskInstance(task.getId());
+
+            assertThat(cmmnHistoryService.getHistoricEntityLinkParentsForTask(task.getId())).isEmpty();
+            assertThat(cmmnHistoryService.getHistoricEntityLinkChildrenForTask(task.getId())).isEmpty();
+
+            cmmnHistoryService.deleteHistoricCaseInstance(caseInstance.getId());
+        } finally {
+            cmmnEngineConfiguration.setHistoryLevel(historyLevel);
+        }
+    }
+
+    @Test
+    @CmmnDeployment(resources = {
+            "org/flowable/cmmn/test/runtime/CaseTaskTest.testBasicBlocking.cmmn",
+            "org/flowable/cmmn/test/runtime/oneTaskCase.cmmn"
+    })
+    public void deleteHistoricCaseInstanceRemovesReferenceScopeOrphans() {
+        HistoryLevel historyLevel = cmmnEngineConfiguration.getHistoryLevel();
+        try {
+            cmmnEngineConfiguration.setHistoryLevel(HistoryLevel.FULL);
+            CaseInstance parentCase = cmmnRuntimeService.createCaseInstanceBuilder()
+                    .caseDefinitionKey("myCase")
+                    .start();
+
+            // Trigger Task One so the entry sentry on the case task fires and the sub-case starts.
+            PlanItemInstance taskOnePlanItem = cmmnRuntimeService.createPlanItemInstanceQuery()
+                    .caseInstanceId(parentCase.getId())
+                    .planItemDefinitionId("task1")
+                    .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                    .singleResult();
+            cmmnRuntimeService.triggerPlanItemInstance(taskOnePlanItem.getId());
+
+            CaseInstance subCase = cmmnRuntimeService.createCaseInstanceQuery()
+                    .caseDefinitionKey("oneTaskCase")
+                    .singleResult();
+            assertThat(subCase).isNotNull();
+
+            PlanItemInstance subTaskPlanItem = cmmnRuntimeService.createPlanItemInstanceQuery()
+                    .caseInstanceId(subCase.getId())
+                    .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                    .singleResult();
+            cmmnRuntimeService.triggerPlanItemInstance(subTaskPlanItem.getId());
+
+            waitForAsyncHistoryExecutorToProcessAllJobs();
+
+            // The sub-case is propagated as the REFERENCE_SCOPE_ID_ in the parent's child entity link.
+            assertThat(cmmnHistoryService.getHistoricEntityLinkParentsForCaseInstance(subCase.getId())).isNotEmpty();
+
+            cmmnHistoryService.deleteHistoricCaseInstance(subCase.getId());
+
+            assertThat(cmmnHistoryService.getHistoricEntityLinkParentsForCaseInstance(subCase.getId())).isEmpty();
+            assertThat(cmmnHistoryService.getHistoricEntityLinkChildrenForCaseInstance(subCase.getId())).isEmpty();
+
+            // Trigger Task Two so the parent case completes, then drop it from history.
+            PlanItemInstance taskTwoPlanItem = cmmnRuntimeService.createPlanItemInstanceQuery()
+                    .caseInstanceId(parentCase.getId())
+                    .planItemDefinitionId("task2")
+                    .planItemInstanceState(PlanItemInstanceState.ACTIVE)
+                    .singleResult();
+            cmmnRuntimeService.triggerPlanItemInstance(taskTwoPlanItem.getId());
+            waitForAsyncHistoryExecutorToProcessAllJobs();
+            cmmnHistoryService.deleteHistoricCaseInstance(parentCase.getId());
+        } finally {
+            cmmnEngineConfiguration.setHistoryLevel(historyLevel);
+        }
+    }
+
     protected void validateEmptyHistoricDataForCaseInstance(String caseInstanceId) {
         assertThat(cmmnHistoryService.createHistoricVariableInstanceQuery().caseInstanceId(caseInstanceId).list()).hasSize(0);
         assertThat(cmmnHistoryService.getHistoricIdentityLinksForCaseInstance(caseInstanceId)).hasSize(0);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/history/DefaultHistoryManager.java
@@ -144,7 +144,8 @@ public class DefaultHistoryManager extends AbstractHistoryManager {
             processEngineConfiguration.getIdentityLinkServiceConfiguration().getHistoricIdentityLinkService().deleteHistoricIdentityLinksByProcessInstanceId(processInstanceId);
             
             if (processEngineConfiguration.isEnableEntityLinks()) {
-                processEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService().deleteHistoricEntityLinksByScopeIdAndScopeType(processInstanceId, ScopeTypes.BPMN);
+                processEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService()
+                        .deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(processInstanceId, ScopeTypes.BPMN);
             }
             
             getCommentEntityManager().deleteCommentsByProcessInstanceId(processInstanceId);
@@ -183,7 +184,8 @@ public class DefaultHistoryManager extends AbstractHistoryManager {
             processEngineConfiguration.getIdentityLinkServiceConfiguration().getHistoricIdentityLinkService().bulkDeleteHistoricIdentityLinksForProcessInstanceIds(processInstanceIds);
             
             if (processEngineConfiguration.isEnableEntityLinks()) {
-                processEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService().bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(ScopeTypes.BPMN, processInstanceIds);
+                processEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService()
+                        .bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(ScopeTypes.BPMN, processInstanceIds);
             }
             
             getCommentEntityManager().bulkDeleteCommentsForProcessInstanceIds(processInstanceIds);

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/util/TaskHelper.java
@@ -660,6 +660,11 @@ public class TaskHelper {
                 }
                 processEngineConfiguration.getIdentityLinkServiceConfiguration().getHistoricIdentityLinkService().deleteHistoricIdentityLinksByTaskId(taskId);
 
+                if (processEngineConfiguration.isEnableEntityLinks()) {
+                    processEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService()
+                            .deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(taskId, ScopeTypes.TASK);
+                }
+
                 historicTaskService.deleteHistoricTask(historicTaskInstance);
             }
         }
@@ -711,6 +716,11 @@ public class TaskHelper {
         processEngineConfiguration.getHistoricDetailEntityManager().bulkDeleteHistoricDetailsByTaskIds(taskIds);
         processEngineConfiguration.getVariableServiceConfiguration().getHistoricVariableService().bulkDeleteHistoricVariableInstancesByTaskIds(taskIds);
         processEngineConfiguration.getIdentityLinkServiceConfiguration().getHistoricIdentityLinkService().bulkDeleteHistoricIdentityLinksForTaskIds(taskIds);
+
+        if (processEngineConfiguration.isEnableEntityLinks()) {
+            processEngineConfiguration.getEntityLinkServiceConfiguration().getHistoricEntityLinkService()
+                    .bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(ScopeTypes.TASK, taskIds);
+        }
 
         historicTaskService.bulkDeleteHistoricTaskInstances(taskIds);
         historicTaskService.bulkDeleteHistoricTaskLogEntriesForTaskIds(taskIds);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/BulkDeleteHistoricProcessInstanceTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/history/BulkDeleteHistoricProcessInstanceTest.java
@@ -456,6 +456,104 @@ public class BulkDeleteHistoricProcessInstanceTest extends PluggableFlowableTest
         }
     }
 
+    @Test
+    @Deployment(resources = { "org/flowable/engine/test/history/callActivity.bpmn20.xml",
+            "org/flowable/engine/test/history/subProcess.bpmn20.xml" })
+    public void deleteHistoricTaskInstanceRemovesReferenceScopeOrphans() {
+        HistoryLevel historyLevel = processEngineConfiguration.getHistoryLevel();
+        try {
+            processEngineConfiguration.setHistoryLevel(HistoryLevel.FULL);
+            ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
+
+            Task mainTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            taskService.complete(mainTask.getId());
+
+            ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+            Task subTask = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+            String subTaskId = subTask.getId();
+
+            // Complete the sub-task so it has an endTime; deleteHistoricTaskInstance only works on completed tasks.
+            taskService.complete(subTaskId);
+            waitForHistoryJobExecutorToProcessAllJobs(10000, 400);
+
+            // The sub-process task carries a parent link (root scope = parent process instance) before delete.
+            assertThat(historyService.getHistoricEntityLinkParentsForTask(subTaskId)).isNotEmpty();
+
+            historyService.deleteHistoricTaskInstance(subTaskId);
+
+            // After deleting only the historic task, no row in ACT_HI_ENTITYLINK may still reference it.
+            assertThat(historyService.getHistoricEntityLinkParentsForTask(subTaskId)).isEmpty();
+            assertThat(historyService.getHistoricEntityLinkChildrenForTask(subTaskId)).isEmpty();
+
+            historyService.deleteHistoricProcessInstance(processInstance.getId());
+        } finally {
+            processEngineConfiguration.setHistoryLevel(historyLevel);
+        }
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/engine/test/history/callActivity.bpmn20.xml",
+            "org/flowable/engine/test/history/subProcess.bpmn20.xml" })
+    public void deleteHistoricProcessInstanceRemovesReferenceScopeOrphans() {
+        HistoryLevel historyLevel = processEngineConfiguration.getHistoryLevel();
+        try {
+            processEngineConfiguration.setHistoryLevel(HistoryLevel.FULL);
+            ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
+
+            Task mainTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            taskService.complete(mainTask.getId());
+
+            ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+            Task subTask = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+            taskService.complete(subTask.getId());
+
+            waitForHistoryJobExecutorToProcessAllJobs(10000, 400);
+
+            // The sub-process is propagated as the REFERENCE_SCOPE_ID_ in the parent's child entity link.
+            assertThat(historyService.getHistoricEntityLinkParentsForProcessInstance(subProcessInstance.getId())).isNotEmpty();
+
+            historyService.deleteHistoricProcessInstance(subProcessInstance.getId());
+
+            assertThat(historyService.getHistoricEntityLinkParentsForProcessInstance(subProcessInstance.getId())).isEmpty();
+            assertThat(historyService.getHistoricEntityLinkChildrenForProcessInstance(subProcessInstance.getId())).isEmpty();
+
+            historyService.deleteHistoricProcessInstance(processInstance.getId());
+        } finally {
+            processEngineConfiguration.setHistoryLevel(historyLevel);
+        }
+    }
+
+    @Test
+    @Deployment(resources = { "org/flowable/engine/test/history/callActivity.bpmn20.xml",
+            "org/flowable/engine/test/history/subProcess.bpmn20.xml" })
+    public void bulkDeleteHistoricProcessInstancesRemovesReferenceScopeOrphans() {
+        HistoryLevel historyLevel = processEngineConfiguration.getHistoryLevel();
+        try {
+            processEngineConfiguration.setHistoryLevel(HistoryLevel.FULL);
+            ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("callActivity");
+
+            Task mainTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            taskService.complete(mainTask.getId());
+
+            ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+            Task subTask = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+            taskService.complete(subTask.getId());
+
+            waitForHistoryJobExecutorToProcessAllJobs(10000, 400);
+
+            assertThat(historyService.getHistoricEntityLinkParentsForProcessInstance(subProcessInstance.getId())).isNotEmpty();
+
+            historyService.bulkDeleteHistoricProcessInstances(Collections.singletonList(subProcessInstance.getId()));
+
+            assertThat(historyService.getHistoricEntityLinkParentsForProcessInstance(subProcessInstance.getId())).isEmpty();
+            assertThat(historyService.getHistoricEntityLinkChildrenForProcessInstance(subProcessInstance.getId())).isEmpty();
+
+            historyService.deleteHistoricProcessInstance(processInstance.getId());
+        } finally {
+            processEngineConfiguration.setHistoryLevel(historyLevel);
+        }
+    }
+
     protected void validateEmptyHistoricDataForProcessInstance(String processInstanceId) {
         assertThat(historyService.createHistoricDetailQuery().processInstanceId(processInstanceId).list()).hasSize(0);
         assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceId).list()).hasSize(0);

--- a/modules/flowable-entitylink-service-api/src/main/java/org/flowable/entitylink/api/history/HistoricEntityLinkService.java
+++ b/modules/flowable-entitylink-service-api/src/main/java/org/flowable/entitylink/api/history/HistoricEntityLinkService.java
@@ -66,9 +66,22 @@ public interface HistoricEntityLinkService {
     
     void deleteHistoricEntityLinksByScopeIdAndScopeType(String scopeId, String scopeType);
     
+    /**
+     * Delete every historic entity link where the given id appears as either the scope id
+     * (with the given scope type) or the reference scope id (with the given reference scope type).
+     * Used when an entity is removed from history to ensure no orphan rows are left pointing at it
+     * from either direction.
+     */
+    void deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(String id, String scopeType);
+
     void deleteHistoricEntityLinksByScopeDefinitionIdAndScopeType(String scopeDefinitionId, String scopeType);
     
     void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(String scopeType, Collection<String> scopeIds);
+
+    /**
+     * Bulk variant of {@link #deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(String, String)}.
+     */
+    void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(String scopeType, Collection<String> ids);
     
     void deleteHistoricEntityLinksForNonExistingProcessInstances();
     

--- a/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/HistoricEntityLinkServiceImpl.java
+++ b/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/HistoricEntityLinkServiceImpl.java
@@ -79,6 +79,11 @@ public class HistoricEntityLinkServiceImpl extends CommonServiceImpl<EntityLinkS
     }
     
     @Override
+    public void deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(String id, String scopeType) {
+        getHistoricEntityLinkEntityManager().deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(id, scopeType);
+    }
+
+    @Override
     public void deleteHistoricEntityLinksByScopeDefinitionIdAndScopeType(String scopeDefinitionId, String scopeType) {
         getHistoricEntityLinkEntityManager().deleteHistoricEntityLinksByScopeDefinitionIdAndScopeType(scopeDefinitionId, scopeType);
     }
@@ -86,6 +91,11 @@ public class HistoricEntityLinkServiceImpl extends CommonServiceImpl<EntityLinkS
     @Override
     public void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(String scopeType, Collection<String> scopeIds) {
         getHistoricEntityLinkEntityManager().bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(scopeType, scopeIds);
+    }
+
+    @Override
+    public void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(String scopeType, Collection<String> ids) {
+        getHistoricEntityLinkEntityManager().bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(scopeType, ids);
     }
 
     @Override

--- a/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/persistence/entity/HistoricEntityLinkEntityManager.java
+++ b/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/persistence/entity/HistoricEntityLinkEntityManager.java
@@ -32,9 +32,13 @@ public interface HistoricEntityLinkEntityManager extends EntityManager<HistoricE
 
     void deleteHistoricEntityLinksByScopeIdAndScopeType(String scopeId, String scopeType);
     
+    void deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(String id, String scopeType);
+
     void deleteHistoricEntityLinksByScopeDefinitionIdAndScopeType(String scopeDefinitionId, String scopeType);
     
     void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(String scopeType, Collection<String> scopeIds);
+
+    void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(String scopeType, Collection<String> ids);
 
     void deleteHistoricEntityLinksForNonExistingProcessInstances();
     

--- a/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/persistence/entity/HistoricEntityLinkEntityManagerImpl.java
+++ b/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/persistence/entity/HistoricEntityLinkEntityManagerImpl.java
@@ -62,6 +62,11 @@ public class HistoricEntityLinkEntityManagerImpl
     }
     
     @Override
+    public void deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType(String id, String scopeType) {
+        dataManager.deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndType(id, scopeType);
+    }
+
+    @Override
     public void deleteHistoricEntityLinksByScopeDefinitionIdAndScopeType(String scopeDefinitionId, String scopeType) {
         dataManager.deleteHistoricEntityLinksByScopeDefinitionIdAndType(scopeDefinitionId, scopeType);
     }
@@ -69,6 +74,11 @@ public class HistoricEntityLinkEntityManagerImpl
     @Override
     public void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(String scopeType, Collection<String> scopeIds) {
         dataManager.bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(scopeType, scopeIds);
+    }
+
+    @Override
+    public void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(String scopeType, Collection<String> ids) {
+        dataManager.bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(scopeType, ids);
     }
 
     @Override

--- a/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/persistence/entity/data/HistoricEntityLinkDataManager.java
+++ b/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/persistence/entity/data/HistoricEntityLinkDataManager.java
@@ -35,9 +35,13 @@ public interface HistoricEntityLinkDataManager extends DataManager<HistoricEntit
     
     void deleteHistoricEntityLinksByScopeIdAndType(String scopeId, String scopeType);
     
+    void deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndType(String id, String scopeType);
+
     void deleteHistoricEntityLinksByScopeDefinitionIdAndType(String scopeDefinitionId, String scopeType);
     
     void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds(String scopeType, Collection<String> scopeIds);
+
+    void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(String scopeType, Collection<String> ids);
     
     void deleteHistoricEntityLinksForNonExistingProcessInstances();
     

--- a/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/persistence/entity/data/impl/MybatisHistoricEntityLinkDataManager.java
+++ b/modules/flowable-entitylink-service/src/main/java/org/flowable/entitylink/service/impl/persistence/entity/data/impl/MybatisHistoricEntityLinkDataManager.java
@@ -102,6 +102,14 @@ public class MybatisHistoricEntityLinkDataManager extends AbstractDataManager<Hi
     }
     
     @Override
+    public void deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndType(String id, String scopeType) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("id", id);
+        parameters.put("scopeType", scopeType);
+        getDbSqlSession().delete("deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType", parameters, HistoricEntityLinkEntityImpl.class);
+    }
+
+    @Override
     public void deleteHistoricEntityLinksByScopeDefinitionIdAndType(String scopeDefinitionId, String scopeType) {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("scopeDefinitionId", scopeDefinitionId);
@@ -115,6 +123,14 @@ public class MybatisHistoricEntityLinkDataManager extends AbstractDataManager<Hi
         parameters.put("scopeType", scopeType);
         parameters.put("scopeIds", createSafeInValuesList(scopeIds));
         getDbSqlSession().delete("bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIds", parameters, HistoricEntityLinkEntityImpl.class);
+    }
+
+    @Override
+    public void bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds(String scopeType, Collection<String> ids) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("scopeType", scopeType);
+        parameters.put("ids", createSafeInValuesList(ids));
+        getDbSqlSession().delete("bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds", parameters, HistoricEntityLinkEntityImpl.class);
     }
 
     @Override

--- a/modules/flowable-entitylink-service/src/main/resources/org/flowable/entitylink/service/db/mapping/entity/HistoricEntityLink.xml
+++ b/modules/flowable-entitylink-service/src/main/resources/org/flowable/entitylink/service/db/mapping/entity/HistoricEntityLink.xml
@@ -87,6 +87,12 @@
     delete from ${prefix}ACT_HI_ENTITYLINK where SCOPE_ID_ = #{scopeId, jdbcType=NVARCHAR} and SCOPE_TYPE_ = #{scopeType, jdbcType=NVARCHAR}
   </delete>
   
+  <delete id="deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType" parameterType="java.util.Map">
+    delete from ${prefix}ACT_HI_ENTITYLINK
+    where (SCOPE_ID_     = #{id, jdbcType=NVARCHAR} and SCOPE_TYPE_     = #{scopeType, jdbcType=NVARCHAR})
+       or (REF_SCOPE_ID_ = #{id, jdbcType=NVARCHAR} and REF_SCOPE_TYPE_ = #{scopeType, jdbcType=NVARCHAR})
+  </delete>
+
   <delete id="deleteHistoricEntityLinksByScopeDefinitionIdAndScopeType" parameterType="java.util.Map">
     delete from ${prefix}ACT_HI_ENTITYLINK where SCOPE_DEFINITION_ID_ = #{scopeDefinitionId, jdbcType=NVARCHAR} and SCOPE_TYPE_ = #{scopeType, jdbcType=NVARCHAR}
   </delete>
@@ -102,6 +108,31 @@
           #{scopeId, jdbcType=NVARCHAR}
         </foreach>
     </foreach>)
+  </delete>
+
+  <delete id="bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds" parameterType="java.util.Map">
+    delete from ${prefix}ACT_HI_ENTITYLINK where
+    (SCOPE_TYPE_ = #{scopeType, jdbcType=NVARCHAR} and
+     (<foreach item="listItem" index="listIndex" collection="ids">
+        <if test="listIndex &gt; 0">
+        or
+        </if>
+        SCOPE_ID_ in
+        <foreach item="id" index="index" collection="listItem" open="(" separator="," close=")">
+          #{id, jdbcType=NVARCHAR}
+        </foreach>
+     </foreach>))
+    or
+    (REF_SCOPE_TYPE_ = #{scopeType, jdbcType=NVARCHAR} and
+     (<foreach item="listItem" index="listIndex" collection="ids">
+        <if test="listIndex &gt; 0">
+        or
+        </if>
+        REF_SCOPE_ID_ in
+        <foreach item="id" index="index" collection="listItem" open="(" separator="," close=")">
+          #{id, jdbcType=NVARCHAR}
+        </foreach>
+     </foreach>))
   </delete>
   
   <delete id="bulkDeleteHistoricProcessEntityLinks" parameterType="java.util.Map">


### PR DESCRIPTION
Historic entity-link cleanup only deleted rows where the deleted entity appeared as the `SCOPE_ID_`, leaving orphan rows where it appeared as the `REFERENCE_SCOPE_ID_`. Subsequent reads of those links could return entries pointing at scopes that no longer exist.

Add `deleteHistoricEntityLinksByScopeIdOrReferenceScopeIdAndScopeType` and `bulkDeleteHistoricEntityLinksForScopeTypeAndScopeIdsOrReferenceScopeIds` on `HistoricEntityLinkService` and use them from
`TaskHelper#deleteHistoricTask` (BPMN and CMMN, single and bulk), `DefaultHistoryManager#recordProcessInstanceDeleted` / `recordBulkDeleteProcessInstances`,
`DefaultCmmnHistoryManager#recordHistoricCaseInstanceDeleted`, and `CmmnHistoryHelper#bulkDeleteHistoricCaseInstances`. A single SQL delete now removes every row mentioning the deleted entity in either direction.
