### PR TITLE
Record a delete reason when an error event sub-process interrupts. Fixes #4257

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ErrorPropagation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/bpmn/helper/ErrorPropagation.java
@@ -47,6 +47,7 @@ import org.flowable.common.engine.api.delegate.BusinessError;
 import org.flowable.engine.delegate.BpmnError;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.event.impl.FlowableEventBuilder;
+import org.flowable.engine.history.DeleteReason;
 import org.flowable.common.engine.impl.callback.CallbackData;
 import org.flowable.common.engine.impl.callback.RuntimeInstanceStateChangeCallback;
 import org.flowable.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -298,14 +299,16 @@ public class ErrorPropagation {
                 LOGGER.debug(
                         "Ending and deleting child executions for parent execution '{}'. Reason: Parent Execution is processIntanceType. Current Execution '{}'",
                         parentExecution, currentExecution);
-                executionEntityManager.deleteChildExecutions(parentExecution, null, true);
+                executionEntityManager.deleteChildExecutions(parentExecution,
+                        DeleteReason.EVENT_SUBPROCESS_INTERRUPTING + "(" + event.getId() + ")", true);
             } else if (!currentExecution.getParentId().equals(parentExecution.getId())) {
                 LOGGER.debug("Planing destroyScopeOperation for execution {}. Reason: {}. Parent execution: {}", currentExecution,
                         "Current execution parentId odes not match parentExecution id", parentExecution);
                 CommandContextUtil.getAgenda().planDestroyScopeOperation(currentExecution);
             } else {
                 LOGGER.debug("Deleting execution and related data for execution {}.", currentExecution);
-                executionEntityManager.deleteExecutionAndRelatedData(currentExecution, null, false);
+                executionEntityManager.deleteExecutionAndRelatedData(currentExecution,
+                        DeleteReason.EVENT_SUBPROCESS_INTERRUPTING + "(" + event.getId() + ")", false);
             }
 
             ExecutionEntity eventSubProcessExecution = executionEntityManager.createChildExecution(parentExecution);

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.java
@@ -1,0 +1,85 @@
+package org.flowable.engine.test.api.deletereason;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.flowable.engine.history.DeleteReason;
+import org.flowable.engine.history.HistoricActivityInstance;
+import org.flowable.engine.impl.test.PluggableFlowableTestCase;
+import org.flowable.engine.runtime.ProcessInstance;
+import org.flowable.engine.test.Deployment;
+import org.flowable.task.api.Task;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Companion to DeleteReasonTest#testInterruptingBoundaryEvent.
+ *
+ * An interrupting error event sub-process terminates the executions in its
+ * scope with a null delete reason, so an activity it killed is indistinguishable
+ * in history from one that completed normally. Every other interrupting event
+ * sub-process start type records DeleteReason.EVENT_SUBPROCESS_INTERRUPTING.
+ */
+public class ErrorEventSubProcessDeleteReasonTest extends PluggableFlowableTestCase {
+
+    /**
+     * A forked process: one branch parks on a user task, the other throws a
+     * BpmnError from a start execution listener. The interrupting error event
+     * sub-process catches it and terminates the whole scope.
+     */
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.bpmn20.xml")
+    public void testInterruptingErrorEventSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("errorEventSubProcessDeleteReason");
+
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
+
+        // The parked branch's user task was destroyed by the interruption.
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).count()).isZero();
+
+        HistoricActivityInstance parkedBranch = historicActivity(processInstance.getId(), "waitingCall");
+
+        // It has an end time and a called process instance, exactly as a call
+        // activity that ran to completion does. By the documented contract of
+        // getDeleteReason() -- "if completed normally, no delete reason is set"
+        // -- a null reason here says this activity finished. It did not.
+        assertThat(parkedBranch.getEndTime()).isNotNull();
+        assertThat(parkedBranch.getCalledProcessInstanceId()).isNotNull();
+
+        // FAILS: actual is null.
+        assertThat(parkedBranch.getDeleteReason())
+                .as("delete reason on an activity terminated by the interrupting error event sub-process")
+                .isEqualTo(DeleteReason.EVENT_SUBPROCESS_INTERRUPTING + "(errorHandlerStart)");
+    }
+
+    /**
+     * The same shape with an interrupting *boundary* event rather than an event
+     * sub-process. This one passes: BoundaryEventActivityBehavior records
+     * DeleteReason.BOUNDARY_EVENT_INTERRUPTING.
+     */
+    @Test
+    @Deployment(resources = "org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.boundary.bpmn20.xml")
+    public void testInterruptingBoundaryEventForComparison() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("boundaryDeleteReason");
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task).isNotNull();
+        taskService.complete(task.getId());
+
+        waitForHistoryJobExecutorToProcessAllJobs(7000, 100);
+
+        HistoricActivityInstance subProcess = historicActivity(processInstance.getId(), "theSubProcess");
+        assertThat(subProcess.getDeleteReason()).contains(DeleteReason.BOUNDARY_EVENT_INTERRUPTING);
+    }
+
+    private HistoricActivityInstance historicActivity(String processInstanceId, String activityId) {
+        List<HistoricActivityInstance> instances = historyService.createHistoricActivityInstanceQuery()
+                .processInstanceId(processInstanceId)
+                .activityId(activityId)
+                .list();
+        assertThat(instances).hasSize(1);
+        return instances.get(0);
+    }
+
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.engine.test.api.deletereason;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,19 +25,20 @@ import org.flowable.task.api.Task;
 import org.junit.jupiter.api.Test;
 
 /**
- * Companion to DeleteReasonTest#testInterruptingBoundaryEvent.
+ * Companion to {@link DeleteReasonTest#testInterruptingBoundaryEvent()}, for the
+ * interrupting error event sub-process.
  *
- * An interrupting error event sub-process terminates the executions in its
- * scope with a null delete reason, so an activity it killed is indistinguishable
- * in history from one that completed normally. Every other interrupting event
- * sub-process start type records DeleteReason.EVENT_SUBPROCESS_INTERRUPTING.
+ * An activity terminated by an interrupting start event is recorded with
+ * DeleteReason.EVENT_SUBPROCESS_INTERRUPTING, so history can tell it apart from
+ * one that completed normally.
  */
 public class ErrorEventSubProcessDeleteReasonTest extends PluggableFlowableTestCase {
 
     /**
-     * A forked process: one branch parks on a user task, the other throws a
-     * BpmnError from a start execution listener. The interrupting error event
-     * sub-process catches it and terminates the whole scope.
+     * A forked process: one branch parks on a user task inside a call activity,
+     * the other throws a BpmnError from a start execution listener. The
+     * interrupting error event sub-process catches it and terminates the whole
+     * scope, including the parked branch.
      */
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.bpmn20.xml")
@@ -40,27 +53,25 @@ public class ErrorEventSubProcessDeleteReasonTest extends PluggableFlowableTestC
 
         HistoricActivityInstance parkedBranch = historicActivity(processInstance.getId(), "waitingCall");
 
-        // It has an end time and a called process instance, exactly as a call
-        // activity that ran to completion does. By the documented contract of
-        // getDeleteReason() -- "if completed normally, no delete reason is set"
-        // -- a null reason here says this activity finished. It did not.
+        // An end time and a called process instance are also what a call
+        // activity that ran to completion records, so the delete reason is the
+        // only thing separating the two.
         assertThat(parkedBranch.getEndTime()).isNotNull();
         assertThat(parkedBranch.getCalledProcessInstanceId()).isNotNull();
 
-        // FAILS: actual is null.
         assertThat(parkedBranch.getDeleteReason())
                 .as("delete reason on an activity terminated by the interrupting error event sub-process")
                 .isEqualTo(DeleteReason.EVENT_SUBPROCESS_INTERRUPTING + "(errorHandlerStart)");
     }
 
     /**
-     * The same shape with an interrupting *boundary* event rather than an event
-     * sub-process. This one passes: BoundaryEventActivityBehavior records
-     * DeleteReason.BOUNDARY_EVENT_INTERRUPTING.
+     * The same BpmnError caught by an interrupting boundary event instead, which
+     * records DeleteReason.BOUNDARY_EVENT_INTERRUPTING. The two paths differ only
+     * in which vehicle catches the error.
      */
     @Test
     @Deployment(resources = "org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.boundary.bpmn20.xml")
