### PR TITLE
fix Calling getValue() directly will throw an NPE if the record of next.dbid does not exist in the database (property is null)

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetNextIdBlockCmd.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cmd/GetNextIdBlockCmd.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.engine.impl.cmd;
 
+import org.flowable.common.engine.api.FlowableException;
 import org.flowable.common.engine.impl.db.IdBlock;
 import org.flowable.common.engine.impl.interceptor.Command;
 import org.flowable.common.engine.impl.interceptor.CommandContext;
@@ -33,7 +34,15 @@ public class GetNextIdBlockCmd implements Command<IdBlock> {
     @Override
     public IdBlock execute(CommandContext commandContext) {
         PropertyEntity property = (PropertyEntity) CommandContextUtil.getPropertyEntityManager(commandContext).findById("next.dbid");
-        long oldValue = Long.parseLong(property.getValue());
+        if (property == null) {
+            throw new FlowableException("Property 'next.dbid' not found. Database may not have been properly initialized.");
+        }
+        long oldValue;
+        try {
+            oldValue = Long.parseLong(property.getValue());
+        } catch (NumberFormatException e) {
+            throw new FlowableException("Invalid value for property 'next.dbid': " + property.getValue(), e);
+        }
         long newValue = oldValue + idBlockSize;
         property.setValue(Long.toString(newValue));
         return new IdBlock(oldValue, newValue - 1);

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetNextIdBlockCmd.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/cmd/GetNextIdBlockCmd.java
@@ -12,6 +12,7 @@
  */
 package org.activiti.engine.impl.cmd;
 
+import org.activiti.engine.ActivitiException;
 import org.activiti.engine.impl.db.IdBlock;
 import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
@@ -34,7 +35,15 @@ public class GetNextIdBlockCmd implements Command<IdBlock> {
         PropertyEntity property = commandContext
                 .getPropertyEntityManager()
                 .findPropertyById("next.dbid");
-        long oldValue = Long.parseLong(property.getValue());
+        if (property == null) {
+            throw new ActivitiException("Property 'next.dbid' not found. Database may not have been properly initialized.");
+        }
+        long oldValue;
+        try {
+            oldValue = Long.parseLong(property.getValue());
+        } catch (NumberFormatException e) {
+            throw new ActivitiException("Invalid value for property 'next.dbid': " + property.getValue(), e);
+        }
         long newValue = oldValue + idBlockSize;
         property.setValue(Long.toString(newValue));
         return new IdBlock(oldValue, newValue - 1);


### PR DESCRIPTION
fix Calling getValue() directly will throw an NPE if the record of next.dbid does not exist in the database (property is null)