### PR TITLE
Fix self-deadlock in registerTenant() on databases with transactional…

### DIFF
--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/AbstractEngineConfiguration.java
@@ -1121,7 +1121,16 @@ public abstract class AbstractEngineConfiguration {
     }
 
     public LockManager getLockManager(String lockName) {
-        return new LockManagerImpl(commandExecutor, lockName, getLockPollRate(), getEngineCfgKey());
+        return getLockManager(lockName, false);
+    }
+
+    /**
+     * @param reuseCurrentCommandContext see {@link LockManagerImpl#LockManagerImpl(CommandExecutor, String, Duration, Duration, String, boolean)}.
+     *         Pass {@code true} when the lock is (or may be) acquired from within a command that already holds uncommitted DDL
+     *         on the current connection, e.g. schema creation/update, to avoid a self-deadlock on databases with transactional DDL.
+     */
+    public LockManager getLockManager(String lockName, boolean reuseCurrentCommandContext) {
+        return new LockManagerImpl(commandExecutor, lockName, getLockPollRate(), null, getEngineCfgKey(), reuseCurrentCommandContext);
     }
 
     // getters and setters

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/EngineSchemaManagerLockConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/EngineSchemaManagerLockConfiguration.java
@@ -44,6 +44,11 @@ public class EngineSchemaManagerLockConfiguration implements SchemaManagerLockCo
     }
 
     @Override
+    public LockManager getLockManager(String lockName, boolean reuseCurrentCommandContext) {
+        return getEngineConfiguration().getLockManager(lockName, reuseCurrentCommandContext);
+    }
+
+    @Override
     public Duration getSchemaLockWaitTime() {
         return getEngineConfiguration().getSchemaLockWaitTime();
     }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/EngineSqlScriptBasedDbSchemaManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/EngineSqlScriptBasedDbSchemaManager.java
