### PR TITLE
Prevent XXE in process diagram layout parser

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
@@ -22,8 +22,10 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import javax.imageio.ImageIO;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
@@ -102,6 +104,20 @@ public class ProcessDiagramLayoutFactory {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         // Get one that understands namespaces
         factory.setNamespaceAware(true);
+
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (ParserConfigurationException e) {
+            throw new FlowableException("Error configuring XML parser for safe BPMN parsing", e);
+        }
 
         DocumentBuilder builder;
         Document bpmnModel;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactoryTest.java
@@ -1,0 +1,27 @@
+package org.flowable.engine.impl.bpmn.diagram;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.flowable.common.engine.api.FlowableException;
+import org.junit.jupiter.api.Test;
+
+public class ProcessDiagramLayoutFactoryTest {
+
+	@Test
+	public void testParseXmlXXEProtection() {
+		String maliciousBpmn = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE bpmn2:definitions [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+    <bpmn2:definitions id="&xxe;">
+    </bpmn2:definitions>""";
+
+		ProcessDiagramLayoutFactory factory = new ProcessDiagramLayoutFactory();
+
+		assertThatThrownBy(() -> factory.parseXml(new ByteArrayInputStream(maliciousBpmn.getBytes(StandardCharsets.UTF_8))))
+			.isInstanceOf(FlowableException.class)
+			.hasMessageContaining("Error while parsing BPMN model");
+	}
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactoryTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactoryTest.java
@@ -1,3 +1,16 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.flowable.engine.impl.bpmn.diagram;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
+++ b/modules/flowable5-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
@@ -22,8 +22,10 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import javax.imageio.ImageIO;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
@@ -98,6 +100,20 @@ public class ProcessDiagramLayoutFactory {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         // Get one that understands namespaces
         factory.setNamespaceAware(true);
+        
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (ParserConfigurationException e) {
+            throw new FlowableException("Error configuring XML parser for safe BPMN parsing", e);
+        }
 
         DocumentBuilder builder;
         Document bpmnModel;


### PR DESCRIPTION
Fixes #4216 

Fix XXE vulnerability in ProcessDiagramLayoutFactory by securely configuring the XML parser to reject DOCTYPE declarations, disable external entity and DTD resolution, disable XInclude and entity expansion, and add regression coverage for malicious BPMN XML. Apply the same hardening to the Flowable 5 compatibility parser.

#### Checklist:
* Unit tests: YES
* Documentation: NA
