### PR TITLE
Add binary (byte[]) request body support to FlowableHttpClient

### DIFF
--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/api/HttpRequest.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/api/HttpRequest.java
@@ -35,6 +35,12 @@ public class HttpRequest {
     protected String body;
     protected String bodyEncoding;
     /**
+     * Raw binary body to be sent in the request. Mutually exclusive with {@link #body}, {@link #multiValueParts}
+     * and {@link #formParameters}. Use this for a raw binary payload that must not go through the textual
+     * {@link #body}, which would corrupt it.
+     */
+    protected byte[] bodyBytes;
+    /**
      * Multi-value parts to be sent in the request.
      * This is used for multipart/form-data requests and will be encoded as such.
      */
@@ -93,7 +99,9 @@ public class HttpRequest {
     }
 
     public void setBody(String body) {
-        if (multiValueParts != null && !multiValueParts.isEmpty()) {
+        if (bodyBytes != null) {
+            throw new FlowableIllegalStateException("Cannot set both body and body bytes");
+        } else if (multiValueParts != null && !multiValueParts.isEmpty()) {
             throw new FlowableIllegalStateException("Cannot set both body and multi value parts");
         } else if (formParameters != null && !formParameters.isEmpty()) {
             throw new FlowableIllegalStateException("Cannot set both body and form parameters");
@@ -109,6 +117,21 @@ public class HttpRequest {
         this.bodyEncoding = bodyEncoding;
     }
 
+    public byte[] getBodyBytes() {
+        return bodyBytes;
+    }
+
+    public void setBodyBytes(byte[] bodyBytes) {
+        if (body != null) {
+            throw new FlowableIllegalStateException("Cannot set both body and body bytes");
+        } else if (multiValueParts != null && !multiValueParts.isEmpty()) {
+            throw new FlowableIllegalStateException("Cannot set both body bytes and multi value parts");
+        } else if (formParameters != null && !formParameters.isEmpty()) {
+            throw new FlowableIllegalStateException("Cannot set both body bytes and form parameters");
+        }
+        this.bodyBytes = bodyBytes;
+    }
+
     public Collection<MultiValuePart> getMultiValueParts() {
         return multiValueParts;
     }
@@ -116,6 +139,8 @@ public class HttpRequest {
     public void addMultiValuePart(MultiValuePart part) {
         if (body != null) {
             throw new FlowableIllegalStateException("Cannot set both body and multi value parts");
+        } else if (bodyBytes != null) {
+            throw new FlowableIllegalStateException("Cannot set both body bytes and multi value parts");
         } else if (formParameters != null && !formParameters.isEmpty()) {
             throw new FlowableIllegalStateException("Cannot set both form parameters and multi value parts");
         }
@@ -132,6 +157,8 @@ public class HttpRequest {
     public void addFormParameter(String key, String value) {
         if (body != null) {
             throw new FlowableIllegalStateException("Cannot set both body and form parameters");
+        } else if (bodyBytes != null) {
+            throw new FlowableIllegalStateException("Cannot set both body bytes and form parameters");
         } else if (multiValueParts != null && !multiValueParts.isEmpty()) {
             throw new FlowableIllegalStateException("Cannot set both multi value parts and form parameters");
         }

--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/ApacheHttpComponentsFlowableHttpClient.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/ApacheHttpComponentsFlowableHttpClient.java
@@ -48,6 +48,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.HttpMultipartMode;
@@ -247,6 +248,9 @@ public class ApacheHttpComponentsFlowableHttpClient implements FlowableHttpClien
             } else {
                 requestBase.setEntity(new StringEntity(requestInfo.getBody()));
             }
+        } else if (requestInfo.getBodyBytes() != null) {
+            // A caller-supplied Content-Type header (added afterwards) takes precedence over this default.
+            requestBase.setEntity(new ByteArrayEntity(requestInfo.getBodyBytes(), ContentType.APPLICATION_OCTET_STREAM));
         } else if (requestInfo.getMultiValueParts() != null) {
             if (MULTIPART_ENTITY_BUILDER_PRESENT) {
                 MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();

--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/client5/ApacheHttpComponents5FlowableHttpClient.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/apache/client5/ApacheHttpComponents5FlowableHttpClient.java
@@ -234,6 +234,9 @@ public class ApacheHttpComponents5FlowableHttpClient implements FlowableAsyncHtt
             } else {
                 requestBase.setEntity(AsyncEntityProducers.create(requestInfo.getBody()));
             }
+        } else if (requestInfo.getBodyBytes() != null) {
+            // A caller-supplied Content-Type header (added afterwards) takes precedence over this default.
+            requestBase.setEntity(requestInfo.getBodyBytes(), ContentType.APPLICATION_OCTET_STREAM);
         } else if (requestInfo.getMultiValueParts() != null) {
             MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
             entityBuilder.setMode(multipartMode);

--- a/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/spring/reactive/SpringWebClientFlowableHttpClient.java
+++ b/modules/flowable-http-common/src/main/java/org/flowable/http/common/impl/spring/reactive/SpringWebClientFlowableHttpClient.java
@@ -190,6 +190,10 @@ public class SpringWebClientFlowableHttpClient implements FlowableAsyncHttpClien
             }
 
             requestBodySpec.bodyValue(requestInfo.getBody());
+        } else if (requestInfo.getBodyBytes() != null) {
+            // A caller-supplied Content-Type header (added afterwards) takes precedence over this default.
+            requestBodySpec.contentType(MediaType.APPLICATION_OCTET_STREAM);
+            requestBodySpec.bodyValue(requestInfo.getBodyBytes());
         } else if (requestInfo.getMultiValueParts() != null) {
             MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
             for (MultiValuePart part : requestInfo.getMultiValueParts()) {

--- a/modules/flowable-http-common/src/test/java/org/flowable/http/common/api/HttpRequestTest.java
+++ b/modules/flowable-http-common/src/test/java/org/flowable/http/common/api/HttpRequestTest.java
@@ -84,6 +84,66 @@ class HttpRequestTest {
     }
 
     @Test
+    void setBodyBytesShouldNotBePossibleWhenBodyIsSet() {
+        HttpRequest request = new HttpRequest();
+        request.setBody("test");
+        assertThatThrownBy(() -> request.setBodyBytes(new byte[] { 1, 2, 3 }))
+                .isInstanceOf(FlowableIllegalStateException.class)
+                .hasMessage("Cannot set both body and body bytes");
+        assertThat(request.getBodyBytes()).isNull();
+    }
+
+    @Test
+    void setBodyBytesShouldNotBePossibleWhenMultiValuePartsAreSet() {
+        HttpRequest request = new HttpRequest();
+        request.addMultiValuePart(MultiValuePart.fromText("name", "kermit"));
+        assertThatThrownBy(() -> request.setBodyBytes(new byte[] { 1, 2, 3 }))
+                .isInstanceOf(FlowableIllegalStateException.class)
+                .hasMessage("Cannot set both body bytes and multi value parts");
+        assertThat(request.getBodyBytes()).isNull();
+    }
+
+    @Test
+    void setBodyBytesShouldNotBePossibleWhenFormParametersAreSet() {
+        HttpRequest request = new HttpRequest();
+        request.addFormParameter("name", "kermit");
+        assertThatThrownBy(() -> request.setBodyBytes(new byte[] { 1, 2, 3 }))
+                .isInstanceOf(FlowableIllegalStateException.class)
+                .hasMessage("Cannot set both body bytes and form parameters");
+        assertThat(request.getBodyBytes()).isNull();
+    }
+
+    @Test
+    void setBodyShouldNotBePossibleWhenBodyBytesAreSet() {
+        HttpRequest request = new HttpRequest();
+        request.setBodyBytes(new byte[] { 1, 2, 3 });
+        assertThatThrownBy(() -> request.setBody("test"))
+                .isInstanceOf(FlowableIllegalStateException.class)
+                .hasMessage("Cannot set both body and body bytes");
+        assertThat(request.getBody()).isNull();
+    }
+
+    @Test
+    void addMultiValuePartShouldNotBePossibleWhenBodyBytesAreSet() {
+        HttpRequest request = new HttpRequest();
+        request.setBodyBytes(new byte[] { 1, 2, 3 });
+        assertThatThrownBy(() -> request.addMultiValuePart(MultiValuePart.fromText("name", "kermit")))
+                .isInstanceOf(FlowableIllegalStateException.class)
+                .hasMessage("Cannot set both body bytes and multi value parts");
+        assertThat(request.getMultiValueParts()).isNull();
+    }
+
+    @Test
+    void addFormParameterShouldNotBePossibleWhenBodyBytesAreSet() {
+        HttpRequest request = new HttpRequest();
+        request.setBodyBytes(new byte[] { 1, 2, 3 });
+        assertThatThrownBy(() -> request.addFormParameter("name", "kermit"))
+                .isInstanceOf(FlowableIllegalStateException.class)
+                .hasMessage("Cannot set both body bytes and form parameters");
+        assertThat(request.getFormParameters()).isNull();
+    }
+
+    @Test
     void getHttpHeadersAsString() {
         HttpRequest request = new HttpRequest();
         assertThat(request.getHttpHeadersAsString()).isNull();

--- a/modules/flowable-http/src/test/java/org/flowable/http/FlowableHttpClientTest.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/FlowableHttpClientTest.java
@@ -88,6 +88,46 @@ class FlowableHttpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(FlowableHttpClientArgumentProvider.class)
+    void postBinaryBody(FlowableHttpClient httpClient) {
+        // Bytes spanning the full 0-255 range would be corrupted if sent through the textual body.
+        byte[] content = new byte[1024];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) i;
+        }
+
+        HttpRequest request = new HttpRequest();
+        request.setUrl("http://localhost:9798/binary");
+        request.setMethod("POST");
+        request.setBodyBytes(content);
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Content-Type", "application/pdf");
+        request.setHttpHeaders(httpHeaders);
+        HttpResponse response = httpClient.prepareRequest(request).call();
+
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getBodyBytes()).isEqualTo(content);
+        // The caller-supplied Content-Type header wins over the application/octet-stream default, exactly once.
+        assertThat(response.getHttpHeaders().get("Content-Type")).containsExactly("application/pdf");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FlowableHttpClientArgumentProvider.class)
+    void putBinaryBodyWithoutContentTypeDefaultsToOctetStream(FlowableHttpClient httpClient) {
+        byte[] content = { 0, 1, 2, 3, (byte) 200, (byte) 255 };
+
+        HttpRequest request = new HttpRequest();
+        request.setUrl("http://localhost:9798/binary");
+        request.setMethod("PUT");
+        request.setBodyBytes(content);
+        HttpResponse response = httpClient.prepareRequest(request).call();
+
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getBodyBytes()).isEqualTo(content);
+        assertThat(response.getHttpHeaders().get("Content-Type")).containsExactly("application/octet-stream");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FlowableHttpClientArgumentProvider.class)
     void getWithAllParameters(FlowableHttpClient httpClient) {
         HttpRequest request = new HttpRequest();
         request.setUrl("http://localhost:9798/api/test?testArg=testValue");

--- a/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTestServer.java
+++ b/modules/flowable-http/src/test/java/org/flowable/http/bpmn/HttpServiceTaskTestServer.java
@@ -108,6 +108,7 @@ public class HttpServiceTaskTestServer {
             contextHandler.addServlet(new ServletHolder(new ArrayResponseServlet()), "/array-response");
             contextHandler.addServlet(new ServletHolder(new DeleteResponseServlet()), "/delete");
             contextHandler.addServlet(new ServletHolder(new ClasspathResourceServlet()), "/resource");
+            contextHandler.addServlet(new ServletHolder(new BinaryEchoServlet()), "/binary");
             server.setHandler(contextHandler);
             server.start();
         } catch (Exception e) {
@@ -365,6 +366,25 @@ public class HttpServiceTaskTestServer {
             } else {
                 resp.sendError(400, "resource not provided");
             }
+        }
+    }
+
+    /**
+     * Echoes the raw request body back verbatim and reflects the received {@code Content-Type} back as the response
+     * content type, so a binary round-trip can assert both that the bytes were not corrupted and that the content type
+     * arrived correctly (exactly once).
+     */
+    protected static class BinaryEchoServlet extends HttpServlet {
+
+        @Override
+        protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            byte[] body = IOUtils.toByteArray(req.getInputStream());
+            resp.setStatus(200);
+            String contentType = req.getContentType();
+            if (StringUtils.isNotEmpty(contentType)) {
+                resp.setContentType(contentType);
+            }
+            resp.getOutputStream().write(body);
         }
     }
 


### PR DESCRIPTION
FlowableHttpClient could only send a textual request body (HttpRequest.body), which corrupts binary content such as file uploads. Add HttpRequest.bodyBytes, a raw byte[] body sent as an octet-stream entity, mutually exclusive with the string body, multipart parts and form parameters. A caller-supplied Content-Type header takes precedence over the octet-stream default.

Implemented in all three clients (Apache HttpComponents 4 and 5, and the Spring WebClient) and covered by the parameterized FlowableHttpClientTest against each.

#### Check List:
* Unit tests: YES / NO / NA
* Documentation: YES / NO / NA