-    public void testInterruptingBoundaryEventForComparison() {
+    public void testInterruptingBoundaryEvent() {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("boundaryDeleteReason");
 
         Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ThrowBpmnErrorListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ThrowBpmnErrorListener.java
@@ -1,0 +1,26 @@
+package org.flowable.engine.test.api.deletereason;
+
+import org.flowable.engine.delegate.BpmnError;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.ExecutionListener;
+import org.flowable.engine.delegate.JavaDelegate;
+
+/** Raises a BpmnError from a start execution listener. */
+public class ThrowBpmnErrorListener implements ExecutionListener {
+
+    @Override
+    public void notify(DelegateExecution execution) {
+        throw new BpmnError("someError", "raised from a start execution listener");
+    }
+
+}
+
+/** Never reached; the listener throws before the behaviour runs. */
+class NoopDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) {
+        // no-op
+    }
+
+}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ThrowBpmnErrorListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ThrowBpmnErrorListener.java
@@ -1,3 +1,15 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.flowable.engine.test.api.deletereason;
 
 import org.flowable.engine.delegate.BpmnError;

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ThrowBpmnErrorListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ThrowBpmnErrorListener.java
@@ -26,13 +26,3 @@ public class ThrowBpmnErrorListener implements ExecutionListener {
     }
 
 }
