### PR TITLE
Add DependsOnDatabaseInitializationDetector so engines wait for database initializers

### DIFF
--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableDependsOnDatabaseInitializationDetector.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/FlowableDependsOnDatabaseInitializationDetector.java
@@ -1,0 +1,46 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.spring.boot;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.flowable.common.engine.api.Engine;
+import org.springframework.boot.sql.init.dependency.AbstractBeansOfTypeDependsOnDatabaseInitializationDetector;
+import org.springframework.core.env.Environment;
+
+/**
+ * {@link org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitializationDetector}
+ * marking all Flowable {@link Engine} beans as depending on database initialization, so Spring
+ * Boot orders them after Flyway, Liquibase or spring.sql.init have run.
+ *
+ * <p>Can be opted out of by setting {@code flowable.depends-on-database-initialization-detection}
+ * to {@code false}, mirroring the JPA detector's opt-out behavior.
+ *
+ * @author Nikhil Bharadwaj Ramashasthri
+ */
+class FlowableDependsOnDatabaseInitializationDetector extends AbstractBeansOfTypeDependsOnDatabaseInitializationDetector {
+
+    private final Environment environment;
+
+    FlowableDependsOnDatabaseInitializationDetector(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    protected Set<Class<?>> getDependsOnDatabaseInitializationBeanTypes() {
+        boolean detectionEnabled = environment
+                .getProperty("flowable.depends-on-database-initialization-detection", Boolean.class, true);
+        return detectionEnabled ? Collections.singleton(Engine.class) : Collections.emptySet();
+    }
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -714,6 +714,12 @@
       "name": "flowable.process.async-history.executor.timer-runnable-needed",
       "type": "java.lang.Boolean",
       "defaultValue": false
+    },
+    {
+      "name": "flowable.depends-on-database-initialization-detection",
+      "type": "java.lang.Boolean",
+      "description": "Whether Flowable engine beans should be marked as depending on Spring Boot managed database initializers (Flyway, Liquibase, spring.sql.init), ensuring they start only after schema initialization has run.",
+      "defaultValue": true
     }
   ],
   "hints": [
@@ -761,7 +767,6 @@
           "value": "spring_delegating_noop",
           "description": "Use the Spring Security 5 PasswordEncoderFactories.createDelegatingPasswordEncoder(). With NoopPasswordEncoder as the default password encoder for matches. This should be used for backwards compatibility with older versions."
         }
