### PR TITLE
fix If the construction of the wrapped BufferedReader fails, is may not be closed properly. Moreover, the reader variable is declared within the try block and cannot be accessed in the finally block.

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ShellActivityBehavior.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/behavior/ShellActivityBehavior.java
@@ -146,14 +146,11 @@ public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
             Writer writer = new StringWriter();
 
             char[] buffer = new char[1024];
-            try {
-                Reader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+            try (Reader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
                 int n;
                 while ((n = reader.read(buffer)) != -1) {
                     writer.write(buffer, 0, n);
                 }
-            } finally {
-                is.close();
             }
             return writer.toString();
         } else {


### PR DESCRIPTION
fix If the construction of the wrapped BufferedReader fails, is may not be closed properly. Moreover, the reader variable is declared within the try block and cannot be accessed in the finally block.