-
-/** Never reached; the listener throws before the behaviour runs. */
-class NoopDelegate implements JavaDelegate {
-
-    @Override
-    public void execute(DelegateExecution execution) {
-        // no-op
-    }
-
-}

--- a/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ThrowBpmnErrorListener.java
+++ b/modules/flowable-engine/src/test/java/org/flowable/engine/test/api/deletereason/ThrowBpmnErrorListener.java
@@ -15,7 +15,6 @@ package org.flowable.engine.test.api.deletereason;
 import org.flowable.engine.delegate.BpmnError;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.engine.delegate.ExecutionListener;
-import org.flowable.engine.delegate.JavaDelegate;
 
 /** Raises a BpmnError from a start execution listener. */
 public class ThrowBpmnErrorListener implements ExecutionListener {

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.boundary.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.boundary.bpmn20.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="deleteReason">
+
+  <error id="someError" errorCode="someError"/>
+
+  <!--
+    The same BpmnError as the event sub-process case, caught by a boundary event
+    instead. BoundaryEventActivityBehavior records
+    DeleteReason.BOUNDARY_EVENT_INTERRUPTING on the activity it interrupts, so
+    the only difference between this file and the other one is which vehicle
+    catches the error.
+  -->
+  <process id="boundaryDeleteReason" isExecutable="true">
+
+    <startEvent id="start"/>
+    <sequenceFlow id="toSubProcess" sourceRef="start" targetRef="theSubProcess"/>
+
+    <subProcess id="theSubProcess" name="The Sub Process">
+      <startEvent id="innerStart"/>
+      <sequenceFlow id="innerToTask" sourceRef="innerStart" targetRef="innerTask"/>
+      <userTask id="innerTask" name="Inner Task" flowable:assignee="kermit"/>
+      <sequenceFlow id="innerTaskToError" sourceRef="innerTask" targetRef="innerErrorEnd"/>
+      <endEvent id="innerErrorEnd">
+        <errorEventDefinition errorRef="someError"/>
+      </endEvent>
+    </subProcess>
+
+    <sequenceFlow id="subProcessToEnd" sourceRef="theSubProcess" targetRef="endNormal"/>
+    <endEvent id="endNormal"/>
+
+    <boundaryEvent id="errorBoundary" attachedToRef="theSubProcess" cancelActivity="true">
+      <errorEventDefinition/>
+    </boundaryEvent>
+    <sequenceFlow id="boundaryToEnd" sourceRef="errorBoundary" targetRef="endCaught"/>
+    <endEvent id="endCaught"/>
+
+  </process>
+</definitions>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.bpmn20.xml
@@ -17,8 +17,7 @@
 
     <!-- Branch B: a start execution listener raises a BpmnError. -->
     <sequenceFlow id="toThrowing" sourceRef="fork" targetRef="throwingTask"/>
-    <serviceTask id="throwingTask" name="Throwing Task"
-                 flowable:class="org.flowable.engine.test.api.deletereason.NoopDelegate">
+    <serviceTask id="throwingTask" name="Throwing Task" flowable:expression="${true}">
       <extensionElements>
         <flowable:executionListener event="start"
             class="org.flowable.engine.test.api.deletereason.ThrowBpmnErrorListener"/>

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/api/deletereason/ErrorEventSubProcessDeleteReasonTest.bpmn20.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:flowable="http://flowable.org/bpmn"
+             targetNamespace="deleteReason">
+
+  <process id="errorEventSubProcessDeleteReason" isExecutable="true">
+
+    <startEvent id="start"/>
+    <sequenceFlow id="toFork" sourceRef="start" targetRef="fork"/>
+    <parallelGateway id="fork"/>
+
+    <!-- Branch A: a call activity whose child parks on a user task. -->
+    <sequenceFlow id="toWaiting" sourceRef="fork" targetRef="waitingCall"/>
+    <callActivity id="waitingCall" name="Waiting Call" calledElement="waitingChild"/>
+    <sequenceFlow id="waitingToEnd" sourceRef="waitingCall" targetRef="endA"/>
+    <endEvent id="endA"/>
+
+    <!-- Branch B: a start execution listener raises a BpmnError. -->
+    <sequenceFlow id="toThrowing" sourceRef="fork" targetRef="throwingTask"/>
+    <serviceTask id="throwingTask" name="Throwing Task"
+                 flowable:class="org.flowable.engine.test.api.deletereason.NoopDelegate">
+      <extensionElements>
+        <flowable:executionListener event="start"
+            class="org.flowable.engine.test.api.deletereason.ThrowBpmnErrorListener"/>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="throwingToEnd" sourceRef="throwingTask" targetRef="endB"/>
+    <endEvent id="endB"/>
+
+    <!-- Interrupting error event sub-process: catches, and terminates the scope. -->
+    <subProcess id="errorHandler" triggeredByEvent="true">
+      <startEvent id="errorHandlerStart" isInterrupting="true">
+        <errorEventDefinition/>
+      </startEvent>
+      <sequenceFlow id="handlerToEnd" sourceRef="errorHandlerStart" targetRef="errorHandlerEnd"/>
+      <endEvent id="errorHandlerEnd"/>
+    </subProcess>
+
+  </process>
+
+  <!-- Branch A's called process: raises a user task and waits. -->
+  <process id="waitingChild" isExecutable="true">
+    <startEvent id="childStart"/>
+    <sequenceFlow id="childToTask" sourceRef="childStart" targetRef="waitingTask"/>
+    <userTask id="waitingTask" name="Waiting Task" flowable:assignee="kermit"/>
+    <sequenceFlow id="childTaskToEnd" sourceRef="waitingTask" targetRef="childEnd"/>
+    <endEvent id="childEnd"/>
+  </process>
+</definitions>


### PR DESCRIPTION
Fixes [4257](https://github.com/flowable/flowable-engine/issues/4257)

`ErrorPropagation.executeEventHandler` deletes the executions an interrupting error event sub-process terminates without passing a delete reason, so `ACT_HI_ACTINST.DELETE_REASON_` is left null and a terminated activity is indistinguishable in history from one that completed normally — which contradicts `HistoricActivityInstance#getDeleteReason()`, whose javadoc states that no reason is set precisely when an activity completes normally. Every other interrupting event sub-process start type records `DeleteReason.EVENT_SUBPROCESS_INTERRUPTING`, and boundary events record `BOUNDARY_EVENT_INTERRUPTING`; the error start is the only one that does not. This passes that same reason at both call sites, and adds the `DeleteReasonTest` case that was missing for this start type.

#### Check List:
* Unit tests: YES
* Documentation: Causes behavior to conform to [existing documentation](https://www.flowable.com/open-source/docs/all-javadocs/org/flowable/engine/history/HistoricActivityInstance.html#:~:text=%C2%A0getDeleteReason()-,Returns%20the%20delete%20reason%20for%20this%20activity%2C%20if%20any%20was%20set%20(if%20completed%20normally%2C%20no%20delete%20reason%20is%20set),-getTenantId)