@@ -82,7 +82,11 @@ public abstract class EngineSqlScriptBasedDbSchemaManager extends AbstractSqlScr
     public void schemaCreate() {
 
         if (lockConfiguration.isUseLockForDatabaseSchemaUpdate()) {
-            LockManager lockManager = lockConfiguration.getLockManager(getDbSchemaLockName());
+            // Reuse the current command context/connection: schemaCreateInLock() may run DDL on the same connection.
+            // Acquiring the lock on a separate, newly opened connection/transaction would self-deadlock on databases
+            // with transactional DDL (e.g. SQL Server, PostgreSQL) once an earlier schema manager in this same build
+            // has already executed uncommitted DDL on this connection.
+            LockManager lockManager = lockConfiguration.getLockManager(getDbSchemaLockName(), true);
             lockManager.waitForLockRunAndRelease(lockConfiguration.getSchemaLockWaitTime(), () -> {
                 schemaCreateInLock();
                 return null;
@@ -123,7 +127,8 @@ public abstract class EngineSqlScriptBasedDbSchemaManager extends AbstractSqlScr
     @Override
     public String schemaUpdate() {
         if (lockConfiguration.isUseLockForDatabaseSchemaUpdate()) {
-            LockManager lockManager = lockConfiguration.getLockManager(getDbSchemaLockName());
+            // See the comment in schemaCreate() above for why the current command context/connection is reused here.
+            LockManager lockManager = lockConfiguration.getLockManager(getDbSchemaLockName(), true);
             return lockManager.waitForLockRunAndRelease(lockConfiguration.getSchemaLockWaitTime(), this::schemaUpdateInLock);
         } else {
             return schemaUpdateInLock();

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/SchemaManagerLockConfiguration.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/db/SchemaManagerLockConfiguration.java
@@ -25,5 +25,15 @@ public interface SchemaManagerLockConfiguration {
 
     LockManager getLockManager(String lockName);
 
+    /**
+     * @param reuseCurrentCommandContext when {@code true}, the returned lock manager acquires/releases the lock using the
+     *         currently active command context (same connection/transaction), instead of a brand new one. This must be used
+     *         when locking around schema creation/update, to avoid a self-deadlock on databases with transactional DDL
+     *         (SQL Server, PostgreSQL, ...) - see {@code LockManagerImpl} for details.
+     */
+    default LockManager getLockManager(String lockName, boolean reuseCurrentCommandContext) {
+        return getLockManager(lockName);
+    }
+
     Duration getSchemaLockWaitTime();
 }

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/lock/LockManagerImpl.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/lock/LockManagerImpl.java
@@ -51,6 +51,24 @@ public class LockManagerImpl implements LockManager {
     }
 
     public LockManagerImpl(CommandExecutor commandExecutor, String lockName, Duration lockPollRate, Duration forceAcquireAfter, String engineType) {
+        this(commandExecutor, lockName, lockPollRate, forceAcquireAfter, engineType, false);
+    }
+
+    /**
+     * @param reuseCurrentCommandContext when {@code true}, lock commands are executed on the currently active
+     *         {@link org.flowable.common.engine.impl.interceptor.CommandContext} (i.e. the same database connection/transaction),
+     *         instead of the default behaviour of always running them in a brand new, independently committed transaction.
+     *         <p>
+     *         This must be used whenever the lock is acquired from a command that may already hold uncommitted DDL on the
+     *         same connection (typically during schema creation/update). On databases with transactional DDL (SQL Server,
+     *         PostgreSQL, ...) a schema-modification lock taken by such DDL is held until the enclosing transaction commits.
+     *         If the lock command were to run on a <em>different</em>, newly opened connection/transaction (the default),
+     *         it would block forever waiting for that still-open outer transaction to release the schema lock - which it
+     *         can't do until the (nested) lock command itself returns. This is a self-deadlock: the same call stack is
+     *         waiting on itself, on two different connections, so no database deadlock detector will ever catch it.
+     */
+    public LockManagerImpl(CommandExecutor commandExecutor, String lockName, Duration lockPollRate, Duration forceAcquireAfter, String engineType,
+            boolean reuseCurrentCommandContext) {
         this.commandExecutor = commandExecutor;
         if (lockName.length() > 64) {
             this.lockName = StringUtils.substring(lockName, 0, LOCK_NAME_MAX_LENGTH);
@@ -61,7 +79,9 @@ public class LockManagerImpl implements LockManager {
         }
         this.lockPollRate = lockPollRate;
         this.engineType = engineType;
-        this.lockCommandConfig = new CommandConfig(false, TransactionPropagation.REQUIRES_NEW);
+        this.lockCommandConfig = reuseCurrentCommandContext
+                ? new CommandConfig(true, TransactionPropagation.REQUIRED)
+                : new CommandConfig(false, TransactionPropagation.REQUIRES_NEW);
         this.lockForceAcquireAfter = forceAcquireAfter;
     }
 

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/db/ProcessDbSchemaManager.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/db/ProcessDbSchemaManager.java
@@ -88,7 +88,8 @@ public class ProcessDbSchemaManager extends AbstractSqlScriptBasedDbSchemaManage
         
         ProcessEngineConfigurationImpl processEngineConfiguration = getProcessEngineConfiguration();
         if (processEngineConfiguration.isUseLockForDatabaseSchemaUpdate()) {
-            LockManager lockManager = processEngineConfiguration.getManagementService().getLockManager(PROCESS_DB_SCHEMA_LOCK_NAME);
+            // Reuse the current command context/connection (see the equivalent comment in #schemaUpdate() below for details).
+            LockManager lockManager = processEngineConfiguration.getLockManager(PROCESS_DB_SCHEMA_LOCK_NAME, true);
             lockManager.waitForLockRunAndRelease(processEngineConfiguration.getSchemaLockWaitTime(), () -> {
                 schemaCreateInLock();
                 return null;
@@ -162,7 +163,24 @@ public class ProcessDbSchemaManager extends AbstractSqlScriptBasedDbSchemaManage
         ProcessEngineConfigurationImpl processEngineConfiguration = getProcessEngineConfiguration();
         LockManager lockManager;
         if (processEngineConfiguration.isUseLockForDatabaseSchemaUpdate()) {
-            lockManager = processEngineConfiguration.getManagementService().getLockManager(PROCESS_DB_SCHEMA_LOCK_NAME);
+            // IMPORTANT: this method (schemaUpdate) runs as part of SchemaOperationsEngineBuild, which is itself a single
+            // Command executed within one CommandContext/connection for its entire duration. By the time we get here,
+            // the CommonDbSchemaManager (run earlier in that same command, see SchemaOperationsEngineBuild) may already
+            // have executed unlocked DDL against ACT_GE_PROPERTY on that connection - e.g. creating the table for the
+            // very first time on a fresh schema.
+            //
+            // On databases with transactional DDL (SQL Server, PostgreSQL, ...) that DDL's schema-modification lock is
+            // held until the *outer* transaction commits, which cannot happen until this whole command returns. If the
+            // lock below were acquired on a separate, newly opened connection/transaction (the historical default -
+            // see LockManagerImpl), it would try to read from that same table and block forever waiting for a lock that
+            // can only be released by this very call returning: a self-deadlock that no database deadlock detector can
+            // catch, because the "blocking" session is simply idle rather than genuinely waiting on the other one.
+            //
+            // Passing reuseCurrentCommandContext=true makes the lock acquire/release run on the SAME connection as the
+            // rest of this schema build, so it sees the outer transaction's own uncommitted DDL instead of blocking on
+            // it. Other nodes/processes acquiring this lock on their own connections are still correctly blocked until
+            // this transaction commits, so the cross-process mutual exclusion guarantee is preserved.
+            lockManager = processEngineConfiguration.getLockManager(PROCESS_DB_SCHEMA_LOCK_NAME, true);
             lockManager.waitForLock(processEngineConfiguration.getSchemaLockWaitTime());
         } else {
             lockManager = null;


### PR DESCRIPTION
Description

MultiSchemaMultiTenantProcessEngineConfiguration.registerTenant(...) (modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/multitenant/MultiSchemaMultiTenantProcessEngineConfiguration.java) hangs indefinitely on databases with transactional DDL (SQL Server, PostgreSQL) when both databaseSchemaUpdate=true and useLockForDatabaseSchemaUpdate=true are set. Not reproducible on MySQL/MariaDB, since DDL there implicitly commits.

Root Cause

The schema build (SchemaOperationsEngineBuild) runs as a single top-level command on one connection (C_outer) for its entire duration. CommonDbSchemaManager.schemaUpdate() runs first, unlocked, and issues DDL against ACT_GE_PROPERTY (e.g. CREATE TABLE on a fresh schema). On SQL Server/PostgreSQL, that DDL's schema-modification lock is held until C_outer's transaction commits.

ProcessDbSchemaManager.schemaUpdate() then acquires the schema lock via LockManagerImpl.waitForLock(), which is hard-coded to new CommandConfig(false, TransactionPropagation.REQUIRES_NEW) — forcing a brand-new connection (C_inner), since contextReusePossible=false alone triggers this in CommandContextInterceptor regardless of whether a transaction interceptor is configured. The lock command's SELECT against ACT_GE_PROPERTY on C_inner then blocks on the schema lock still held by the uncommitted DDL on C_outer. C_outer can't commit until the outer command returns, which can't happen until that inner SELECT completes — a self-deadlock invisible to the database's own deadlock detector, since C_outer is idle rather than genuinely blocked.

Confirmed via sys.dm_exec_requests on SQL Server: the blocking session is idle, holding LCK_M_SCH_S on ACT_GE_PROPERTY, and both sessions originate from the same application host/thread.

Fix

Added an opt-in reuseCurrentCommandContext mode to LockManagerImpl, exposed via AbstractEngineConfiguration#getLockManager(String, boolean) and threaded through SchemaManagerLockConfiguration / EngineSchemaManagerLockConfiguration. When enabled, the lock is acquired and released on the same connection/transaction as the surrounding schema build instead of a newly opened one, so it sees the outer transaction's own uncommitted DDL rather than blocking on it. Other nodes/processes attempting to acquire the same lock on their own connections are still correctly blocked until the schema-build transaction commits, so cross-process mutual exclusion is preserved.

Applied to ProcessDbSchemaManager (the class in the reported stack trace) and, for consistency, to EngineSqlScriptBasedDbSchemaManager, which is shared by the cmmn/dmn/app/event-registry/idm engines and has the identical structural exposure. Existing callers of getLockManager(String) are unaffected, since the new parameter defaults to false.

fixes #4215