### PR TITLE
fix(DeploymentCollectionResource):When using fileName.split("\\.")[0] to get the filename, a ArrayIndexOutOfBoundsException will be thrown if the filename has no extension.

### DIFF
--- a/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/repository/DeploymentCollectionResource.java
+++ b/modules/flowable-cmmn-rest/src/main/java/org/flowable/cmmn/rest/service/api/repository/DeploymentCollectionResource.java
@@ -206,7 +206,11 @@ public class DeploymentCollectionResource {
             }
 
             if (!decodedQueryStrings.containsKey("deploymentName") || StringUtils.isEmpty(decodedQueryStrings.get("deploymentName"))) {
-                String fileNameWithoutExtension = fileName.split("\\.")[0];
+                String fileNameWithoutExtension = fileName;
+                int dotIndex = fileName.lastIndexOf('.');
+                if (dotIndex > 0) {
+                    fileNameWithoutExtension = fileName.substring(0, dotIndex);
+                }
 
                 if (StringUtils.isNotEmpty(fileNameWithoutExtension)) {
                     fileName = fileNameWithoutExtension;

--- a/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/repository/DeploymentCollectionResource.java
+++ b/modules/flowable-event-registry-rest/src/main/java/org/flowable/eventregistry/rest/service/api/repository/DeploymentCollectionResource.java
@@ -195,7 +195,11 @@ public class DeploymentCollectionResource {
             }
 
             if (!decodedQueryStrings.containsKey("deploymentName") || StringUtils.isEmpty(decodedQueryStrings.get("deploymentName"))) {
-                String fileNameWithoutExtension = fileName.split("\\.")[0];
+                String fileNameWithoutExtension = fileName;
+                int dotIndex = fileName.lastIndexOf('.');
+                if (dotIndex > 0) {
+                    fileNameWithoutExtension = fileName.substring(0, dotIndex);
+                }
 
                 if (StringUtils.isNotEmpty(fileNameWithoutExtension)) {
                     fileName = fileNameWithoutExtension;

--- a/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentCollectionResource.java
+++ b/modules/flowable-rest/src/main/java/org/flowable/rest/service/api/repository/DeploymentCollectionResource.java
@@ -205,7 +205,11 @@ public class DeploymentCollectionResource {
             }
 
             if (!decodedQueryStrings.containsKey("deploymentName") || StringUtils.isEmpty(decodedQueryStrings.get("deploymentName"))) {
-                String fileNameWithoutExtension = fileName.split("\\.")[0];
+                String fileNameWithoutExtension = fileName;
+                int dotIndex = fileName.lastIndexOf('.');
+                if (dotIndex > 0) {
+                    fileNameWithoutExtension = fileName.substring(0, dotIndex);
+                }
 
                 if (StringUtils.isNotEmpty(fileNameWithoutExtension)) {
                     fileName = fileNameWithoutExtension;


### PR DESCRIPTION
fix(DeploymentCollectionResource):When using fileName.split("\\.")[0] to get the filename, a ArrayIndexOutOfBoundsException will be thrown if the filename has no extension.