### PR TITLE
fix Calling get(0) without checking the event definitions of targetEvent

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -1646,7 +1646,8 @@ public abstract class AbstractDynamicStateManager {
             return false;
         }
         
-        if (sourceEvent.getEventDefinitions() != null && !sourceEvent.getEventDefinitions().isEmpty()) {
+        if (sourceEvent.getEventDefinitions() != null && !sourceEvent.getEventDefinitions().isEmpty()
+                && targetEvent.getEventDefinitions() != null && !targetEvent.getEventDefinitions().isEmpty()) {
             EventDefinition sourceEventDef = sourceEvent.getEventDefinitions().get(0);
             EventDefinition targetEventDef = targetEvent.getEventDefinitions().get(0);
             


### PR DESCRIPTION
fix Calling get(0) without checking the event definitions of targetEvent