### PR TITLE
Upgrade to Spring Boot 4.1.0-RC1

### DIFF
--- a/modules/flowable-dependencies/pom.xml
+++ b/modules/flowable-dependencies/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <!-- External dependencies -->
         <angus-mail.version>2.0.4</angus-mail.version>
-        <artemis.version>2.44.0</artemis.version>
+        <artemis.version>2.53.0</artemis.version>
         <camel.version>4.8.0</camel.version>
         <commons-codec.version>1.20.0</commons-codec.version>
         <commons-io.version>2.21.0</commons-io.version>
@@ -51,12 +51,12 @@
         <reactor-netty.version>1.3.0</reactor-netty.version>
         <slf4j.version>2.0.17</slf4j.version>
         <!-- When updating one spring version, make sure that all of them are updated to their latest compatible versions -->
-        <spring.amqp.version>4.0.2</spring.amqp.version>
-        <spring.boot.version>4.0.2</spring.boot.version>
-        <spring.kafka.version>4.0.2</spring.kafka.version>
-        <spring.ldap.version>4.0.1</spring.ldap.version>
-        <spring.framework.version>7.0.3</spring.framework.version>
-        <spring.security.version>7.0.2</spring.security.version>
+        <spring.amqp.version>4.1.0-RC1</spring.amqp.version>
+        <spring.boot.version>4.1.0-RC1</spring.boot.version>
+        <spring.kafka.version>4.1.0-RC1</spring.kafka.version>
+        <spring.ldap.version>4.1.0-RC1</spring.ldap.version>
+        <spring.framework.version>7.0.7</spring.framework.version>
+        <spring.security.version>7.1.0-RC1</spring.security.version>
         <swagger.version>1.6.2</swagger.version>
 
         <!-- JDBC Driver dependencies -->

--- a/modules/flowable-event-registry-spring/src/main/java/org/flowable/eventregistry/spring/kafka/SimpleKafkaListenerEndpoint.java
+++ b/modules/flowable-event-registry-spring/src/main/java/org/flowable/eventregistry/spring/kafka/SimpleKafkaListenerEndpoint.java
@@ -127,6 +127,11 @@ public class SimpleKafkaListenerEndpoint<K, V> implements KafkaListenerEndpoint,
     }
 
     @Override
+    public String getAckMode() {
+        return null;
+    }
+
+    @Override
     public Properties getConsumerProperties() {
         return consumerProperties;
     }

--- a/modules/flowable-event-registry-spring/src/main/java/org/flowable/eventregistry/spring/rabbit/RabbitChannelDefinitionProcessor.java
+++ b/modules/flowable-event-registry-spring/src/main/java/org/flowable/eventregistry/spring/rabbit/RabbitChannelDefinitionProcessor.java
@@ -35,7 +35,7 @@ import org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPo
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitOperations;
-import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.amqp.core.MessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;

--- a/modules/flowable-spring-boot/pom.xml
+++ b/modules/flowable-spring-boot/pom.xml
@@ -27,18 +27,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!--
-                Spring Boot 4.0 is using Artemis 2.43.0 which is not compatible with java 25.
-                Therefore, we override it like this.
-                Once we upgrade to a Spring Boot version that uses Artemis that supports Java 25 we can remove this artemis-bom import
-             -->
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-bom</artifactId>
-                <version>${artemis.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Bumps Spring Boot, Framework, Security, AMQP, Kafka and LDAP to the 4.1.0-RC1-aligned versions, drops the Artemis 2.43.0 workaround now that Boot 4.1 ships Artemis 2.53.0, and adapts to two source-level breaking changes:

- Spring Kafka 4.1 added KafkaListenerEndpoint#getAckMode() as a required method; SimpleKafkaListenerEndpoint now implements it.
- Spring AMQP 4.1 deprecated org.springframework.amqp.rabbit.listener .MessageListenerContainer in favor of the core variant, which is what RabbitListenerEndpointRegistry now returns.

