### PR TITLE
Fix identityService binding name in VariableScopeResolver

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/scripting/VariableScopeResolver.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/scripting/VariableScopeResolver.java
@@ -44,7 +44,7 @@ public class VariableScopeResolver implements Resolver {
             "managementService", ProcessEngineConfiguration::getManagementService,
             "historyService", ProcessEngineConfiguration::getHistoryService,
             "formService", ProcessEngineConfiguration::getFormService,
-            "identityServiceKey", ProcessEngineConfiguration::getIdentityService
+            "identityService", ProcessEngineConfiguration::getIdentityService
     );
 
     public VariableScopeResolver(ProcessEngineConfigurationImpl processEngineConfiguration, VariableContainer scopeContainer,

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/scripting/VariableScopeResolver.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/scripting/VariableScopeResolver.java
@@ -44,7 +44,9 @@ public class VariableScopeResolver implements Resolver {
             "managementService", ProcessEngineConfiguration::getManagementService,
             "historyService", ProcessEngineConfiguration::getHistoryService,
             "formService", ProcessEngineConfiguration::getFormService,
-            "identityService", ProcessEngineConfiguration::getIdentityService
+            "identityService", ProcessEngineConfiguration::getIdentityService,
+            // the identity service was historically exposed under this name, kept for backwards compatibility
+            "identityServiceKey", ProcessEngineConfiguration::getIdentityService
     );
 
     public VariableScopeResolver(ProcessEngineConfigurationImpl processEngineConfiguration, VariableContainer scopeContainer,

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
@@ -82,6 +82,18 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
 
     @Test
     @Deployment
+    public void testIdentityServiceAvailableInScript() {
+        identityService.saveUser(identityService.newUser("kermit"));
+        try {
+            String id = runtimeService.startProcessInstanceByKey("identityServiceInScript").getId();
+            assertThat(runtimeService.getVariable(id, "userCount")).isEqualTo(1L);
+        } finally {
+            identityService.deleteUser("kermit");
+        }
+    }
+
+    @Test
+    @Deployment
     public void testInputVariables() {
         // The first script should use the input variables
         // i.e. when input parameters are defined then doNotIncludeVariables is ignored

--- a/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.java
@@ -87,6 +87,8 @@ public class ScriptTaskTest extends PluggableFlowableTestCase {
         try {
             String id = runtimeService.startProcessInstanceByKey("identityServiceInScript").getId();
             assertThat(runtimeService.getVariable(id, "userCount")).isEqualTo(1L);
+            // the identity service is still available under its former name
+            assertThat(runtimeService.getVariable(id, "legacyUserCount")).isEqualTo(1L);
         } finally {
             identityService.deleteUser("kermit");
         }

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testIdentityServiceAvailableInScript.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testIdentityServiceAvailableInScript.bpmn20.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="identityServiceInScript">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="script1"/>
+
+        <scriptTask id="script1" scriptFormat="groovy" flowable:autoStoreVariables="false">
+            <script><![CDATA[
+        execution.setVariable('userCount', identityService.createUserQuery().count());
+        ]]></script>
+        </scriptTask>
+        <sequenceFlow id="flow2" sourceRef="script1" targetRef="theTask"/>
+
+        <userTask id="theTask" name="keep-alive task"/>
+        <sequenceFlow id="flow3" sourceRef="theTask" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testIdentityServiceAvailableInScript.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/examples/bpmn/scripttask/ScriptTaskTest.testIdentityServiceAvailableInScript.bpmn20.xml
@@ -26,6 +26,7 @@
         <scriptTask id="script1" scriptFormat="groovy" flowable:autoStoreVariables="false">
             <script><![CDATA[
         execution.setVariable('userCount', identityService.createUserQuery().count());
+        execution.setVariable('legacyUserCount', identityServiceKey.createUserQuery().count());
         ]]></script>
         </scriptTask>
         <sequenceFlow id="flow2" sourceRef="script1" targetRef="theTask"/>


### PR DESCRIPTION
The identity service was registered in `SERVICE_RESOLVERS` under the key `identityServiceKey` instead of `identityService`. The map key is the name a script author types, so `identityService` did not resolve in BPMN scripts while every other engine service was exposed under its plain name.

The typo originates from the original `String` constants, where the field name was accidentally used as the value (all seven siblings followed `<name>ServiceKey = "<name>Service"`), and was carried over verbatim when the constants were replaced by the `SERVICE_RESOLVERS` map.

`identityService` is now the primary binding name. The former `identityServiceKey` is kept as an alias so that scripts relying on it keep working, so this change is not breaking.

#### Check List:
* Unit tests: YES
* Documentation: NA