-
       ]
     },
     {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,5 @@
 
 org.springframework.boot.EnvironmentPostProcessor=\
   org.flowable.spring.boot.environment.FlowableDefaultPropertiesEnvironmentPostProcessor
+org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitializationDetector=\
+  org.flowable.spring.boot.FlowableDependsOnDatabaseInitializationDetector

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableDependsOnDatabaseInitializationDetectorTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableDependsOnDatabaseInitializationDetectorTest.java
@@ -1,0 +1,76 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flowable.test.spring.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.flowable.spring.boot.ProcessEngineAutoConfiguration;
+import org.flowable.spring.boot.ProcessEngineServicesAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceInitializationAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * The Flowable engines create/validate their own schema on engine build, so their beans must be
+ * ordered after Spring Boot managed database initializers (Flyway, Liquibase, spring.sql.init).
+ * This is done through the {@code DependsOnDatabaseInitializationDetector} SPI (issue #4213).
+ *
+ * @author Nikhil Bharadwaj Ramashasthri
+ */
+class FlowableDependsOnDatabaseInitializationDetectorTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    DataSourceAutoConfiguration.class,
+                    DataSourceTransactionManagerAutoConfiguration.class,
+                    DataSourceInitializationAutoConfiguration.class,
+                    ProcessEngineAutoConfiguration.class,
+                    ProcessEngineServicesAutoConfiguration.class));
+
+    @Test
+    void processEngineDependsOnDatabaseInitialization() {
+        contextRunner
+                .withPropertyValues("spring.sql.init.mode=always")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    String[] dependsOn = context.getBeanFactory()
+                            .getBeanDefinition("processEngine")
+                            .getDependsOn();
+                    assertThat(dependsOn)
+                            .as("processEngine must wait for the SQL init database initializer")
+                            .isNotNull()
+                            .contains("dataSourceScriptDatabaseInitializer");
+                });
+    }
+
+    @Test
+    void detectionCanBeOptedOut() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.sql.init.mode=always",
+                        "flowable.depends-on-database-initialization-detection=false")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    String[] dependsOn = context.getBeanFactory()
+                            .getBeanDefinition("processEngine")
+                            .getDependsOn();
+                    assertThat(dependsOn == null || !java.util.Arrays.asList(dependsOn)
+                            .contains("dataSourceScriptDatabaseInitializer"))
+                            .as("opt-out must remove the database initializer dependency")
+                            .isTrue();
+                });
+    }
+}

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableDependsOnDatabaseInitializationDetectorTest.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/test/java/org/flowable/test/spring/boot/FlowableDependsOnDatabaseInitializationDetectorTest.java
@@ -43,7 +43,9 @@ class FlowableDependsOnDatabaseInitializationDetectorTest {
     @Test
     void processEngineDependsOnDatabaseInitialization() {
         contextRunner
-                .withPropertyValues("spring.sql.init.mode=always")
+                .withPropertyValues(
+                        "spring.sql.init.mode=always",
+                        "flowable.check-process-definitions=false")
                 .run(context -> {
                     assertThat(context).hasNotFailed();
                     String[] dependsOn = context.getBeanFactory()
@@ -51,7 +53,6 @@ class FlowableDependsOnDatabaseInitializationDetectorTest {
                             .getDependsOn();
                     assertThat(dependsOn)
                             .as("processEngine must wait for the SQL init database initializer")
-                            .isNotNull()
                             .contains("dataSourceScriptDatabaseInitializer");
                 });
     }
@@ -61,16 +62,16 @@ class FlowableDependsOnDatabaseInitializationDetectorTest {
         contextRunner
                 .withPropertyValues(
                         "spring.sql.init.mode=always",
+                        "flowable.check-process-definitions=false",
                         "flowable.depends-on-database-initialization-detection=false")
                 .run(context -> {
                     assertThat(context).hasNotFailed();
                     String[] dependsOn = context.getBeanFactory()
                             .getBeanDefinition("processEngine")
                             .getDependsOn();
-                    assertThat(dependsOn == null || !java.util.Arrays.asList(dependsOn)
-                            .contains("dataSourceScriptDatabaseInitializer"))
+                    assertThat(dependsOn)
                             .as("opt-out must remove the database initializer dependency")
-                            .isTrue();
+                            .isNullOrEmpty();
                 });
     }
 }


### PR DESCRIPTION
Implements #4213, following the approach @filiphr outlined there ("You can go ahead and create a PR for this").

**What:** a `FlowableDependsOnDatabaseInitializationDetector` extending Spring Boot's `AbstractBeansOfTypeDependsOnDatabaseInitializationDetector` for `org.flowable.common.engine.api.Engine` (covering process/cmmn/dmn/app/idm engines through the shared interface, no bean names), registered under the `DependsOnDatabaseInitializationDetector` SPI in `spring.factories`. Spring Boot's `DatabaseInitializationDependencyConfigurer` then orders every engine bean after Flyway/Liquibase/`spring.sql.init` initializers.

**Opt-out:** `flowable.depends-on-database-initialization-detection=false` (default `true`), mirroring the JPA detector's opt-out pattern per the issue discussion; documented in `additional-spring-configuration-metadata.json`.

**Testing:** `FlowableDependsOnDatabaseInitializationDetectorTest` uses `ApplicationContextRunner` with `spring.sql.init` and asserts the `processEngine` bean definition gains `dependsOn` on `dataSourceScriptDatabaseInitializer`, plus the opt-out case. Verified the assertion goes red when the `spring.factories` registration is removed. I can add a Flyway-based sample under `flowable-spring-boot-samples` as a follow-up if you'd prefer that shape of test as well.

- [x] Unit tests added
- [x] Documentation: property registered in configuration metadata

Developed with AI assistance (Claude Code), reviewed and driven by a human.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flowable/codesmith/flowable-engine/pr/4222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786673757&installation_id=145635894&pr_number=4222&repository=flowable%2Fflowable-engine&return_to=https%3A%2F%2Fgithub.com%2Fflowable%2Fflowable-engine%2Fpull%2F4222&signature=00aa8800cb270317cd4249d8088f92de6828d076fe62a803e2289b50aedf54db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->